### PR TITLE
Destructuring binding

### DIFF
--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -14,7 +14,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { DeclarativeEnvironmentRecord } from "../environment.js";
 import { Reference } from "../environment.js";
 import { BreakCompletion, AbruptCompletion, ContinueCompletion } from "../completions.js";
-import { EmptyValue, ObjectValue, Value, NullValue, UndefinedValue, StringValue } from "../values/index.js";
+import { EmptyValue, ObjectValue, Value, NullValue, UndefinedValue } from "../values/index.js";
 import invariant from "../invariant.js";
 import {
   InitializeReferencedBinding,

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -23,7 +23,6 @@ import {
   CreateIterResultObject,
   CreateMethodProperty,
   SameValue,
-  HasCompatibleType
 } from "./index.js";
 import invariant from "../invariant.js";
 import type { IterationKind } from "../types.js";

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -72,6 +72,10 @@ export default class ObjectValue extends ConcreteValue {
   $MapData: void | Array<{$Key: void | Value, $Value: void | Value}>;
   $Map: void | ObjectValue | UndefinedValue;
 
+  // list
+  $ListIteratorNextIndex: void | number;
+  $IteratorNext: void | ObjectValue;
+
   // weak map
   $WeakMapData: void | Array<{$Key: void | Value, $Value: void | Value}>;
 


### PR DESCRIPTION
This is a work in progress of filling in sections 13.3.3.5 and 13.3.3.6; this causes more tests to run (and pass) for for-of and catch clauses (whether this is sufficient is very difficult for me to judge)
The tests selected by -- destructuring/binding only runs 4 non-syntactic tests, all of which fail and none of which use the semantics of 13.3.3.5 and 13.3.3.6 directly and it's unclear how/whether to hook the initializeBinding function into the function call semantics.