### PR TITLE
Do not compose introspection error completions

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -31,6 +31,8 @@ export class NormalCompletion extends Completion {}
 export class ThrowCompletion extends AbruptCompletion {
   constructor(value: Value, nativeStack?: ?string) {
     super(value);
+    invariant(value.getType() !== value.$Realm.intrinsics.__IntrospectionError ||
+      this instanceof IntrospectionThrowCompletion);
     this.nativeStack = nativeStack || new Error().stack;
     this.pushedContext = false;
   }
@@ -38,6 +40,7 @@ export class ThrowCompletion extends AbruptCompletion {
   nativeStack: string;
   pushedContext: boolean;
 }
+export class IntrospectionThrowCompletion extends ThrowCompletion {}
 export class ContinueCompletion extends AbruptCompletion {}
 export class BreakCompletion extends AbruptCompletion {}
 export class ReturnCompletion extends AbruptCompletion {}

--- a/src/evaluators/BlockStatement.js
+++ b/src/evaluators/BlockStatement.js
@@ -13,7 +13,7 @@ import type { BabelNodeBlockStatement } from "babel-types";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
-import { AbruptCompletion, ComposedAbruptCompletion, ComposedPossiblyNormalCompletion, NormalCompletion, PossiblyNormalCompletion } from "../completions.js";
+import { AbruptCompletion, ComposedAbruptCompletion, ComposedPossiblyNormalCompletion, NormalCompletion, PossiblyNormalCompletion, IntrospectionThrowCompletion } from "../completions.js";
 import { Reference } from "../environment.js";
 import { EmptyValue, StringValue, Value } from "../values/index.js";
 import { NewDeclarativeEnvironment, BlockDeclarationInstantiation } from "../methods/index.js";
@@ -52,7 +52,11 @@ export default function (ast: BabelNodeBlockStatement, strictCode: boolean, env:
             if (res instanceof AbruptCompletion) throw res;
             invariant(res instanceof NormalCompletion || res instanceof Value);
             blockValue = res;
+          } else if (res instanceof IntrospectionThrowCompletion) {
+            throw res;
           } else if (res instanceof AbruptCompletion) {
+            // todo: this is a join point. Join up all of the effects that
+            // lead here, apply them and then throw.
             throw new ComposedAbruptCompletion(blockValue, res);
           } else if (blockValue instanceof NormalCompletion) {
             if (res instanceof Value)

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -12,9 +12,8 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Reference } from "../environment.js";
-import { AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { AbruptCompletion, IntrospectionThrowCompletion, ThrowCompletion } from "../completions.js";
 import { Value } from "../values/index.js";
-import { IsIntrospectionErrorCompletion } from "../methods/index.js";
 import type { BabelNodeTryStatement } from "babel-types";
 
 export default function (ast: BabelNodeTryStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value | Reference {
@@ -23,7 +22,7 @@ export default function (ast: BabelNodeTryStatement, strictCode: boolean, env: L
   let blockRes = env.evaluateCompletion(ast.block, strictCode);
 
   // can't catch or run finally clauses on introspection errors
-  if (blockRes instanceof AbruptCompletion && IsIntrospectionErrorCompletion(realm, blockRes)) throw blockRes;
+  if (blockRes instanceof IntrospectionThrowCompletion) throw blockRes;
 
   if (blockRes instanceof ThrowCompletion && ast.handler) {
     completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -331,11 +331,6 @@ export function IsIntrospectionError(realm: Realm, value: Value): boolean {
   return value.$GetPrototypeOf() === realm.intrinsics.__IntrospectionErrorPrototype;
 }
 
-export function IsIntrospectionErrorCompletion(realm: Realm, completion: Completion): boolean {
-  if (!(completion instanceof ThrowCompletion)) return false;
-  return IsIntrospectionError(realm, completion.value);
-}
-
 export function IsReadOnlyError(realm: Realm, value: Value): boolean {
   if (!value.mightBeObject()) return false;
   value = value.throwIfNotConcreteObject();

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -17,7 +17,7 @@ import type { Descriptor, PropertyBinding } from "../types.js";
 import { AbruptCompletion, BreakCompletion, Completion, ContinueCompletion,
    ComposedAbruptCompletion, ComposedPossiblyNormalCompletion,
    PossiblyNormalCompletion, JoinedAbruptCompletions,
-   ReturnCompletion, ThrowCompletion } from "../completions.js";
+   ReturnCompletion, IntrospectionThrowCompletion, ThrowCompletion } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { Reference } from "../environment.js";
 import { cloneDescriptor, IsDataDescriptor, StrictEqualityComparison } from "../methods/index.js";
@@ -66,6 +66,8 @@ export function joinEffects(realm: Realm, joinCondition: AbstractValue,
   let [result1, gen1, bindings1, properties1, createdObj1] = e1;
   let [result2, gen2, bindings2, properties2, createdObj2] = e2;
 
+  if (result1 instanceof IntrospectionThrowCompletion) return e1;
+  if (result2 instanceof IntrospectionThrowCompletion) return e2;
   let result = joinResults(realm, joinCondition, result1, result2, e1, e2);
   if (result1 instanceof AbruptCompletion) {
     if (!(result2 instanceof AbruptCompletion)) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -18,7 +18,7 @@ import { LexicalEnvironment, Reference, GlobalEnvironmentRecord } from "./enviro
 import type { Binding } from "./environment.js";
 import { cloneDescriptor, GetValue, NewGlobalEnvironment, Construct, ThrowIfMightHaveBeenDeleted } from "./methods/index.js";
 import type { NormalCompletion } from "./completions.js";
-import { Completion, ThrowCompletion } from "./completions.js";
+import { Completion, IntrospectionThrowCompletion, ThrowCompletion } from "./completions.js";
 import invariant from "./invariant.js";
 import initializeGlobal from "./global.js";
 import seedrandom from "seedrandom";
@@ -499,6 +499,8 @@ export class Realm {
     if (message === undefined) message = "TODO";
     if (typeof message === "string") message = new StringValue(this, message);
     invariant(message instanceof StringValue);
+    if (type === this.intrinsics.__IntrospectionError)
+      return new IntrospectionThrowCompletion(Construct(this, type, [message]));
     return new ThrowCompletion(Construct(this, type, [message]));
   }
 }

--- a/src/serialiser.js
+++ b/src/serialiser.js
@@ -12,8 +12,8 @@
 import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "./environment.js";
 import { Realm, ExecutionContext } from "./realm.js";
 import type { RealmOptions, Descriptor } from "./types.js";
-import { IsUnresolvableReference, ResolveBinding, ToLength, IsArray, HasProperty, ToStringPartial, Get, InstanceofOperator, IsIntrospectionErrorCompletion } from "./methods/index.js";
-import { Completion, AbruptCompletion, ThrowCompletion } from "./completions.js";
+import { IsUnresolvableReference, ResolveBinding, ToLength, IsArray, HasProperty, ToStringPartial, Get, InstanceofOperator } from "./methods/index.js";
+import { Completion, AbruptCompletion, IntrospectionThrowCompletion, ThrowCompletion } from "./completions.js";
 import { BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, NumberValue, FunctionValue, Value, ObjectValue, PrimitiveValue, StringValue, NativeFunctionValue, UndefinedValue } from "./values/index.js";
 import { describeLocation } from "./intrinsics/ecma262/Error.js";
 import * as t from "babel-types";
@@ -1146,7 +1146,7 @@ export default class Serialiser {
         if (compl instanceof Completion) {
           realm.restoreBindings(bindings);
           realm.restoreProperties(properties);
-          if (IsIntrospectionErrorCompletion(realm, compl)) {
+          if (compl instanceof IntrospectionThrowCompletion) {
             let value = compl.value;
             invariant(value instanceof ObjectValue);
             let message: string = this.tryQuery(() => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "message")), "(cannot get message)", false);


### PR DESCRIPTION
We would like the original introspection error to bubble up all the way the speculative inline code.