### PR TITLE
Fix code sample height with scrollbars

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -56,6 +56,8 @@ pre[class*="language-"] {
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
 	background: #fdfaeb;
+	overflow: auto;
+	height: 160px;
 }
 
 /* Inline code */

--- a/css/prism.css
+++ b/css/prism.css
@@ -51,7 +51,6 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 pre[class*="language-"] {
 	padding: 1em;
 	margin: 0;
-	overflow: auto;
 }
 
 :not(pre) > code[class*="language-"],

--- a/css/prism.css
+++ b/css/prism.css
@@ -51,13 +51,13 @@ code[class*="language-"]::selection, code[class*="language-"] ::selection {
 pre[class*="language-"] {
 	padding: 1em;
 	margin: 0;
+	height: 100%;
 }
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
 	background: #fdfaeb;
 	overflow: auto;
-	height: 160px;
 }
 
 /* Inline code */

--- a/css/style.css
+++ b/css/style.css
@@ -185,7 +185,6 @@ header, .repl-container {
   flex: 1;
   margin: 5px;
   max-width: 50%;
-  overflow: auto;
   background-color: #fdfaeb;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -185,6 +185,7 @@ header, .repl-container {
   flex: 1;
   margin: 5px;
   max-width: 50%;
+  overflow: auto;
   background-color: #fdfaeb;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,7 @@
 
 *, ::before, ::after {
   -webkit-font-smoothing: antialiased;
+  box-sizing: border-box;
 }
 
 html {
@@ -182,10 +183,16 @@ header, .repl-container {
 }
 
 .example-code {
+  height: 100%;
+}
+
+.example-input, .example-output {
   flex: 1;
-  margin: 5px;
-  max-width: 50%;
+  margin: 0 5px;
   background-color: #fdfaeb;
+  width: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (max-width: 800px) {
@@ -198,7 +205,7 @@ header, .repl-container {
   }
 }
 
-.example-code::before {
+.example-input::before, .example-output::before, .code-block::before {
   background: #FBF4D0;
   color: #B0A673;
   display: block;
@@ -229,18 +236,6 @@ header, .repl-container {
 .code-block {
   margin: 5px;
   background-color: #fdfaeb;
-}
-
-.code-block::before {
-  background: #FBF4D0;
-  color: #B0A673;
-  display: block;
-  font-size: 11px;
-  font-weight: bold;
-  height: 34px;
-  line-height: 34px;
-  padding: 0 10px;
-  text-align: left;
 }
 
 .code-block.language-js::before {

--- a/index.html
+++ b/index.html
@@ -68,24 +68,29 @@
 
           <h3>Hello World</h3>
           <div class="example">
-            <div class="example-code example-input">
-              <pre><code class="language-js">(function () {
+            <div class="example-input">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   function hello() { return 'hello'; }
   function world() { return 'world'; }
   global.s = hello() + ' ' + world();
 })();</code></pre>
+              </div>
             </div>
-            <div class="example-code example-output">
-              <pre><code class="language-js">(function () {
+            <div class="example-output">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   s = "hello world";
 })();</code></pre>
+              </div>
             </div>
           </div>
 
           <h3>Elimination of abstraction tax</h3>
           <div class="example">
-            <div class="example-code example-input">
-              <pre><code class="language-js">(function () {
+            <div class="example-input">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   var self = this;
   ['A', 'B', 42].forEach(function(x) {
     var name = '_' + x.toString()[0].toLowerCase();
@@ -93,38 +98,46 @@
     self[name] = y ? y : x;
   });
 })();</code></pre>
+              </div>
             </div>
-            <div class="example-code example-output">
-              <pre><code class="language-js">(function () {
+            <div class="example-output">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   _a = "A";
   _b = "B";
   _4 = 42;
 })();</code></pre>
+              </div>
             </div>
           </div>
 
 
           <h3>Fibonacci</h3>
           <div class="example">
-            <div class="example-code example-input">
-              <pre><code class="language-js">(function () {
+            <div class="example-input">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   function fibonacci(x) {
     return x <= 1 ? x : fibonacci(x - 1) + fibonacci(x - 2);
   }
   global.x = fibonacci(23);
 })();</code></pre>
+              </div>
             </div>
-            <div class="example-code example-output">
-              <pre><code class="language-js">(function () {
+            <div class="example-output">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   x = 28657;
 })();</code></pre>
+              </div>
             </div>
           </div>
 
           <h3>Module Initialization</h3>
           <div class="example">
-            <div class="example-code example-input">
-              <pre><code class="language-js">(function () {
+            <div class="example-input">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   let moduleTable = {};
   function define(id, f) { moduleTable[id] = f; }
   function require(id) {
@@ -138,9 +151,11 @@
   define("four", function() { return require("three") + require("one"); });
 })();
 three = require("three");</code></pre>
+              </div>
             </div>
-            <div class="example-code example-output">
-              <pre><code class="language-js">(function () {
+            <div class="example-output">
+              <div class="example-code">
+                <pre><code class="language-js">(function () {
   function _2() {
     return 3 + 1;
   }
@@ -160,6 +175,7 @@ three = require("three");</code></pre>
   require = _0;
   three = 3;
 })();</code></pre>
+              </div>
             </div>
           </div>
 
@@ -169,15 +185,18 @@ three = require("three");</code></pre>
 
           <h3>Environment Interactions and Branching</h3>
           <div class="example">
-            <div class="example-code example-input">
-              <pre><code class="language-js">(function(){
+            <div class="example-input">
+              <div class="example-code">
+                <pre><code class="language-js">(function(){
   function fib(x) { return x <= 1 ? x : fib(x - 1) + fib(x - 2); }
   let x = Date.now();
   if (x === 0) x = fib(10);
   global.result = x;
 })();</code></pre>
+              </div>
             </div>
-            <div class="example-code example-output">
+            <div class="example-output">
+              <div class="example-code">
               <pre><code class="language-js">(function () {
   var _0 = Date.now();
   if (typeof _0 !== "number") {


### PR DESCRIPTION
Fixes #555. Continuation of #560 by @solodynamo.

Uses flexbox to make the code sample input and output boxes the same height.

The elements in this screenshot have borders just to show that everything is lined up nicely.

![screen shot 2017-05-05 at 11 10 07 am](https://cloud.githubusercontent.com/assets/249164/25758593/07a12142-3184-11e7-9170-dc6535eec7e5.png)

This didn't effect anything on the getting started page.

And here is a screenshot the way it actually is (with the scrollbar visible for proof).

![screen shot 2017-05-05 at 11 15 29 am](https://cloud.githubusercontent.com/assets/249164/25758652/40c41f92-3184-11e7-96d3-590ca680f5cc.png)
