### PR TITLE
Remove Redundant Code in Strict Equality

### DIFF
--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -217,13 +217,9 @@ export function StrictEqualityComparison(realm: Realm, x: ConcreteValue, y: Conc
     if (isNaN(y.value)) return false;
 
     // c. If x is the same Number value as y, return true.
+    // d. If x is +0 and y is -0, return true. (handled by c)
+    // e. If x is -0 and y is +0, return true. (handled by c)
     if (x.value === y.value) return true;
-
-    // d. If x is +0 and y is -0, return true.
-    if (Object.is(x, +0) && Object.is(y, -0)) return true;
-
-    // e. If x is -0 and y is +0, return true.
-    if (Object.is(x, -0) && Object.is(y, +0)) return true;
 
     // f. Return false.
     return false;


### PR DESCRIPTION
I think firstly, d and e should be comparing `x.value` to ±`0` (rather than x itself).

But I think these are then redundant, since c handles this for us. Sorry if I'm wrong on this!