### PR TITLE
Special case non array objects with Array.prototype as prototype

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -14,7 +14,7 @@ import { Realm, ExecutionContext } from "../realm.js";
 import type { RealmOptions, Descriptor, PropertyBinding } from "../types.js";
 import { IsUnresolvableReference, ResolveBinding, ToLength, IsArray, Get } from "../methods/index.js";
 import { Completion } from "../completions.js";
-import { BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, NumberValue, FunctionValue, Value, ObjectValue, PrimitiveValue, NativeFunctionValue, UndefinedValue } from "../values/index.js";
+import { ArrayValue, BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, NumberValue, FunctionValue, Value, ObjectValue, PrimitiveValue, NativeFunctionValue, UndefinedValue } from "../values/index.js";
 import { describeLocation } from "../intrinsics/ecma262/Error.js";
 import * as t from "babel-types";
 import type { BabelNode, BabelNodeExpression, BabelNodeStatement, BabelNodeIdentifier, BabelNodeBlockStatement, BabelNodeObjectExpression, BabelNodeStringLiteral, BabelNodeLVal, BabelNodeSpreadElement, BabelVariableKind, BabelNodeFunctionDeclaration } from "babel-types";
@@ -258,8 +258,10 @@ export class Serializer {
     */
 
     let proto = val.$GetPrototypeOf();
-    if (proto.isIntrinsic()) {
-      // TODO: serialize modified prototypes that are intrinsic objects
+    if (proto === this.realm.intrinsics.ArrayPrototype) {
+      if (val instanceof ArrayValue) proto = null;
+    } else if (proto.isIntrinsic()) {
+      // TODO: check if val will be serialized as a constructor call
       proto = null;
     }
 

--- a/test/serializer/basic/ArrayPrototype.js
+++ b/test/serializer/basic/ArrayPrototype.js
@@ -1,0 +1,4 @@
+na = Object.create(Array.prototype);
+a = [];
+
+inspect = function() { a.push(123); na.push(123); return a[0] + na[0]; }


### PR DESCRIPTION
When serializing a value that is not created as an array, but which has Array.prototype as its prototype, arrange things so that its prototype is explicitly set in the serialized code.

See issue #405.