### PR TITLE
Fix GetPartialValue for non partial objects

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -998,6 +998,8 @@ export class Serializer {
   }
 
   _serializeAbstractValue(name: string, val: AbstractValue, reasons: Array<string>): BabelNodeExpression {
+    if (val.kind === "sentinel member expression")
+      this.logger.logError(val, "expressions of type o[p] are not yet supported for partially known o and unknown p");
     let serializedArgs = val.args.map((abstractArg, i) => this.serializeValue(abstractArg, reasons.concat(`Argument ${i} of ${name}`)));
     let serializedValue = val.buildNode(serializedArgs);
     if (serializedValue.type === "Identifier") {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -418,9 +418,14 @@ export default class ObjectValue extends ConcreteValue {
     if (this !== Receiver || !this.isSimple() || P.mightNotBeString())
       throw this.$Realm.createIntrospectionErrorThrowCompletion("TODO");
     // If all else fails, use this expression
-    let result = this.$Realm.createAbstract(TypesDomain.topVal, ValuesDomain.topVal,
+    let result;
+    if (this.isPartial()) {
+      result = this.$Realm.createAbstract(TypesDomain.topVal, ValuesDomain.topVal,
         [this, P],
         ([o, x]) => t.memberExpression(o, x, true), "sentinel member expression");
+    } else {
+      result = this.$Realm.intrinsics.undefined;
+    }
     // Get a specialization of the join of all values written to the object
     // with abstract property names.
     let prop = this.unknownProperty;

--- a/test/serializer/abstract/ForInStatement2a.js
+++ b/test/serializer/abstract/ForInStatement2a.js
@@ -1,0 +1,9 @@
+// throws introspection error
+let x = __abstract("boolean", "true");
+let ob = x ? { a: 1 } : { b: 2 };
+let src = __abstract({}, "({})")
+if (global.__makeSimple) __makeSimple(src);
+let tgt = {};
+for (var p in ob) {
+  tgt[p] = src[p];
+}

--- a/test/serializer/abstract/GetValue7.js
+++ b/test/serializer/abstract/GetValue7.js
@@ -1,5 +1,3 @@
-// skip
-
 var n = global.__abstract ? __abstract("string", '("x")') : "x";
 var m = global.__abstract ? __abstract("string", '("z")') : "z";
 

--- a/test/serializer/abstract/GetValue8.js
+++ b/test/serializer/abstract/GetValue8.js
@@ -1,3 +1,5 @@
+// cannot serialize
+
 let ob = global.__abstract ? __abstract({}, "({a: 1})") : {a: 1};
 if (global.__makeSimple) __makeSimple(ob);
 var n = global.__abstract ? __abstract("string", '("a")') : "a";


### PR DESCRIPTION
Fixes Issue #486.

The problem was that defaulting to a member expression reading from the underlying object does not work unless the object is partial (i.e. obtained from the outside world).

Since we know all of the writes to a non partial object, it suffices to put undefined at the end of the chain of comparisons of the unknown property value to previously written known and unknown property names.

Fixing this invalidated an invariant in emitResidualLoopIfSafe, so that code now has a check rather than an invariant.