### PR TITLE
Fix unlabelled break out of loop

### DIFF
--- a/src/evaluators/BlockStatement.js
+++ b/src/evaluators/BlockStatement.js
@@ -17,7 +17,7 @@ import { AbruptCompletion, NormalCompletion, PossiblyNormalCompletion, Introspec
 import { Reference } from "../environment.js";
 import { EmptyValue, StringValue, Value } from "../values/index.js";
 import { joinPossiblyNormalCompletions, joinPossiblyNormalCompletionWithAbruptCompletion,
-   NewDeclarativeEnvironment, BlockDeclarationInstantiation } from "../methods/index.js";
+   NewDeclarativeEnvironment, BlockDeclarationInstantiation, UpdateEmpty } from "../methods/index.js";
 import invariant from "../invariant.js";
 
 // ECMA262 13.2.13
@@ -50,7 +50,8 @@ export default function (ast: BabelNodeBlockStatement, strictCode: boolean, env:
         invariant(!(res instanceof Reference));
         if (!(res instanceof EmptyValue)) {
           if (blockValue === undefined || blockValue instanceof Value) {
-            if (res instanceof AbruptCompletion) throw res;
+            if (res instanceof AbruptCompletion)
+              throw UpdateEmpty(realm, res, blockValue || realm.intrinsics.empty);
             invariant(res instanceof NormalCompletion || res instanceof Value);
             blockValue = res;
           } else {

--- a/src/evaluators/DoWhileStatement.js
+++ b/src/evaluators/DoWhileStatement.js
@@ -16,7 +16,7 @@ import type { Reference } from "../environment.js";
 import { EmptyValue } from "../values/index.js";
 import { ToBooleanPartial, GetValue, UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
-import { AbruptCompletion } from "../completions.js";
+import { AbruptCompletion, BreakCompletion } from "../completions.js";
 import invariant from "../invariant.js";
 import type { BabelNodeDoWhileStatement } from "babel-types";
 
@@ -34,6 +34,11 @@ export default function (ast: BabelNodeDoWhileStatement, strictCode: boolean, en
     // b. If LoopContinues(stmt, labelSet) is false, return Completion(UpdateEmpty(stmt, V)).
     if (LoopContinues(realm, stmt, labelSet) === false) {
       invariant(stmt instanceof AbruptCompletion);
+      // ECMA262 13.1.7
+      if (stmt instanceof BreakCompletion) {
+        if (!stmt.target)
+          return (UpdateEmpty(realm, stmt, V): any).value;
+      }
       throw UpdateEmpty(realm, stmt, V);
     }
 

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -12,7 +12,7 @@
 import type { LexicalEnvironment, Reference } from "../environment.js";
 import type { Realm } from "../realm.js";
 import { Value, EmptyValue } from "../values/index.js";
-import { AbruptCompletion } from "../completions.js";
+import { AbruptCompletion, BreakCompletion } from "../completions.js";
 import { BoundNames, NewDeclarativeEnvironment, GetValue, ToBooleanPartial, UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
 import invariant from "../invariant.js";
@@ -79,6 +79,11 @@ function ForBodyEvaluation(realm: Realm, test, increment, stmt, perIterationBind
     // c. If LoopContinues(result, labelSet) is false, return Completion(UpdateEmpty(result, V)).
     if (!LoopContinues(realm, result, labelSet)) {
       invariant(result instanceof AbruptCompletion);
+      // ECMA262 13.1.7
+      if (result instanceof BreakCompletion) {
+        if (!result.target)
+          return (UpdateEmpty(realm, result, V): any).value;
+      }
       throw UpdateEmpty(realm, result, V);
     }
 

--- a/src/scripts/test262-runner.js
+++ b/src/scripts/test262-runner.js
@@ -613,7 +613,7 @@ function handleFinished(
 
   // exit status
   if (args.timeout === 10) numPassedES5 += 4;
-  if (!args.filterString && (numPassedES5 < 22638 || numPassedES6 < 7446)) {
+  if (!args.filterString && (numPassedES5 < 22763 || numPassedES6 < 7456)) {
     console.log(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {


### PR DESCRIPTION
Since we have no production corresponding to BreakableStatement:IterationStatement, the logic for handling unlabelled break completions was not included anywhere in our interpreter. I've now added this to DoWhileStatement and ForStatement.