### PR TITLE
Use a separate domain for tracking might be deleted

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -256,9 +256,12 @@ export function joinValuesAsConditional(
     realm: Realm, condition: AbstractValue, v1: void | Value, v2: void | Value): AbstractValue {
   let types = TypesDomain.joinValues(v1, v2);
   let values = ValuesDomain.joinValues(realm, v1, v2);
-  return realm.createAbstract(types, values,
+  let result = realm.createAbstract(types, values,
     [condition, v1 || realm.intrinsics.undefined, v2 || realm.intrinsics.undefined],
     (args) => t.conditionalExpression(args[0], args[1], args[2]));
+  if (v1) result.mightBeEmpty = v1.mightHaveBeenDeleted();
+  if (v2 && !result.mightBeEmpty) result.mightBeEmpty = v2.mightHaveBeenDeleted();
+  return result;
 }
 
 export function joinPropertyBindings(realm: Realm, joinCondition: AbstractValue,

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -44,7 +44,7 @@ export default class ConcreteValue extends Value {
   }
 
   mightHaveBeenDeleted(): boolean {
-    return false;
+    return this instanceof EmptyValue;
   }
 
   promoteEmptyToUndefined(): Value {

--- a/test/serializer/abstract/PutValue13.js
+++ b/test/serializer/abstract/PutValue13.js
@@ -1,0 +1,8 @@
+(function() {
+    let a = global.__abstract ? __abstract("boolean", "(false)") : false;
+    let obj = {};
+    if (a) {
+        obj.notAnObject = Date.now();
+    }
+    inspect = function() { return obj.notAnObject instanceof Object; }
+})();


### PR DESCRIPTION
This resolves issue #499.

ValuesDomain.topValue occurs in abstract values that should not be treated as possibly deleted, but neither should joining Empty with Top result in a value that is treated as not possibly deleted.

Consequently there is now an additional field in AbstractValue that tracks the possibly deleted status of an abstract value.

Quick reminder on "possibly deleted": If we join a branch where a property exists with a branch where it is deleted, the joined abstract value stored in that property has to reflect that there is a branch where the property does not exist, so that any checks for its existence become conditional.