### PR TITLE
Captured variables

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -407,6 +407,12 @@ export class Serializer {
         reasons.concat(`access in ${functionName} to ${n}`));
       serializedBinding = { serializedValue, value };
       serializedBindings[n] = serializedBinding;
+      if (value.mightBeObject()) {
+        // Increment ref count one more time to ensure that this object will be assigned a unique id.
+        // This ensures that only once instance is created across all possible residual function invocations.
+        this._incrementValToRefCount(value);
+
+      }
     }
     return serializedBinding;
   }
@@ -724,25 +730,24 @@ export class Serializer {
         }
       }
       let delayReason = this._shouldDelayValues(referencedValues);
+      let serialize = () => {
+        let serializedBinding = serializeBindingFunc();
+        invariant(serializedBinding);
+        serializedBindings[innerName] = serializedBinding;
+        invariant(functionInfo);
+        if (functionInfo.modified[innerName]) serializedBinding.modified = true;
+      };
       if (delayReason) {
         delayed++;
         this._delay(delayReason, referencedValues, () => {
-          let serializedBinding = serializeBindingFunc();
-          invariant(serializedBinding);
-          serializedBindings[innerName] = serializedBinding;
-          invariant(functionInfo);
-          if (functionInfo.modified[innerName]) serializedBinding.modified = true;
+          serialize();
           if (--delayed === 0) {
             instance.bodyReference = this._getBodyReference();
             this.functionInstances.push(instance);
           }
         });
       } else {
-        let serializedBinding = serializeBindingFunc();
-        invariant(serializedBinding);
-        serializedBindings[innerName] = serializedBinding;
-        invariant(functionInfo);
-        if (functionInfo.modified[innerName]) serializedBinding.modified = true;
+        serialize();
       }
     }
 

--- a/test/serializer/basic/ResidualIdentityObservation.js
+++ b/test/serializer/basic/ResidualIdentityObservation.js
@@ -1,0 +1,10 @@
+(function() {
+    var a = {x: 4};
+    function f() {
+        return a;
+    }
+    function g() {
+        return a;
+    }
+    inspect = function() { return f() === g(); }
+})();


### PR DESCRIPTION
that are referenced by residual functions
and that possibly hold objects
need to be treated as locations, not values that can be re-created on-the-fly,
as the object identity may be observed.

Added regression test.

This effectively fixes #424.