### PR TITLE
Properly leak Introspection Error objects

### DIFF
--- a/test/serialiser/abstract/CantCatchIntrospectionError.js
+++ b/test/serialiser/abstract/CantCatchIntrospectionError.js
@@ -1,8 +1,9 @@
 // throws introspection error
+let x = __abstract("boolean", "true");
 
 try {
   var obj = __abstract("object");
-  delete obj.someProperty;
+  if (x) delete obj.someProperty;
 } catch(err) {
   throw new Error("Cannot catch");
 } finally {


### PR DESCRIPTION
Introspection errors that are created inside of a partially_evaluate become invalid once control leaves its finally block, because all of the effects done inside the call to partially_evaluate are rolled back by the finally block.

Among other things, later checks to see if a completion wraps an introspection error will fail.

To fix this, the error is recreated in the outer state once the finally has done its roll back.