### PR TITLE
Join new properties with empty rather than undefined

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -309,15 +309,15 @@ export function joinDescriptors(realm: Realm,
       throw new Error("TODO: join computed properties");
     let dc = cloneDescriptor(d);
     invariant(dc !== undefined);
-    dc.value = getAbstractValue(d.value, undefined);
+    dc.value = getAbstractValue(d.value, realm.intrinsics.empty);
     return dc;
   }
   if (d1 === undefined) {
     if (d2 === undefined) return undefined;
-    // d2 is a new property created in only one branch, join with undefined
+    // d2 is a new property created in only one branch, join with empty
     return clone_with_abstract_value(d2);
   } else if (d2 === undefined) {
-    // d1 is a new property created in only one branch, join with undefined
+    // d1 is a new property created in only one branch, join with empty
     return clone_with_abstract_value(d1);
   } else {
     let d3 : Descriptor = { };

--- a/test/serializer/abstract/PutValue11.js
+++ b/test/serializer/abstract/PutValue11.js
@@ -1,0 +1,5 @@
+var c = global.__abstract ? __abstract("boolean", "false") : false;
+a = {};
+if (c) a.f = a;
+
+inspect = function() { return 'f' in a; }


### PR DESCRIPTION
A new property that is created in only one branch of an abstract conditional should be joined with empty rather than undefined, so that it exists in a state of being "possibly deleted", rather than "possibly undefined".

This resolves issue #410.