### PR TITLE
Encode IteratorPrototypes as Intrinsic Names

### DIFF
--- a/src/intrinsics/index.js
+++ b/src/intrinsics/index.js
@@ -239,11 +239,11 @@ export function initialize(i: Intrinsics, realm: Realm): Intrinsics {
   i.Uint32ArrayPrototype = new ObjectValue(realm, i.ObjectPrototype, "Uint32Array.prototype");
 
   // iterator prototypes
-  i.IteratorPrototype = new ObjectValue(realm, i.ObjectPrototype, "IteratorPrototype");
-  i.MapIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "MapIteratorPrototype");
-  i.SetIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "SetIteratorPrototype");
-  i.ArrayIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "ArrayIteratorPrototype");
-  i.StringIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "StringIteratorPrototype");
+  i.IteratorPrototype = new ObjectValue(realm, i.ObjectPrototype, "([][Symbol.iterator]().__proto__.__proto__)");
+  i.MapIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "(new Map()[Symbol.iterator]().__proto__)");
+  i.SetIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "(new Set()[Symbol.iterator]().__proto__)");
+  i.ArrayIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "([][Symbol.iterator]().__proto__)");
+  i.StringIteratorPrototype = new ObjectValue(realm, i.IteratorPrototype, "(\"\"[Symbol.iterator]().__proto__)");
 
   //
   initializeObjectPrototype(realm, i.ObjectPrototype);

--- a/test/serializer/basic/IteratorPrototype.js
+++ b/test/serializer/basic/IteratorPrototype.js
@@ -1,0 +1,5 @@
+let IteratorPrototype = [][Symbol.iterator]().__proto__.__proto__;
+
+inspect = function() {
+  return IteratorPrototype;
+};

--- a/test/serializer/basic/MapIteratorPrototype.js
+++ b/test/serializer/basic/MapIteratorPrototype.js
@@ -1,0 +1,5 @@
+let MapIteratorPrototype = new Map()[Symbol.iterator]().__proto__;
+
+inspect = function() {
+  return MapIteratorPrototype;
+};


### PR DESCRIPTION
Kind of abusing the intrinsic string name here but that's ok for now.

Fixes #608