### PR TITLE
Resolve #370 - refactor common throw pattern

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -17,7 +17,7 @@ import type { SourceType } from "./types.js";
 import { AbruptCompletion, Completion, ComposedAbruptCompletion, JoinedAbruptCompletions, PossiblyNormalCompletion, ThrowCompletion } from "./completions.js";
 import { ExecutionContext } from "./realm.js";
 import { Value } from "./values/index.js";
-import { AbstractValue, NullValue, SymbolValue, BooleanValue, FunctionValue, StringValue, ObjectValue, AbstractObjectValue, UndefinedValue } from "./values/index.js";
+import { AbstractValue, NullValue, SymbolValue, BooleanValue, FunctionValue, ObjectValue, AbstractObjectValue, UndefinedValue } from "./values/index.js";
 import parse from "./utils/parse.js";
 import invariant from "./invariant.js";
 import traverse from "./traverse.js";
@@ -25,7 +25,6 @@ import {
   ToBooleanPartial,
   HasProperty,
   Get,
-  Construct,
   GetValue,
   DefinePropertyOrThrow,
   Set,
@@ -166,9 +165,7 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
     if (!binding) {
       // a. If S is true, throw a ReferenceError exception.
       if (S) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.ReferenceError, [new StringValue(realm, `${N} not found`)])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, `${N} not found`);
       }
 
       // b. Perform envRec.CreateMutableBinding(N, true).
@@ -186,9 +183,7 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
 
     // 4. If the binding for N in envRec has not yet been initialized, throw a ReferenceError exception.
     if (!binding.initialized) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.ReferenceError, [new StringValue(realm, `${N} has not yet been initialized`)])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, `${N} has not yet been initialized`);
     } else if (binding.mutable) { // 5. Else if the binding for N in envRec is a mutable binding, change its bound value to V.
        realm.recordModifiedBinding(binding, envRec).value = V;
     } else { // 6. Else,
@@ -196,9 +191,7 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
 
       // b. If S is true, throw a TypeError exception.
       if (S) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "attempt to change immutable binding")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "attempt to change immutable binding");
       }
     }
 

--- a/src/evaluators/LabeledStatement.js
+++ b/src/evaluators/LabeledStatement.js
@@ -12,10 +12,8 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
-import { StringValue } from "../values/index.js";
 import type { Reference } from "../environment.js";
-import { BreakCompletion, ThrowCompletion } from "../completions.js";
-import { Construct } from "../methods/construct.js";
+import { BreakCompletion } from "../completions.js";
 import type { BabelNodeLabeledStatement, BabelNode } from "babel-types";
 
 // ECMA262 13.13.14
@@ -54,10 +52,8 @@ function LabelledEvaluation(labelSet: Array<string>, ast: BabelNode, strictCode:
       // fall through to throw
     case 'FunctionDeclaration':
     case 'ClassDeclaration':
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError,
-           [new StringValue(realm, ast.type + " may not have a label")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError,
+        ast.type + " may not have a label");
 
     default:
       return env.evaluate(ast, strictCode, labelSet);

--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -12,12 +12,10 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Reference } from "../environment.js";
-import { Value, EmptyValue, StringValue } from "../values/index.js";
+import { Value, EmptyValue } from "../values/index.js";
 import { GlobalEnvironmentRecord } from "../environment.js";
 import { FindVarScopedDeclarations } from "../methods/function.js";
 import { BoundNames } from "../methods/index.js";
-import { ThrowCompletion } from "../completions.js";
-import { Construct } from "../methods/construct.js";
 import IsStrict from "../utils/strict.js";
 import invariant from "../invariant.js";
 import traverse from "../traverse.js";
@@ -54,18 +52,14 @@ function GlobalDeclarationInstantiation(realm: Realm, ast: BabelNodeProgram, env
   for (let name of lexNames) {
     // a. If envRec.HasVarDeclaration(name) is true, throw a SyntaxError exception.
     if (envRec.HasVarDeclaration(name)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError,
-           [new StringValue(realm, name + " already declared with var")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError,
+        name + " already declared with var");
     }
 
     // b. If envRec.HasLexicalDeclaration(name) is true, throw a SyntaxError exception.
     if (envRec.HasLexicalDeclaration(name)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError,
-           [new StringValue(realm, name + " already declared with let or const")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError,
+        name + " already declared with let or const");
     }
 
     // c. Let hasRestrictedGlobal be ? envRec.HasRestrictedGlobalProperty(name).
@@ -73,10 +67,8 @@ function GlobalDeclarationInstantiation(realm: Realm, ast: BabelNodeProgram, env
 
     // d. If hasRestrictedGlobal is true, throw a SyntaxError exception.
     if (hasRestrictedGlobal) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError,
-           [new StringValue(realm, name + " global object is restricted")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError,
+        name + " global object is restricted");
     }
   }
 
@@ -84,10 +76,8 @@ function GlobalDeclarationInstantiation(realm: Realm, ast: BabelNodeProgram, env
   for (let name of varNames) {
     // a. If envRec.HasLexicalDeclaration(name) is true, throw a SyntaxError exception.
     if (envRec.HasLexicalDeclaration(name)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError,
-           [new StringValue(realm, name + " already declared with let or const")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError,
+        name + " already declared with let or const");
     }
   }
 
@@ -119,10 +109,8 @@ function GlobalDeclarationInstantiation(realm: Realm, ast: BabelNodeProgram, env
 
         // 2. If fnDefinable is false, throw a TypeError exception.
         if (!fnDefinable) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError,
-               [new StringValue(realm, fn + ": global function declarations are not allowed")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+            fn + ": global function declarations are not allowed");
         }
 
         // 3. Append fn to declaredFunctionNames.
@@ -150,10 +138,8 @@ function GlobalDeclarationInstantiation(realm: Realm, ast: BabelNodeProgram, env
 
           // 2. If vnDefinable is false, throw a TypeError exception.
           if (!vnDefinable) {
-            throw new ThrowCompletion(
-              Construct(realm, realm.intrinsics.TypeError,
-                 [new StringValue(realm, vn + ": global variable declarations are not allowed")])
-            );
+            throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+              vn + ": global variable declarations are not allowed");
           }
 
           // 3. If vn is not an element of declaredVarNames, then

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ThrowCompletion, AbruptCompletion } from "../../completions.js";
+import { AbruptCompletion } from "../../completions.js";
 import {
     AbstractValue,
     BooleanValue,
@@ -91,9 +91,7 @@ export default function (realm: Realm): NativeFunctionValue {
 
         // b If intLen ≠ len, throw a RangeError exception.
         if (intLen !== len.value) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "intLen ≠ len")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "intLen ≠ len");
         }
       }
 
@@ -224,9 +222,7 @@ export default function (realm: Realm): NativeFunctionValue {
       // a. If IsCallable(mapfn) is false, throw a TypeError exception.
       if (IsCallable(realm, mapfn) === false) {
         mapfn.throwIfNotConcrete();
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsCallable(mapfn) is false")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsCallable(mapfn) is false");
       }
 
       // b. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -263,9 +259,7 @@ export default function (realm: Realm): NativeFunctionValue {
         // i. If k ≥ 2^53-1, then
         if (k >= Math.pow(2, 53) - 1) {
           // 1. Let error be Completion{[[Type]]: throw, [[Value]]: a newly created TypeError object, [[Target]]: empty}.
-          let error = new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "k >= 2^53 - 1")])
-          );
+          let error = realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "k >= 2^53 - 1");
 
           // 2. Return ? IteratorClose(iterator, error).
           throw IteratorClose(realm, iterator, error);

--- a/src/intrinsics/ecma262/ArrayBufferPrototype.js
+++ b/src/intrinsics/ecma262/ArrayBufferPrototype.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ThrowCompletion } from "../../completions.js";
 import { ObjectValue, StringValue, NumberValue, UndefinedValue } from "../../values/index.js";
 import { Construct, SpeciesConstructor, IsDetachedBuffer, ToInteger, SameValue, CopyDataBlockBytes } from "../../methods/index.js";
 import invariant from "../../invariant.js";
@@ -23,23 +22,17 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
     if (!('$ArrayBufferData' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have an [[ArrayBufferData]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have an [[ArrayBufferData]] internal slot");
     }
 
     // 4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (IsDetachedBuffer(realm, O) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(O) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(O) is true");
     }
 
     // 5. Let length be O.[[ArrayBufferByteLength]].
@@ -57,23 +50,17 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
     if (!('$ArrayBufferData' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have an [[ArrayBufferData]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have an [[ArrayBufferData]] internal slot");
     }
 
     // 4. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (IsDetachedBuffer(realm, O) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(O) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(O) is true");
     }
 
     // 5. Let len be O.[[ArrayBufferByteLength]].
@@ -103,39 +90,29 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 13. If New does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
     if (!('$ArrayBufferData' in New)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "new does not have an [[ArrayBufferData]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "new does not have an [[ArrayBufferData]] internal slot");
     }
 
     // 14. If IsDetachedBuffer(New) is true, throw a TypeError exception.
     if (IsDetachedBuffer(realm, New) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(new) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(new) is true");
     }
 
     // 15. If SameValue(New, O) is true, throw a TypeError exception.
     if (SameValue(realm, New, O) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "SameValue(new, O) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "SameValue(new, O) is true");
     }
 
     // 16. If new.[[ArrayBufferByteLength]] < newLen, throw a TypeError exception.
     if (typeof New.$ArrayBufferByteLength !== "number" || New.$ArrayBufferByteLength < newLen) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "new.[[ArrayBufferByteLength]] < newLen")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "new.[[ArrayBufferByteLength]] < newLen");
     }
 
     // 17. NOTE: Side-effects of the above steps may have detached O.
 
     // 18. If IsDetachedBuffer(O) is true, throw a TypeError exception.
     if (IsDetachedBuffer(realm, O) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(O) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(O) is true");
     }
 
     // 19. Let fromBuf be O.[[ArrayBufferData]].

--- a/src/intrinsics/ecma262/ArrayIteratorPrototype.js
+++ b/src/intrinsics/ecma262/ArrayIteratorPrototype.js
@@ -14,8 +14,6 @@ import { CreateIterResultObject, CreateArrayFromList } from "../../methods/creat
 import { NumberValue, ObjectValue, UndefinedValue, StringValue } from "../../values/index.js";
 import { ToLength } from "../../methods/to.js";
 import { Get } from "../../methods/get.js";
-import { Construct } from "../../methods/construct.js";
-import { ThrowCompletion } from "../../completions.js";
 import invariant from "../../invariant.js";
 
 export default function (realm: Realm, obj: ObjectValue): void {
@@ -26,16 +24,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an object");
     }
 
     // 3. If O does not have all of the internal slots of an Array Iterator Instance (22.1.5.3), throw a TypeError exception.
     if (O.$IteratedObject === undefined || O.$ArrayIteratorNextIndex === undefined || O.$ArrayIterationKind === undefined) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "ArrayIteratorPrototype.next isn't generic")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "ArrayIteratorPrototype.next isn't generic");
     }
 
     // 4. Let a be the value of the [[IteratedObject]] internal slot of O.

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ThrowCompletion } from "../../completions.js";
 import { NumberValue, StringValue, ObjectValue, UndefinedValue, NullValue, Value } from "../../values/index.js";
 import invariant from "../../invariant.js";
 import { ObjectCreate, CreateDataProperty } from "../../methods/create.js";
@@ -29,7 +28,6 @@ import {
   CreateDataPropertyOrThrow,
   CreateArrayIterator,
   ArraySpeciesCreate,
-  Construct,
   ToString,
   ToStringPartial,
   ToInteger,
@@ -83,9 +81,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
         // ii. If n + len > 2^53-1, throw a TypeError exception.
         if (n + len > Math.pow(2, 53) - 1) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "too damn high")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "too damn high");
         }
 
         // iv. Repeat, while k < len
@@ -114,9 +110,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
       } else { // d. Else E is added as a single item rather than spread,
         // i. If n≥2^53-1, throw a TypeError exception.
         if (n > Math.pow(2, 53) - 1) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "too damn high")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "too damn high");
         }
 
         // ii. Perform ? CreateDataPropertyOrThrow(A, ! ToString(n), E).
@@ -235,9 +229,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -320,9 +312,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -381,9 +371,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(predicate) is false, throw a TypeError exception.
     if (!IsCallable(realm, predicate)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -424,9 +412,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(predicate) is false, throw a TypeError exception.
     if (IsCallable(realm, predicate) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -467,9 +453,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -727,9 +711,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -821,9 +803,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 5. If len + argCount > 2^53-1, throw a TypeError exception.
     if (len + argCount > Math.pow(2, 53) - 1) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Array.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Array.prototype");
     }
 
     // 6. Repeat, while items is not empty
@@ -855,16 +835,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If len is 0 and initialValue is not present, throw a TypeError exception.
     if (len === 0 && !initialValue) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Array.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Array.prototype");
     }
 
     // 5. Let k be 0.
@@ -899,9 +875,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // c. If kPresent is false, throw a TypeError exception.
       if (!kPresent) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "kPresent is false")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "kPresent is false");
       }
 
       invariant(accumulator);
@@ -942,16 +916,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 4. If len is 0 and initialValue is not present, throw a TypeError exception.
     if (len === 0 && !initialValue) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Array.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Array.prototype");
     }
 
     // 5. Let k be len-1.
@@ -986,9 +956,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // c. If kPresent is false, throw a TypeError exception.
       if (!kPresent || !accumulator) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Array.prototype")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Array.prototype");
       }
     }
 
@@ -1230,9 +1198,8 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "callback passed to Array.prototype.some isn't callable")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "callback passed to Array.prototype.some isn't callable");
     }
 
     // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -1433,9 +1400,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
         let ok = O.$Set(j.toString(), arr[j], O);
         // If any [[Set]] call returns false a TypeError exception is thrown.
         if (!ok)
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "[[Set]] returned false")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "[[Set]] returned false");
 
       } else {
         // If obj is not sparse then DeletePropertyOrThrow must not be called.
@@ -1492,9 +1457,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 8. If len+insertCount-actualDeleteCount > 2^53-1, throw a TypeError exception.
     if (len + insertCount - actualDeleteCount > Math.pow(2, 53) - 1) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "the item count is too damn high")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "the item count is too damn high");
     }
 
     // 9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
@@ -1708,9 +1671,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
     if (argCount > 0) {
       // a. If len+argCount > 2^53-1, throw a TypeError exception.
       if (len + argCount > Math.pow(2, 53) - 1) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "too damn high")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "too damn high");
       }
 
       // b. Let k be len.

--- a/src/intrinsics/ecma262/DataViewPrototype.js
+++ b/src/intrinsics/ecma262/DataViewPrototype.js
@@ -10,9 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ThrowCompletion } from "../../completions.js";
 import { ObjectValue, StringValue, NumberValue } from "../../values/index.js";
-import { Construct } from "../../methods/construct.js";
 import { IsDetachedBuffer } from "../../methods/is.js";
 import { GetViewValue, SetViewValue } from "../../methods/arraybuffer.js";
 import invariant from "../../invariant.js";
@@ -25,16 +23,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
     if (!('$DataView' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[DataView]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[DataView]] internal slot");
     }
 
     // 4. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -54,16 +48,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
     if (!('$DataView' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[DataView]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[DataView]] internal slot");
     }
 
     // 4. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -74,9 +64,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
     if (IsDetachedBuffer(realm, buffer) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
     }
 
     // 7. Let size be O.[[ByteLength]].
@@ -94,16 +82,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
     if (!('$DataView' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[DataView]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[DataView]] internal slot");
     }
 
     // 4. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -114,9 +98,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
     if (IsDetachedBuffer(realm, buffer) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
     }
 
     // 7. Let offset be O.[[ByteOffset]].

--- a/src/intrinsics/ecma262/DatePrototype.js
+++ b/src/intrinsics/ecma262/DatePrototype.js
@@ -11,7 +11,6 @@
 
 import type { Realm } from "../../realm.js";
 import { StringValue, ObjectValue, NumberValue } from "../../values/index.js";
-import { ThrowCompletion } from "../../completions.js";
 import {
   ToNumber,
   ToObject,
@@ -37,7 +36,6 @@ import {
   MonthFromTime,
   msPerMinute,
   UTC,
-  Construct,
   OrdinaryToPrimitive,
 } from "../../methods/index.js";
 import invariant from "../../invariant.js";
@@ -754,9 +752,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     let tryFirst;
@@ -769,9 +765,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
       // a. Let tryFirst be "number".
       tryFirst = "number";
     } else { // 5. Else, throw a TypeError exception.
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 6. Return ? OrdinaryToPrimitive(O, tryFirst).

--- a/src/intrinsics/ecma262/FunctionPrototype.js
+++ b/src/intrinsics/ecma262/FunctionPrototype.js
@@ -16,7 +16,6 @@ import { DefinePropertyOrThrow } from "../../methods/properties.js";
 import { BooleanValue, NullValue, UndefinedValue, NumberValue, StringValue, FunctionValue, NativeFunctionValue, ObjectValue } from "../../values/index.js";
 import { Call } from "../../methods/call.js";
 import { ToInteger } from "../../methods/to.js";
-import { Construct } from "../../methods/construct.js";
 import { CreateListFromArrayLike } from "../../methods/create.js";
 import { Get } from "../../methods/get.js";
 import { IsCallable } from "../../methods/is.js";
@@ -41,9 +40,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
   obj.defineNativeMethod("call", 1, (func, [thisArg, ...argList]) => {
     // 1. If IsCallable(func) is false, throw a TypeError exception.
     if (IsCallable(realm, func) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not callable")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
     }
 
     // 2. Let argList be a new empty List.
@@ -61,9 +58,8 @@ export default function (realm: Realm, obj: ObjectValue): void {
   obj.defineNativeMethod("apply", 2, (func, [thisArg, argArray]) => {
     // 1. If IsCallable(func) is false, throw a TypeError exception.
     if (IsCallable(realm, func) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not callable")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "not callable");
     }
 
     // 2. If argArray is null or undefined, then
@@ -162,6 +158,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
     } else if (context instanceof FunctionValue) {
       return new StringValue(realm, "function () { TODO: provide function source code }");
     } else {
+      // Can I use realm.createErrorThrowCompletion here? what `type` error is this?
       throw new ThrowCompletion(new StringValue(realm, "Function.prototype.toString is not generic"));
     }
   });

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -11,8 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NullValue, BooleanValue, StringValue, PrimitiveValue, ArrayValue, ObjectValue, NumberValue, AbstractValue, UndefinedValue, Value, AbstractObjectValue } from "../../values/index.js";
-import { Call, ToLength, EnumerableOwnProperties, ToInteger, ToNumber, IsArray, Get, CreateDataProperty, ObjectCreate, Construct, ToString, ToStringPartial, IsCallable, HasSomeCompatibleType, ThrowIfMightHaveBeenDeleted } from "../../methods/index.js";
-import { ThrowCompletion } from "../../completions.js";
+import { Call, ToLength, EnumerableOwnProperties, ToInteger, ToNumber, IsArray, Get, CreateDataProperty, ObjectCreate, ToString, ToStringPartial, IsCallable, HasSomeCompatibleType, ThrowIfMightHaveBeenDeleted } from "../../methods/index.js";
 import { InternalizeJSONProperty } from "../../methods/json.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import nativeToInterp from "../../utils/native-to-interp.js";
@@ -33,9 +32,7 @@ type Context = {
 function SerializeJSONArray(realm: Realm, value: ObjectValue, context: Context): string {
   // 1. If stack contains value, throw a TypeError exception because the structure is cyclical.
   if (context.stack.indexOf(value) >= 0) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "cyclical error")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "cyclical error");
   }
 
   // 2. Append value to stack.
@@ -111,9 +108,7 @@ function QuoteJSONString(realm: Realm, value: StringValue): string {
 function SerializeJSONObject(realm: Realm, value: ObjectValue, context: Context): string {
   // 1. If stack contains value, throw a TypeError exception because the structure is cyclical.
   if (context.stack.indexOf(value) >= 0) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "cyclical error")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "cyclical error");
   }
 
   // 2. Append value to stack.
@@ -525,9 +520,7 @@ export default function (realm: Realm): ObjectValue {
         unfiltered = nativeToInterp(realm, JSON.parse(JText));
       } catch (err) {
         if (err instanceof SyntaxError) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, err.message)])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, err.message);
         } else {
           throw err;
         }

--- a/src/intrinsics/ecma262/MapIteratorPrototype.js
+++ b/src/intrinsics/ecma262/MapIteratorPrototype.js
@@ -12,8 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { StringValue, NumberValue, ObjectValue, UndefinedValue } from "../../values/index.js";
 import { CreateIterResultObject, CreateArrayFromList } from "../../methods/create.js";
-import { Construct } from "../../methods/construct.js";
-import { ThrowCompletion } from "../../completions.js";
 import invariant from "../../invariant.js";
 
 export default function (realm: Realm, obj: ObjectValue): void {
@@ -24,16 +22,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an object");
     }
 
     // 3. If O does not have all of the internal slots of a Set Iterator Instance (23.2.5.3), throw a TypeError exception.
     if (O.$Map === undefined || O.$MapNextIndex === undefined || O.$MapIterationKind === undefined) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "MapIteratorPrototype.next isn't generic")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "MapIteratorPrototype.next isn't generic");
     }
 
     // 4. Let m be O.[[Map]].

--- a/src/intrinsics/ecma262/NumberPrototype.js
+++ b/src/intrinsics/ecma262/NumberPrototype.js
@@ -11,8 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, UndefinedValue } from "../../values/index.js";
-import { ThrowCompletion } from "../../completions.js";
-import { Construct, ToInteger, ToString, thisNumberValue } from "../../methods/index.js";
+import { ToInteger, ToString, thisNumberValue } from "../../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
@@ -58,9 +57,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 8. If f < 0 or f > 20, throw a RangeError exception. However, an implementation is permitted to extend the behaviour of toExponential for values of f less than 0 or greater than 20. In this case toExponential would not necessarily throw RangeError for such values.
     if (f < 0 || f > 20) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "f < 0 || f > 20")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "f < 0 || f > 20");
     }
 
     let positiveResultString = x.toExponential(fractionDigits instanceof UndefinedValue ? undefined : f);
@@ -74,8 +71,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If f < 0 or f > 20, throw a RangeError exception.
     if (f < 0 || f > 20) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "f < 0 || f > 20")]));
+      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "f < 0 || f > 20");
     }
 
     // 3. Let x be this Number value.
@@ -136,9 +132,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
     // values.
     if (p < 1 || p > 21) {
       // for simplicity, throw the error
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.RangeError,
-          [new StringValue(realm, "p should be in between 1 and 21 inclusive")]));
+      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "p should be in between 1 and 21 inclusive");
     }
     return new StringValue(realm, s + x.toPrecision(p));
   });

--- a/src/intrinsics/ecma262/ObjectPrototype.js
+++ b/src/intrinsics/ecma262/ObjectPrototype.js
@@ -10,14 +10,12 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { NativeFunctionValue, ObjectValue, BooleanValue, StringValue,  NullValue } from "../../values/index.js";
-import { ThrowCompletion } from "../../completions.js";
+import { NativeFunctionValue, ObjectValue, BooleanValue, NullValue } from "../../values/index.js";
 import { ToPropertyKey, ToObject, ToObjectPartial } from "../../methods/to.js";
 import { SameValuePartial, RequireObjectCoercible } from "../../methods/abstract.js";
 import { HasOwnProperty, HasSomeCompatibleType } from "../../methods/has.js";
 import { Invoke } from "../../methods/call.js";
 import { ThrowIfMightHaveBeenDeleted } from "../../methods/index.js";
-import { Construct } from "../../methods/construct.js";
 import invariant from "../../invariant.js";
 
 export default function (realm: Realm, obj: ObjectValue): void {
@@ -123,9 +121,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 5. If status is false, throw a TypeError exception.
       if (!status) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "couldn't set proto")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "couldn't set proto");
       }
 
       // 6. Return undefined.

--- a/src/intrinsics/ecma262/RegExpPrototype.js
+++ b/src/intrinsics/ecma262/RegExpPrototype.js
@@ -11,7 +11,6 @@
 
 import type { Realm } from "../../realm.js";
 import invariant from "../../invariant.js";
-import { ThrowCompletion } from "../../completions.js";
 import { BooleanValue, StringValue, ObjectValue, NullValue, NumberValue, UndefinedValue, Value } from "../../values/index.js";
 import { ArrayCreate, CreateDataProperty } from "../../methods/create.js";
 import { SameValue } from "../../methods/abstract.js";
@@ -29,9 +28,7 @@ function InternalHasFlag(realm: Realm, context: Value, flag: string): Value {
 
   // 2. If Type(R) is not Object, throw a TypeError exception.
   if (!(R instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
   }
 
   // 3. If R does not have an [[OriginalFlags]] internal slot, throw a TypeError exception.
@@ -40,9 +37,7 @@ function InternalHasFlag(realm: Realm, context: Value, flag: string): Value {
     if (SameValue(realm, R, realm.intrinsics.RegExpPrototype)) {
       return realm.intrinsics.undefined;
     } else { // b. Otherwise, throw a TypeError exception.
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "R does not have an [[OriginalFlags]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "R does not have an [[OriginalFlags]] internal slot");
     }
   }
 
@@ -66,16 +61,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(R) is not Object, throw a TypeError exception.
     if (!(R instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. If R does not have a [[RegExpMatcher]] internal slot, throw a TypeError exception.
     if (R.$RegExpMatcher === undefined) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "R does not have a [[RegExpMatcher]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "R does not have a [[RegExpMatcher]] internal slot");
     }
 
     // 4. Let S be ? ToString(string).
@@ -92,9 +83,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(R) is not Object, throw a TypeError exception.
     if (!(R instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. Let result be the empty String.
@@ -151,9 +140,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(rx) is not Object, throw a TypeError exception.
     if (!(rx instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. Let S be ? ToString(string).
@@ -235,9 +222,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(rx) is not Object, throw a TypeError exception.
     if (!(rx instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. Let S be ? ToString(string).
@@ -412,9 +397,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(rx) is not Object, throw a TypeError exception.
     if (!(rx instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. Let S be ? ToString(string).
@@ -446,9 +429,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(R) is not Object, throw a TypeError exception.
     if (!(R instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. If R does not have an [[OriginalSource]] internal slot, throw a TypeError exception.
@@ -457,9 +438,8 @@ export default function (realm: Realm, obj: ObjectValue): void {
       if (SameValue(realm, R, realm.intrinsics.RegExpPrototype)) {
         return new StringValue(realm, "(?:)");
       } else { // b. Otherwise, throw a TypeError exception.
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "R does not have an [[OriginalSource]] internal slot")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+          "R does not have an [[OriginalSource]] internal slot");
       }
     }
 
@@ -485,9 +465,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(rx) is not Object, throw a TypeError exception.
     if (!(rx instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(rx) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(rx) is not an object");
     }
 
     // 3. Let S be ? ToString(string).
@@ -646,9 +624,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(R) is not Object, throw a TypeError exception.
     if (!(R instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. Let string be ? ToString(S).
@@ -668,9 +644,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(R) is not Object, throw a TypeError exception.
     if (!(R instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(R) is not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(R) is not an object");
     }
 
     // 3. Let pattern be ? ToString(? Get(R, "source")).

--- a/src/intrinsics/ecma262/SetIteratorPrototype.js
+++ b/src/intrinsics/ecma262/SetIteratorPrototype.js
@@ -12,8 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { StringValue, ObjectValue, UndefinedValue } from "../../values/index.js";
 import { CreateIterResultObject, CreateArrayFromList } from "../../methods/create.js";
-import { Construct } from "../../methods/construct.js";
-import { ThrowCompletion } from "../../completions.js";
 import invariant from "../../invariant.js";
 
 
@@ -25,16 +23,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not an object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an object");
     }
 
     // 3. If O does not have all of the internal slots of a Set Iterator Instance (23.2.5.3), throw a TypeError exception.
     if (!('$IteratedSet' in O) || !('$SetNextIndex' in O) || !('$SetIterationKind' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "SetIteratorPrototype.next isn't generic")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "SetIteratorPrototype.next isn't generic");
     }
 
     // 4. Let s be O.[[IteratedSet]].

--- a/src/intrinsics/ecma262/String.js
+++ b/src/intrinsics/ecma262/String.js
@@ -10,9 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ThrowCompletion } from "../../completions.js";
 import { NativeFunctionValue, NumberValue, StringValue, SymbolValue } from "../../values/index.js";
-import { Construct } from "../../methods/construct.js";
 import { ToString, ToStringPartial, ToUint16, ToNumber, ToInteger, ToObjectPartial, ToLength } from "../../methods/to.js";
 import { Get } from "../../methods/get.js";
 import {
@@ -106,16 +104,14 @@ export default function (realm: Realm): NativeFunctionValue {
 
       // c. If SameValue(nextCP, ToInteger(nextCP)) is false, throw a RangeError exception.
       if (nextCP !== ToInteger(realm, nextCP)) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "SameValue(nextCP, ToInteger(nextCP)) is false")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError,
+          "SameValue(nextCP, ToInteger(nextCP)) is false");
       }
 
       // d. If nextCP < 0 or nextCP > 0x10FFFF, throw a RangeError exception.
       if (nextCP < 0 || nextCP > 0x10FFFF) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "SameValue(nextCP, ToInteger(nextCP)) is false")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError,
+          "SameValue(nextCP, ToInteger(nextCP)) is false");
       }
 
       // e. Append the elements of the UTF16Encoding of nextCP to the end of elements.

--- a/src/intrinsics/ecma262/StringIteratorPrototype.js
+++ b/src/intrinsics/ecma262/StringIteratorPrototype.js
@@ -10,10 +10,8 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ThrowCompletion } from "../../completions.js";
 import { CreateIterResultObject } from "../../methods/create.js";
 import { ObjectValue, StringValue } from "../../values/index.js";
-import { Construct } from "../../methods/construct.js";
 import invariant from "../../invariant.js";
 
 export default function (realm: Realm, obj: ObjectValue): void {
@@ -24,16 +22,14 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "Type(O) is not Object");
     }
 
     // 3. If O does not have all of the internal slots of an String Iterator Instance (21.1.5.3), throw a TypeError exception.
     if (!('$IteratedString' in O && '$StringIteratorNextIndex' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "Type(O) is not Object");
     }
 
     // 4. Let s be O.[[IteratedString]].

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -10,11 +10,9 @@
 /* @flow */
 
 import { Realm } from "../../realm.js";
-import { ThrowCompletion } from "../../completions.js";
 import { AbstractValue, UndefinedValue, NumberValue, ObjectValue, StringValue, NullValue } from "../../values/index.js";
 import { IsCallable, IsRegExp } from "../../methods/is.js";
 import { GetMethod, GetSubstitution } from "../../methods/get.js";
-import { Construct } from "../../methods/construct.js";
 import { Call, Invoke } from "../../methods/call.js";
 import { CreateStringIterator, CreateDataProperty, ArrayCreate, CreateHTML } from "../../methods/create.js";
 import { RegExpCreate } from "../../methods/regexp.js";
@@ -143,9 +141,8 @@ export default function (realm: Realm, obj: ObjectValue): ObjectValue {
 
     // 4. If isRegExp is true, throw a TypeError exception.
     if (isRegExp) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "String.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "String.prototype");
     }
 
     // 5. Let searchStr be ? ToString(searchString).
@@ -196,9 +193,8 @@ export default function (realm: Realm, obj: ObjectValue): ObjectValue {
 
     // 4. If isRegExp is true, throw a TypeError exception.
     if (isRegExp) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "String.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "String.prototype");
     }
 
     // 5. Let searchStr be ? ToString(searchString).
@@ -719,9 +715,8 @@ export default function (realm: Realm, obj: ObjectValue): ObjectValue {
 
     // 4. If isRegExp is true, throw a TypeError exception.
     if (isRegExp) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "String.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "String.prototype");
     }
 
     // 5. Let searchStr be ? ToString(searchString).

--- a/src/intrinsics/ecma262/Symbol.js
+++ b/src/intrinsics/ecma262/Symbol.js
@@ -11,8 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, StringValue, SymbolValue, UndefinedValue } from "../../values/index.js";
-import { ThrowCompletion } from "../../completions.js";
-import { Construct, ToStringPartial } from "../../methods/index.js";
+import { ToStringPartial } from "../../methods/index.js";
 import { SameValue } from "../../methods/abstract.js";
 
 let GlobalSymbolRegistry: Array<{$Key: string, $Symbol: SymbolValue}> = [];
@@ -66,9 +65,8 @@ export default function (realm: Realm): NativeFunctionValue {
   func.defineNativeMethod("keyFor", 1, (context, [sym]) => {
     // 1. If Type(sym) is not Symbol, throw a TypeError exception.
     if (!(sym instanceof SymbolValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(sym) is not Symbol")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+        "Type(sym) is not Symbol");
     }
 
     // 2. For each element e of the GlobalSymbolRegistry List (see 19.4.2.1),

--- a/src/intrinsics/ecma262/TypedArray.js
+++ b/src/intrinsics/ecma262/TypedArray.js
@@ -13,9 +13,8 @@ import type { Realm } from "../../realm.js";
 import type { ElementType, TypedArrayKind } from "../../types.js";
 import { ElementSize } from "../../types.js";
 import { NumberValue, NativeFunctionValue, ObjectValue, StringValue, UndefinedValue } from "../../values/index.js";
-import { ThrowCompletion } from "../../completions.js";
 import { ArrayElementSize, ArrayElementType, AllocateTypedArray, AllocateTypedArrayBuffer, TypedArrayCreate } from "../../methods/typedarray.js";
-import { Construct, SpeciesConstructor } from "../../methods/construct.js";
+import { SpeciesConstructor } from "../../methods/construct.js";
 import { ToIndexPartial, ToLength, ToString, ToObjectPartial } from "../../methods/to.js";
 import { Get, GetMethod } from "../../methods/get.js";
 import { Set } from "../../methods/properties.js";
@@ -28,9 +27,7 @@ import invariant from "../../invariant.js";
 export default function (realm: Realm): NativeFunctionValue {
   let func = new NativeFunctionValue(realm, 'TypedArray', 'TypedArray', 0, (context) => {
     // 1. Throw a TypeError exception.
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "TypedArray")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "TypedArray");
   });
 
   // ECMA262 22.2.2.1
@@ -40,9 +37,7 @@ export default function (realm: Realm): NativeFunctionValue {
 
     // 2. If IsConstructor(C) is false, throw a TypeError exception.
     if (IsConstructor(realm, C) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsConstructor(C) is false")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsConstructor(C) is false");
     }
     invariant(C instanceof ObjectValue);
 
@@ -51,9 +46,7 @@ export default function (realm: Realm): NativeFunctionValue {
     if (mapfn !== undefined && !mapfn.mightBeUndefined()) {
       // a. If IsCallable(mapfn) is false, throw a TypeError exception.
       if (IsCallable(realm, mapfn) === false) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsConstructor(C) is false")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsConstructor(C) is false");
       }
 
       // b. Let mapping be true.
@@ -169,9 +162,7 @@ export default function (realm: Realm): NativeFunctionValue {
 
     // 4. If IsConstructor(C) is false, throw a TypeError exception.
     if (IsConstructor(realm, C) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsConstructor(C) is false")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsConstructor(C) is false");
     }
     invariant(C instanceof ObjectValue);
 
@@ -232,9 +223,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
       // 1. If NewTarget is undefined, throw a TypeError exception.
       if (!NewTarget) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "NewTarget is undefined")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "NewTarget is undefined");
       }
 
       // 2. Let constructorName be the String value of the Constructor Name value specified in Table 50 for this TypedArray constructor.
@@ -251,9 +240,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
       // 2. If NewTarget is undefined, throw a TypeError exception.
       if (!NewTarget) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "NewTarget is undefined")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "NewTarget is undefined");
       }
 
       // 3. Let elementLength be ? ToIndex(length).
@@ -273,9 +260,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
       // 2. If NewTarget is undefined, throw a TypeError exception.
       if (!NewTarget) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "NewTarget is undefined")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "NewTarget is undefined");
       }
 
       // 3. Let constructorName be the String value of the Constructor Name value specified in Table 50 for this TypedArray constructor.
@@ -292,9 +277,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
       // 7. If IsDetachedBuffer(srcData) is true, throw a TypeError exception.
       if (IsDetachedBuffer(realm, srcData) === true) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(srcData) is true")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(srcData) is true");
       }
 
       // 8. Let constructorName be the String value of O.[[TypedArrayName]].
@@ -338,9 +321,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
         // c. If IsDetachedBuffer(srcData) is true, throw a TypeError exception.
         if (IsDetachedBuffer(realm, srcData) === true) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(srcData) is true")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(srcData) is true");
         }
 
         // d. Let srcByteIndex be srcByteOffset.
@@ -394,9 +375,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
       // 2. If NewTarget is undefined, throw a TypeError exception.
       if (!NewTarget) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "NewTarget is undefined")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "NewTarget is undefined");
       }
 
       // 3. Let constructorName be the String value of the Constructor Name value specified in Table 50 for this TypedArray constructor.
@@ -484,9 +463,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
       // 2. If NewTarget is undefined, throw a TypeError exception.
       if (!NewTarget) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "NewTarget is undefined")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "NewTarget is undefined");
       }
 
       // 3. Let constructorName be the String value of the Constructor Name value specified in Table 50 for this TypedArray constructor.
@@ -506,16 +483,12 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
       // 8. If offset modulo elementSize ≠ 0, throw a RangeError exception.
       if (offset % elementSize !== 0) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "offset modulo elementSize ≠ 0")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "offset modulo elementSize ≠ 0");
       }
 
       // 9. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
       if (IsDetachedBuffer(realm, buffer) === true) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
       }
 
       // 10. Let bufferByteLength be buffer.[[ArrayBufferByteLength]].
@@ -526,18 +499,14 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
       if (!length || length instanceof UndefinedValue) {
         // a. If bufferByteLength modulo elementSize ≠ 0, throw a RangeError exception.
         if (bufferByteLength % elementSize !== 0) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "bufferByteLength modulo elementSize ≠ 0")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "bufferByteLength modulo elementSize ≠ 0");
         }
         // b. Let newByteLength be bufferByteLength - offset.
         newByteLength = bufferByteLength - offset;
 
         // c. If newByteLength < 0, throw a RangeError exception.
         if (newByteLength < 0) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "newByteLength < 0")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "newByteLength < 0");
         }
       } else { // 12. Else,
         // a. Let newLength be ? ToIndex(length).
@@ -548,9 +517,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
 
         // c. If offset+newByteLength > bufferByteLength, throw a RangeError exception.
         if (offset + newByteLength > bufferByteLength) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "offset+newByteLength > bufferByteLength")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "offset+newByteLength > bufferByteLength");
         }
       }
 

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -11,10 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import type { ElementType } from "../../types.js";
-import { ThrowCompletion } from "../../completions.js";
 import { ElementSize } from "../../types.js";
 import { ObjectValue, StringValue, NumberValue, UndefinedValue, NullValue } from "../../values/index.js";
-import { Construct } from "../../methods/construct.js";
 import { ToInteger, ToString, ToStringPartial, ToBooleanPartial, ToObject, ToObjectPartial, ToLength, ToNumber } from "../../methods/to.js";
 import { Call, Invoke } from "../../methods/call.js";
 import { Get } from "../../methods/get.js";
@@ -36,16 +34,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, return undefined.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
     if (!('$TypedArrayName' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[TypedArrayName]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[TypedArrayName]] internal slot");
     }
 
     // 4. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -65,16 +59,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
     if (!('$TypedArrayName' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[TypedArrayName]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[TypedArrayName]] internal slot");
     }
 
     // 4. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
@@ -101,16 +91,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
     if (!('$TypedArrayName' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[TypedArrayName]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[TypedArrayName]] internal slot");
     }
 
     // 4. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
@@ -239,9 +225,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -331,9 +315,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (IsCallable(realm, callbackfn) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsCallable(callbackfn) is false")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsCallable(callbackfn) is false");
     }
 
     // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -404,9 +386,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(predicate) is false, throw a TypeError exception.
     if (!IsCallable(realm, predicate)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -450,9 +430,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(predicate) is false, throw a TypeError exception.
     if (IsCallable(realm, predicate) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -496,9 +474,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -768,16 +744,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
     if (!('$TypedArrayName' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[TypedArrayName]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[TypedArrayName]] internal slot");
     }
 
     // 4. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
@@ -810,9 +782,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (IsCallable(realm, callbackfn) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsCallable(callbackfn) is false")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsCallable(callbackfn) is false");
     }
 
     // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -859,16 +829,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 5. If len is 0 and initialValue is not present, throw a TypeError exception.
     if (len === 0 && !initialValue) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Array.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Array.prototype");
     }
 
     // 6. Let k be 0.
@@ -903,9 +869,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // c. If kPresent is false, throw a TypeError exception.
       if (!kPresent) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "kPresent is false")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "kPresent is false");
       }
 
       invariant(accumulator);
@@ -949,16 +913,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
     }
 
     // 5. If len is 0 and initialValue is not present, throw a TypeError exception.
     if (len === 0 && !initialValue) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Array.prototype")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Array.prototype");
     }
 
     // 6. Let k be len-1.
@@ -993,9 +953,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // c. If kPresent is false, throw a TypeError exception.
       if (!kPresent || !accumulator) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Array.prototype")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Array.prototype");
       }
     }
 
@@ -1123,16 +1081,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 3. If Type(target) is not Object, throw a TypeError exception.
       if (!(target instanceof ObjectValue)) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(target) is not Object")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(target) is not Object");
       }
 
       // 4. If target does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
       if (typeof target.$TypedArrayName !== "string") {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "target does not have a [[TypedArrayName]] internal slot")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "target does not have a [[TypedArrayName]] internal slot");
       }
 
       // 5. Assert: target has a [[ViewedArrayBuffer]] internal slot.
@@ -1143,9 +1097,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 7. If targetOffset < 0, throw a RangeError exception.
       if (targetOffset < 0) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "targetOffset < 0")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "targetOffset < 0");
       }
 
       // 8. Let targetBuffer be target.[[ViewedArrayBuffer]].
@@ -1153,9 +1105,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 9. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
       if (IsDetachedBuffer(realm, targetBuffer) === true) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(targetBuffer) is true")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(targetBuffer) is true");
       }
 
       // 10. Let targetLength be target.[[ArrayLength]].
@@ -1181,9 +1131,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 17. If srcLength + targetOffset > targetLength, throw a RangeError exception.
       if (srcLength + targetOffset > targetLength) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "srcLength + targetOffset > targetLength")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "srcLength + targetOffset > targetLength");
       }
 
       // 18. Let targetByteIndex be targetOffset × targetElementSize + targetByteOffset.
@@ -1205,9 +1153,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
         // c. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
         if (IsDetachedBuffer(realm, targetBuffer) === true) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(targetBuffer) is true")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(targetBuffer) is true");
         }
 
         // d. Perform SetValueInBuffer(targetBuffer, targetByteIndex, targetType, kNumber).
@@ -1233,16 +1179,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 3. If Type(target) is not Object, throw a TypeError exception.
       if (!(target instanceof ObjectValue)) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(target) is not Object")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(target) is not Object");
       }
 
       // 4. If target does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
       if (typeof target.$TypedArrayName !== "string") {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "target does not have a [[TypedArrayName]] internal slot")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "target does not have a [[TypedArrayName]] internal slot");
       }
 
       // 5. Assert: target has a [[ViewedArrayBuffer]] internal slot.
@@ -1253,9 +1195,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 7. If targetOffset < 0, throw a RangeError exception.
       if (targetOffset < 0) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "targetOffset < 0")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "targetOffset < 0");
       }
 
       // 8. Let targetBuffer be target.[[ViewedArrayBuffer]].
@@ -1263,9 +1203,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 9. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
       if (IsDetachedBuffer(realm, targetBuffer) === true) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(targetBuffer) is true")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(targetBuffer) is true");
       }
 
       // 10. Let targetLength be target.[[ArrayLength]].
@@ -1276,9 +1214,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 12. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
       if (IsDetachedBuffer(realm, srcBuffer) === true) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(srcBuffer) is true")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(srcBuffer) is true");
       }
 
       // 13. Let targetName be the String value of target.[[TypedArrayName]].
@@ -1312,9 +1248,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // 22. If srcLength + targetOffset > targetLength, throw a RangeError exception.
       if (srcLength + targetOffset > targetLength) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "srcLength + targetOffset > targetLength")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "srcLength + targetOffset > targetLength");
       }
 
       let srcByteIndex;
@@ -1447,9 +1381,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
       // b. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
       if (IsDetachedBuffer(realm, srcBuffer) === true) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(srcBuffer) is true")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(srcBuffer) is true");
       }
 
       // c. Let targetBuffer be A.[[ViewedArrayBuffer]].
@@ -1505,9 +1437,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "callback passed to Array.prototype.some isn't callable")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "callback passed to Array.prototype.some isn't callable");
     }
 
     // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
@@ -1569,9 +1499,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
         // b. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
         if (IsDetachedBuffer(realm, buffer) === true)
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "array buffer has been detached")])
-          );
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "array buffer has been detached");
 
         // c. If v is NaN, return +0.
         if (v instanceof NumberValue && isNaN(v.value)) return realm.intrinsics.zero;
@@ -1649,16 +1577,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(O) is not Object, throw a TypeError exception.
     if (!(O instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
     if (!('$TypedArrayName' in O)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "O does not have a [[TypedArrayName]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "O does not have a [[TypedArrayName]] internal slot");
     }
 
     // 4. Assert: O has a [[ViewedArrayBuffer]] internal slot.

--- a/src/intrinsics/ecma262/WeakSet.js
+++ b/src/intrinsics/ecma262/WeakSet.js
@@ -10,11 +10,10 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { NativeFunctionValue, NullValue, StringValue, UndefinedValue } from "../../values/index.js";
-import { ThrowCompletion, AbruptCompletion } from "../../completions.js";
+import { NativeFunctionValue, NullValue, UndefinedValue } from "../../values/index.js";
+import { AbruptCompletion } from "../../completions.js";
 import {
   OrdinaryCreateFromConstructor,
-  Construct,
   Get,
   IsCallable,
   IteratorClose,
@@ -55,9 +54,7 @@ export default function (realm: Realm): NativeFunctionValue {
 
       // b. If IsCallable(adder) is false, throw a TypeError exception.
       if (!IsCallable(realm, adder)) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsCallable(adder) is false")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsCallable(adder) is false");
       }
 
       // c. Let iter be ? GetIterator(iterable).

--- a/src/intrinsics/ecma262/WeakSetPrototype.js
+++ b/src/intrinsics/ecma262/WeakSetPrototype.js
@@ -10,9 +10,8 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ThrowCompletion } from "../../completions.js";
 import { StringValue, ObjectValue } from "../../values/index.js";
-import { Construct, SameValuePartial, ThrowIfInternalSlotNotWritable } from "../../methods/index.js";
+import { SameValuePartial, ThrowIfInternalSlotNotWritable } from "../../methods/index.js";
 import invariant from "../../invariant.js";
 
 export default function (realm: Realm, obj: ObjectValue): void {
@@ -23,24 +22,18 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(S) is not Object, throw a TypeError exception.
     if (!(S instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(S) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(S) is not Object");
     }
 
     // 3. If S does not have a [[WeakSetData]] internal slot, throw a TypeError exception.
     if (!S.$WeakSetData) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "S does not have a [[WeakSetData]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "S does not have a [[WeakSetData]] internal slot");
     }
 
     // 4. If Type(value) is not Object, throw a TypeError exception.
     value = value.throwIfNotConcrete();
     if (!(value instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(value) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(value) is not Object");
     }
 
     // 5. Let entries be the List that is S.[[WeakSetData]].
@@ -71,16 +64,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(S) is not Object, throw a TypeError exception.
     if (!(S instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(S) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(S) is not Object");
     }
 
     // 3. If S does not have a [[WeakSetData]] internal slot, throw a TypeError exception.
     if (!S.$WeakSetData) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "S does not have a [[WeakSetData]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "S does not have a [[WeakSetData]] internal slot");
     }
 
     // 4. If Type(value) is not Object, throw a TypeError exception.
@@ -118,16 +107,12 @@ export default function (realm: Realm, obj: ObjectValue): void {
 
     // 2. If Type(S) is not Object, throw a TypeError exception.
     if (!(S instanceof ObjectValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(S) is not Object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(S) is not Object");
     }
 
     // 3. If S does not have a [[WeakSetData]] internal slot, throw a TypeError exception.
     if (!S.$WeakSetData) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "S does not have a [[WeakSetData]] internal slot")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "S does not have a [[WeakSetData]] internal slot");
     }
 
     // 4. Let entries be the List that is S.[[WeakSetData]].

--- a/src/intrinsics/ecma262/decodeURI.js
+++ b/src/intrinsics/ecma262/decodeURI.js
@@ -12,8 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { ToString } from "../../methods/index.js";
-import { ThrowCompletion } from "../../completions.js";
-import { Construct } from "../../methods/construct.js";
 import { StringValue } from "../../values/index.js";
 
 export default function (realm: Realm): NativeFunctionValue {
@@ -22,8 +20,7 @@ export default function (realm: Realm): NativeFunctionValue {
   return new NativeFunctionValue(realm, name, name, 1,
     (context, [encodedURI], argCount, NewTarget) => {
       if (NewTarget)
-        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
-          `${name} is not a constructor`);
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, `${name} is not a constructor`);
 
       encodedURI = encodedURI.throwIfNotConcrete();
       // 1. Let uriString be ? ToString(encodedURI).
@@ -33,12 +30,7 @@ export default function (realm: Realm): NativeFunctionValue {
       try {
         return new StringValue(realm, decodeURI(uriString));
       } catch (e) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.URIError, [new StringValue(
-            realm,
-            e.message
-          )])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.URIError, e.message);
       }
     }
   );

--- a/src/intrinsics/ecma262/decodeURIComponent.js
+++ b/src/intrinsics/ecma262/decodeURIComponent.js
@@ -12,8 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { ToString } from "../../methods/index.js";
-import { ThrowCompletion } from "../../completions.js";
-import { Construct } from "../../methods/construct.js";
 import { StringValue } from "../../values/index.js";
 
 export default function (realm: Realm): NativeFunctionValue {
@@ -22,8 +20,7 @@ export default function (realm: Realm): NativeFunctionValue {
   return new NativeFunctionValue(realm, name, name, 1,
     (context, [encodedURIComponent], argCount, NewTarget) => {
       if (NewTarget)
-        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
-          `${name} is not a constructor`);
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, `${name} is not a constructor`);
 
       encodedURIComponent = encodedURIComponent.throwIfNotConcrete();
 
@@ -35,12 +32,7 @@ export default function (realm: Realm): NativeFunctionValue {
       try {
         return new StringValue(realm, decodeURIComponent(componentString));
       } catch (e) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.URIError, [new StringValue(
-            realm,
-            e.message
-          )])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.URIError, e.message);
       }
     }
   );

--- a/src/intrinsics/ecma262/encodeURI.js
+++ b/src/intrinsics/ecma262/encodeURI.js
@@ -12,8 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { ToString } from "../../methods/index.js";
-import { ThrowCompletion } from "../../completions.js";
-import { Construct } from "../../methods/construct.js";
 import { StringValue } from "../../values/index.js";
 
 export default function (realm: Realm): NativeFunctionValue {
@@ -22,8 +20,7 @@ export default function (realm: Realm): NativeFunctionValue {
   return new NativeFunctionValue(realm, name, name, 1,
     (context, [uri], argCount, NewTarget) => {
       if (NewTarget)
-        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
-          `${name} is not a constructor`);
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, `${name} is not a constructor`);
 
       uri = uri.throwIfNotConcrete();
       // 1. Let uriString be ? ToString(uri).
@@ -33,12 +30,7 @@ export default function (realm: Realm): NativeFunctionValue {
       try {
         return new StringValue(realm, encodeURI(uriString));
       } catch (e) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.URIError, [new StringValue(
-            realm,
-            e.message
-          )])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.URIError, e.message);
       }
     }
   );

--- a/src/intrinsics/ecma262/encodeURIComponent.js
+++ b/src/intrinsics/ecma262/encodeURIComponent.js
@@ -12,8 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { ToString } from "../../methods/index.js";
-import { ThrowCompletion } from "../../completions.js";
-import { Construct } from "../../methods/construct.js";
 import { StringValue } from "../../values/index.js";
 
 export default function (realm: Realm): NativeFunctionValue {
@@ -35,12 +33,7 @@ export default function (realm: Realm): NativeFunctionValue {
       try {
         return new StringValue(realm, encodeURIComponent(componentString));
       } catch (e) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.URIError, [new StringValue(
-            realm,
-            e.message
-          )])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.URIError, e.message);
       }
     }
   );

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -12,8 +12,7 @@
 import type { Realm } from "../../realm.js";
 import { Value, StringValue, BooleanValue, ObjectValue, FunctionValue, NativeFunctionValue, AbstractValue, AbstractObjectValue, UndefinedValue } from "../../values/index.js";
 import { ToStringPartial } from "../../methods/index.js";
-import { ThrowCompletion } from "../../completions.js";
-import { Construct, ObjectCreate } from "../../methods/index.js";
+import { ObjectCreate } from "../../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import * as t from "babel-types";
@@ -43,17 +42,13 @@ export default function (realm: Realm): void {
       let typeNameString = ToStringPartial(realm, typeNameOrTemplate);
       let type = Value.getTypeFromName(typeNameString);
       if (type === undefined) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "unknown typeNameOrTemplate")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown typeNameOrTemplate");
       }
       return { type, template: Value.isTypeCompatibleWith(type, ObjectValue) ? ObjectCreate(realm, realm.intrinsics.ObjectPrototype) : undefined };
     } else if (typeNameOrTemplate instanceof ObjectValue) {
       return { type: ObjectValue, template: typeNameOrTemplate };
     } else {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "typeNameOrTemplate has unsupoorted type")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "typeNameOrTemplate has unsupported type");
     }
   }
 
@@ -66,9 +61,7 @@ export default function (realm: Realm): void {
   global.$DefineOwnProperty("__abstract", {
     value: new NativeFunctionValue(realm, "global.__abstract", "__abstract", 0, (context, [typeNameOrTemplate, name]) => {
       if (!realm.isPartial) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "realm is not partial")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
       }
 
       let { type, template } = parseTypeNameOrTemplate(typeNameOrTemplate);
@@ -112,17 +105,13 @@ export default function (realm: Realm): void {
   global.$DefineOwnProperty("__residual", {
     value: new NativeFunctionValue(realm, "global.__residual", "__residual", 2, (context, [typeNameOrTemplate, f, ...args]) => {
       if (!realm.isPartial) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "realm is not partial")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
       }
 
       let { type, template } = parseTypeNameOrTemplate(typeNameOrTemplate);
 
       if (f.constructor !== FunctionValue) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "cannot determine residual function")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "cannot determine residual function");
       }
       invariant(f instanceof FunctionValue);
       f.isResidual = true;
@@ -168,9 +157,7 @@ export default function (realm: Realm): void {
         (object: any).makePartial();
         return context.$Realm.intrinsics.undefined;
       }
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not an (abstract) object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an (abstract) object");
     }),
     writable: true,
     enumerable: false,
@@ -185,9 +172,7 @@ export default function (realm: Realm): void {
         (object: any).makeSimple();
         return context.$Realm.intrinsics.undefined;
       }
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not an (abstract) object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an (abstract) object");
     }),
     writable: true,
     enumerable: false,
@@ -198,9 +183,7 @@ export default function (realm: Realm): void {
   global.$DefineOwnProperty("__assumeDataProperty", {
     value: new NativeFunctionValue(realm, "global.__assumeDataProperty", "__assumeDataProperty", 3, (context, [object, propertyName, value]) => {
       if (!realm.isPartial) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "realm is not partial")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
       }
 
       let key = ToStringPartial(realm, propertyName);
@@ -221,9 +204,7 @@ export default function (realm: Realm): void {
         return context.$Realm.intrinsics.undefined;
       }
 
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not an (abstract) object")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an (abstract) object");
     }),
     writable: true,
     enumerable: false,

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -17,7 +17,6 @@ import { Call } from "./call.js";
 import { IsCallable } from "./is.js";
 import { Completion, ReturnCompletion, ThrowCompletion } from "../completions.js";
 import { GetMethod, Get } from "./get.js";
-import { Construct } from "./construct.js";
 import { HasCompatibleType, HasSomeCompatibleType } from "./has.js";
 import { ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
@@ -57,9 +56,7 @@ export function SplitMatch(realm: Realm, S: string, q: number, R: string): false
 // ECMA262 7.2.1
 export function RequireObjectCoercible<T: Value>(realm: Realm, arg: T): T {
   if (HasSomeCompatibleType(realm, arg, NullValue, UndefinedValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "null or undefined")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "null or undefined");
   } else {
     return arg;
   }
@@ -386,9 +383,7 @@ export function Add(realm: Realm, a: number, b: number, subtract?: boolean = fal
 export function InstanceofOperator(realm: Realm, O: Value, C: Value): boolean {
   // 1. If Type(C) is not Object, throw a TypeError exception.
   if (!C.mightBeObject()) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Expecting a function in instanceof check")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Expecting a function in instanceof check");
   }
 
   // 2. Let instOfHandler be ? GetMethod(C, @@hasInstance).
@@ -402,9 +397,7 @@ export function InstanceofOperator(realm: Realm, O: Value, C: Value): boolean {
 
   // 4. If IsCallable(C) is false, throw a TypeError exception.
   if (IsCallable(realm, C) === false) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Expecting a function in instanceof check")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Expecting a function in instanceof check");
   }
 
   // 5. Return ? OrdinaryHasInstance(C, O).
@@ -435,9 +428,7 @@ export function OrdinaryHasInstance(realm: Realm, C: Value, O: Value): boolean {
 
   // 5. If Type(P) is not Object, throw a TypeError exception.
   if (!(P instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(P) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(P) is not Object");
   }
 
   // 6. Repeat

--- a/src/methods/arraybuffer.js
+++ b/src/methods/arraybuffer.js
@@ -11,10 +11,9 @@
 
 import type { Realm } from "../realm.js";
 import type { DataBlock, ElementType } from "../types.js";
-import { ThrowCompletion } from "../completions.js";
-import { Value, ObjectValue, NumberValue, EmptyValue, NullValue, StringValue, UndefinedValue } from "../values/index.js";
+import { Value, ObjectValue, NumberValue, EmptyValue, NullValue, UndefinedValue } from "../values/index.js";
 import { OrdinaryCreateFromConstructor } from "../methods/create.js";
-import { Construct, SpeciesConstructor } from "../methods/construct.js";
+import { SpeciesConstructor } from "../methods/construct.js";
 import { IsConstructor } from "../methods/index.js";
 import { ToIndexPartial, ToBooleanPartial, ToNumber, ElementConv } from "./to.js";
 import { IsDetachedBuffer } from "../methods/is.js";
@@ -33,9 +32,7 @@ export function CreateByteDataBlock(realm: Realm, size: number): DataBlock {
     db = new Uint8Array(size);
   } catch (e) {
     if (e instanceof RangeError) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "Invalid typed array length")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "Invalid typed array length");
     } else {
       throw e;
     }
@@ -131,16 +128,12 @@ export function GetViewValue(realm: Realm, view: Value, requestIndex: Value, isL
 
   // 1. If Type(view) is not Object, throw a TypeError exception.
   if (!(view instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(view) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(view) is not Object");
   }
 
   // 2. If view does not have a [[DataView]] internal slot, throw a TypeError exception.
   if (!('$DataView' in view)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "view does not have a [[DataView]] internal slot")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "view does not have a [[DataView]] internal slot");
   }
 
   // 3. Assert: view has a [[ViewedArrayBuffer]] internal slot.
@@ -157,9 +150,7 @@ export function GetViewValue(realm: Realm, view: Value, requestIndex: Value, isL
 
   // 7. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   if (IsDetachedBuffer(realm, buffer) === true) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
   }
 
   // 8. Let viewOffset be view.[[ByteOffset]].
@@ -173,9 +164,7 @@ export function GetViewValue(realm: Realm, view: Value, requestIndex: Value, isL
 
   // 11. If getIndex + elementSize > viewSize, throw a RangeError exception.
   if (getIndex + elementSize > viewSize) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "getIndex + elementSize > viewSize")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "getIndex + elementSize > viewSize");
   }
 
   // 12. Let bufferIndex be getIndex + viewOffset.
@@ -258,16 +247,12 @@ export function SetViewValue(realm: Realm, view: Value, requestIndex: Value, isL
 
   // 1. If Type(view) is not Object, throw a TypeError exception.
   if (!(view instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(view) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(view) is not Object");
   }
 
   // 2. If view does not have a [[DataView]] internal slot, throw a TypeError exception.
   if (!('$DataView' in view)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "view does not have a [[DataView]] internal slot")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "view does not have a [[DataView]] internal slot");
   }
 
   // 3. Assert: view has a [[ViewedArrayBuffer]] internal slot.
@@ -287,9 +272,7 @@ export function SetViewValue(realm: Realm, view: Value, requestIndex: Value, isL
 
   // 8. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   if (IsDetachedBuffer(realm, buffer) === true) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
   }
 
   // 9. Let viewOffset be view.[[ByteOffset]].
@@ -303,9 +286,7 @@ export function SetViewValue(realm: Realm, view: Value, requestIndex: Value, isL
 
   // 12. If getIndex + elementSize > viewSize, throw a RangeError exception.
   if (getIndex + elementSize > viewSize) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "getIndex + elementSize > viewSize")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "getIndex + elementSize > viewSize");
   }
 
   // 13. Let bufferIndex be getIndex + viewOffset.
@@ -327,9 +308,7 @@ export function CloneArrayBuffer(realm: Realm, srcBuffer: ObjectValue, srcByteOf
 
     // b. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
     if (IsDetachedBuffer(realm, srcBuffer) === true) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(srcBuffer) is true")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(srcBuffer) is true");
     }
   }
 
@@ -353,9 +332,7 @@ export function CloneArrayBuffer(realm: Realm, srcBuffer: ObjectValue, srcByteOf
 
   // 9. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
   if (IsDetachedBuffer(realm, srcBuffer) === true) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(srcBuffer) is true")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(srcBuffer) is true");
   }
 
   // 10. Let targetBlock be targetBuffer.[[ArrayBufferData]].

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -13,12 +13,11 @@ import type { PropertyKeyValue } from "../types.js";
 import { LexicalEnvironment, Reference, EnvironmentRecord, GlobalEnvironmentRecord } from "../environment.js";
 import { Realm, ExecutionContext } from "../realm.js";
 import Value from "../values/Value.js";
-import { FunctionValue, StringValue, ObjectValue, NullValue, UndefinedValue, NativeFunctionValue, AbstractObjectValue, AbstractValue } from "../values/index.js";
+import { FunctionValue, ObjectValue, NullValue, UndefinedValue, NativeFunctionValue, AbstractObjectValue, AbstractValue } from "../values/index.js";
 import {
   GetBase,
   GetValue,
   ToObjectPartial,
-  Construct,
   IsCallable,
   IsPropertyReference,
   IsPropertyKey,
@@ -32,7 +31,7 @@ import {
 } from "./index.js";
 import { GeneratorStart } from "../methods/generator.js";
 import { OrdinaryCreateFromConstructor } from "../methods/create.js";
-import { ThrowCompletion, ReturnCompletion, AbruptCompletion, ComposedAbruptCompletion, JoinedAbruptCompletions, PossiblyNormalCompletion } from "../completions.js";
+import { ReturnCompletion, AbruptCompletion, ComposedAbruptCompletion, JoinedAbruptCompletions, PossiblyNormalCompletion } from "../completions.js";
 import { GetTemplateObject, GetV, GetThisValue } from "../methods/get.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
@@ -352,16 +351,12 @@ export function EvaluateDirectCall(realm: Realm, strictCode: boolean, env: Lexic
 
   // 2. If Type(func) is not Object, throw a TypeError exception.
   if (!(func instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not an object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an object");
   }
 
   // 3. If IsCallable(func) is false, throw a TypeError exception.
   if (!IsCallable(realm, func)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not callable")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
   }
 
   // 4. If tailPosition is true, perform PrepareForTailCall().
@@ -402,9 +397,7 @@ export function Call(realm: Realm, F: Value, V: Value, argsList?: Array<Value>):
 
   // 2. If IsCallable(F) is false, throw a TypeError exception.
   if (IsCallable(realm, F) === false) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not callable")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
   }
   invariant(F instanceof ObjectValue);
 

--- a/src/methods/construct.js
+++ b/src/methods/construct.js
@@ -10,8 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import { ThrowCompletion } from "../completions.js";
-import { FunctionValue, ObjectValue, UndefinedValue, NullValue, StringValue, Value, AbstractObjectValue } from "../values/index.js";
+import { FunctionValue, ObjectValue, UndefinedValue, NullValue, Value, AbstractObjectValue } from "../values/index.js";
 import { IsConstructor } from "./is.js";
 import { ObjectCreate } from "./create.js";
 import { DefinePropertyOrThrow } from "./properties.js";
@@ -95,9 +94,7 @@ export function SpeciesConstructor(realm: Realm, O: ObjectValue, defaultConstruc
   // 4. If Type(C) is not Object, throw a TypeError exception.
   if (!(C instanceof ObjectValue || C instanceof AbstractObjectValue)) {
     C.throwIfNotConcrete();
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(C) is not an object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(C) is not an object");
   }
 
   // 5. Let S be ? Get(C, @@species).
@@ -113,7 +110,5 @@ export function SpeciesConstructor(realm: Realm, O: ObjectValue, defaultConstruc
   }
 
   // 8. Throw a TypeError exception.
-  throw new ThrowCompletion(
-    Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Throw a TypeError exception")])
-  );
+  throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Throw a TypeError exception");
 }

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -29,7 +29,6 @@ import {
 } from "../values/index.js";
 import { GetPrototypeFromConstructor } from "./get.js";
 import { DefinePropertyOrThrow, OrdinaryDefineOwnProperty } from "./properties.js";
-import { ThrowCompletion } from "../completions.js";
 import { IsConstructor, IsPropertyKey, IsArray } from "./is.js";
 import { Type, SameValue, RequireObjectCoercible } from "./abstract.js";
 import { ToStringPartial, ToLength } from "./to.js";
@@ -213,9 +212,7 @@ export function ArraySpeciesCreate(realm: Realm, originalArray: ObjectValue, len
   // 7. If IsConstructor(C) is false, throw a TypeError exception.
   if (!IsConstructor(realm, C)) {
     C.throwIfNotConcrete();
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a constructor")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a constructor");
   }
   invariant(C instanceof ObjectValue);
 
@@ -277,9 +274,7 @@ export function ArrayCreate(realm: Realm, length: number, proto?: ObjectValue): 
 
   // 3. If length>232-1, throw a RangeError exception.
   if (length > Math.pow(2, 32) - 1) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "length>2^32-1")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "length>2^32-1");
   }
 
   // 4. If the proto argument was not passed, let proto be the intrinsic object %ArrayPrototype%.
@@ -559,9 +554,7 @@ export function CreateDataPropertyOrThrow(realm: Realm, O: Value, P: PropertyKey
 
   // 4. If success is false, throw a TypeError exception.
   if (success === false) {
-    throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not a function")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
   }
 
   // 5. Return success.
@@ -610,9 +603,7 @@ export function CreateListFromArrayLike(realm: Realm, obj: Value, elementTypes?:
 
   // 2. If Type(obj) is not Object, throw a TypeError exception.
   if (!(obj instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Not an object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Not an object");
   }
 
   // 3. Let len be ? ToLength(? Get(obj, "length")).
@@ -634,9 +625,7 @@ export function CreateListFromArrayLike(realm: Realm, obj: Value, elementTypes?:
 
     // c. If Type(next) is not an element of elementTypes, throw a TypeError exception.
     if (elementTypes.indexOf(Type(realm, next)) < 0) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "invalid element type")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "invalid element type");
     }
 
     // d. Append next as the last element of list.
@@ -723,15 +712,11 @@ export function CreateDynamicFunction(realm: Realm, constructor: ObjectValue, ne
   try {
     ast = parse(realm, "function" + (kind === "generator" ? "*" : "") + " _(" + P + "){" + bodyText + "}", "eval");
   } catch (e) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "parse failed")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "parse failed");
   }
   let { program: { body: [functionDeclaration] } } = ast;
   if (!functionDeclaration) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "parse failed")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "parse failed");
   }
   invariant(functionDeclaration.type === "FunctionDeclaration");
   let { params, body } = ((functionDeclaration: any): BabelNodeFunctionDeclaration);
@@ -771,9 +756,7 @@ export function CreateDynamicFunction(realm: Realm, constructor: ObjectValue, ne
       });
     }
     if (containsYield) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "parse failed")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "parse failed");
     }
   }
 

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import { ThrowCompletion } from "../completions.js";
 import * as t from "babel-types";
 import invariant from "../invariant.js";
 import {
@@ -36,7 +35,6 @@ import {
   LexicalEnvironment
 } from "../environment.js";
 import {
-  Construct,
   GetV,
   GetThisValue,
   ToObjectPartial,
@@ -85,9 +83,7 @@ export function GetValue(realm: Realm, V: Reference | Value): Value {
 
   // 4. If IsUnresolvableReference(V) is true, throw a ReferenceError exception.
   if (IsUnresolvableReference(realm, V)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.ReferenceError, [new StringValue(realm, `${V.referencedName.toString()} is not defined`)])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, `${V.referencedName.toString()} is not defined`);
   }
 
   // 5. If IsPropertyReference(V) is true, then
@@ -275,10 +271,8 @@ export function BlockDeclarationInstantiation(realm: Realm, strictCode: boolean,
     for (let dn of BoundNames(realm, d)) {
       if (envRec.HasBinding(dn)) {
         //ECMA262 13.2.1
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.SyntaxError,
-             [new StringValue(realm, dn + " already declared")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError,
+          dn + " already declared");
       }
       // i. If IsConstantDeclaration of d is true, then
       if (d.type === "VariableDeclaration" && d.kind === "const") {

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1154,10 +1154,8 @@ export function EvalDeclarationInstantiation(realm: Realm, body: BabelNodeBlockS
           // a. If thisEnvRec.HasBinding(name) is true, then
           if (thisEnvRec.HasBinding(name)) {
             // i. Throw a SyntaxError exception.
-            throw new ThrowCompletion(
-              Construct(realm, realm.intrinsics.SyntaxError,
-                 [new StringValue(realm, name + " global object is restricted")])
-            );
+            throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError,
+              name + " global object is restricted");
             // ii. NOTE: Annex B.3.5 defines alternate semantics for the above step.
           }
           // b. NOTE: A direct eval will not hoist var declaration over a like-named lexical declaration.
@@ -1192,10 +1190,8 @@ export function EvalDeclarationInstantiation(realm: Realm, body: BabelNodeBlockS
           let fnDefinable = varEnvRec.CanDeclareGlobalFunction(fn);
           // b. If fnDefinable is false, throw a TypeError exception.
           if (!fnDefinable) {
-            throw new ThrowCompletion(
-              Construct(realm, realm.intrinsics.TypeError,
-                 [new StringValue(realm, fn + " is not definable")])
-            );
+            throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+              fn + " is not definable");
           }
         }
         // 2. Append fn to declaredFunctionNames.
@@ -1225,10 +1221,8 @@ export function EvalDeclarationInstantiation(realm: Realm, body: BabelNodeBlockS
             let vnDefinable = varEnvRec.CanDeclareGlobalVar(vn);
             // ii. If vnDefinable is false, throw a TypeError exception.
             if (!vnDefinable) {
-              throw new ThrowCompletion(
-                Construct(realm, realm.intrinsics.TypeError,
-                   [new StringValue(realm, vn + " is not definable")])
-              );
+              throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError,
+                vn + " is not definable");
             }
           }
           // b. If vn is not an element of declaredVarNames, then

--- a/src/methods/generator.js
+++ b/src/methods/generator.js
@@ -10,10 +10,9 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import { ThrowCompletion, AbruptCompletion } from "../completions.js";
-import { Value, ObjectValue, StringValue, UndefinedValue } from "../values/index.js";
+import { AbruptCompletion } from "../completions.js";
+import { Value, ObjectValue, UndefinedValue } from "../values/index.js";
 import { CreateIterResultObject } from "../methods/create.js";
-import { Construct } from "../methods/construct.js";
 import { ThrowIfInternalSlotNotWritable } from "../methods/properties.js";
 import invariant from "../invariant.js";
 import type { BabelNodeBlockStatement } from "babel-types";
@@ -58,16 +57,12 @@ export function GeneratorStart(realm: Realm, generator: ObjectValue, generatorBo
 export function GeneratorValidate(realm: Realm, generator: Value) {
   // 1. If Type(generator) is not Object, throw a TypeError exception.
   if (!(generator instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "Type(generator) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "Type(generator) is not Object");
   }
 
   // 2. If generator does not have a [[GeneratorState]] internal slot, throw a TypeError exception.
   if (!('$GeneratorState' in generator)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "Type(generator) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "Type(generator) is not Object");
   }
 
   // 3. Assert: generator also has a [[GeneratorContext]] internal slot.
@@ -78,9 +73,7 @@ export function GeneratorValidate(realm: Realm, generator: Value) {
 
   // 5. If state is "executing", throw a TypeError exception.
   if (state === "executing") {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "Type(generator) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "Type(generator) is not Object");
   }
 
   // 6. Return state.

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -13,13 +13,11 @@ import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, CallableObjectValue } from "../types.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { Value, AbstractValue, BooleanValue, BoundFunctionValue, NumberValue, ProxyValue, UndefinedValue, StringValue, ObjectValue, NullValue, AbstractObjectValue } from "../values/index.js";
-import { ThrowCompletion } from "../completions.js";
 import { Reference } from "../environment.js";
 import { ArrayCreate } from "./create.js";
 import { SetIntegrityLevel } from "./integrity.js";
 import { ToString } from "./to.js";
 import {
-  Construct,
   ToObjectPartial,
   IsPropertyKey,
   IsCallable,
@@ -61,9 +59,7 @@ export function GetFunctionRealm(realm: Realm, obj: ObjectValue): Realm {
   if (obj instanceof ProxyValue) {
     // a. If the value of the [[ProxyHandler]] internal slot of obj is null, throw a TypeError exception.
     if (obj.$ProxyHandler instanceof NullValue) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "proxy handler is null")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "proxy handler is null");
     }
     invariant(obj.$ProxyTarget instanceof ObjectValue);
 
@@ -247,9 +243,7 @@ export function GetMethod(realm: Realm, V: Value, P: PropertyKeyValue): Undefine
 
   // 4. If IsCallable(func) is false, throw a TypeError exception.
   if (!IsCallable(realm, func)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "not callable")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
   }
 
   // 5. Return func.
@@ -333,9 +327,7 @@ export function GetNewTarget(realm: Realm): UndefinedValue | ObjectValue {
   if (!('$NewTarget' in envRec)) {
     // In the spec we should not get here because earlier static checks are supposed to prevent it.
     // However, we do not have an appropriate place to do this check earlier.
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "new.target not allowed here")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "new.target not allowed here");
   }
 
   // 3. Return envRec.[[NewTarget]].

--- a/src/methods/promise.js
+++ b/src/methods/promise.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { ResolvingFunctions, PromiseCapability, PromiseReaction } from "../types.js";
-import { AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { AbruptCompletion } from "../completions.js";
 import { Value, ObjectValue, StringValue, NativeFunctionValue, FunctionValue } from "../values/index.js";
 import { SameValue } from "../methods/abstract.js";
 import { Construct } from "../methods/construct.js";
@@ -32,9 +32,7 @@ export function EnqueueJob(realm: Realm, queueName: string, job: Function, args:
 export function NewPromiseCapability(realm: Realm, C: Value): PromiseCapability {
   // 1. If IsConstructor(C) is false, throw a TypeError exception.
   if (IsConstructor(realm, C) === false) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsConstructor(C) is false")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsConstructor(C) is false");
   }
   invariant(C instanceof ObjectValue);
 
@@ -57,17 +55,13 @@ export function NewPromiseCapability(realm: Realm, C: Value): PromiseCapability 
 
     // 3. If promiseCapability.[[Resolve]] is not undefined, throw a TypeError exception.
     if (!promiseCapability.resolve.mightBeUndefined()) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "promiseCapability.[[Resolve]] is not undefined")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "promiseCapability.[[Resolve]] is not undefined");
     }
     promiseCapability.resolve.throwIfNotConcrete();
 
     // 4. If promiseCapability.[[Reject]] is not undefined, throw a TypeError exception.
     if (!promiseCapability.reject.mightBeUndefined()) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "promiseCapability.[[Reject]] is not undefined")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "promiseCapability.[[Reject]] is not undefined");
     }
     promiseCapability.reject.throwIfNotConcrete();
 
@@ -89,16 +83,12 @@ export function NewPromiseCapability(realm: Realm, C: Value): PromiseCapability 
 
   // 7. If IsCallable(promiseCapability.[[Resolve]]) is false, throw a TypeError exception.
   if (IsCallable(realm, promiseCapability.resolve) === false) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsCallable(promiseCapability.[[Resolve]]) is false")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsCallable(promiseCapability.[[Resolve]]) is false");
   }
 
   // 8. If IsCallable(promiseCapability.[[Reject]]) is false, throw a TypeError exception.
   if (IsCallable(realm, promiseCapability.reject) === false) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsCallable(promiseCapability.[[Reject]]) is false")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsCallable(promiseCapability.[[Reject]]) is false");
   }
 
   // 9. Set promiseCapability.[[Promise]] to promise.

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -12,7 +12,6 @@
 import type { Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding, PropertyKeyValue } from "../types.js";
 import { ArrayValue, UndefinedValue, NumberValue, SymbolValue, NullValue, BooleanValue, ObjectValue, StringValue, Value, ConcreteValue, AbstractValue, AbstractObjectValue } from "../values/index.js";
-import { ThrowCompletion } from "../completions.js";
 import { EnvironmentRecord, Reference } from "../environment.js";
 import { CreateIterResultObject } from "../methods/create.js";
 import invariant from "../invariant.js";
@@ -31,7 +30,6 @@ import {
   GetReferencedNamePartial,
   GetThisValue,
   HasPrimitiveBase,
-  Construct,
   Call,
   ToObject,
   ToObjectPartial,
@@ -375,9 +373,7 @@ export function DeletePropertyOrThrow(realm: Realm, O: ObjectValue, P: PropertyK
 
   // 4. If success is false, throw a TypeError exception.
   if (!success) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "couldn't delete property")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "couldn't delete property");
   }
 
   // 5. Return success.
@@ -735,9 +731,7 @@ export function PutValue(realm: Realm, V: Value | Reference, W: Value) {
 
   // 3. If Type(V) is not Reference, throw a ReferenceError exception.
   if (!(V instanceof Reference)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.ReferenceError, [new StringValue(realm, "can't put a value to a non-reference")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, "can't put a value to a non-reference");
   }
 
   // 4. Let base be GetBase(V).
@@ -813,9 +807,7 @@ export function ArraySetLength(realm: Realm, A: ArrayValue, Desc: Descriptor): b
 
   // 5. If newLen ≠ numberLen, throw a RangeError exception.
   if (newLen !== numberLen) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "should be a uint")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "should be a uint");
   }
 
   // 6. Set newLenDesc.[[Value]] to newLen.

--- a/src/methods/regexp.js
+++ b/src/methods/regexp.js
@@ -11,9 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import invariant from "../invariant.js";
-import { ThrowCompletion } from "../completions.js";
 import { NullValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "../values/index.js";
-import { Construct } from "./construct.js";
 import { ArrayCreate, OrdinaryCreateFromConstructor, CreateDataProperty } from "./create.js";
 import { DefinePropertyOrThrow, Set } from "./properties.js";
 import { ToString, ToStringPartial, ToLength } from "./to.js";
@@ -77,15 +75,11 @@ export function RegExpInitialize(realm: Realm, obj: ObjectValue, pattern: ?Value
   // 5. If F contains any code unit other than "g", "i", "m", "u", or "y" or if it contains the same code unit more than once, throw a SyntaxError exception.
   for (let i = 0; i < F.length; ++i) {
     if ("gimuy".indexOf(F.charAt(i)) < 0) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "invalid RegExp flag")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "invalid RegExp flag");
     }
     for (let j = i + 1; j < F.length; ++j) {
       if (F.charAt(i) === F.charAt(j)) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "duplicate RegExp flag")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "duplicate RegExp flag");
       }
     }
   }
@@ -139,9 +133,7 @@ export function RegExpInitialize(realm: Realm, obj: ObjectValue, pattern: ?Value
     };
   } catch (e) {
     if (e instanceof SyntaxError) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, "invalid RegExp")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "invalid RegExp");
     } else
       throw e;
   }
@@ -171,9 +163,7 @@ export function RegExpExec(realm: Realm, R: ObjectValue, S: string): ObjectValue
 
     // b. If Type(result) is neither Object or Null, throw a TypeError exception.
     if (!HasSomeCompatibleType(realm, result, ObjectValue, NullValue)) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(result) is neither Object or Null")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(result) is neither Object or Null");
     }
 
     // c. Return result.
@@ -182,9 +172,7 @@ export function RegExpExec(realm: Realm, R: ObjectValue, S: string): ObjectValue
 
   // 5. If R does not have a [[RegExpMatcher]] internal slot, throw a TypeError exception.
   if (R.$RegExpMatcher === undefined) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "R does not have a [[RegExpMatcher]] internal slot")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "R does not have a [[RegExpMatcher]] internal slot");
   }
 
   // 6. Return ? RegExpBuiltinExec(R, S).

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -14,11 +14,9 @@ import type { Realm } from "../realm.js";
 import { GetMethod, Get } from "./get.js";
 import { StringCreate } from "./create.js";
 import { HasProperty } from "./has.js";
-import { Construct } from "./construct.js";
 import { Call } from "./call.js";
 import { IsCallable } from "./is.js";
 import { SameValue, SameValueZero } from "./abstract.js";
-import { ThrowCompletion } from "../completions.js";
 import { Value, ConcreteValue, PrimitiveValue, UndefinedValue, BooleanValue, ObjectValue, SymbolValue, StringValue, NumberValue, NullValue, AbstractValue, AbstractObjectValue } from "../values/index.js";
 import invariant from "../invariant.js";
 
@@ -420,9 +418,7 @@ export function ToIndex(realm: Realm, value: number | ConcreteValue): number {
 
     // b. If integerIndex < 0, throw a RangeError exception.
     if (integerIndex < 0) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "integerIndex < 0")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "integerIndex < 0");
     }
 
     // c. Let index be ! ToLength(integerIndex).
@@ -430,9 +426,7 @@ export function ToIndex(realm: Realm, value: number | ConcreteValue): number {
 
     // d. If SameValueZero(integerIndex, index) is false, throw a RangeError exception.
     if (SameValueZero(realm, new NumberValue(realm, integerIndex), new NumberValue(realm, index)) === false) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.RangeError, [new StringValue(realm, "integerIndex < 0")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "integerIndex < 0");
     }
   }
   // 3. Return index.
@@ -467,9 +461,7 @@ export function ToNumber(realm: Realm, val: numberOrValue): number {
   } else if (val instanceof StringValue) {
     return Number(val.value);
   } else {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "unknown value type, can't coerce to a number")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to a number");
   }
 }
 
@@ -570,9 +562,7 @@ export function OrdinaryToPrimitive(realm: Realm, input: ObjectValue, hint: "str
   }
 
   // 6. Throw a TypeError exception.
-  throw new ThrowCompletion(
-    Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "can't turn to primitive")])
-  );
+  throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "can't turn to primitive");
 }
 
 // ECMA262 7.1.12
@@ -595,9 +585,7 @@ export function ToString(realm: Realm, val: string | ConcreteValue): string {
     let primValue = ToPrimitive(realm, val, "string");
     return ToString(realm, primValue);
   } else {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "unknown value type, can't coerce to string")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to string");
   }
 }
 
@@ -623,9 +611,7 @@ export function ToBoolean(realm: Realm, val: ConcreteValue): boolean {
     return true;
   } else {
     invariant(!(val instanceof AbstractValue));
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "unknown value type, can't coerce to a boolean")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to a boolean");
   }
 }
 

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -11,8 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { TypedArrayKind } from "../types.js";
-import { ThrowCompletion } from "../completions.js";
-import { AbstractValue, IntegerIndexedExotic, ObjectValue, Value, StringValue, NumberValue, UndefinedValue } from "../values/index.js";
+import { AbstractValue, IntegerIndexedExotic, ObjectValue, Value, NumberValue, UndefinedValue } from "../values/index.js";
 import { GetPrototypeFromConstructor } from "../methods/get.js";
 import { AllocateArrayBuffer } from "../methods/arraybuffer.js";
 import { IsDetachedBuffer, IsInteger } from "../methods/is.js";
@@ -84,9 +83,7 @@ export function IntegerIndexedElementGet(realm: Realm, O: ObjectValue, index: nu
 
   // 4. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   if (IsDetachedBuffer(realm, buffer) === true) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
   }
 
   // 5. If IsInteger(index) is false, return undefined.
@@ -136,9 +133,7 @@ export function IntegerIndexedElementSet(realm: Realm, O: ObjectValue, index: nu
 
   // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   if (IsDetachedBuffer(realm, buffer) === true) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
   }
 
   // 6. If IsInteger(index) is false, return false.
@@ -181,16 +176,12 @@ export function ValidateTypedArray(realm: Realm, O: Value) {
 
   // 1. If Type(O) is not Object, throw a TypeError exception.
   if (!(O instanceof ObjectValue)) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
   }
 
   // 2. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
   if (!O.$TypedArrayName) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "Type(O) is not Object")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
   }
 
   // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -201,9 +192,7 @@ export function ValidateTypedArray(realm: Realm, O: Value) {
 
   // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
   if (IsDetachedBuffer(realm, buffer) === true) {
-    throw new ThrowCompletion(
-      Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "IsDetachedBuffer(buffer) is true")])
-    );
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
   }
 
   // 6. Return buffer.
@@ -308,9 +297,7 @@ export function TypedArrayCreate(realm: Realm, constructor: ObjectValue, argumen
     // a. If newTypedArray.[[ArrayLength]] < argumentList[0], throw a TypeError exception.
     invariant(typeof newTypedArray.$ArrayLength === "number");
     if (newTypedArray.$ArrayLength < ((argumentList[0].throwIfNotConcrete(): any): NumberValue).value) {
-      throw new ThrowCompletion(
-        Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "newTypedArray.[[ArrayLength]] < argumentList[0]")])
-      );
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "newTypedArray.[[ArrayLength]] < argumentList[0]");
     }
   }
 

--- a/src/values/IntegerIndexedExotic.js
+++ b/src/values/IntegerIndexedExotic.js
@@ -11,7 +11,6 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
-import { ThrowCompletion } from "../completions.js";
 import { ObjectValue, NumberValue, StringValue, Value, UndefinedValue } from "../values/index.js";
 import { OrdinaryGetOwnProperty, OrdinaryDefineOwnProperty, OrdinarySet } from "../methods/properties.js";
 import { CanonicalNumericIndexString, ToString } from "../methods/to.js";
@@ -19,7 +18,6 @@ import { IsInteger, IsArrayIndex, IsAccessorDescriptor, IsDetachedBuffer, IsProp
 import { OrdinaryGet } from "../methods/get.js";
 import { OrdinaryHasProperty } from "../methods/has.js";
 import { IntegerIndexedElementSet, IntegerIndexedElementGet } from "../methods/typedarray.js";
-import { Construct } from "../methods/construct.js";
 import invariant from "../invariant";
 
 export default class IntegerIndexedExotic extends ObjectValue {
@@ -85,9 +83,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
 
         // ii. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
         if (IsDetachedBuffer(this.$Realm, buffer) === true) {
-          throw new ThrowCompletion(
-            Construct(this.$Realm, this.$Realm.intrinsics.TypeError, [new StringValue(this.$Realm, "IsDetachedBuffer(buffer) is true")])
-          );
+          throw this.$Realm.createErrorThrowCompletion(this.$Realm.intrinsics.TypeError, "IsDetachedBuffer(buffer) is true");
         }
 
         // iii. If IsInteger(numericIndex) is false, return false.

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -12,13 +12,11 @@
 import { Realm } from "../realm.js";
 import { Value, SymbolValue, NullValue, ObjectValue, UndefinedValue, StringValue } from "./index.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
-import { ThrowCompletion } from "../completions.js";
 import invariant from "../invariant.js";
 import {
   ToBooleanPartial,
   ToPropertyDescriptor
 } from "../methods/to.js";
-import { Construct } from "../methods/construct.js";
 import { SameValue, SameValuePartial, SamePropertyKey } from "../methods/abstract.js";
 import { GetMethod } from "../methods/get.js";
 import {
@@ -768,9 +766,7 @@ export default class ProxyValue extends ObjectValue {
       // a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
       let index = FindPropertyKey(realm, uncheckedResultKeys, key);
       if (index < 0) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "key is not an element of uncheckedResultKeys")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "key is not an element of uncheckedResultKeys");
       }
 
       // b. Remove key from uncheckedResultKeys.
@@ -785,9 +781,7 @@ export default class ProxyValue extends ObjectValue {
       // a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
       let index = FindPropertyKey(realm, uncheckedResultKeys, key);
       if (index < 0) {
-        throw new ThrowCompletion(
-          Construct(realm, realm.intrinsics.TypeError, [new StringValue(realm, "key is not an element of uncheckedResultKeys")])
-        );
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "key is not an element of uncheckedResultKeys");
       }
 
       // b. Remove key from uncheckedResultKeys.


### PR DESCRIPTION
Use `throw realm.createErrorThrowCompletion(...)` in lieu of `throw new ThrowCompletion(Construct(realm, ...))`

Passes lint and flow checks, and didn't seem to break anymore test262 tests than were already failing....

Resolves #370 