### PR TITLE
Fix arguments object to deal with duplicate parameter names

### DIFF
--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -40,8 +40,7 @@ import IsStrict from "../utils/strict.js";
 import invariant from "../invariant.js";
 import parse from "../utils/parse.js";
 import traverse from "../traverse.js";
-import * as t from "babel-types";
-import type { BabelNodeLVal, BabelNodeFunctionDeclaration } from "babel-types";
+import type { BabelNodeIdentifier, BabelNodeLVal, BabelNodeFunctionDeclaration } from "babel-types";
 
 // ECMA262 9.4.3.3
 export function StringCreate(realm: Realm, value: StringValue, prototype: ObjectValue): ObjectValue {
@@ -443,7 +442,10 @@ export function CreateMappedArgumentsObject(realm: Realm, func: FunctionValue, f
   obj.$ParameterMap = map;
 
   // 14. Let parameterNames be the BoundNames of formals.
-  let parameterNames = Object.keys(t.getBindingIdentifiers(formals));
+  let parameterNames = [];
+  for (let param of formals) {
+    parameterNames.push(((param: any): BabelNodeIdentifier).name);
+  }
 
   // 15. Let numberOfParameters be the number of elements in parameterNames.
   let numberOfParameters = parameterNames.length;
@@ -505,10 +507,10 @@ export function CreateMappedArgumentsObject(realm: Realm, func: FunctionValue, f
           configurable: true
         });
       }
-
-      // iii. Let index be index - 1.
-      index--;
     }
+
+    // c. Let index be index - 1.
+    index--;
   }
 
   // 22. Perform ! DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor {[[Value]]:

--- a/src/scripts/test262-runner.js
+++ b/src/scripts/test262-runner.js
@@ -612,7 +612,7 @@ function handleFinished(
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 22799 || numPassedES6 < 7390)) {
+  if (!args.filterString && (numPassedES5 < 22799 || numPassedES6 < 7391)) {
     console.log(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {


### PR DESCRIPTION
The code for obtaining the list of parameter names to use for initializing an arguments object did not take into account the possibility that parameter names may be duplicated. Fixing this uncovered a further error where a related loop counter was not being decremented when a duplicate argument is encountered.