### PR TITLE
Use public APIs in tests

### DIFF
--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -9,9 +9,7 @@
 
 /* @flow */
 
-import Serializer from "../lib/serializer/index.js";
-import construct_realm from "../lib/construct_realm.js";
-import initializeGlobals from "../lib/globals.js";
+import { prepack } from "../lib/prepack-node.js";
 
 let chalk = require("chalk");
 let path  = require("path");
@@ -43,10 +41,13 @@ let tests = search(`${__dirname}/../test/internal`, "test/internal");
 function runTest(name: string, code: string): boolean {
   console.log(chalk.inverse(name));
   try {
-    let realm = construct_realm({ partial: true, compatibility: "jsc-600-1-4-17", mathRandomSeed: "0" });
-    initializeGlobals(realm);
-    let serializer = new Serializer(realm, { internalDebug: true, initializeMoreModules: true });
-    let serialized = serializer.init(name, code, "", false);
+    let serialized = prepack(code, {
+      filename: name,
+      internalDebug: true,
+      compatibility: "jsc-600-1-4-17",
+      mathRandomSeed: "0",
+      speculate: true
+    });
     if (!serialized) {
       console.log(chalk.red("Error during serialization"));
       return false;

--- a/src/options.js
+++ b/src/options.js
@@ -16,7 +16,7 @@ export type Options = {|
   filename?: string,
   inputSourceMapFilename?: string,
   sourceMaps?: boolean,
-  compatibility?: "browser" | "jsc-600-1-4-17",
+  compatibility?: "browser" | "node-source-maps" | "jsc-600-1-4-17",
   mathRandomSeed?: string,
   speculate?: boolean,
   trace?: boolean,

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -40,7 +40,12 @@ export function prepackFile(filename: string, options: Options = defaultOptions,
           realm,
           getSerializerOptions(options),
         );
-        serialized = serializer.init(filename, code, sourceMap, options.sourceMaps);
+        serialized = serializer.init(
+          options.filename || filename,
+          code,
+          sourceMap,
+          options.sourceMaps
+        );
         if (!serialized) {
           throw new InitializationError();
         }
@@ -68,7 +73,12 @@ export function prepackFileSync(filename: string, options: Options = defaultOpti
     realm,
     getSerializerOptions(options),
   );
-  let serialized = serializer.init(filename, code, sourceMap, options.sourceMaps);
+  let serialized = serializer.init(
+    options.filename || filename,
+    code,
+    sourceMap,
+    options.sourceMaps
+  );
   if (!serialized) {
     throw new InitializationError();
   }

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -34,7 +34,7 @@ export function prepack(code: string, options: Options = defaultOptions) {
   let realm = construct_realm(getRealmOptions(options));
   initializeGlobals(realm);
   let serializer = new Serializer(realm, getSerializerOptions(options));
-  let serialized = serializer.init(filename, code, "", false);
+  let serialized = serializer.init(filename, code, "", options.sourceMaps);
   if (!serialized) {
     throw new InitializationError();
   }

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1427,7 +1427,7 @@ export class Serializer {
         Array.from(this.preludeGenerator.declaredGlobals).map(key =>
           t.variableDeclarator(t.identifier(key)))));
     if (body.length) {
-      if (this.realm.isCompatibleWith('node')) {
+      if (this.realm.isCompatibleWith('node-source-maps')) {
         ast_body.push(
           t.expressionStatement(
             t.callExpression(

--- a/src/types.js
+++ b/src/types.js
@@ -28,7 +28,7 @@ export type IterationKind = "key+value" | "value" | "key";
 
 export type SourceType = "module" | "script";
 
-export type Compatibility = "browser" | "jsc-600-1-4-17" | "node";
+export type Compatibility = "browser" | "jsc-600-1-4-17" | "node-source-maps";
 
 export type RealmOptions = {
   partial?: boolean,


### PR DESCRIPTION
This gives us some better end-to-end coverage and makes it easier move internals around.

This surfaced a few bugs/issues in the API.

I left the thing that detects introspection errors but this surfaced that we don't have a way to pass custom error loggers through the public API. I didn't want to expose the whole Realm and Value types externally. It might be worth having a string based way to get logs in the future though.