### PR TITLE
Better errors

### DIFF
--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -26,7 +26,8 @@ export default function (realm: Realm): NativeFunctionValue {
   let offsetGenerator;
   function getCurrentTime() {
     if (realm.isPartial) {
-      return realm.deriveAbstract(new TypesDomain(NumberValue), ValuesDomain.topVal, [], buildDateNow);
+      let dummyArg = new StringValue(realm, "__Date.now()");
+      return realm.deriveAbstract(new TypesDomain(NumberValue), ValuesDomain.topVal, [dummyArg], buildDateNow);
     } else {
       let newNow = Date.now();
       if (realm.strictlyMonotonicDateNow && lastNow >= newNow) {

--- a/src/scripts/test-internal.js
+++ b/src/scripts/test-internal.js
@@ -41,7 +41,7 @@ let tests = search(`${__dirname}/../../test/internal`, "test/internal");
 function runTest(name: string, code: string): boolean {
   console.log(chalk.inverse(name));
   try {
-    let serialized = new Serializer({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }, { internalDebug: true }).init(name, code, "", false);
+    let serialized = new Serializer({ partial: true, compatibility: "jsc", mathRandomSeed: "0" }, { internalDebug: true, initializeMoreModules: true }).init(name, code, "", false);
     if (!serialized) {
       console.log(chalk.red("Error during serialization"));
       return false;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -154,7 +154,7 @@ export class Serializer {
     }
 
     if (val instanceof AbstractValue && val.hasIdentifier()) {
-      invariant(!this.preludeGenerator.derivedIds.has(val.getIdentifier()) ||
+      invariant(!this.preludeGenerator.derivedIds.has(val.getIdentifier().name) ||
         this.declaredDerivedIds.has(val.getIdentifier()));
       return true;
     }
@@ -796,7 +796,7 @@ export class Serializer {
     let serializedValue = val.buildNode(serializedArgs);
     if (serializedValue.type === "Identifier") {
       let id = ((serializedValue: any): BabelNodeIdentifier);
-      invariant(!this.preludeGenerator.derivedIds.has(id) ||
+      invariant(!this.preludeGenerator.derivedIds.has(id.name) ||
         this.declaredDerivedIds.has(id));
     }
     return serializedValue;

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -164,7 +164,7 @@ export class Generator {
   derive(types: TypesDomain, values: ValuesDomain, args: Array<Value>, buildNode_: AbstractValueBuildNodeFunction | BabelNodeExpression, kind?: string): AbstractValue {
     invariant(buildNode_ instanceof Function || args.length === 0);
     let id = t.identifier(this.preludeGenerator.generateUid());
-    this.preludeGenerator.derivedIds.add(id);
+    this.preludeGenerator.derivedIds.set(id.name, args);
     this.body.push({
       declaresDerivedId: id,
       args,
@@ -219,13 +219,13 @@ export class Generator {
 export class PreludeGenerator {
   constructor() {
     this.prelude = [];
-    this.derivedIds = new Set();
+    this.derivedIds = new Map();
     this.memoizedRefs = new Map();
     this.uidCounter = 0;
   }
 
   prelude: Array<BabelNodeStatement>;
-  derivedIds: Set<BabelNodeIdentifier>;
+  derivedIds: Map<string, Array<Value>>;
   memoizedRefs: Map<string, BabelNodeIdentifier | BabelNodeMemberExpression>;
   uidCounter: number;
 


### PR DESCRIPTION
When Prepack encounters and expression that cannot yet be partially evaluated, give an error message that incorporates more information about the values that comprise the expression.

This is especially useful for failures that stem from errors and omissions from the model for the environment.