### PR TITLE
Fix assignment of nested intrinsicNames to help debugging

### DIFF
--- a/src/global.js
+++ b/src/global.js
@@ -132,7 +132,6 @@ export default function (realm: Realm): ObjectValue {
       let result = realm.createAbstract(types, values, [], buildNode, undefined, nameString);
       if (template) {
         template.makePartial();
-        template.intrinsicName = nameString;
         if (nameString) realm.rebuildNestedProperties(result, nameString);
       }
       return result;

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -466,7 +466,6 @@ export default function (realm: Realm): ObjectValue {
       if (clonedValue instanceof ObjectValue) {
         let iName = result.intrinsicName;
         invariant(iName);
-        clonedValue.intrinsicName = iName;
         realm.rebuildNestedProperties(result, iName);
       }
       return result;
@@ -512,7 +511,6 @@ export default function (realm: Realm): ObjectValue {
       let values = template ? new ValuesDomain(new Set([template])) : ValuesDomain.topVal;
       unfiltered = realm.deriveAbstract(types, values, [text], buildNode, "JSON.parse(...)");
       if (template) {
-        template.intrinsicName = unfiltered.intrinsicName;
         invariant(unfiltered.intrinsicName);
         realm.rebuildNestedProperties(unfiltered, unfiltered.intrinsicName);
       }

--- a/src/serialiser.js
+++ b/src/serialiser.js
@@ -65,6 +65,8 @@ function shouldVisit(node, data) {
 //       if any parent nodes are marked visited, but that seem unnecessary right now.let closureRefReplacer = {
 let closureRefReplacer = {
   ReferencedIdentifier(path, state) {
+    if (ignorePath(path)) return;
+
     let serialisedBindings = state.serialisedBindings;
     let innerName = path.node.name;
     if (path.scope.hasBinding(innerName, /*noGlobals*/true)) return;
@@ -121,9 +123,16 @@ function visitName(state, name, modified) {
   if (modified) state.functionInfo.modified[name] = true;
 }
 
+function ignorePath(path) {
+  let parent = path.parent;
+  return t.isLabeledStatement(parent) || t.isBreakStatement(parent) || t.isContinueStatement(parent);
+}
+
 // TODO doesn't check that `arguments` and `this` is in top function
 let closureRefVisitor = {
   ReferencedIdentifier(path, state) {
+    if (ignorePath(path)) return;
+
     let innerName = path.node.name;
     if (innerName === "arguments") {
       state.functionInfo.usesArguments = true;


### PR DESCRIPTION
Don't attempt to wrap introspection errors during partial evaluation
In serializer, ignore identifiers that represent labels