### PR TITLE
Support non-direct calls of abstract functions

### DIFF
--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -396,6 +396,17 @@ export function Call(realm: Realm, F: Value, V: Value, argsList?: Array<Value>):
   if (IsCallable(realm, F) === false) {
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
   }
+  if (F instanceof AbstractValue && F.getType() === FunctionValue) {
+    let fullArgs = [F].concat(argsList);
+    return realm.deriveAbstract(
+      TypesDomain.topVal,
+      ValuesDomain.topVal,
+      fullArgs,
+      (nodes) => {
+        let fun_args = ((nodes.slice(1): any): Array<BabelNodeExpression | BabelNodeSpreadElement>);
+        return t.callExpression(nodes[0], fun_args);
+      });
+  }
   invariant(F instanceof ObjectValue);
 
   // 3. Return ? F.[[Call]](V, argumentsList).

--- a/test/serializer/abstract/Call4.js
+++ b/test/serializer/abstract/Call4.js
@@ -1,0 +1,5 @@
+function f(v) { return v*2; }
+var g = global.__abstract ? global.__abstract(f, "f") : f;
+let v = [1].map(g)
+
+inspect = function() { return v }


### PR DESCRIPTION
Makes the following pass:
```js
__assumeDataProperty(global, "func", __abstract("function"))
[1].map(func)
```