### PR TITLE
Move $ContextStack to $ErrorData, and append location data for syntax errors

### DIFF
--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -58,7 +58,7 @@ export function describeLocation(realm: Realm, callerFn: ?FunctionValue, env: ?L
 function buildStack(realm: Realm, context: ObjectValue) {
   invariant(context.$ErrorData);
 
-  let stack = context.$ContextStack;
+  let stack = context.$ErrorData.contextStack;
   if (!stack) return realm.intrinsics.undefined;
 
   let lines = [];
@@ -90,10 +90,12 @@ export function build(name: string, realm: Realm, inheritError?: boolean = true)
 
     // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%ErrorPrototype%", « [[ErrorData]] »).
     let O = OrdinaryCreateFromConstructor(realm, newTarget, `${name}Prototype`, { $ErrorData: undefined });
-    O.$ErrorData = O; // The value is never used, but allows us to use undefined as a way to say "not in"
+    O.$ErrorData = {
+      contextStack: realm.contextStack.slice(1),
+      locationData: undefined
+    };
 
     // Build a text description of the stack.
-    O.$ContextStack = realm.contextStack.slice(1);
     let stackDesc = {
       value: buildStack(realm, O),
       enumerable: false,

--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -74,7 +74,9 @@ export class Logger {
         let message = object.properties.get("message");
         console.error((message && message.descriptor && message.descriptor.value instanceof StringValue) ? message.descriptor.value.value : "(no message available)");
         console.error(err.stack);
-        console.error(object.$ContextStack);
+        if (object.$ErrorData) {
+          console.error(object.$ErrorData.contextStack);
+        }
       }
     } else {
       try {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -68,9 +68,15 @@ export default class ObjectValue extends ConcreteValue {
   $BooleanData: void | BooleanValue;
 
   // error
-  $ErrorData: void | ObjectValue; // undefined when the property is "missing"
-  $ContextStack: void | Array<ExecutionContext>;
-
+  $ErrorData: void | { // undefined when the property is "missing"
+    contextStack: Array<ExecutionContext>,
+    locationData: void | {
+      filename: string,
+      sourceCode: string,
+      loc: { line: number, column: number },
+      stackDecorated: boolean
+    }
+  };
 
   // function
   $Call: void | ((thisArgument: Value, argumentsList: Array<Value>) => Value);


### PR DESCRIPTION
I believe the $ErrorData slot is meant to be an internal host provided object that keeps things like the context stack on it. So we don't need to come up with another slot to store it. We might want to minimize internal fields to create monomorphic data structures as a perf optimization.

I also added another field to $ErrorData that stores the source location of syntax errors when the parser causes an error.

This is used inside hosting environments such as Node to print a nicer error message with the location of the syntax error. This is different from the contextStack since this is not actually part of the execution stack.

This can be used to print messages with an error showing the location of the syntax error.

```
foo.js:3
x ++ y
     ^
SyntaxError: Unexpected identifier
```

You can see how I use it to model the [contextify module in node.js](https://github.com/sebmarkbage/prepack/blob/21b632d1de999ebd145aef433b1e253b0d3a7a84/src/intrinsics/node/contextify.js#L174-L197) which uses this data to append to the stack of an error if it bubbles up to the evaluation of a script boundary (a contextify script).

We could do the same thing in the Repl for example to show where syntax errors occurred.