### PR TITLE
Add negative test cases for for-in loop

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -265,13 +265,15 @@ export class Serializer {
 
     // inject properties with computed names
     if (obj.unknownProperty !== undefined) {
-      let desc = obj.unknownProperty.descriptor; invariant(desc !== undefined);
-      let val = desc.value;
-      invariant(val instanceof AbstractValue);
-      this._eagerOrDelay(this._getNestedAbstractValues(val, [obj]), () => {
+      let desc = obj.unknownProperty.descriptor;
+      if (desc !== undefined) {
+        let val = desc.value;
         invariant(val instanceof AbstractValue);
-        this._emitPropertiesWithComputedNames(obj, val, reasons);
-      });
+        this._eagerOrDelay(this._getNestedAbstractValues(val, [obj]), () => {
+          invariant(val instanceof AbstractValue);
+          this._emitPropertiesWithComputedNames(obj, val, reasons);
+        });
+      }
     }
 
     // prototype

--- a/test/serializer/abstract/ForInStatement1.js
+++ b/test/serializer/abstract/ForInStatement1.js
@@ -1,0 +1,7 @@
+// throws introspection error
+let x = __abstract("boolean", "true");
+let ob = x ? { a: 1 } : { b: 2 };
+let tgt = {};
+for (var p in ob) {
+  tgt[p] = p+p;
+}

--- a/test/serializer/abstract/ForInStatement10.js
+++ b/test/serializer/abstract/ForInStatement10.js
@@ -1,0 +1,9 @@
+// throws introspection error
+
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+
+let tgt = {};
+for (var p in ob) {
+  break;
+}

--- a/test/serializer/abstract/ForInStatement11.js
+++ b/test/serializer/abstract/ForInStatement11.js
@@ -1,0 +1,9 @@
+// throws introspection error
+
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+
+let tgt = {};
+for (var p in ob) {
+  console.log(p);
+}

--- a/test/serializer/abstract/ForInStatement2.js
+++ b/test/serializer/abstract/ForInStatement2.js
@@ -1,0 +1,8 @@
+// throws introspection error
+let x = __abstract("boolean", "true");
+let ob = x ? { a: 1 } : { b: 2 };
+let src = {};
+let tgt = {};
+for (var p in ob) {
+  tgt[p] = src[p];
+}

--- a/test/serializer/abstract/ForInStatement3.js
+++ b/test/serializer/abstract/ForInStatement3.js
@@ -1,0 +1,10 @@
+// throws introspection error
+let ob = __abstract({}, "({})")
+if (global.__makeSimple) __makeSimple(ob);
+let x = __abstract("string");
+
+ob[x] = 123;
+let tgt = {};
+for (var p in ob) {
+  tgt[p] = ob[p];
+}

--- a/test/serializer/abstract/ForInStatement3a.js
+++ b/test/serializer/abstract/ForInStatement3a.js
@@ -1,0 +1,11 @@
+// throws introspection error
+let ob = __abstract({}, "({})")
+if (global.__makeSimple) __makeSimple(ob);
+let x = __abstract("string");
+
+ob[x] = 123;
+let tgt = {};
+tgt[x] = 456;
+for (var p in ob) {
+  tgt[p] = ob[p];
+}

--- a/test/serializer/abstract/ForInStatement4.js
+++ b/test/serializer/abstract/ForInStatement4.js
@@ -1,0 +1,9 @@
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+
+let tgt = {};
+for (var p in ob) {
+  tgt[p] = ob[p];
+}
+
+inspect = function() { return ""; }

--- a/test/serializer/abstract/ForInStatement5.js
+++ b/test/serializer/abstract/ForInStatement5.js
@@ -1,0 +1,9 @@
+// throws introspection error
+
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+
+let tgt = {};
+for (var p in ob) {
+  tgt[p] = ob[p+p];
+}

--- a/test/serializer/abstract/ForInStatement6.js
+++ b/test/serializer/abstract/ForInStatement6.js
@@ -1,0 +1,9 @@
+// throws introspection error
+
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+
+let tgt = {};
+for (var p in ob) {
+  tgt[p] = ob.x;
+}

--- a/test/serializer/abstract/ForInStatement7.js
+++ b/test/serializer/abstract/ForInStatement7.js
@@ -1,0 +1,9 @@
+// throws introspection error
+
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+
+let tgt = {};
+for (var p in ob) {
+  tgt.x = 1;
+}

--- a/test/serializer/abstract/ForInStatement8.js
+++ b/test/serializer/abstract/ForInStatement8.js
@@ -1,0 +1,11 @@
+// throws introspection error
+
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+
+let tgt = {};
+for (var p in ob) {
+  tgt = ob.x;
+}
+
+z = tgt;

--- a/test/serializer/abstract/ForInStatement9.js
+++ b/test/serializer/abstract/ForInStatement9.js
@@ -1,0 +1,12 @@
+// throws introspection error
+
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+if (global.__makeSimple) __makeSimple(ob);
+function f() { }
+
+let tgt = {};
+for (var p in ob) {
+  new f();
+}
+
+z = tgt;

--- a/test/serializer/abstract/ObjectAssign3.js
+++ b/test/serializer/abstract/ObjectAssign3.js
@@ -1,5 +1,3 @@
-// skip
-
 let ob = global.__abstract ? __abstract({}, "({p: 1})") : {p: 1};
 if (global.__makeSimple) __makeSimple(ob);
 


### PR DESCRIPTION
Added test cases to get code coverage for emitResidualLoopIfSafe.

Removed a bad invariant from serializer.js.

Re-enabled objectAssign3.js test.