### PR TITLE
Add source location to logError messages

### DIFF
--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -12,7 +12,7 @@
 import { Realm, ExecutionContext } from "../realm.js";
 import { ToStringPartial, Get, InstanceofOperator } from "../methods/index.js";
 import { Completion, ThrowCompletion } from "../completions.js";
-import { ObjectValue, StringValue } from "../values/index.js";
+import { ObjectValue, StringValue, Value } from "../values/index.js";
 import invariant from "../invariant.js";
 
 export class Logger {
@@ -90,7 +90,14 @@ export class Logger {
     this._hasErrors = true;
   }
 
-  logError(message: string) {
+  logError(value: Value, message: string) {
+    let loc = value.expressionLocation;
+    if (loc) {
+      let locString = `${loc.start.line}:${loc.start.column + 1}`;
+      if (loc.source) locString = `${loc.source}:${locString}`;
+      message = `${message}\nat: ${locString}`;
+    }
+
     console.error(message);
     this._hasErrors = true;
   }

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -60,10 +60,10 @@ class ModuleTracer extends Tracer {
       if (moduleId instanceof NumberValue || moduleId instanceof StringValue) {
         moduleIdValue = moduleId.value;
         if (!this.modules.moduleIds.has(moduleIdValue)) {
-          this.modules.logger.logError("Module referenced by require call has not been defined.");
+          this.modules.logger.logError(moduleId, "Module referenced by require call has not been defined.");
         }
       } else {
-        this.modules.logger.logError("First argument to require function is not a number or string value.");
+        this.modules.logger.logError(moduleId, "First argument to require function is not a number or string value.");
         return undefined;
       }
       this.log(`>require(${moduleIdValue})`);
@@ -101,13 +101,13 @@ class ModuleTracer extends Tracer {
       if (result instanceof Completion) throw result;
       return result;
     } else if (F === this.modules.getDefine()) {
-      if (this.partialEvaluation !== 0) this.modules.logger.logError("Defining a module in nested partial evaluation is not supported.");
+      if (this.partialEvaluation !== 0) this.modules.logger.logError(F, "Defining a module in nested partial evaluation is not supported.");
       let factoryFunction = argumentsList[0];
       if (factoryFunction instanceof FunctionValue) this.modules.factoryFunctions.add(factoryFunction);
-      else this.modules.logger.logError("First argument to define function is not a function value.");
+      else this.modules.logger.logError(factoryFunction, "First argument to define function is not a function value.");
       let moduleId = argumentsList[1];
       if (moduleId instanceof NumberValue || moduleId instanceof StringValue) this.modules.moduleIds.add(moduleId.value);
-      else this.modules.logger.logError("Second argument to define function is not a number or string value.");
+      else this.modules.logger.logError(moduleId, "Second argument to define function is not a number or string value.");
     }
     return undefined;
   }

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -192,7 +192,7 @@ export class Serializer {
     } else if (val instanceof FunctionValue) {
       if (t.isIdentifier(key, { name: "length" })) {
         if (desc.value === undefined) {
-          this.logger.logError("Functions with length accessor properties are not supported.");
+          this.logger.logError(val, "Functions with length accessor properties are not supported.");
           // Rationale: .bind() would call the accessor, which might throw, mutate state, or do whatever...
         }
         // length property will be inferred already by the amount of parameters
@@ -823,7 +823,7 @@ export class Serializer {
       );
 
       if (val.isResidual && Object.keys(functionInfo.names).length) {
-        this.logger.logError(`residual function ${describeLocation(this.realm, val, undefined, code.loc) || "(unknown)"} refers to the following identifiers defined outside of the local scope: ${Object.keys(functionInfo.names).join(", ")}`);
+        this.logger.logError(val, `residual function ${describeLocation(this.realm, val, undefined, code.loc) || "(unknown)"} refers to the following identifiers defined outside of the local scope: ${Object.keys(functionInfo.names).join(", ")}`);
       }
     }
 
@@ -939,9 +939,9 @@ export class Serializer {
         return t.newExpression(this.preludeGenerator.memoizeReference("Date"), [serializedDateValue]);
       default:
         if (kind !== "Object")
-          this.logger.logError(`Serialization of an object of kind ${kind} is not supported.`);
+          this.logger.logError(val, `Serialization of an object of kind ${kind} is not supported.`);
         if (this.$ParameterMap !== undefined)
-          this.logger.logError(`Serialization of an arguments object is not supported.`);
+          this.logger.logError(val, `Serialization of an arguments object is not supported.`);
 
         let remainingProperties = new Map(val.properties);
         let props = [];

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import type { BabelNodeSourceLocation } from "babel-types";
 import type { Realm } from "../realm.js";
 import { EmptyValue, UndefinedValue, NullValue, BooleanValue, StringValue, SymbolValue, NumberValue, ObjectValue, ConcreteValue, AbstractObjectValue, FunctionValue } from "./index.js";
 
@@ -20,6 +21,7 @@ export default class Value {
 
     this.$Realm = realm;
     this.intrinsicName = intrinsicName;
+    this.expressionLocation = realm.currentLocation;
   }
   // Name from original source if existant
   __originalName: void | string;
@@ -48,7 +50,8 @@ export default class Value {
   }
 
   intrinsicName: ?string;
-
+  // The source location of the expression that first produced this value.
+  expressionLocation: ?BabelNodeSourceLocation;
   $Realm: Realm;
 
   isIntrinsic(): boolean {


### PR DESCRIPTION
When the serializer fails to serialize some value, it is nice to know where in the source code the value is first produced.

The basic change here is that every value now tracks the first AST node that was evaluated to produce the value.