### PR TITLE
throw or return introspection completions, as appropriate

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -57,11 +57,11 @@ export class ComposedAbruptCompletion extends AbruptCompletion {
   priorCompletion: NormalCompletion;
   subsequentCompletion: AbruptCompletion;
 
-  throwIntrospectionError<T>(): T {
+  createIntrospectionErrorThrowCompletion(): IntrospectionThrowCompletion {
     if (this.priorCompletion instanceof PossiblyNormalCompletion)
-      return AbstractValue.throwIntrospectionError(this.priorCompletion.joinCondition);
+      return AbstractValue.createIntrospectionErrorThrowCompletion(this.priorCompletion.joinCondition);
     invariant(this.subsequentCompletion instanceof PossiblyNormalCompletion);
-    return AbstractValue.throwIntrospectionError(this.subsequentCompletion.joinCondition);
+    return AbstractValue.createIntrospectionErrorThrowCompletion(this.subsequentCompletion.joinCondition);
   }
 }
 

--- a/src/environment.js
+++ b/src/environment.js
@@ -965,26 +965,17 @@ export class LexicalEnvironment {
     try {
       return this.evaluate(ast, strictCode, metadata);
     } catch (err) {
-      if (err instanceof JoinedAbruptCompletions || err instanceof ComposedAbruptCompletion || err instanceof PossiblyNormalCompletion) {
-        try {
-          if (err instanceof ComposedAbruptCompletion) {
-            return err.throwIntrospectionError();
-          } else {
-            return AbstractValue.throwIntrospectionError(err.joinCondition);
-          }
-         } catch (e) {
-           return e;
-         }
-      }
-      if (err instanceof AbruptCompletion) {
+      if (err instanceof ComposedAbruptCompletion)
+        return err.createIntrospectionErrorThrowCompletion();
+      if (err instanceof JoinedAbruptCompletions || err instanceof PossiblyNormalCompletion)
+        return AbstractValue.createIntrospectionErrorThrowCompletion(err.joinCondition);
+      if (err instanceof AbruptCompletion)
         return err;
-      } else if (err instanceof Error) {
+      if (err instanceof Error)
         // rethrowing Error should preserve stack trace
         throw err;
-      } else {
-        // let's wrap into a proper Error to create stack trace
-        throw new Error(err);
-      }
+      // let's wrap into a proper Error to create stack trace
+      throw new Error(err);
     }
   }
 
@@ -992,15 +983,13 @@ export class LexicalEnvironment {
     try {
       return this.evaluateAbstract(ast, strictCode, metadata);
     } catch (err) {
-      if (err instanceof AbruptCompletion) {
+      if (err instanceof AbruptCompletion)
         return err;
-      } else if (err instanceof Error) {
+      if (err instanceof Error)
         // rethrowing Error should preserve stack trace
         throw err;
-      } else {
-        // let's wrap into a proper Error to create stack trace
-        throw new Error(err);
-      }
+      // let's wrap into a proper Error to create stack trace
+      throw new Error(err);
     }
   }
 
@@ -1050,7 +1039,7 @@ export class LexicalEnvironment {
   evaluate(ast: BabelNode, strictCode: boolean, metadata?: any): Value | Reference {
     let res = this.evaluateAbstract(ast, strictCode, metadata);
     if (res instanceof PossiblyNormalCompletion)
-      return AbstractValue.throwIntrospectionError(res.joinCondition);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(res.joinCondition);
     invariant(res instanceof Value || res instanceof Reference, ast.type);
     return res;
   }

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -65,8 +65,7 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean, e
   // todo: don't just give up on abrupt completions, but try to join states
   // eg. foo || throwSomething()
   if (!(compl2 instanceof Value))
-    AbstractValue.throwIntrospectionError(lval);
-  invariant(compl2 instanceof Value);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(lval);
 
   // Join the effects, creating an abstract view of what happened, regardless
   // of the actual value of ast.left.

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -283,10 +283,8 @@ function InternalGetTemplate(realm: Realm, val: AbstractObjectValue): ObjectValu
     invariant(binding.descriptor !== undefined);
     let value = binding.descriptor.value;
     ThrowIfMightHaveBeenDeleted(value);
-    if (value === undefined) {
-      AbstractValue.throwIntrospectionError(val, key); // cannot handle accessors
-      invariant(false);
-    }
+    if (value === undefined)
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(val, key); // cannot handle accessors
     CreateDataProperty(realm, template, key, InternalJSONClone(realm, value));
   }
   if (valTemplate.isPartial()) template.makePartial();

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -93,7 +93,8 @@ export default function (realm: Realm): NativeFunctionValue {
         // properties at runtime that will overwrite current properties in to.
         // For now, just throw if this happens.
         let to_keys = to.$OwnPropertyKeys();
-        if (to_keys.length !== 0) AbstractValue.throwIntrospectionError(nextSource);
+        if (to_keys.length !== 0)
+          throw AbstractValue.createIntrospectionErrorThrowCompletion(nextSource);
       }
 
       invariant(frm, "from required");

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -799,7 +799,7 @@ export default function (realm: Realm, obj: ObjectValue): ObjectValue {
 
     if (realm.isPartial && (type === "LocaleUpper" || type === "LocaleLower")) {
       // The locale is environment-dependent
-      AbstractValue.throwIntrospectionError(O);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(O);
     }
 
     // Omit the rest of the arguments. Just use the native impl.

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -477,7 +477,7 @@ export function Type(realm: Realm, val: Value): string {
     return "Object";
   } else {
     invariant(val instanceof AbstractValue);
-    return AbstractValue.throwIntrospectionError(val);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(val);
   }
 }
 

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -306,10 +306,10 @@ export function OrdinaryCallEvaluateBody(realm: Realm, F: FunctionValue, argumen
     }
     if (c instanceof JoinedAbruptCompletions) {
       if (e !== undefined) realm.apply_effects(e);
-      return AbstractValue.throwIntrospectionError(c.joinCondition);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(c.joinCondition);
     } else if (c instanceof ComposedAbruptCompletion) {
       if (e !== undefined) realm.apply_effects(e);
-      return c.throwIntrospectionError();
+      throw c.createIntrospectionErrorThrowCompletion();
     } else if (c instanceof PossiblyNormalCompletion) {
       // If the abrupt part of the completion is a return completion, then the
       // effects of its independent control path must be joined with the effects

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -125,7 +125,7 @@ export function OrdinaryGet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, R
   if (IsDataDescriptor(realm, desc)) return descValue;
   if (dataOnly) {
     invariant(descValue instanceof AbstractValue);
-    return AbstractValue.throwIntrospectionError(descValue);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(descValue);
   }
 
   // 5. Assert: IsAccessorDescriptor(desc) is true.

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -125,7 +125,7 @@ export function HasCompatibleType(realm: Realm, value: Value, type: typeof Value
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    return AbstractValue.throwIntrospectionError(value);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(value);
   }
   return Value.isTypeCompatibleWith(valueType, type);
 }
@@ -134,7 +134,7 @@ export function HasSomeCompatibleType(realm: Realm, value: Value, ...manyTypes: 
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    return AbstractValue.throwIntrospectionError(value);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(value);
   }
   return manyTypes.some(Value.isTypeCompatibleWith.bind(null, valueType));
 }

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -141,7 +141,7 @@ export function IsPropertyKey(realm: Realm, arg: string | Value): boolean {
   // 2. If Type(argument) is Symbol, return true.
   if (arg instanceof SymbolValue) return true;
 
-  if (arg instanceof AbstractValue) return AbstractValue.throwIntrospectionError(arg);
+  if (arg instanceof AbstractValue) throw AbstractValue.createIntrospectionErrorThrowCompletion(arg);
 
   // 3. Return false.
   return false;

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -95,7 +95,7 @@ export function joinEffectsAndRemoveNestedReturnCompletions(
       e1[0] = new ReturnCompletion(realm.intrinsics.undefined);
       return joinEffects(realm, c.joinCondition, e1, e2);
     } else {
-      return AbstractValue.throwIntrospectionError(c.joinCondition);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(c.joinCondition);
     }
   }
   invariant(false);
@@ -142,7 +142,7 @@ function joinResults(realm: Realm, joinCondition: AbstractValue,
     return joinValuesAsConditional(realm, joinCondition, v1, v2);
   }
   if (result1 instanceof Reference || result2 instanceof Reference)
-    return AbstractValue.throwIntrospectionError(joinCondition);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(joinCondition);
   if (result1 instanceof BreakCompletion && result2 instanceof BreakCompletion &&
       result1.target === result2.target) {
     return new BreakCompletion(realm.intrinsics.empty, result1.target);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -171,7 +171,7 @@ export function OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V
       // actually have a say. Give up, unless the parent would be OK with it.
       if (!parentPermitsChildPropertyCreation(realm, parent, P)) {
         invariant(ownDescValue instanceof AbstractValue);
-        return AbstractValue.throwIntrospectionError(ownDescValue);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(ownDescValue);
       }
       // Since the parent is OK with us creating a local property for O
       // we can carry on as if there were no parent.
@@ -196,7 +196,7 @@ export function OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V
         // But maybe it does not and thus would succeed.
         // Since we don't know what will happen, give up for now.
         invariant(ownDescValue instanceof AbstractValue);
-        return AbstractValue.throwIntrospectionError(ownDescValue);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(ownDescValue);
       }
       return false;
     }
@@ -224,7 +224,7 @@ export function OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V
         // If we are not sure the receiver actually has a property P we can't just return false here.
         if (existingDescValue.mightHaveBeenDeleted()) {
           invariant(existingDescValue instanceof AbstractValue);
-          return AbstractValue.throwIntrospectionError(existingDescValue);
+          throw AbstractValue.createIntrospectionErrorThrowCompletion(existingDescValue);
         }
         return false;
       }
@@ -918,7 +918,7 @@ export function OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: Property
   let existingBinding = InternalGetPropertiesMap(O, P).get(InternalGetPropertiesKey(P));
   if (!existingBinding) {
     if (O.isPartial() && !O.isSimple()) {
-      AbstractValue.throwIntrospectionError(O, P);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(O, P);
     }
     return undefined;
   }
@@ -1072,10 +1072,10 @@ export function ThrowIfMightHaveBeenDeleted(value: void | Value): void {
   if (value === undefined) return;
   if (!value.mightHaveBeenDeleted()) return;
   invariant(value instanceof AbstractValue); // real empty values should never get here
-  AbstractValue.throwIntrospectionError(value);
+  throw AbstractValue.createIntrospectionErrorThrowCompletion(value);
 }
 
 export function ThrowIfInternalSlotNotWritable<T: ObjectValue>(realm: Realm, object: T, key: string): T {
-  if (!realm.isNewObject(object)) AbstractValue.throwIntrospectionError(object, key);
+  if (!realm.isNewObject(object)) throw AbstractValue.createIntrospectionErrorThrowCompletion(object, key);
   return object;
 }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -438,7 +438,7 @@ export function ToNumber(realm: Realm, val: numberOrValue): number {
   if (typeof val === "number") {
     return val;
   } else if (val instanceof AbstractValue) {
-    return AbstractValue.throwIntrospectionError(val);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(val);
   } else if (val instanceof UndefinedValue) {
     return NaN;
   } else if (val instanceof NullValue) {

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -302,7 +302,7 @@ export function TypedArrayCreate(realm: Realm, constructor: ObjectValue, argumen
   if (argumentList.length === 1 && argumentList[0].mightBeNumber()) {
     if (argumentList[0].mightNotBeNumber()) {
       invariant(argumentList[0] instanceof AbstractValue);
-      return AbstractValue.throwIntrospectionError(argumentList[0]);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(argumentList[0]);
     }
     // a. If newTypedArray.[[ArrayLength]] < argumentList[0], throw a TypeError exception.
     invariant(typeof newTypedArray.$ArrayLength === "number");

--- a/src/realm.js
+++ b/src/realm.js
@@ -358,15 +358,15 @@ export class Realm {
     }
   }
 
-  throwReadOnlyError(msg: string) {
-    let completion = this.createErrorThrowCompletion(this.intrinsics.__IntrospectionError, msg);
-    invariant(completion instanceof IntrospectionThrowCompletion);
+  createReadOnlyError(msg: string): IntrospectionThrowCompletion {
+    let completion = this.createIntrospectionErrorThrowCompletion(msg);
     completion.reason = "readonly";
-    throw completion;
+    return completion;
   }
 
   outputToConsole(str: string): void {
-    if (this.isReadOnly) this.throwReadOnlyError("Trying to create console output in read-only realm");
+    if (this.isReadOnly)
+      throw this.createReadOnlyError("Trying to create console output in read-only realm");
     if (this.isPartial) {
       invariant(this.generator !== undefined);
       this.generator.emitConsoleLog(str);
@@ -378,7 +378,8 @@ export class Realm {
   // Record the current value of binding in this.modifiedBindings unless
   // there is already an entry for binding.
   recordModifiedBinding(binding: Binding, env: EnvironmentRecord): Binding {
-    if (env.isReadOnly) this.throwReadOnlyError("Trying to modify a binding in read-only realm");
+    if (env.isReadOnly)
+      throw this.createReadOnlyError("Trying to modify a binding in read-only realm");
     if (this.modifiedBindings !== undefined && !this.modifiedBindings.has(binding))
       this.modifiedBindings.set(binding, binding.value);
     return binding;
@@ -388,7 +389,7 @@ export class Realm {
   // there is already an entry for binding.
   recordModifiedProperty(binding: PropertyBinding): void {
     if (this.isReadOnly && (this.getRunningContext().isReadOnly || !this.isNewObject(binding.object))) {
-      this.throwReadOnlyError("Trying to modify a property in read-only realm");
+      throw this.createReadOnlyError("Trying to modify a property in read-only realm");
     }
     if (this.modifiedProperties !== undefined && !this.modifiedProperties.has(binding)) {
       this.modifiedProperties.set(binding, cloneDescriptor(binding.descriptor));
@@ -478,7 +479,7 @@ export class Realm {
       invariant(binding.descriptor !== undefined);
       let value = binding.descriptor.value;
       ThrowIfMightHaveBeenDeleted(value);
-      if (value === undefined) return AbstractValue.throwIntrospectionError(abstractValue, key);
+      if (value === undefined) throw AbstractValue.createIntrospectionErrorThrowCompletion(abstractValue, key);
       this.rebuildObjectProperty(abstractValue, key, value, path);
     }
   }
@@ -514,13 +515,20 @@ export class Realm {
     //}
   }
 
-  createErrorThrowCompletion(type: NativeFunctionValue, message?: void | string | StringValue): ThrowCompletion {
+  createIntrospectionErrorThrowCompletion(message?: void | string | StringValue): IntrospectionThrowCompletion {
     if (message === undefined) message = "TODO";
     if (typeof message === "string") message = new StringValue(this, message);
     invariant(message instanceof StringValue);
     this.nextContextLocation = this.currentLocation;
-    if (type === this.intrinsics.__IntrospectionError)
-      return new IntrospectionThrowCompletion(Construct(this, type, [message]));
+    return new IntrospectionThrowCompletion(Construct(this, this.intrinsics.__IntrospectionError, [message]));
+  }
+
+  createErrorThrowCompletion(type: NativeFunctionValue, message?: void | string | StringValue): ThrowCompletion {
+    invariant(type !== this.intrinsics.__IntrospectionError);
+    if (message === undefined) message = "TODO";
+    if (typeof message === "string") message = new StringValue(this, message);
+    invariant(message instanceof StringValue);
+    this.nextContextLocation = this.currentLocation;
     return new ThrowCompletion(Construct(this, type, [message]));
   }
 }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -48,7 +48,7 @@ export default class AbstractObjectValue extends AbstractValue {
         break;
       }
     }
-    return AbstractValue.throwIntrospectionError(this);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
   }
 
   isPartial(): boolean {
@@ -58,10 +58,10 @@ export default class AbstractObjectValue extends AbstractValue {
       if (result === undefined)
         result = element.isPartial();
       else if (result !== element.isPartial())
-        AbstractValue.throwIntrospectionError(this);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
     }
     if (result === undefined)
-      return AbstractValue.throwIntrospectionError(this);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
     return result;
   }
 
@@ -123,7 +123,7 @@ export default class AbstractObjectValue extends AbstractValue {
             if  (!IsDataDescriptor(this.$Realm, d)) continue;
           } else {
             if (!equalDescriptors(d, desc))
-              return AbstractValue.throwIntrospectionError(this, P);
+              throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
             if  (!IsDataDescriptor(this.$Realm, desc)) continue;
             // values may be different
             let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
@@ -134,7 +134,7 @@ export default class AbstractObjectValue extends AbstractValue {
         }
       }
       if (hasProp && doesNotHaveProp)
-        return AbstractValue.throwIntrospectionError(this, P);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
       return desc;
     }
   }
@@ -152,7 +152,7 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(false);
     } else {
       if (!IsDataDescriptor(this.$Realm, Desc))
-        return AbstractValue.throwIntrospectionError(this, P);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
       let desc = {
         value: 'value' in Desc ? Desc.value : this.$Realm.intrinsics.undefined,
         writable: 'writable' in Desc ? Desc.writable : false,
@@ -166,7 +166,7 @@ export default class AbstractObjectValue extends AbstractValue {
         invariant(cv instanceof ObjectValue);
         let d = cv.$GetOwnProperty(P);
         if (d !== undefined && !equalDescriptors(d, desc))
-          return AbstractValue.throwIntrospectionError(this, P);
+          throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
         let dval = d === undefined || d.vale === undefined ?
          this.$Realm.intrinsics.empty : d.value;
         let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
@@ -179,7 +179,7 @@ export default class AbstractObjectValue extends AbstractValue {
           sawFalse = true;
       }
       if (sawTrue && sawFalse)
-        return AbstractValue.throwIntrospectionError(this, P);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
       return sawTrue;
     }
   }
@@ -203,7 +203,7 @@ export default class AbstractObjectValue extends AbstractValue {
         if (cv.$HasProperty(P)) hasProp = true; else doesNotHaveProp = true;
       }
       if (hasProp && doesNotHaveProp)
-        return AbstractValue.throwIntrospectionError(this, P);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
       return hasProp;
     }
   }
@@ -235,7 +235,7 @@ export default class AbstractObjectValue extends AbstractValue {
         let d = cv.$GetOwnProperty(P);
         // We do not currently join property getters
         if (d !== undefined && !IsDataDescriptor(this.$Realm, d))
-          return AbstractValue.throwIntrospectionError(this, P);
+          throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
         let cvVal = d === undefined ? this.$Realm.intrinsics.undefined : d.value;
         if (result === undefined)
           result = cvVal;
@@ -271,7 +271,7 @@ export default class AbstractObjectValue extends AbstractValue {
         invariant(cv instanceof ObjectValue);
         let d = cv.$GetOwnProperty(P);
         if (d !== undefined && !IsDataDescriptor(this.$Realm, d))
-          return AbstractValue.throwIntrospectionError(this, P);
+          throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
         let oldVal = d === undefined ? this.$Realm.intrinsics.empty : d.value;
         let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
           [this, cv],
@@ -280,7 +280,7 @@ export default class AbstractObjectValue extends AbstractValue {
         if (cv.$Set(P, v, cv)) sawTrue = true; else sawFalse = true;
       }
       if (sawTrue && sawFalse)
-        return AbstractValue.throwIntrospectionError(this, P);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
       return sawTrue;
     }
   }
@@ -304,7 +304,7 @@ export default class AbstractObjectValue extends AbstractValue {
         let d = cv.$GetOwnProperty(P);
         if (d === undefined) continue;
         if (!IsDataDescriptor(this.$Realm, d))
-          AbstractValue.throwIntrospectionError(this, P);
+          throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
         let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal,
           [this, cv],
           ([x, y]) => t.binaryExpression("===", x, y));
@@ -312,7 +312,7 @@ export default class AbstractObjectValue extends AbstractValue {
         if (cv.$Set(P, v, cv)) sawTrue = true; else sawFalse = true;
       }
       if (sawTrue && sawFalse)
-        return AbstractValue.throwIntrospectionError(this, P);
+        throw AbstractValue.createIntrospectionErrorThrowCompletion(this, P);
       return sawTrue;
     }
   }
@@ -326,7 +326,7 @@ export default class AbstractObjectValue extends AbstractValue {
       }
       invariant(false);
     } else {
-      return AbstractValue.throwIntrospectionError(this);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
     }
   }
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -13,6 +13,7 @@ import type { BabelNodeExpression, BabelNodeIdentifier, BabelNodeSourceLocation 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
 
+import { IntrospectionThrowCompletion } from "../completions.js";
 import { AbstractObjectValue, BooleanValue, ConcreteValue, EmptyValue, NullValue, NumberValue, ObjectValue, StringValue, SymbolValue, UndefinedValue, Value } from "./index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
@@ -166,23 +167,23 @@ export default class AbstractValue extends Value {
   }
 
   throwIfNotConcrete(): ConcreteValue {
-    return AbstractValue.throwIntrospectionError(this);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
   }
 
   throwIfNotConcreteNumber(): NumberValue {
-    return AbstractValue.throwIntrospectionError(this);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
   }
 
   throwIfNotConcreteObject(): ObjectValue {
-    return AbstractValue.throwIntrospectionError(this);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
   }
 
   throwIfNotObject(): AbstractObjectValue {
     invariant(!(this instanceof AbstractObjectValue));
-    return AbstractValue.throwIntrospectionError(this);
+    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
   }
 
-  static throwIntrospectionError<T>(val: Value, propertyName: void | PropertyKeyValue): T {
+  static createIntrospectionErrorThrowCompletion(val: Value, propertyName: void | PropertyKeyValue): IntrospectionThrowCompletion {
     let realm = val.$Realm;
 
     let identity;
@@ -210,7 +211,7 @@ export default class AbstractValue extends Value {
 
     let message = `This operation is not yet supported on ${identity} ${location}`;
 
-    throw realm.createErrorThrowCompletion(realm.intrinsics.__IntrospectionError, message);
+    return realm.createIntrospectionErrorThrowCompletion(message);
   }
 
 }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -260,7 +260,7 @@ export default class ObjectValue extends ConcreteValue {
 
   getOwnPropertyKeysArray(): Array<string> {
     if (this.isPartial()) {
-      AbstractValue.throwIntrospectionError(this);
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
     }
 
     let o = this;
@@ -276,7 +276,7 @@ export default class ObjectValue extends ConcreteValue {
          // We can at best return an abstract keys array.
          // For now just terminate.
          invariant(pv instanceof AbstractValue);
-         AbstractValue.throwIntrospectionError(pv);
+         throw AbstractValue.createIntrospectionErrorThrowCompletion(pv);
       });
     return keyArray;
   }


### PR DESCRIPTION
Instead of using a helper to always throw introspection error completions, provide a factory and let the caller decide whether to throw or return the completion.