### PR TITLE
Fix includesValueNotOfType

### DIFF
--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -38,7 +38,7 @@ export default class ValuesDomain {
   }
 
   includesValueNotOfType(type: typeof Value): boolean {
-    if (this.isTop()) return true;
+    invariant(!this.isTop());
     for (let cval of this.getElements()) {
       if (!(cval instanceof type)) return true;
     }
@@ -46,7 +46,7 @@ export default class ValuesDomain {
   }
 
   includesValueOfType(type: typeof Value): boolean {
-    if (this.isTop()) return false;
+    invariant(!this.isTop());
     for (let cval of this.getElements()) {
       if (cval instanceof type) return true;
     }

--- a/test/serializer/abstract/IsPrototypeOf.js
+++ b/test/serializer/abstract/IsPrototypeOf.js
@@ -1,0 +1,11 @@
+// throws introspection error
+
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let ob = global.__abstract ? __abstract({}, "({})") : {};
+if (global.__makeSimple) global.__makeSimple(ob);
+
+let p = x ? {} : ob.p;
+
+y = Object.prototype.isPrototypeOf(p);
+
+inspect = function() { return "" + y; }

--- a/test/serializer/abstract/ObjectCreate.js
+++ b/test/serializer/abstract/ObjectCreate.js
@@ -1,0 +1,11 @@
+// throws introspection error
+
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let ob = global.__abstract ? __abstract({}, "({})") : {};
+if (global.__makeSimple) global.__makeSimple(ob);
+
+let p = x ? undefined : ob.p;
+
+y = Object.create(Object.prototype, p);
+
+inspect = function() { return "" + y; }

--- a/test/serializer/abstract/TypesDomain3.js
+++ b/test/serializer/abstract/TypesDomain3.js
@@ -1,0 +1,11 @@
+// throws introspection error
+
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let ob = global.__abstract ? __abstract({}, "({})") : {};
+if (global.__makeSimple) global.__makeSimple(ob);
+
+let p = x ? 1 : ob.p;
+
+z = Number.isFinite(p);
+
+inspect = function() { return "" + z; }


### PR DESCRIPTION
includesValueNotOfType used to return true for the top value of the domain. Since don't know anything for Top, it is confusing to return true and also inconsistent with includesValueOfType.

Fixing this uncovered broken assumptions in the Value.mightXXX methods, so those are fixed as well. Test cases have been beefed up a bit to include case that will do the wrong thing without the fixes.