### PR TITLE
Encode invalid identifiers (such as "0") as computed string expressions

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -78,11 +78,12 @@ export class Generator {
   }
 
   emitPropertyAssignment(object: Value, key: string, value: Value) {
+    let isValidId = t.isValidIdentifier(key);
     this.body.push({
       args: [object, value],
       buildNode: ([objectNode, valueNode]) => t.expressionStatement(t.assignmentExpression(
         "=",
-        t.memberExpression(objectNode, t.identifier(key)),
+        t.memberExpression(objectNode, isValidId ? t.identifier(key) : t.stringLiteral(key), !isValidId),
         valueNode))
     });
   }

--- a/test/serializer/basic/IntrinsicPutValue.js
+++ b/test/serializer/basic/IntrinsicPutValue.js
@@ -1,0 +1,2 @@
+Object["0"] = 1;
+inspect = function() { return Object["0"]; }


### PR DESCRIPTION
This used to encode it as `Object.0 = 1;`