### PR TITLE
Serialize [[PreventExtensions]]

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -284,6 +284,21 @@ export class Serializer {
     this.addObjectPrototype(name, obj, reasons);
     if (obj instanceof FunctionValue) this.addConstructorPrototype(name, obj, reasons);
 
+    // extentions
+    if (!obj.$IsExtensible()) {
+      this._eagerOrDelay([obj], () => {
+        let uid = this._getValIdForReference(obj);
+        this.body.push(
+          t.expressionStatement(
+            t.callExpression(
+              this.preludeGenerator.memoizeReference("Object.preventExtensions"),
+              [uid]
+            )
+          )
+        );
+      });
+    }
+
     this.statistics.objects++;
     this.statistics.objectProperties += obj.properties.size;
   }

--- a/test/serializer/basic/PreventExtensions.js
+++ b/test/serializer/basic/PreventExtensions.js
@@ -1,0 +1,6 @@
+let obj = {x:1};
+Object.preventExtensions(obj);
+inspect = function() {
+  obj.y = 1;
+  return obj.y;
+}


### PR DESCRIPTION
If the [[PreventExtensions]] property has been set on an object, we need the serializer to call Object.preventExtensions.

See issue: #585