### PR TITLE
Delay allocation of referentialized values

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -229,7 +229,7 @@ export class ResidualHeapVisitor {
       let binding = r.bindings[n];
       invariant(!binding.deletable);
       let value = (binding.initialized && binding.value) || realm.intrinsics.undefined;
-      visitedBinding = { global: false, value, modified: false };
+      visitedBinding = { value, modified: false, declarativeEnvironmentRecord: r };
       visitedBindings[n] = visitedBinding;
       this.visitValue(value);
     }
@@ -499,7 +499,7 @@ export class ResidualHeapVisitor {
     let binding = this.globalBindings.get(key);
     if (!binding) {
       let value = this.realm.getGlobalLetBinding(key);
-      binding = ({ global: true, value, modified: true }: VisitedBinding);
+      binding = ({ value, modified: true }: VisitedBinding);
       this.globalBindings.set(key, binding);
       // Check for let binding vs global property
       if (value) this.visitValue(value);

--- a/test/serializer/basic/CapturedScope.js
+++ b/test/serializer/basic/CapturedScope.js
@@ -1,0 +1,31 @@
+// serialized function clone count: 0
+function f (x) {
+  var valueA = 0;
+  var valueB = 1;
+  var valueC = 2;
+
+  function a() { // no inline
+    valueA++;
+    return b();
+  }
+
+  function b() { // no inline
+    valueA++;
+    valueB++;
+    return c();
+  }
+
+  function c() {
+    x ? valueC++ : valueC += 2;
+    return valueA * valueB * valueC;
+  }
+
+  return a;
+}
+
+var s = f(true);
+var r = f(false);
+
+inspect = function() {
+  return s() + ' ' + r();
+}

--- a/test/serializer/basic/CapturedScope2.js
+++ b/test/serializer/basic/CapturedScope2.js
@@ -1,0 +1,12 @@
+// serialized function clone count: 1
+var f = function(x) {
+  var i = x > 5 ? 0 : 1;
+  return function() {
+    i += 1;
+    return i;
+  }
+}
+
+var g = [f(2), f(6), f(4), f(9)];
+
+inspect = function() { return g[0]() + " " + g[1]() + " " + g[2]() + " " + g[3](); }

--- a/test/serializer/basic/CapturedScope3.js
+++ b/test/serializer/basic/CapturedScope3.js
@@ -1,0 +1,43 @@
+// serialized function clone count: 0
+function p(object, name, desc) {
+  var value;
+  var valueSet = false;
+
+  function get() {
+    if(!valueSet) {
+      valueSet = true;
+      set(desc.get());
+    }
+    return value;
+  }
+
+  function set(newValue){
+    value = newValue;
+    valueSet = true;
+
+    Object.defineProperty(object,name,{
+      value: newValue,
+      configurable: true,
+      enumerable: true,
+      writable: true
+    });
+  }
+
+  Object.defineProperty(object, name, {
+    get: get,
+    set: set,
+    configurable: true,
+    enumerable: true
+  });
+}
+
+var x = {};
+var y = {};
+
+p(x, "foo", { get: function get() { return 5; } });
+p(x, "foo", { get: function get() { return 7; } });
+p(y, "bar", { get: function get() { return 8; } });
+
+inspect = function() {
+  return x.foo + " " + y.bar;
+}

--- a/test/serializer/basic/CapturedScope4.js
+++ b/test/serializer/basic/CapturedScope4.js
@@ -1,0 +1,28 @@
+// serialized function clone count: 0
+function f (x) {
+  var valueA = 0;
+  var valueB = 1;
+  var valueC = 0;
+
+  function a() { // Prevent Inline foo bar
+    valueA++;
+    valueC++;
+    return b();
+  }
+
+  function b() { // Prevent Inline foo bar
+    valueB++;
+    valueA++;
+    valueC++;
+    return valueB * valueA * valueC;
+  }
+
+  return [a, b];
+}
+
+var s = f();
+var r = f();
+
+inspect = function() {
+  return s[0]() + ' ' + r[1]();
+}

--- a/test/serializer/basic/CapturedScope5.js
+++ b/test/serializer/basic/CapturedScope5.js
@@ -1,0 +1,42 @@
+// serialized function clone count: 0
+function f (x) {
+  var valueA = 1;
+  var valueB = 2;
+  var valueC = 3;
+
+  function a() { // Prevent Inline foo bar
+    valueA++;
+    valueC++;
+    return c();
+  }
+
+  function b() { // Prevent Inline foo bar
+    valueB++;
+    return c();
+  }
+
+  function c() {
+    valueC++;
+    return valueB * valueA * valueC;
+  }
+
+  function d() {
+    var valueF = 10;
+
+    function g() {
+      valueA = valueB * valueF;
+      return c();
+    }
+
+    return [g];
+  }
+
+  return [a, b, c, d];
+}
+
+var s = f();
+var r = f();
+
+inspect = function() {
+  return s[0]() + ' ' + r[1]() + " " + r[2]() + " " + r[3]()[0]();
+}

--- a/test/serializer/basic/CapturedScope6.js
+++ b/test/serializer/basic/CapturedScope6.js
@@ -1,0 +1,27 @@
+// Tests multiple captured scopes in generated function
+// serialized function clone count: 0
+function f (x) {
+  var valueA = 1;
+
+  function a() { // Prevent Inline foo bar
+    return valueA++;
+  }
+
+  function c() {
+    var valueC = 10;
+
+    return function () {
+      valueC++;
+      return valueA * valueC;
+    }
+  }
+
+  return [a, c()];
+}
+
+var s = f();
+var r = f();
+
+inspect = function() {
+  return s[0]() + ' ' + s[1]() + " " + s[1]() + " " + r[1]();
+}


### PR DESCRIPTION
Addresses #494 

This PR moves initialization of modified values from the global scope to the function as outlined in #494. Opening for discussion, work is still needed here, specifically:

* I try to batch function instances by their modified bindings, but I don't know what the correct way to do that is. For now I'm just doing a straight `===` equality check. @cblappert hinted to me that I might be able to use Babel node references here, but I wasn't quite able to figure that out. 

* Testing - I can definitely add more tests. I was also wondering if there are tests for the serialized output somewhere? Seems like it would be good to test that this doesn't just create the same # of functions as before but w/ extra cruft

* Measurement of improvement - Is there an established way to approach this / is it necessary for this change?

* All the other things I probably screwed up :)