### PR TITLE
Provide a way to test console output

### DIFF
--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -46,20 +46,20 @@ export function evaluateWithAbstractConditional(condValue: AbstractValue,
     consequent: BabelNode, alternate: ?BabelNode, strictCode: boolean,
     env: LexicalEnvironment, realm: Realm): NormalCompletion | Value | Reference {
   // Evaluate consequent and alternate in sandboxes and get their effects.
-  let [compl1, gen1, bindings1, properties1, createdObj1, consoleOut1] =
+  let [compl1, gen1, bindings1, properties1, createdObj1] =
     realm.partially_evaluate(consequent, strictCode, env);
 
-  let [compl2, gen2, bindings2, properties2, createdObj2, consoleOut2] =
+  let [compl2, gen2, bindings2, properties2, createdObj2] =
     alternate ?
       realm.partially_evaluate(alternate, strictCode, env) :
       construct_empty_effects(realm);
 
   // Join the effects, creating an abstract view of what happened, regardless
   // of the actual value of condValue.
-  let [completion, generator, bindings, properties, createdObjects, consoleOut] =
+  let [completion, generator, bindings, properties, createdObjects] =
     joinEffects(realm, condValue,
-      [compl1, gen1, bindings1, properties1, createdObj1, consoleOut1],
-      [compl2, gen2, bindings2, properties2, createdObj2, consoleOut2], true);
+      [compl1, gen1, bindings1, properties1, createdObj1],
+      [compl2, gen2, bindings2, properties2, createdObj2]);
 
   // Apply the joined effects to the global state
   realm.restoreBindings(bindings);
@@ -70,11 +70,6 @@ export function evaluateWithAbstractConditional(condValue: AbstractValue,
   invariant(realmGenerator);
   let realmGeneratorBody = realmGenerator.body;
   generator.body.forEach((v, k, a) => realmGeneratorBody.push(v));
-
-  // Output any console strings
-  consoleOut.forEach((line) => {
-    realm.outputToConsole(line);
-  });
 
   // Ignore created Objects
   createdObjects;

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -49,11 +49,11 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean, e
   }
 
   // Create empty effects for the case where ast.left is defined
-  let [compl1, gen1, bindings1, properties1, createdObj1, consoleOut1] =
+  let [compl1, gen1, bindings1, properties1, createdObj1] =
     construct_empty_effects(realm);
 
   // Evaluate ast.right in a sandbox to get its effects
-  let [compl2, gen2, bindings2, properties2, createdObj2, consoleOut2] =
+  let [compl2, gen2, bindings2, properties2, createdObj2] =
     realm.partially_evaluate(ast.right, strictCode, env);
 
   // todo: don't just give up on abrupt completions, but try to join states
@@ -63,15 +63,15 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean, e
 
   // Join the effects, creating an abstract view of what happened, regardless
   // of the actual value of ast.left.
-  let [completion, generator, bindings, properties, createdObjects, consoleOut] =
+  let [completion, generator, bindings, properties, createdObjects] =
     ast.operator === "&&" ?
       joinEffects(realm, lval,
-        [compl2, gen2, bindings2, properties2, createdObj2, consoleOut2],
-        [compl1, gen1, bindings1, properties1, createdObj1, consoleOut1], true)
+        [compl2, gen2, bindings2, properties2, createdObj2],
+        [compl1, gen1, bindings1, properties1, createdObj1])
     :
       joinEffects(realm, lval,
-        [compl1, gen1, bindings1, properties1, createdObj1, consoleOut1],
-        [compl2, gen2, bindings2, properties2, createdObj2, consoleOut2], true);
+        [compl1, gen1, bindings1, properties1, createdObj1],
+        [compl2, gen2, bindings2, properties2, createdObj2]);
 
 
   // Apply the joined effects to the global state
@@ -83,11 +83,6 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean, e
   invariant(realmGenerator);
   let realmGeneratorBody = realmGenerator.body;
   generator.body.forEach((v, k, a) => realmGeneratorBody.push(v));
-
-  // Dump any console output
-  consoleOut.forEach((line) => {
-    realm.outputToConsole(line);
-  });
 
   // Ignore the joined completion
   completion;

--- a/src/scripts/test-runner.js
+++ b/src/scripts/test-runner.js
@@ -44,6 +44,7 @@ function exec(code: string): string {
 report(inspect());`, { cachedDataProduced: false });
 
   let result = "";
+  let logOutput = "";
   script.runInNewContext({
     setTimeout: setTimeout,
     setInterval: setInterval,
@@ -52,11 +53,11 @@ report(inspect());`, { cachedDataProduced: false });
     },
     console: {
       log(s) {
-        console.log(s);
+        logOutput += "\n" + s;
       }
     }
   });
-  return result;
+  return result + logOutput;
 }
 
 class Success {}

--- a/src/serialiser.js
+++ b/src/serialiser.js
@@ -1115,16 +1115,8 @@ export default class Serialiser {
         if (this.requireReturns.has(moduleId)) continue; // already known to be initialized
         let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
 
-        let [compl, gen, bindings, properties, createdObjects, consoleOutput] =
+        let [compl, gen, bindings, properties, createdObjects] =
           realm.partially_evaluate(node, true, env, false);
-
-        if (consoleOutput.length > 0) {
-          console.log(`=== console output during speculative initialization of module ${moduleId} ===`);
-          // Dump any console output
-          consoleOutput.forEach((line) => {
-            realm.outputToConsole(line);
-          });
-        }
 
         if (compl instanceof Completion) {
           if (IsIntrospectionErrorCompletion(realm, compl)) {
@@ -1199,7 +1191,7 @@ export default class Serialiser {
     for (let moduleId of this.requiredModules) {
       let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
 
-      let [compl, gen, bindings, properties, createdObjects, consoleOutput] =
+      let [compl, gen, bindings, properties, createdObjects] =
         realm.partially_evaluate(node, true, env, false);
       // for lint unused
       invariant(bindings);
@@ -1207,7 +1199,7 @@ export default class Serialiser {
       if (compl instanceof AbruptCompletion) continue;
       invariant(compl instanceof Value);
 
-      if (gen.body.length !== 0 || consoleOutput.length !== 0 ||
+      if (gen.body.length !== 0 ||
         (compl instanceof ObjectValue && createdObjects.has(compl))) continue;
       // Check for escaping property assignments, if none escape, we're safe
       // to replace the require with its exports object

--- a/test/serialiser/abstract/BranchingConsoleLog.js
+++ b/test/serialiser/abstract/BranchingConsoleLog.js
@@ -1,9 +1,6 @@
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 let y = global.__abstract ? __abstract("boolean", "false") : false;
 
-var record = []
-console.log = function(val) { record.push(val); };
-
 if (x) {
   console.log("true");
 } else {
@@ -11,10 +8,8 @@ if (x) {
 }
 
 if (y) {
-  console.log("true");
 } else {
   console.log("false");
 }
 
-
-inspect = function() { return record.toString(); }
+inspect = function() { return ""; }


### PR DESCRIPTION
In partial mode, always write to an internal array of strings. Make this array visible to test code by adding global. __getConsoleOutput.

Reframe the BranchingConsoleLog.js test to do what it was originally intended to do, namely test that console output is correctly captured in the state and correctly joined when abstract conditions are encountered.