### PR TITLE
Let Introspection errors propagate as completions

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -917,7 +917,9 @@ export function OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: Property
   // 2. If O does not have an own property with key P, return undefined.
   let existingBinding = InternalGetPropertiesMap(O, P).get(InternalGetPropertiesKey(P));
   if (!existingBinding) {
-    if (O.isPartial() && !O.isSimple()) Value.throwIntrospectionError(O, P);
+    if (O.isPartial() && !O.isSimple()) {
+      Value.throwIntrospectionError(O, P);
+    }
     return undefined;
   }
   if (!existingBinding.descriptor) return undefined;

--- a/src/scripts/test-internal.js
+++ b/src/scripts/test-internal.js
@@ -41,7 +41,7 @@ let tests = search(`${__dirname}/../../test/internal`, "test/internal");
 function runTest(name: string, code: string): boolean {
   console.log(chalk.inverse(name));
   try {
-    let serialised = new Serialiser({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }, false).init(name, code, "", false);
+    let serialised = new Serialiser({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }).init(name, code, "", false);
     if (!serialised) {
       console.log(chalk.red("Error during serialisation"));
       return false;

--- a/src/serialiser.js
+++ b/src/serialiser.js
@@ -1143,11 +1143,11 @@ export default class Serialiser {
           realm.partially_evaluate_node(node, true, env, false);
 
         if (compl instanceof Completion) {
+          realm.restoreBindings(bindings);
+          realm.restoreProperties(properties);
           if (IsIntrospectionErrorCompletion(realm, compl)) {
             let value = compl.value;
             invariant(value instanceof ObjectValue);
-            realm.restoreBindings(bindings);
-            realm.restoreProperties(properties);
             let message: string = this.tryQuery(() => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "message")), "(cannot get message)", false);
             realm.restoreBindings(bindings);
             realm.restoreProperties(properties);
@@ -1157,9 +1157,9 @@ export default class Serialiser {
           }
 
           console.log(`=== UNEXPECTED ERROR during speculative initialization of module ${moduleId} ===`);
+          this.logCompletion(compl);
           realm.restoreBindings(bindings);
           realm.restoreProperties(properties);
-          this.logCompletion(compl);
           break;
         }
 


### PR DESCRIPTION
Throwing the introspection errors do not play nice with the semantics of partially_evaluate, so go back to treating them just like any other completion (except that they can't be caught by user code).

When such a completion bubbles up pas the top level partially_evaluate, one should restore the effects before checking the properties of the completion.