### PR TITLE
Make Options an exact type

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,7 @@
 import type { RealmOptions } from "./types";
 import type { SerializerOptions } from "./serializer/types";
 
-export type Options = {
+export type Options = {|
   filename?: string,
   inputSourceMapFilename?: string,
   sourceMaps?: boolean,
@@ -29,7 +29,9 @@ export type Options = {
   uniqueSuffix?: string,
   timeout?: number,
   strictlyMonotonicDateNow?: boolean,
-};
+|};
+
+export const defaultOptions = {};
 
 export function getRealmOptions({
   compatibility = "browser",

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -16,10 +16,11 @@ import { getRealmOptions, getSerializerOptions } from "./options";
 import { InitializationError } from "./prepack-standalone";
 
 import type { Options } from "./options";
+import { defaultOptions } from "./options";
 
 export * from "./prepack-standalone";
 
-export function prepackFile(filename: string, options: Options = {}, callback: Function) {
+export function prepackFile(filename: string, options: Options = defaultOptions, callback: Function) {
   let sourceMapFilename = options.inputSourceMapFilename || (filename + ".map");
   fs.readFile(filename, "utf8", function(fileErr, code) {
     if (fileErr) {
@@ -52,7 +53,7 @@ export function prepackFile(filename: string, options: Options = {}, callback: F
   });
 }
 
-export function prepackFileSync(filename: string, options: Options = {}) {
+export function prepackFileSync(filename: string, options: Options = defaultOptions) {
   let code = fs.readFileSync(filename, "utf8");
   let sourceMap = "";
   let sourceMapFilename = options.inputSourceMapFilename || (filename + ".map");

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -15,6 +15,7 @@ import * as t from "babel-types";
 import { getRealmOptions, getSerializerOptions } from "./options";
 
 import type { Options } from "./options";
+import { defaultOptions } from "./options";
 import type { BabelNodeFile, BabelNodeProgram } from "babel-types";
 
 // This should just be a class but Babel classes doesn't work with
@@ -28,7 +29,7 @@ Object.setPrototypeOf(InitializationError, Error);
 Object.setPrototypeOf(InitializationError.prototype, Error.prototype);
 
 
-export function prepack(code: string, options: Options = {}) {
+export function prepack(code: string, options: Options = defaultOptions) {
   let filename = options.filename || 'unknown';
   let realm = construct_realm(getRealmOptions(options));
   initializeGlobals(realm);
@@ -40,7 +41,7 @@ export function prepack(code: string, options: Options = {}) {
   return serialized;
 }
 
-export function prepackFromAst(ast: BabelNodeFile | BabelNodeProgram, code: string, options: Options = {}) {
+export function prepackFromAst(ast: BabelNodeFile | BabelNodeProgram, code: string, options: Options = defaultOptions) {
   if (ast && ast.type === "Program") {
     ast = t.file(ast, [], []);
   } else if (!ast || ast.type !== "File") {


### PR DESCRIPTION
To catch typos in options. I had to be a bit clever here to trick Flow into letting me create an empty object as the default.