### PR TITLE
No need to interact too deeply with serializer state when we are goin…

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1034,12 +1034,7 @@ export class Serializer {
             };
           }
           realmGenerator.body.push({ declaresDerivedId: id, args: bodyEntry.args, buildNode: buildNode });
-          if (id !== undefined) {
-            this.declaredDerivedIds.add(id);
-          }
         }
-
-        this.requireReturns.set(moduleId, this.serializeValue(compl));
 
         // Ignore created objects
         createdObjects;


### PR DESCRIPTION
…g to restart anyway because of anyHeapChanges.

Background: When we find additional modules that we can successfully initialize, we need to carry forward any heap and generator changes. However, it's not necessary to evolve the ongoing code serialization effort, as that effort will start over when anyHeapChanges is set.