### PR TITLE
Make serializer smarter about regular expression literals

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -14,7 +14,7 @@ import { Realm, ExecutionContext } from "../realm.js";
 import type { Descriptor, PropertyBinding } from "../types.js";
 import { IsUnresolvableReference, ResolveBinding, ToLength, IsArray, Get } from "../methods/index.js";
 import { Completion } from "../completions.js";
-import { BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, FunctionValue, Value, ObjectValue, PrimitiveValue, NativeFunctionValue, UndefinedValue } from "../values/index.js";
+import { BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, FunctionValue, NumberValue, Value, ObjectValue, PrimitiveValue, NativeFunctionValue, UndefinedValue } from "../values/index.js";
 import { describeLocation } from "../intrinsics/ecma262/Error.js";
 import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeStatement, BabelNodeIdentifier, BabelNodeBlockStatement, BabelNodeObjectExpression, BabelNodeStringLiteral, BabelNodeLVal, BabelNodeSpreadElement, BabelVariableKind, BabelNodeFunctionDeclaration } from "babel-types";
@@ -224,6 +224,19 @@ export class Serializer {
             desc.value instanceof ObjectValue && desc.value.originalConstructor === val) {
           return true;
         }
+      }
+    } else {
+      let kind = val.getKind();
+      switch (kind) {
+        case "RegExp":
+          if (key === "lastIndex" && desc.writable && !desc.enumerable && !desc.configurable) {
+            // length property has the correct descriptor values
+            let v = desc.value;
+            return v instanceof NumberValue && v.value === 0;
+          }
+          break;
+        default:
+          break;
       }
     }
 
@@ -1029,8 +1042,9 @@ export class Serializer {
   }
 
   _canEmbedProperty(obj: ObjectValue, key: string, prop: Descriptor): boolean {
-    if (obj instanceof FunctionValue && key === "prototype")
-      return !!prop.writable && !prop.configurable && !prop.enumerable && !prop.set && !prop.get;
+    if ((obj instanceof FunctionValue && key === "prototype") ||
+        (obj.getKind() === "RegExp" && key === "lastIndex"))
+    return !!prop.writable && !prop.configurable && !prop.enumerable && !prop.set && !prop.get;
     else
       return !!prop.writable && !!prop.configurable && !!prop.enumerable && !prop.set && !prop.get;
   }
@@ -1061,7 +1075,8 @@ export class Serializer {
         invariant(typeof source === "string");
         invariant(typeof flags === "string");
         this.addProperties(name, val, reasons);
-        return t.callExpression(this.preludeGenerator.memoizeReference("RegExp"), [t.stringLiteral(source), t.stringLiteral(flags)]);
+        source = new RegExp(source).source; // add escapes as per 21.2.3.2.4
+        return t.regExpLiteral(source, flags);
       case "Number":
         let numberData = val.$NumberData;
         invariant(numberData !== undefined);

--- a/test/serializer/basic/RegExp.js
+++ b/test/serializer/basic/RegExp.js
@@ -1,3 +1,11 @@
 regexp = /Facebook/i;
+regexp2 = /books/;
+regexp3 = new RegExp("/");
 
-inspect = function() { return "Facebook is cool".match(regexp).index; }
+regexp2.lastIndex = 8;
+i = "but books are books".match(regexp2);
+j = regexp2.lastIndex;
+
+k = "and /books/ are books too".match(regexp3);
+
+inspect = function() { return "" + i + j + k + "Facebook is cool".match(regexp).index; }


### PR DESCRIPTION
Use a literal expression instead of a call expression and do not set lastIndex to its default value.

Addresses issues #579 and #601.