### PR TITLE
Increase stack space and reported stack trace size when running node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-serialiser-with-coverage": "cd lib && ../node_modules/.bin/istanbul cover scripts/test-runner.js && ../node_modules/.bin/remap-istanbul -i coverage/coverage.json -o coverage-sourcemapped -t html && echo You can find coverage reports here: && echo   lib/coverage/lcov-report/index.html && echo   lib/coverage-sourcemapped/index.html",
     "test-sourcemaps": "node lib/scripts/generate-sourcemaps-test.js && bash < src/scripts/test-sourcemaps.sh",
     "test-test262": "node lib/scripts/test262-runner.js",
-    "test-internal": "node lib/scripts/test-internal.js",
+    "test-internal": "node --stack_size=10000 --stack_trace_limit=200 --max_old_space_size=8192 lib/scripts/test-internal.js",
     "test": "npm run test-serialiser && npm run test-sourcemaps && npm run test-test262 && npm run test-internal",
     "repl": "node lib/repl.js",
     "prepack": "node lib/run_util.js",

--- a/src/scripts/test-internal.js
+++ b/src/scripts/test-internal.js
@@ -40,12 +40,17 @@ let tests = search(`${__dirname}/../../test/internal`, "test/internal");
 
 function runTest(name: string, code: string): boolean {
   console.log(chalk.inverse(name));
-  let serialised = new Serialiser({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }).init(name, code, "", false);
-  if (!serialised) {
-    console.log(chalk.red("Error during serialisation"));
+  try {
+    let serialised = new Serialiser({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }, false).init(name, code, "", false);
+    if (!serialised) {
+      console.log(chalk.red("Error during serialisation"));
+      return false;
+    } else {
+      return true;
+    }
+  } catch (e) {
+    console.log(e);
     return false;
-  } else {
-    return true;
   }
 }
 


### PR DESCRIPTION
Temporarily disable speculative optimizations when running internal tests.
Report crash as test failure.