### PR TITLE
Inline calls of abstract functions created from known functions

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -45,6 +45,8 @@ export default function (realm: Realm): void {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown typeNameOrTemplate");
       }
       return { type, template: Value.isTypeCompatibleWith(type, ObjectValue) ? ObjectCreate(realm, realm.intrinsics.ObjectPrototype) : undefined };
+    } else if (typeNameOrTemplate instanceof FunctionValue) {
+      return { type: FunctionValue, template: typeNameOrTemplate };
     } else if (typeNameOrTemplate instanceof ObjectValue) {
       return { type: ObjectValue, template: typeNameOrTemplate };
     } else {

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -314,7 +314,7 @@ export function joinValuesAsConditional(
   let values = ValuesDomain.joinValues(realm, v1, v2);
   let result = realm.createAbstract(types, values,
     [condition, v1 || realm.intrinsics.undefined, v2 || realm.intrinsics.undefined],
-    (args) => t.conditionalExpression(args[0], args[1], args[2]));
+    (args) => t.conditionalExpression(args[0], args[1], args[2]), "conditional");
   if (v1) result.mightBeEmpty = v1.mightHaveBeenDeleted();
   if (v2 && !result.mightBeEmpty) result.mightBeEmpty = v2.mightHaveBeenDeleted();
   return result;

--- a/test/serializer/abstract/Call.js
+++ b/test/serializer/abstract/Call.js
@@ -1,5 +1,4 @@
 // throws introspection error
 
-function f() {}
-var g = __abstract(f);
+var g = __abstract({});
 g();

--- a/test/serializer/abstract/Call2.js
+++ b/test/serializer/abstract/Call2.js
@@ -1,0 +1,5 @@
+function f() { return 123; }
+var g = global.__abstract ? global.__abstract(f, "f") : f;
+z = g();
+
+inspect = function() { return "" + z }

--- a/test/serializer/abstract/Call3.js
+++ b/test/serializer/abstract/Call3.js
@@ -1,0 +1,15 @@
+var o = global.__abstract ? global.__abstract('number', '1') : 1;
+var obj = {};
+function bar(x) {
+  if (o > 1) {
+    obj.foo = function() { return 1 + x; }
+  } else if (o > 2) {
+    obj.foo = function() { return 2 + x; }
+  } else {
+    obj.foo = function() { return 3 + x; }    
+  }
+}
+bar(5);
+z = obj.foo();
+
+inspect = function() { return "" + z }


### PR DESCRIPTION
Abstract functions that arise from joining concrete functions because of an abstract condition can be invoked at prepack time, provided that their effects are joined together. I.e. it much like calling the two functions from the two different branches of an if statement.

This addresses issue: #437