### PR TITLE
Complete stack traces for errors

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -34,11 +34,9 @@ export class ThrowCompletion extends AbruptCompletion {
     invariant(value.getType() !== value.$Realm.intrinsics.__IntrospectionError ||
       this instanceof IntrospectionThrowCompletion);
     this.nativeStack = nativeStack || new Error().stack;
-    this.pushedContext = false;
   }
 
   nativeStack: string;
-  pushedContext: boolean;
 }
 export class IntrospectionThrowCompletion extends ThrowCompletion {}
 export class ContinueCompletion extends AbruptCompletion {}

--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -92,7 +92,7 @@ export function build(name: string, realm: Realm, inheritError?: boolean = true)
     let O = OrdinaryCreateFromConstructor(realm, newTarget, `${name}Prototype`, { $ErrorData: undefined });
 
     // Build a text description of the stack.
-    O.$ContextStack = realm.contextStack.slice(0, -1);
+    O.$ContextStack = realm.contextStack.slice(1);
     let stackDesc = {
       value: buildStack(realm, O),
       enumerable: false,

--- a/src/realm.js
+++ b/src/realm.js
@@ -139,6 +139,7 @@ export class Realm {
 
   createdObjects: void | CreatedObjects;
 
+  currentLocation: ?BabelNodeSourceLocation;
   nextContextLocation: ?BabelNodeSourceLocation;
   contextStack: Array<ExecutionContext> = [];
   $GlobalEnv: LexicalEnvironment;
@@ -499,6 +500,7 @@ export class Realm {
     if (message === undefined) message = "TODO";
     if (typeof message === "string") message = new StringValue(this, message);
     invariant(message instanceof StringValue);
+    this.nextContextLocation = this.currentLocation;
     if (type === this.intrinsics.__IntrospectionError)
       return new IntrospectionThrowCompletion(Construct(this, type, [message]));
     return new ThrowCompletion(Construct(this, type, [message]));

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -124,10 +124,13 @@ export class Modules {
             let value = compl.value;
             invariant(value instanceof ObjectValue);
             let message: string = this.logger.tryQuery(() => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "message")), "(cannot get message)", false);
+            let stack: string = this.logger.tryQuery(() => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "stack")), "", false);
+            let i = stack.indexOf("\n");
+            if (i >= 0) stack = stack.slice(i);
             realm.restoreBindings(bindings);
             realm.restoreProperties(properties);
-            let moduleIds = introspectionErrors[message] = introspectionErrors[message] || [];
-            moduleIds.push(moduleId);
+            let stacks = introspectionErrors[message] = introspectionErrors[message] || [];
+            stacks.push(stack);
             continue;
           }
 
@@ -174,7 +177,7 @@ export class Modules {
       a.sort((x, y) => y[0].length - x[0].length);
       if (a.length) {
         console.log(`=== speculative module initialization failures ordered by frequency`);
-        for (let [moduleIds, n] of a) console.log(`${moduleIds.length}x ${n} [${moduleIds.join(",")}]`);
+        for (let [stacks, n] of a) console.log(`${stacks.length}x ${n} ${stacks.join("\nas well as")}]`);
       }
     } finally {
       realm.popContext(context);

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -130,7 +130,7 @@ export default class Value {
     if (propertyName instanceof SymbolValue) location = `at symbol [${propertyName.$Description || "(no description)"}]`;
     else if (propertyName instanceof StringValue) location = `at ${propertyName.value}`;
     else if (typeof propertyName === "string") location = `at ${propertyName}`;
-    else location = "at [implementation " + (new Error()).stack.split("\n").slice(2, 4).join(" ***") + "]";
+    else location = "";
 
     let type = val instanceof AbstractValue ? "abstract value" : val instanceof ObjectValue ? `${val.isSimple() ? "simple " : " "}${val.isPartial() ? "partial " : " "}object` : "value";
 

--- a/test/serializer/abstract/Throw2.js
+++ b/test/serializer/abstract/Throw2.js
@@ -3,7 +3,7 @@
 let x = __abstract("boolean", "true");
 
 try {
-  if (x) throw "is true";
+  if (x) throw  new Error("is true");
   z = "is false";
 } catch (e) {
   z = e;


### PR DESCRIPTION
Make sure that stack traces include the source context of the expression causing an exception, not just caller frames.

Change the output from the speculative module initialization to include stack traces for the errors that prevented a module from being initialized at Prepack time.