### PR TITLE
Fixes typo on Getting started page

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -46,7 +46,7 @@
 
           <h3>Compiling a File</h3>
 
-          <p class="align-left">Compile a file an print it to the console:</p>
+          <p class="align-left">Compile a file and print it to the console:</p>
           <div class="code-block language-sh">
             <pre><code>prepack script.js</code></pre>
           </div>


### PR DESCRIPTION
There's a typo on Getting Started Page as well as the Module Initialization scrollbar didnt align (drove me nuts), this should fix it.