### PR TITLE
Check if member expression property name is a valid id

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -231,12 +231,14 @@ export default class AbstractObjectValue extends AbstractValue {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
         if (cv.isSimple() && typeof P === "string") {
-          let pname = P;
+          let generator = this.$Realm.generator;
+          invariant(generator !== undefined);
+          let pname = generator.getAsPropertyNameExpression(P);
           let d = cv.$GetOwnProperty(P);
           if (d === undefined) {
             return this.$Realm.deriveAbstract(TypesDomain.topVal,
                ValuesDomain.topVal, [cv],
-               ([node]) => t.memberExpression(node, t.identifier(pname)));
+               ([node]) => t.memberExpression(node, pname, !t.isIdentifier(pname)));
           }
         }
         return cv.$Get(P, Receiver);

--- a/test/serializer/abstract/DeleteArrayProperty2.js
+++ b/test/serializer/abstract/DeleteArrayProperty2.js
@@ -1,0 +1,5 @@
+var x = global.__abstract ? __abstract("boolean", "true") : true;
+var a = [42];
+o = global.__abstract ? __abstract([42], "a") : a;
+if (x) delete o[0];
+inspect = function() { return o[0]; }

--- a/test/serializer/abstract/GetValue9.js
+++ b/test/serializer/abstract/GetValue9.js
@@ -1,0 +1,5 @@
+let obj = global.__abstract ? __abstract({}, "({'5': 6})") : {'5':6};
+if (global.__makeSimple) __makeSimple(obj);
+x = obj[5];
+
+inspect = function() { return x === 6; }


### PR DESCRIPTION
Use a single method to check if a property name is a valid identifier and generate the appropriate Babel node for use in a MemberExpression.

Addresses issue: #581