### PR TITLE
Don't crash when declaring values defined in nested code blocks

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -12,6 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
 import { AbstractValue, BooleanValue, ObjectValue, StringValue, Value } from "./index.js";
+import type { AbstractValueBuildNodeFunction } from "./AbstractValue.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { IsDataDescriptor, joinValuesAsConditional, cloneDescriptor, equalDescriptors } from "../methods/index.js";
 import type { BabelNodeExpression } from "babel-types";
@@ -24,7 +25,7 @@ export default class AbstractObjectValue extends AbstractValue {
       types: TypesDomain,
       values: ValuesDomain,
       args: Array<Value>,
-      buildNode: (Array<BabelNodeExpression> => BabelNodeExpression) | BabelNodeExpression,
+      buildNode: AbstractValueBuildNodeFunction | BabelNodeExpression,
       kind?: string,
       intrinsicName?: string) {
     super(realm, types, values, args, buildNode, kind, intrinsicName);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -16,13 +16,15 @@ import invariant from "../invariant.js";
 import type { BabelNodeExpression, BabelNodeIdentifier } from "babel-types";
 import * as t from "babel-types";
 
+export type AbstractValueBuildNodeFunction = (Array<BabelNodeExpression>) => BabelNodeExpression;
+
 export default class AbstractValue extends Value {
   constructor(
       realm: Realm,
       types: TypesDomain,
       values: ValuesDomain,
       args: Array<Value>,
-      buildNode: (Array<BabelNodeExpression> => BabelNodeExpression) | BabelNodeExpression,
+      buildNode: AbstractValueBuildNodeFunction | BabelNodeExpression,
       kind?: string,
       intrinsicName?: string) {
     invariant(realm.isPartial);
@@ -58,11 +60,11 @@ export default class AbstractValue extends Value {
   types: TypesDomain;
   values: ValuesDomain;
   args: Array<Value>;
-  _buildNode: (Array<BabelNodeExpression> => BabelNodeExpression) | BabelNodeExpression;
+  _buildNode: AbstractValueBuildNodeFunction | BabelNodeExpression;
 
   buildNode(args: Array<BabelNodeExpression>): BabelNodeExpression {
     return this._buildNode instanceof Function
-      ? ((this._buildNode: any): (Array<BabelNodeExpression> => BabelNodeExpression))(args)
+      ? ((this._buildNode: any): AbstractValueBuildNodeFunction)(args)
       : ((this._buildNode: any): BabelNodeExpression);
   }
 

--- a/src/values/index.js
+++ b/src/values/index.js
@@ -35,5 +35,5 @@ export { default as BooleanValue } from "./BooleanValue.js";
 export { default as StringValue } from "./StringValue.js";
 export { default as SymbolValue } from "./SymbolValue.js";
 
-export { default as AbstractValue } from "./AbstractValue.js";
+export { default as AbstractValue, AbstractValueBuildNodeFunction } from "./AbstractValue.js";
 export { default as AbstractObjectValue } from "./AbstractObjectValue.js";

--- a/test/serialiser/abstract/Branching.js
+++ b/test/serialiser/abstract/Branching.js
@@ -1,0 +1,2 @@
+if (Date.now() > 0) x = Date.now();
+inspect = function() { return ""; }


### PR DESCRIPTION
When embedding nested generators, hook everything up so that  …
- all information is preserved, in particular the declaresDerivedIds
- all auxiliary code generated by the serialiser is emitted to the nested statement block.

Adding test (formerly crashing with internal error)