### PR TITLE
The global object used to have a plain "this" string as its intrinsic…

### DIFF
--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -23,7 +23,7 @@ export default function(opts: RealmOptions = {}): Realm {
   initializeIntrinsics(i, r);
   // TODO: Find a way to let different environments initialize their own global
   // object for special magic host objects such as the window object in the DOM.
-  r.$GlobalObject = new ObjectValue(r, i.ObjectPrototype, "this");
+  r.$GlobalObject = new ObjectValue(r, i.ObjectPrototype, "::global");
   initializeGlobal(r);
   for (let name in evaluators) r.evaluators[name] = evaluators[name];
   r.$GlobalEnv =  NewGlobalEnvironment(r, r.$GlobalObject, r.$GlobalObject);

--- a/test/serializer/basic/GlobalMustBePassedInWhenUsed.js
+++ b/test/serializer/basic/GlobalMustBePassedInWhenUsed.js
@@ -1,0 +1,12 @@
+// does contain:.call(this)
+(function () {
+    var _$0 = this;
+
+    x = 42;
+
+    function _0() {
+        return _$0.x;
+    }
+
+    inspect = _0;
+}).call(this);


### PR DESCRIPTION
… name.

Unfortunately, this didn't get scoped properly.
Since recently, there's the special name "::global" that does the right thing.
So I am using that instead.
Adding a regression test.