### PR TITLE
removing extra moduleName argument in docs example

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
     return x instanceof Function ? (moduleTable[id] = x()) : x;
   }
   global.require = require;
-  define("one", function() { return 1; }, "one");
+  define("one", function() { return 1; });
   define("two", function() { return require("one") + require("one"); });
   define("three", function() { return require("two") + require("one"); });
   define("four", function() { return require("three") + require("one"); });


### PR DESCRIPTION
I'm guessing at some point the order of arguments `define` were reversed and this was missed.