### PR TITLE
Adding test for __assumeDataProperty.

### DIFF
--- a/test/serialiser/basic/AssumeDataProperty.js
+++ b/test/serialiser/basic/AssumeDataProperty.js
@@ -1,0 +1,5 @@
+if (global.__assumeDataProperty) __assumeDataProperty(global, "o", undefined);
+if (global.__assumeDataProperty) __assumeDataProperty(global, "inspect", undefined);
+if (global.__makePartial) __makePartial(global);
+o = 42;
+inspect = function() { return o; }


### PR DESCRIPTION
Wrap code in the serialiser that may run user code into tryQuery (otherwise, it may crash the serialiser, and did so for the new test).