### PR TITLE
Move throwIntrospectionError from Value to AbstractValue

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -59,9 +59,9 @@ export class ComposedAbruptCompletion extends AbruptCompletion {
 
   throwIntrospectionError<T>(): T {
     if (this.priorCompletion instanceof PossiblyNormalCompletion)
-      return Value.throwIntrospectionError(this.priorCompletion.joinCondition);
+      return AbstractValue.throwIntrospectionError(this.priorCompletion.joinCondition);
     invariant(this.subsequentCompletion instanceof PossiblyNormalCompletion);
-    return Value.throwIntrospectionError(this.subsequentCompletion.joinCondition);
+    return AbstractValue.throwIntrospectionError(this.subsequentCompletion.joinCondition);
   }
 }
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -17,7 +17,7 @@ import type { SourceType } from "./types.js";
 import { AbruptCompletion, Completion, ComposedAbruptCompletion, JoinedAbruptCompletions, PossiblyNormalCompletion, ThrowCompletion } from "./completions.js";
 import { ExecutionContext } from "./realm.js";
 import { Value } from "./values/index.js";
-import { NullValue, SymbolValue, BooleanValue, FunctionValue, StringValue, ObjectValue, AbstractObjectValue, UndefinedValue } from "./values/index.js";
+import { AbstractValue, NullValue, SymbolValue, BooleanValue, FunctionValue, StringValue, ObjectValue, AbstractObjectValue, UndefinedValue } from "./values/index.js";
 import parse from "./utils/parse.js";
 import invariant from "./invariant.js";
 import traverse from "./traverse.js";
@@ -966,13 +966,13 @@ export class LexicalEnvironment {
       return this.evaluate(ast, strictCode, metadata);
     } catch (err) {
       if (err instanceof JoinedAbruptCompletions) {
-        return Value.throwIntrospectionError(err.joinCondition);
+        return AbstractValue.throwIntrospectionError(err.joinCondition);
       } else if (err instanceof ComposedAbruptCompletion) {
         return err.throwIntrospectionError();
       } else if (err instanceof AbruptCompletion) {
         return err;
       } else if (err instanceof PossiblyNormalCompletion) {
-        Value.throwIntrospectionError(err.joinCondition);
+        AbstractValue.throwIntrospectionError(err.joinCondition);
       } else if (err instanceof Error) {
         // rethrowing Error should preserve stack trace
         throw err;
@@ -1045,7 +1045,7 @@ export class LexicalEnvironment {
   evaluate(ast: BabelNode, strictCode: boolean, metadata?: any): Value | Reference {
     let res = this.evaluateAbstract(ast, strictCode, metadata);
     if (res instanceof PossiblyNormalCompletion)
-      return Value.throwIntrospectionError(res.joinCondition);
+      return AbstractValue.throwIntrospectionError(res.joinCondition);
     invariant(res instanceof Value || res instanceof Reference, ast.type);
     return res;
   }

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -65,7 +65,7 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean, e
   // todo: don't just give up on abrupt completions, but try to join states
   // eg. foo || throwSomething()
   if (!(compl2 instanceof Value))
-    Value.throwIntrospectionError(lval);
+    AbstractValue.throwIntrospectionError(lval);
   invariant(compl2 instanceof Value);
 
   // Join the effects, creating an abstract view of what happened, regardless

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -284,7 +284,7 @@ function InternalGetTemplate(realm: Realm, val: AbstractObjectValue): ObjectValu
     let value = binding.descriptor.value;
     ThrowIfMightHaveBeenDeleted(value);
     if (value === undefined) {
-      Value.throwIntrospectionError(val, key); // cannot handle accessors
+      AbstractValue.throwIntrospectionError(val, key); // cannot handle accessors
       invariant(false);
     }
     CreateDataProperty(realm, template, key, InternalJSONClone(realm, value));

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ObjectValue, NullValue, UndefinedValue, StringValue, BooleanValue, SymbolValue, Value } from "../../values/index.js";
+import { AbstractValue, ObjectValue, NullValue, UndefinedValue, StringValue, BooleanValue, SymbolValue } from "../../values/index.js";
 import {
   ToObject,
   ToObjectPartial,
@@ -93,7 +93,7 @@ export default function (realm: Realm): NativeFunctionValue {
         // properties at runtime that will overwrite current properties in to.
         // For now, just throw if this happens.
         let to_keys = to.$OwnPropertyKeys();
-        if (to_keys.length !== 0) Value.throwIntrospectionError(nextSource);
+        if (to_keys.length !== 0) AbstractValue.throwIntrospectionError(nextSource);
       }
 
       invariant(frm, "from required");

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { ThrowCompletion } from "../../completions.js";
-import { Value, UndefinedValue, NumberValue, ObjectValue, StringValue, NullValue } from "../../values/index.js";
+import { AbstractValue, UndefinedValue, NumberValue, ObjectValue, StringValue, NullValue } from "../../values/index.js";
 import { IsCallable, IsRegExp } from "../../methods/is.js";
 import { GetMethod, GetSubstitution } from "../../methods/get.js";
 import { Construct } from "../../methods/construct.js";
@@ -799,7 +799,7 @@ export default function (realm: Realm, obj: ObjectValue): ObjectValue {
 
     if (realm.isPartial && (type === "LocaleUpper" || type === "LocaleLower")) {
       // The locale is environment-dependent
-      Value.throwIntrospectionError(O);
+      AbstractValue.throwIntrospectionError(O);
     }
 
     // Omit the rest of the arguments. Just use the native impl.

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -477,7 +477,7 @@ export function Type(realm: Realm, val: Value): string {
     return "Object";
   } else {
     invariant(val instanceof AbstractValue);
-    return Value.throwIntrospectionError(val);
+    return AbstractValue.throwIntrospectionError(val);
   }
 }
 

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -306,7 +306,7 @@ export function OrdinaryCallEvaluateBody(realm: Realm, F: FunctionValue, argumen
     }
     if (c instanceof JoinedAbruptCompletions) {
       if (e !== undefined) realm.apply_effects(e);
-      return Value.throwIntrospectionError(c.joinCondition);
+      return AbstractValue.throwIntrospectionError(c.joinCondition);
     } else if (c instanceof ComposedAbruptCompletion) {
       if (e !== undefined) realm.apply_effects(e);
       return c.throwIntrospectionError();

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -125,7 +125,7 @@ export function HasCompatibleType(realm: Realm, value: Value, type: typeof Value
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    return Value.throwIntrospectionError(value);
+    return AbstractValue.throwIntrospectionError(value);
   }
   return Value.isTypeCompatibleWith(valueType, type);
 }
@@ -134,7 +134,7 @@ export function HasSomeCompatibleType(realm: Realm, value: Value, ...manyTypes: 
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    return Value.throwIntrospectionError(value);
+    return AbstractValue.throwIntrospectionError(value);
   }
   return manyTypes.some(Value.isTypeCompatibleWith.bind(null, valueType));
 }

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -141,7 +141,7 @@ export function IsPropertyKey(realm: Realm, arg: string | Value): boolean {
   // 2. If Type(argument) is Symbol, return true.
   if (arg instanceof SymbolValue) return true;
 
-  if (arg instanceof AbstractValue) return Value.throwIntrospectionError(arg);
+  if (arg instanceof AbstractValue) return AbstractValue.throwIntrospectionError(arg);
 
   // 3. Return false.
   return false;

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -95,7 +95,7 @@ export function joinEffectsAndRemoveNestedReturnCompletions(
       e1[0] = new ReturnCompletion(realm.intrinsics.undefined);
       return joinEffects(realm, c.joinCondition, e1, e2);
     } else {
-      return Value.throwIntrospectionError(c.joinCondition);
+      return AbstractValue.throwIntrospectionError(c.joinCondition);
     }
   }
   invariant(false);
@@ -142,7 +142,7 @@ function joinResults(realm: Realm, joinCondition: AbstractValue,
     return joinValuesAsConditional(realm, joinCondition, v1, v2);
   }
   if (result1 instanceof Reference || result2 instanceof Reference)
-    return Value.throwIntrospectionError(joinCondition);
+    return AbstractValue.throwIntrospectionError(joinCondition);
   if (result1 instanceof BreakCompletion && result2 instanceof BreakCompletion &&
       result1.target === result2.target) {
     return new BreakCompletion(realm.intrinsics.empty, result1.target);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -171,7 +171,7 @@ export function OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V
       // actually have a say. Give up, unless the parent would be OK with it.
       if (!parentPermitsChildPropertyCreation(realm, parent, P)) {
         invariant(ownDescValue instanceof AbstractValue);
-        return Value.throwIntrospectionError(ownDescValue);
+        return AbstractValue.throwIntrospectionError(ownDescValue);
       }
       // Since the parent is OK with us creating a local property for O
       // we can carry on as if there were no parent.
@@ -196,7 +196,7 @@ export function OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V
         // But maybe it does not and thus would succeed.
         // Since we don't know what will happen, give up for now.
         invariant(ownDescValue instanceof AbstractValue);
-        return Value.throwIntrospectionError(ownDescValue);
+        return AbstractValue.throwIntrospectionError(ownDescValue);
       }
       return false;
     }
@@ -224,7 +224,7 @@ export function OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V
         // If we are not sure the receiver actually has a property P we can't just return false here.
         if (existingDescValue.mightHaveBeenDeleted()) {
           invariant(existingDescValue instanceof AbstractValue);
-          return Value.throwIntrospectionError(existingDescValue);
+          return AbstractValue.throwIntrospectionError(existingDescValue);
         }
         return false;
       }
@@ -918,7 +918,7 @@ export function OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: Property
   let existingBinding = InternalGetPropertiesMap(O, P).get(InternalGetPropertiesKey(P));
   if (!existingBinding) {
     if (O.isPartial() && !O.isSimple()) {
-      Value.throwIntrospectionError(O, P);
+      AbstractValue.throwIntrospectionError(O, P);
     }
     return undefined;
   }
@@ -1072,10 +1072,10 @@ export function ThrowIfMightHaveBeenDeleted(value: void | Value): void {
   if (value === undefined) return;
   if (!value.mightHaveBeenDeleted()) return;
   invariant(value instanceof AbstractValue); // real empty values should never get here
-  Value.throwIntrospectionError(value);
+  AbstractValue.throwIntrospectionError(value);
 }
 
 export function ThrowIfInternalSlotNotWritable<T: ObjectValue>(realm: Realm, object: T, key: string): T {
-  if (!realm.isNewObject(object)) Value.throwIntrospectionError(object, key);
+  if (!realm.isNewObject(object)) AbstractValue.throwIntrospectionError(object, key);
   return object;
 }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -438,7 +438,7 @@ export function ToNumber(realm: Realm, val: numberOrValue): number {
   if (typeof val === "number") {
     return val;
   } else if (val instanceof AbstractValue) {
-    return Value.throwIntrospectionError(val);
+    return AbstractValue.throwIntrospectionError(val);
   } else if (val instanceof UndefinedValue) {
     return NaN;
   } else if (val instanceof NullValue) {

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -302,7 +302,7 @@ export function TypedArrayCreate(realm: Realm, constructor: ObjectValue, argumen
   if (argumentList.length === 1 && argumentList[0].mightBeNumber()) {
     if (argumentList[0].mightNotBeNumber()) {
       invariant(argumentList[0] instanceof AbstractValue);
-      return Value.throwIntrospectionError(argumentList[0]);
+      return AbstractValue.throwIntrospectionError(argumentList[0]);
     }
     // a. If newTypedArray.[[ArrayLength]] < argumentList[0], throw a TypeError exception.
     invariant(typeof newTypedArray.$ArrayLength === "number");

--- a/src/realm.js
+++ b/src/realm.js
@@ -478,7 +478,7 @@ export class Realm {
       invariant(binding.descriptor !== undefined);
       let value = binding.descriptor.value;
       ThrowIfMightHaveBeenDeleted(value);
-      if (value === undefined) return Value.throwIntrospectionError(abstractValue, key);
+      if (value === undefined) return AbstractValue.throwIntrospectionError(abstractValue, key);
       this.rebuildObjectProperty(abstractValue, key, value, path);
     }
   }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -48,7 +48,7 @@ export default class AbstractObjectValue extends AbstractValue {
         break;
       }
     }
-    return Value.throwIntrospectionError(this);
+    return AbstractValue.throwIntrospectionError(this);
   }
 
   isPartial(): boolean {
@@ -58,10 +58,10 @@ export default class AbstractObjectValue extends AbstractValue {
       if (result === undefined)
         result = element.isPartial();
       else if (result !== element.isPartial())
-        Value.throwIntrospectionError(this);
+        AbstractValue.throwIntrospectionError(this);
     }
     if (result === undefined)
-      return Value.throwIntrospectionError(this);
+      return AbstractValue.throwIntrospectionError(this);
     return result;
   }
 
@@ -123,7 +123,7 @@ export default class AbstractObjectValue extends AbstractValue {
             if  (!IsDataDescriptor(this.$Realm, d)) continue;
           } else {
             if (!equalDescriptors(d, desc))
-              return Value.throwIntrospectionError(this, P);
+              return AbstractValue.throwIntrospectionError(this, P);
             if  (!IsDataDescriptor(this.$Realm, desc)) continue;
             // values may be different
             let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
@@ -134,7 +134,7 @@ export default class AbstractObjectValue extends AbstractValue {
         }
       }
       if (hasProp && doesNotHaveProp)
-        return Value.throwIntrospectionError(this, P);
+        return AbstractValue.throwIntrospectionError(this, P);
       return desc;
     }
   }
@@ -152,7 +152,7 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(false);
     } else {
       if (!IsDataDescriptor(this.$Realm, Desc))
-        return Value.throwIntrospectionError(this, P);
+        return AbstractValue.throwIntrospectionError(this, P);
       let desc = {
         value: 'value' in Desc ? Desc.value : this.$Realm.intrinsics.undefined,
         writable: 'writable' in Desc ? Desc.writable : false,
@@ -166,7 +166,7 @@ export default class AbstractObjectValue extends AbstractValue {
         invariant(cv instanceof ObjectValue);
         let d = cv.$GetOwnProperty(P);
         if (d !== undefined && !equalDescriptors(d, desc))
-          return Value.throwIntrospectionError(this, P);
+          return AbstractValue.throwIntrospectionError(this, P);
         let dval = d === undefined || d.vale === undefined ?
          this.$Realm.intrinsics.empty : d.value;
         let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
@@ -179,7 +179,7 @@ export default class AbstractObjectValue extends AbstractValue {
           sawFalse = true;
       }
       if (sawTrue && sawFalse)
-        return Value.throwIntrospectionError(this, P);
+        return AbstractValue.throwIntrospectionError(this, P);
       return sawTrue;
     }
   }
@@ -203,7 +203,7 @@ export default class AbstractObjectValue extends AbstractValue {
         if (cv.$HasProperty(P)) hasProp = true; else doesNotHaveProp = true;
       }
       if (hasProp && doesNotHaveProp)
-        return Value.throwIntrospectionError(this, P);
+        return AbstractValue.throwIntrospectionError(this, P);
       return hasProp;
     }
   }
@@ -271,7 +271,7 @@ export default class AbstractObjectValue extends AbstractValue {
         invariant(cv instanceof ObjectValue);
         let d = cv.$GetOwnProperty(P);
         if (d !== undefined && !IsDataDescriptor(this.$Realm, d))
-          return Value.throwIntrospectionError(this, P);
+          return AbstractValue.throwIntrospectionError(this, P);
         let oldVal = d === undefined ? this.$Realm.intrinsics.empty : d.value;
         let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
           [this, cv],
@@ -280,7 +280,7 @@ export default class AbstractObjectValue extends AbstractValue {
         if (cv.$Set(P, v, cv)) sawTrue = true; else sawFalse = true;
       }
       if (sawTrue && sawFalse)
-        return Value.throwIntrospectionError(this, P);
+        return AbstractValue.throwIntrospectionError(this, P);
       return sawTrue;
     }
   }
@@ -304,7 +304,7 @@ export default class AbstractObjectValue extends AbstractValue {
         let d = cv.$GetOwnProperty(P);
         if (d === undefined) continue;
         if (!IsDataDescriptor(this.$Realm, d))
-          Value.throwIntrospectionError(this, P);
+          AbstractValue.throwIntrospectionError(this, P);
         let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
           [this, cv],
           ([x, y]) => t.binaryExpression("===", x, y));
@@ -312,7 +312,7 @@ export default class AbstractObjectValue extends AbstractValue {
         if (cv.$Set(P, v, cv)) sawTrue = true; else sawFalse = true;
       }
       if (sawTrue && sawFalse)
-        return Value.throwIntrospectionError(this, P);
+        return AbstractValue.throwIntrospectionError(this, P);
       return sawTrue;
     }
   }
@@ -326,7 +326,7 @@ export default class AbstractObjectValue extends AbstractValue {
       }
       invariant(false);
     } else {
-      return Value.throwIntrospectionError(this);
+      return AbstractValue.throwIntrospectionError(this);
     }
   }
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -260,7 +260,7 @@ export default class ObjectValue extends ConcreteValue {
 
   getOwnPropertyKeysArray(): Array<string> {
     if (this.isPartial()) {
-      Value.throwIntrospectionError(this);
+      AbstractValue.throwIntrospectionError(this);
     }
 
     let o = this;
@@ -276,7 +276,7 @@ export default class ObjectValue extends ConcreteValue {
          // We can at best return an abstract keys array.
          // For now just terminate.
          invariant(pv instanceof AbstractValue);
-         Value.throwIntrospectionError(pv);
+         AbstractValue.throwIntrospectionError(pv);
       });
     return keyArray;
   }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -10,8 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import { EmptyValue, UndefinedValue, NullValue, BooleanValue, StringValue, SymbolValue, NumberValue, ObjectValue, ConcreteValue, AbstractValue, AbstractObjectValue, FunctionValue } from "./index.js";
-import type { PropertyKeyValue } from "../types.js";
+import { EmptyValue, UndefinedValue, NullValue, BooleanValue, StringValue, SymbolValue, NumberValue, ObjectValue, ConcreteValue, AbstractObjectValue, FunctionValue } from "./index.js";
 
 import invariant from "../invariant.js";
 
@@ -115,28 +114,6 @@ export default class Value {
 
   _serialize(set: Function, stack: Map<Value, any>): any {
     throw new Error("abstract method; please override");
-  }
-
-  static throwIntrospectionError<T>(val: Value, propertyName: void | PropertyKeyValue): T {
-    let realm = val.$Realm;
-
-    let identity;
-    if (val === realm.$GlobalObject) identity = "global";
-    if (!identity) identity = val.intrinsicName;
-    if (!identity && val instanceof AbstractValue) identity = "(some abstract value)";
-    if (!identity) identity = "(some value)";
-
-    let location;
-    if (propertyName instanceof SymbolValue) location = `at symbol [${propertyName.$Description || "(no description)"}]`;
-    else if (propertyName instanceof StringValue) location = `at ${propertyName.value}`;
-    else if (typeof propertyName === "string") location = `at ${propertyName}`;
-    else location = "";
-
-    let type = val instanceof AbstractValue ? "abstract value" : val instanceof ObjectValue ? `${val.isSimple() ? "simple " : " "}${val.isPartial() ? "partial " : " "}object` : "value";
-
-    let message = `Introspection of ${identity} ${location} is not allowed on ${type}`;
-
-    throw realm.createErrorThrowCompletion(realm.intrinsics.__IntrospectionError, message);
   }
 
 }


### PR DESCRIPTION
Reduces the number of modules that Value depends on and makes a bit more sense to me.