### PR TITLE
Don't create a fresh object for function prototypes.

### DIFF
--- a/test/serializer/basic/FunctionPrototype.js
+++ b/test/serializer/basic/FunctionPrototype.js
@@ -1,0 +1,5 @@
+(function() {
+  function f() {}
+  let p = f.prototype;
+  inspect = function() { return p === f.prototype; }
+})();

--- a/test/serializer/basic/SimpleInheritanceChains.js
+++ b/test/serializer/basic/SimpleInheritanceChains.js
@@ -1,0 +1,8 @@
+(function() {
+    function A() {}
+    function B() {}
+    B.prototype = Object.create(A.prototype);
+    inspect = function() {
+        return A.prototype === B.prototype.__proto__;
+    }
+})();


### PR DESCRIPTION
This addresses issue #456: The serializer already had logic to omit emitting a function's prototype property. However, this logic is only sound when we also don't create fresh objects for function prototypes. With this change, we no longer do this.
Adding Sebastian's test, and one more even simpler test.