### PR TITLE
Fix REPL Error highlighting

### DIFF
--- a/js/repl.js
+++ b/js/repl.js
@@ -101,7 +101,7 @@ var input = createEditor(document.querySelector('.input .repl'));
 input.setValue([
   '(function() {',
   '  function fib(x) {',
-  '    return x <= 1 ? x : fibx - 1) + fib(x - 2);',
+  '    return x <= 1 ? x : fib(x - 1) + fib(x - 2);',
   '  }',
   '',
   '  let x = Date.now();',

--- a/js/repl.js
+++ b/js/repl.js
@@ -59,6 +59,11 @@ function compile() {
         output.setValue(code, -1);
       } else if (result.type === 'error') {
         let errorText = result.data;
+        if(!errorText.startsWith('Unexpected')){
+        errorOutput.style.display = 'block';
+        replOutput.style.display = 'none';
+        errorOutput.textContent = errorText;        
+        } else {
         let errorLineLink = document.createElement('a');
         let lineText = getLineText(errorText);
         let lineNumber = lineText.slice(0,1);
@@ -76,6 +81,7 @@ function compile() {
         errorOutput.appendChild(beforeLineNumber);
         errorOutput.appendChild(errorLineLink);
         errorOutput.appendChild(afterLineNumber);
+        }
       }
 
       terminateWorker();
@@ -101,7 +107,7 @@ var input = createEditor(document.querySelector('.input .repl'));
 input.setValue([
   '(function() {',
   '  function fib(x) {',
-  '    return x <= 1 ? x : fib(x - 1) + fib(x - 2);',
+  '    return x <= 1 ? x : fi(x - 1) + fib(x - 2);',
   '  }',
   '',
   '  let x = Date.now();',

--- a/js/repl.js
+++ b/js/repl.js
@@ -66,7 +66,7 @@ function compile() {
         } else {
           let errorLineLink = document.createElement('a');
           let lineText = getLineText(errorText);
-          let lineNumber = lineText.slice(0,1);
+          let lineNumber = lineText.slice(0, lineText.indexOf(":"));          
           errorOutput.style.display = 'block';
           replOutput.style.display = 'none';
           errorLineLink.href = '';

--- a/js/repl.js
+++ b/js/repl.js
@@ -36,7 +36,8 @@ function terminateWorker() {
 function compile() {
   clearTimeout(debounce);
   terminateWorker();
-
+  
+  errorOutput.innerHTML = '';
   errorOutput.style.display = 'none';
   replOutput.style.display = 'block';
 
@@ -57,15 +58,38 @@ function compile() {
         }
         output.setValue(code, -1);
       } else if (result.type === 'error') {
+        let errorText = result.data;
+        let errorLineLink = document.createElement('a');
+        let lineText = getLineText(errorText);
+        let lineNumber = lineText.slice(0,1);
         errorOutput.style.display = 'block';
         replOutput.style.display = 'none';
-        errorOutput.textContent = result.data;
+        errorLineLink.href = '';
+        errorLineLink.onclick = function() {
+          input.gotoLine(lineNumber);
+          return false;
+        }
+        errorLineLink.text = lineText;
+        errorLineLink.style.color = 'red';
+        let beforeLineNumber = document.createTextNode(errorText.slice(0, errorText.indexOf(lineText)));
+        let afterLineNumber = document.createTextNode(errorText.slice(errorText.indexOf(')')));
+        errorOutput.appendChild(beforeLineNumber);
+        errorOutput.appendChild(errorLineLink);
+        errorOutput.appendChild(afterLineNumber);
       }
 
       terminateWorker();
     };
     worker.postMessage(input.getValue());
   }, 500);
+}
+
+let getLineText = function(errorText){
+  // Of the form (7:5);
+  let lineRegEx = /[:\d)]/g;
+  let closingBraceIndex = errorText.indexOf(')');
+  return errorText.slice(lineRegEx.exec(errorText).index, closingBraceIndex);
+
 }
 
 var output = createEditor(replOutput);
@@ -77,7 +101,7 @@ var input = createEditor(document.querySelector('.input .repl'));
 input.setValue([
   '(function() {',
   '  function fib(x) {',
-  '    return x <= 1 ? x : fib(x - 1) + fib(x - 2);',
+  '    return x <= 1 ? x : fibx - 1) + fib(x - 2);',
   '  }',
   '',
   '  let x = Date.now();',

--- a/js/repl.js
+++ b/js/repl.js
@@ -58,29 +58,29 @@ function compile() {
         }
         output.setValue(code, -1);
       } else if (result.type === 'error') {
-        let errorText = result.data;
-        if(!errorText.startsWith('Unexpected')){
-        errorOutput.style.display = 'block';
-        replOutput.style.display = 'none';
-        errorOutput.textContent = errorText;        
+          let errorText = result.data;
+          if (!errorText.startsWith('Unexpected')) {
+            errorOutput.style.display = 'block';
+            replOutput.style.display = 'none';
+            errorOutput.textContent = errorText;        
         } else {
-        let errorLineLink = document.createElement('a');
-        let lineText = getLineText(errorText);
-        let lineNumber = lineText.slice(0,1);
-        errorOutput.style.display = 'block';
-        replOutput.style.display = 'none';
-        errorLineLink.href = '';
-        errorLineLink.onclick = function() {
+          let errorLineLink = document.createElement('a');
+          let lineText = getLineText(errorText);
+          let lineNumber = lineText.slice(0,1);
+          errorOutput.style.display = 'block';
+          replOutput.style.display = 'none';
+          errorLineLink.href = '';
+          errorLineLink.onclick = function() {
           input.gotoLine(lineNumber);
           return false;
-        }
-        errorLineLink.text = lineText;
-        errorLineLink.style.color = 'red';
-        let beforeLineNumber = document.createTextNode(errorText.slice(0, errorText.indexOf(lineText)));
-        let afterLineNumber = document.createTextNode(errorText.slice(errorText.indexOf(')')));
-        errorOutput.appendChild(beforeLineNumber);
-        errorOutput.appendChild(errorLineLink);
-        errorOutput.appendChild(afterLineNumber);
+          }
+          errorLineLink.text = lineText;
+          errorLineLink.style.color = 'red';
+          let beforeLineNumber = document.createTextNode(errorText.slice(0, errorText.indexOf(lineText)));
+          let afterLineNumber = document.createTextNode(errorText.slice(errorText.indexOf(')')));
+          errorOutput.appendChild(beforeLineNumber);
+          errorOutput.appendChild(errorLineLink);
+          errorOutput.appendChild(afterLineNumber);
         }
       }
 
@@ -107,7 +107,7 @@ var input = createEditor(document.querySelector('.input .repl'));
 input.setValue([
   '(function() {',
   '  function fib(x) {',
-  '    return x <= 1 ? x : fi(x - 1) + fib(x - 2);',
+  '    return x <= 1 ? x : fib(x - 1) + fib(x - 2);',
   '  }',
   '',
   '  let x = Date.now();',


### PR DESCRIPTION
Currently, due to a mistake in my last pull request, the error highlighting only works if the line number is a single digit number. (I was using `slice(0,1)` :laughing: ). This is a fix for that sorcery. :tada: