### PR TITLE
Allow possibly normal completions inside abstract conditional code

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -49,6 +49,12 @@ export class Generator {
   body: Array<BodyEntry>;
   preludeGenerator: PreludeGenerator;
 
+  clone(): Generator {
+    let result = new Generator(this.realm);
+    result.body = this.body.slice(0);
+    return result;
+  }
+
   getAsPropertyNameExpression(key: string, canBeIdentifier: boolean = true) {
     // If key is a non-negative numeric string literal, parse it and set it as a numeric index instead.
     let index = Number.parseInt(key, 10);

--- a/test/serializer/abstract/Return7.js
+++ b/test/serializer/abstract/Return7.js
@@ -1,0 +1,20 @@
+let c = 0;
+let overflow = false;
+function check() {
+  return global.__abstract ? __abstract('boolean', 'true') : true;
+}
+function call() {
+  if (check()) {
+    c = c + 1;
+    if (c > 2) {
+      overflow = true;
+      return 3;
+    }
+  }
+  return 4;
+}
+a = call();
+b = call();
+inspect = function() {
+  return overflow;
+};


### PR DESCRIPTION
If control can leave a block in more than one way, then additional work is needed to come up with the effects of the block if it is evaluated by partially_evaluate.

Fixing this also showed up an incompleteness in the logic for joining completions. Adding more functionality to the joining logic makes up the bulk of the changes in this request.

This addresses issue #596.