### PR TITLE
Only print "native" stack trace when running in debug mode.

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1008,11 +1008,17 @@ export class LexicalEnvironment {
     context.lexicalEnvironment = this;
     context.variableEnvironment = this;
     context.realm = this.realm;
+
     this.realm.pushContext(context);
 
     let ast, res;
     try {
-      ast = parse(this.realm, code, filename, sourceType);
+      try {
+        ast = parse(this.realm, code, filename, sourceType);
+      } catch (e) {
+        if (e instanceof ThrowCompletion) return e;
+        throw e;
+      }
       res = this.evaluateCompletion(ast, false);
       if (map.length > 0) this.fixup_source_locations(ast, map);
     } finally {

--- a/src/prepack.js
+++ b/src/prepack.js
@@ -13,7 +13,7 @@ import invariant from "./invariant.js";
 let fs        = require("fs");
 
 function run_internal(name: string, raw: string, map: string = "", compatibility?: "browser" | "jsc" = "browser", mathRandomSeed: void | string, outputFilename?: string, outputMap?: string, speculate: boolean = false) {
-  let serialized = new Serializer({ partial: true, compatibility, mathRandomSeed }, speculate).init(name, raw, map, outputMap !== undefined);
+  let serialized = new Serializer({ partial: true, compatibility, mathRandomSeed }, { initializeMoreModules: speculate, internalDebug: true }).init(name, raw, map, outputMap !== undefined);
   if (!serialized) {
     process.exit(1);
     invariant(false);

--- a/src/scripts/generate-sourcemaps-test.js
+++ b/src/scripts/generate-sourcemaps-test.js
@@ -43,7 +43,7 @@ function generateTest(name: string, test_path: string, code: string): boolean {
   console.log(chalk.inverse(name));
   let newCode1, newMap1, newCode2, newMap2;
   try {
-    let s = new Serializer({ partial: true }).init(test_path, code, "", true);
+    let s = new Serializer({ partial: true }, { internalDebug: true }).init(test_path, code, "", true);
     if (!s) {
       process.exit(1);
       invariant(false);
@@ -52,7 +52,7 @@ function generateTest(name: string, test_path: string, code: string): boolean {
     fs.writeFileSync(name + ".new1.js", newCode1);
     newMap1 = s.map;
     fs.writeFileSync(name + ".new1.js.map", JSON.stringify(newMap1));
-    s = new Serializer({ partial: true, compatibility: "node" }).init(
+    s = new Serializer({ partial: true, compatibility: "node" }, { internalDebug: true }).init(
       test_path, newCode1, JSON.stringify(newMap1), true);
     if (!s) {
       process.exit(1);

--- a/src/scripts/test-internal.js
+++ b/src/scripts/test-internal.js
@@ -41,7 +41,7 @@ let tests = search(`${__dirname}/../../test/internal`, "test/internal");
 function runTest(name: string, code: string): boolean {
   console.log(chalk.inverse(name));
   try {
-    let serialized = new Serializer({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }).init(name, code, "", false);
+    let serialized = new Serializer({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }, { internalDebug: true }).init(name, code, "", false);
     if (!serialized) {
       console.log(chalk.red("Error during serialization"));
       return false;

--- a/src/scripts/test-runner.js
+++ b/src/scripts/test-runner.js
@@ -65,15 +65,16 @@ class Success {}
 function runTest(name: string, code: string): boolean {
   console.log(chalk.inverse(name));
   let compatibility = code.includes("// jsc") ? "jsc" : undefined;
-  let opts = { partial: true, compatibility };
+  let realmOptions = { partial: true, compatibility };
   let initializeMoreModules = code.includes("// initialize more modules");
+  let serializerOptions = { initializeMoreModules, internalDebug: true };
   if (code.includes("// throws introspection error")) {
     let onError = (realm, e) => {
       if (IsIntrospectionError(realm, e))
         throw new Success();
     };
     try {
-      let serialized = new Serializer(opts, initializeMoreModules).init(name, code, "", false, onError);
+      let serialized = new Serializer(realmOptions, serializerOptions).init(name, code, "", false, onError);
       if (!serialized) {
         console.log(chalk.red("Error during serialization"));
       } else {
@@ -87,7 +88,7 @@ function runTest(name: string, code: string): boolean {
     return false;
   } else if (code.includes("// no effect")) {
     try {
-      let serialized = new Serializer(opts, initializeMoreModules).init(name, code);
+      let serialized = new Serializer(realmOptions, serializerOptions).init(name, code);
       if (!serialized) {
         console.log(chalk.red("Error during serialization!"));
         return false;
@@ -123,7 +124,7 @@ function runTest(name: string, code: string): boolean {
       let max = 4;
       let oldCode = code;
       for (; i < max; i++) {
-        let serialized = new Serializer(opts, initializeMoreModules).init(name, oldCode);
+        let serialized = new Serializer(realmOptions, serializerOptions).init(name, oldCode);
         if (!serialized) {
           console.log(chalk.red("Error during serialization!"));
           break;

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -52,3 +52,8 @@ export class BodyReference {
   body: Array<BabelNodeStatement>;
   index: number;
 }
+
+export type SerializerOptions = {
+  initializeMoreModules?: boolean;
+  internalDebug?: boolean;
+}


### PR DESCRIPTION
Make sure we don't crash on syntax errors.