### PR TITLE
Handle PossiblyNormalCompletions

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -967,11 +967,15 @@ export class LexicalEnvironment {
       return this.evaluate(ast, strictCode, metadata);
     } catch (err) {
       if (err instanceof JoinedAbruptCompletions) {
-        Value.throwIntrospectionError(err.joinCondition);
+        return Value.throwIntrospectionError(err.joinCondition);
       } else if (err instanceof ComposedAbruptCompletion) {
-        return Value.throwIntrospectionError(err.priorCompletion.joinCondition);
-      } if (err instanceof AbruptCompletion) {
+        return err.throwIntrospectionError();
+      } else if (err instanceof AbruptCompletion) {
         return err;
+      } else if (err instanceof PossiblyNormalCompletion) {
+        Value.throwIntrospectionError(err.joinCondition);
+      } else if (err instanceof ComposedPossiblyNormalCompletion) {
+        return err.throwIntrospectionError();
       } else if (err instanceof Error) {
         // rethrowing Error should preserve stack trace
         throw err;

--- a/test/serialiser/abstract/Return1.js
+++ b/test/serialiser/abstract/Return1.js
@@ -1,0 +1,15 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+y = 1;
+
+function f(b) {
+  if (b) return 1;
+  y = 2;
+}
+
+z = f(x);
+z1 = y;
+z2 = f(!x);
+z3 = y;
+
+inspect = function() { return "" + z + z1 + z2 + z3; }


### PR DESCRIPTION
When one branch of an if returns and the other one falls through to the next statement, the subsequent "normal" code needs to be executed with change tracking on, so that the normal effects can be rolled back and then joined with the return branch when the end of the function is reached.