### PR TITLE
Update Circle CI Node Version to 7.9.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.1.0
+    version: 7.9.0
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 


### PR DESCRIPTION
As discussed with @NTillmann...

The purpose of this is to be able to land #397 with some test coverage. In its current form it is too specific in its implementation and only works on a specific version of Node. In the future we'll want to make that more abstract and general so that it can work on ranges and other major versions.

I have noticed that this version had some Test262 timeouts on my machine. We might need to tweak them if CI starts being flaky.
