### PR TITLE
Revert 582 regexp

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -14,7 +14,7 @@ import { Realm, ExecutionContext } from "../realm.js";
 import type { Descriptor, PropertyBinding } from "../types.js";
 import { IsUnresolvableReference, ResolveBinding, ToLength, IsArray, Get } from "../methods/index.js";
 import { Completion } from "../completions.js";
-import { BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, FunctionValue, NumberValue, Value, ObjectValue, PrimitiveValue, NativeFunctionValue, UndefinedValue } from "../values/index.js";
+import { BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, FunctionValue, Value, ObjectValue, PrimitiveValue, NativeFunctionValue, UndefinedValue } from "../values/index.js";
 import { describeLocation } from "../intrinsics/ecma262/Error.js";
 import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeStatement, BabelNodeIdentifier, BabelNodeBlockStatement, BabelNodeObjectExpression, BabelNodeStringLiteral, BabelNodeLVal, BabelNodeSpreadElement, BabelVariableKind, BabelNodeFunctionDeclaration } from "babel-types";
@@ -224,19 +224,6 @@ export class Serializer {
             desc.value instanceof ObjectValue && desc.value.originalConstructor === val) {
           return true;
         }
-      }
-    } else {
-      let kind = val.getKind();
-      switch (kind) {
-        case "RegExp":
-          if (key === "lastIndex" && desc.writable && !desc.enumerable && !desc.configurable) {
-            // length property has the correct descriptor values
-            let v = desc.value;
-            return v instanceof NumberValue && v.value === 0;
-          }
-          break;
-        default:
-          break;
       }
     }
 
@@ -1025,9 +1012,8 @@ export class Serializer {
   }
 
   _canEmbedProperty(obj: ObjectValue, key: string, prop: Descriptor): boolean {
-    if ((obj instanceof FunctionValue && key === "prototype") ||
-        (obj.getKind() === "RegExp" && key === "lastIndex"))
-    return !!prop.writable && !prop.configurable && !prop.enumerable && !prop.set && !prop.get;
+    if (obj instanceof FunctionValue && key === "prototype")
+      return !!prop.writable && !prop.configurable && !prop.enumerable && !prop.set && !prop.get;
     else
       return !!prop.writable && !!prop.configurable && !!prop.enumerable && !prop.set && !prop.get;
   }
@@ -1058,7 +1044,7 @@ export class Serializer {
         invariant(typeof source === "string");
         invariant(typeof flags === "string");
         this.addProperties(name, val, reasons);
-        return t.regExpLiteral(source, flags);
+        return t.callExpression(this.preludeGenerator.memoizeReference("RegExp"), [t.stringLiteral(source), t.stringLiteral(flags)]);
       case "Number":
         let numberData = val.$NumberData;
         invariant(numberData !== undefined);

--- a/test/serializer/basic/RegExp.js
+++ b/test/serializer/basic/RegExp.js
@@ -1,8 +1,3 @@
 regexp = /Facebook/i;
-regexp2 = /books/;
 
-regexp2.lastIndex = 8;
-i = "but books are books".match(regexp2);
-j = regexp2.lastIndex;
-
-inspect = function() { return "" + i + j + "Facebook is cool".match(regexp).index; }
+inspect = function() { return "Facebook is cool".match(regexp).index; }


### PR DESCRIPTION
This change does not properly take into account `/` inside of strings passed to the RegExp constructor.

Test creating a regexp on `/\/+/g` and `"a/b"`.