### PR TITLE
Check if tests are finished at the end for singleThreaded runner

### DIFF
--- a/src/scripts/test262-runner.js
+++ b/src/scripts/test262-runner.js
@@ -425,11 +425,6 @@ function masterRunSingleProcess(
   let numLeft = tests.length;
   for (let t of tests) {
     handleTest(t, harnesses, args.timeout, (err, results) => {
-      numLeft--;
-      if (numLeft === 0) {
-        // all done
-        process.exit(handleFinished(args, groups, numFiltered));
-      }
       if (err) {
         if (args.verbose) {
           console.log(err);
@@ -445,6 +440,11 @@ function masterRunSingleProcess(
         if (progress) {
           console.log(progress);
         }
+      }
+      numLeft--;
+      if (numLeft === 0) {
+        // all done
+        process.exit(handleFinished(args, groups, numFiltered));
       }
     });
   }


### PR DESCRIPTION
The result of the very last test is currently ignored. In particular, if
a single test is ever run, the output always shows 0/0 success and
no errors are reported.

Example:

```
$ git checkout fix-test-runner 
Switched to branch 'fix-test-runner'
$ node lib/scripts/test262-runner.js --singleThreaded test262/test/language/literals/boolean/S7.8.2_A1_T1.js
Running the tests as a single process
test262/test/language/literals/boolean: Passed: 2 / 2 (100%) (es6): 0 / 0 (100%)
=== RESULTS ===
Passes: 2 / 2 (100%)
ES6 passes: 0 / 0 (100%)
Skipped: 26984

$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
$ node lib/scripts/test262-runner.js --singleThreaded test262/test/language/literals/boolean/S7.8.2_A1_T1.js
Running the tests as a single process
=== RESULTS ===
Passes: 0 / 0 (100%)
ES6 passes: 0 / 0 (100%)
Skipped: 26984
```