### PR TITLE
Optionally tracking and delaying of require() calls

### DIFF
--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -85,10 +85,7 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean, e
   realm.restoreProperties(properties);
 
   // Add generated code for property modifications
-  let realmGenerator = realm.generator;
-  invariant(realmGenerator);
-  let realmGeneratorBody = realmGenerator.body;
-  generator.body.forEach((v, k, a) => realmGeneratorBody.push(v));
+  realm.appendGenerator(generator);
 
   // Ignore the joined completion
   completion;

--- a/src/prepack.js
+++ b/src/prepack.js
@@ -24,11 +24,13 @@ function run_internal(
     trace: boolean = false,
     debugNames: boolean = false,
     singlePass: boolean = false,
-    logStatistics: boolean = false) {
+    logStatistics: boolean = false,
+    logModules: boolean = false,
+    delayUnsupportedRequires: boolean = false) {
   let serialized =
     new Serializer(
       { partial: true, compatibility, mathRandomSeed },
-      { initializeMoreModules: speculate, internalDebug: true, trace, debugNames, singlePass, logStatistics })
+      { initializeMoreModules: speculate, internalDebug: true, trace, debugNames, singlePass, logStatistics, logModules, delayUnsupportedRequires })
         .init(name, raw, map, outputMap !== undefined);
   if (!serialized) {
     process.exit(1);
@@ -67,7 +69,9 @@ export function run(
     trace?: boolean,
     debugNames?: boolean,
     singlePass?: boolean,
-    logStatistics?: boolean) {
+    logStatistics?: boolean,
+    logModules?: boolean,
+    delayUnsupportedRequires?: boolean) {
   let input = fs.readFileSync(inFn, "utf8");
   let map = "";
   let mapFile = inputMap ? inputMap : inFn + ".map";
@@ -76,5 +80,5 @@ export function run(
   } catch (_e) {
     console.log(`No sourcemap found at ${mapFile}.`);
   }
-  run_internal(inFn, input, map, compat, mathRandSeed, outFn, outMap, speculateOpt, trace, debugNames, singlePass, logStatistics);
+  run_internal(inFn, input, map, compat, mathRandSeed, outFn, outMap, speculateOpt, trace, debugNames, singlePass, logStatistics, logModules, delayUnsupportedRequires);
 }

--- a/src/run_util.js
+++ b/src/run_util.js
@@ -25,6 +25,8 @@ let flags = {
   debugNames: false,
   singlePass: false,
   logStatistics: false,
+  logModules: false,
+  delayUnsupportedRequires: false,
 };
 while (args.length) {
   let arg = args[0]; args.shift();
@@ -72,5 +74,5 @@ if (!inputFilename) {
   console.error("Missing input file.");
   process.exit(1);
 } else {
-  run(inputFilename, compatibility, mathRandomSeed, outputFilename, inputMap, ouputMap, flags.speculate, flags.trace, flags.debugNames, flags.singlePass, flags.logStatistics);
+  run(inputFilename, compatibility, mathRandomSeed, outputFilename, inputMap, ouputMap, flags.speculate, flags.trace, flags.debugNames, flags.singlePass, flags.logStatistics, flags.logModules, flags.delayUnsupportedRequires);
 }

--- a/src/scripts/test-runner.js
+++ b/src/scripts/test-runner.js
@@ -67,7 +67,8 @@ function runTest(name: string, code: string): boolean {
   let compatibility = code.includes("// jsc") ? "jsc" : undefined;
   let realmOptions = { partial: true, compatibility };
   let initializeMoreModules = code.includes("// initialize more modules");
-  let serializerOptions = { initializeMoreModules, internalDebug: true };
+  let delayUnsupportedRequires = code.includes("// delay unsupported requires");
+  let serializerOptions = { initializeMoreModules, delayUnsupportedRequires, internalDebug: true };
   if (code.includes("// throws introspection error")) {
     let onError = (realm, e) => {
       if (IsIntrospectionError(realm, e))
@@ -140,7 +141,7 @@ function runTest(name: string, code: string): boolean {
           console.log(chalk.red("Output mismatch!"));
           break;
         }
-        if (oldCode === newCode) {
+        if (oldCode === newCode || delayUnsupportedRequires) {
           // The generated code reached a fixed point!
           return true;
         }

--- a/src/serializer/LoggingTracer.js
+++ b/src/serializer/LoggingTracer.js
@@ -39,7 +39,7 @@ export class LoggingTracer extends Tracer {
   nesting: Array<string>;
 
   log(message: string) {
-    console.log(`${this.nesting.map(_ => "  ").join("")}${message}`);
+    console.log(`[calls] ${this.nesting.map(_ => "  ").join("")}${message}`);
   }
 
   beginPartialEvaluation() {

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -60,7 +60,7 @@ export class Serializer {
     this.realm = construct_realm(realmOptions);
     invariant(this.realm.isPartial);
     this.logger = new Logger(this.realm, !!serializerOptions.internalDebug);
-    this.modules = new Modules(this.realm, this.logger);
+    this.modules = new Modules(this.realm, this.logger, !!serializerOptions.logModules, !!serializerOptions.delayUnsupportedRequires);
     if (serializerOptions.trace) this.realm.tracers.push(new LoggingTracer(this.realm));
 
     let realmGenerator = this.realm.generator;

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -60,6 +60,8 @@ export type SerializerOptions = {
   debugNames?: boolean;
   singlePass?: boolean;
   logStatistics?: boolean;
+  logModules?: boolean;
+  delayUnsupportedRequires?: boolean;
 }
 
 export class SerializerStatistics {

--- a/test/serializer/optimizations/require_delay.js
+++ b/test/serializer/optimizations/require_delay.js
@@ -1,0 +1,112 @@
+// delay unsupported requires
+
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+      try {
+
+   var _moduleObject = { exports: exports };
+
+   factory(global, require, _moduleObject, exports, dependencyMap);
+
+      module.factory = undefined;
+
+   return module.exports = _moduleObject.exports;
+ } catch (e) {
+   module.hasError = true;
+   module.isInitialized = false;
+   module.exports = undefined;
+   throw e;
+ }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+define(function(global, require, module, exports) {
+  var obj = global.__abstract ? __abstract(undefined, "({unsupported: true})") : ({unsupported: true});
+  if (obj.unsupported) {
+    exports.magic = 42;
+  } else {
+    exports.magic = 23;
+  }
+}, 0, null);
+
+define(function(global, require, module, exports) {
+  var x = require(0);
+  module.exports = function() { return x; }
+}, 1, null);
+
+var f = require(1);
+
+inspect = function() { return f().magic; }

--- a/test/serializer/optimizations/require_unsupported.js
+++ b/test/serializer/optimizations/require_unsupported.js
@@ -1,0 +1,104 @@
+// throws introspection error
+
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+      try {
+
+   var _moduleObject = { exports: exports };
+
+   factory(global, require, _moduleObject, exports, dependencyMap);
+
+      module.factory = undefined;
+
+   return module.exports = _moduleObject.exports;
+ } catch (e) {
+   module.hasError = true;
+   module.isInitialized = false;
+   module.exports = undefined;
+   throw e;
+ }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+define(function(global, require, module, exports) {
+  if (__abstract().unsupported) {}
+}, 0, null);
+
+define(function(global, require, module, exports) {
+  module.exports = require(0);
+}, 1, null);
+
+require(1);


### PR DESCRIPTION
- add option to log hierarchy of require() dependencies
- add ability to tracer to wrap around / detour a call
- use that feature to delay require() calls that trigger unsupported operations
- adding tests