### PR TITLE
Special case serialization of Number objects

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -785,6 +785,9 @@ export class Serializer {
       invariant(typeof source === "string");
       invariant(typeof flags === "string");
       return t.callExpression(t.identifier("RegExp"), [t.stringLiteral(source), t.stringLiteral(flags)]);
+    } else if (val.$NumberData !== undefined) {
+      let num = val.$NumberData.value;
+      return t.newExpression(t.identifier("Number"), [t.numericLiteral(num)]);
     } else {
       return t.objectExpression(props);
     }

--- a/test/serializer/abstract/Number.js
+++ b/test/serializer/abstract/Number.js
@@ -1,0 +1,3 @@
+n = new Number(123);
+
+inspect = function() { return "" + n.valueOf() + " " + n.toExponential(5); }


### PR DESCRIPTION
When a Number object is serialized we need to set its prototype to Number.prototype and we need to set its [[NumberData]] internal property. The easiest way to do that is to use the Number constructor.

See issue #405.