### PR TITLE
Rename CallObserver to Tracer.

### DIFF
--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -586,8 +586,8 @@ export function $Call(realm: Realm, F: FunctionValue, thisArgument: Value, argsL
 
   let result;
   try {
-    if (realm.callObserver !== undefined)
-      realm.callObserver.before(F, thisArgument, argsList, undefined);
+    for (let t1 of realm.tracers)
+      t1.beforeCall(F, thisArgument, argsList, undefined);
 
     // 5. Assert: calleeContext is now the running execution context.
     invariant(realm.getRunningContext() === calleeContext, "calleeContext should be current execution context");
@@ -602,8 +602,8 @@ export function $Call(realm: Realm, F: FunctionValue, thisArgument: Value, argsL
     realm.popContext(calleeContext);
     invariant(realm.getRunningContext() === callerContext);
 
-    if (realm.callObserver !== undefined)
-      realm.callObserver.after(F, thisArgument, argsList, undefined, result);
+    for (let t2 of realm.tracers)
+      t2.afterCall(F, thisArgument, argsList, undefined, result);
   }
 
   // 9. If result.[[Type]] is return, return NormalCompletion(result.[[Value]]).
@@ -650,8 +650,8 @@ export function $Construct(realm: Realm, F: FunctionValue, argumentsList: Array<
 
   let result, envRec;
   try {
-    if (realm.callObserver !== undefined)
-      realm.callObserver.before(F, thisArgument, argumentsList, newTarget);
+    for (let t1 of realm.tracers)
+      t1.beforeCall(F, thisArgument, argumentsList, newTarget);
 
     // 8. If kind is "base", perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
     if (kind === "base") {
@@ -672,8 +672,8 @@ export function $Construct(realm: Realm, F: FunctionValue, argumentsList: Array<
     realm.popContext(calleeContext);
     invariant(realm.getRunningContext() === callerContext);
 
-    if (realm.callObserver !== undefined)
-      realm.callObserver.after(F, thisArgument, argumentsList, newTarget, result);
+    for (let t2 of realm.tracers)
+      t2.afterCall(F, thisArgument, argumentsList, newTarget, result);
   }
 
   // 13. If result.[[Type]] is return, then

--- a/src/prepack.js
+++ b/src/prepack.js
@@ -12,8 +12,8 @@ import Serializer from "./serializer/index.js";
 import invariant from "./invariant.js";
 let fs        = require("fs");
 
-function run_internal(name: string, raw: string, map: string = "", compatibility?: "browser" | "jsc" = "browser", mathRandomSeed: void | string, outputFilename?: string, outputMap?: string, speculate: boolean = false, logCalls: boolean = false) {
-  let serialized = new Serializer({ partial: true, compatibility, mathRandomSeed }, { initializeMoreModules: speculate, internalDebug: true, logCalls }).init(name, raw, map, outputMap !== undefined);
+function run_internal(name: string, raw: string, map: string = "", compatibility?: "browser" | "jsc" = "browser", mathRandomSeed: void | string, outputFilename?: string, outputMap?: string, speculate: boolean = false, trace: boolean = false) {
+  let serialized = new Serializer({ partial: true, compatibility, mathRandomSeed }, { initializeMoreModules: speculate, internalDebug: true, trace }).init(name, raw, map, outputMap !== undefined);
   if (!serialized) {
     process.exit(1);
     invariant(false);
@@ -40,7 +40,7 @@ function run_internal(name: string, raw: string, map: string = "", compatibility
   }
 }
 
-export function run(inFn: string, compat?: "browser" | "jsc" = "browser", mathRandSeed: void | string, outFn?: string, inputMap?: string, outMap?: string, speculateOpt?: boolean, logCalls?: boolean) {
+export function run(inFn: string, compat?: "browser" | "jsc" = "browser", mathRandSeed: void | string, outFn?: string, inputMap?: string, outMap?: string, speculateOpt?: boolean, trace?: boolean) {
   let input = fs.readFileSync(inFn, "utf8");
   let map = "";
   let mapFile = inputMap ? inputMap : inFn + ".map";
@@ -49,5 +49,5 @@ export function run(inFn: string, compat?: "browser" | "jsc" = "browser", mathRa
   } catch (_e) {
     console.log(`No sourcemap found at ${mapFile}.`);
   }
-  run_internal(inFn, input, map, compat, mathRandSeed, outFn, outMap, speculateOpt, logCalls);
+  run_internal(inFn, input, map, compat, mathRandSeed, outFn, outMap, speculateOpt, trace);
 }

--- a/src/run_util.js
+++ b/src/run_util.js
@@ -20,7 +20,7 @@ let mathRandomSeed;
 let inputMap;
 let ouputMap;
 let speculate = false;
-let logCalls = false;
+let trace = false;
 while (args.length) {
   let arg = args[0]; args.shift();
   if (arg === "--out") {
@@ -42,10 +42,10 @@ while (args.length) {
     ouputMap = args[0]; args.shift();
   } else if (arg === "--speculate") {
     speculate = true;
-  } else if (arg === "--logCalls") {
-    logCalls = true;
+  } else if (arg === "--trace") {
+    trace = true;
   } else if (arg === "--help") {
-    console.log("Usage: prepack.js [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --speculate ] [ --logCalls ] [ -- | input.js ]");
+    console.log("Usage: prepack.js [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --speculate ] [ --trace ] [ -- | input.js ]");
   } else if (!arg.startsWith("--")) {
     inputFilename = arg;
   } else {
@@ -57,5 +57,5 @@ if (!inputFilename) {
   console.error("Missing input file.");
   process.exit(1);
 } else {
-  run(inputFilename, compatibility, mathRandomSeed, outputFilename, inputMap, ouputMap, speculate, logCalls);
+  run(inputFilename, compatibility, mathRandomSeed, outputFilename, inputMap, ouputMap, speculate, trace);
 }

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -30,7 +30,7 @@ import { BodyReference, AreSameSerializedBindings } from "./types.js";
 import { ClosureRefVisitor, ClosureRefReplacer } from "./visitors.js";
 import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
-import { LoggingCallObserver } from "./LoggingCallObserver.js";
+import { LoggingTracer } from "./LoggingTracer.js";
 
 function isSameNode(left, right) {
   let type = left.type;
@@ -60,7 +60,7 @@ export class Serializer {
     invariant(this.realm.isPartial);
     this.logger = new Logger(this.realm, !!serializerOptions.internalDebug);
     this.modules = new Modules(this.realm, this.logger);
-    if (serializerOptions.logCalls) this.realm.callObserver = new LoggingCallObserver(this.realm);
+    if (serializerOptions.trace) this.realm.tracers.push(new LoggingTracer(this.realm));
 
     let realmGenerator = this.realm.generator;
     invariant(realmGenerator);

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -56,5 +56,5 @@ export class BodyReference {
 export type SerializerOptions = {
   initializeMoreModules?: boolean;
   internalDebug?: boolean;
-  logCalls?: boolean;
+  trace?: boolean;
 }


### PR DESCRIPTION
Make all methods trivial and not throw --- it's really a base class, not an abstract class.
Make it more general by also adding tracing events for partial evaluation.
Allow for many tracers being active.
Rename logCalls to trace.