### PR TITLE
show nav item border on hover

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -145,10 +145,7 @@ header, .repl-container {
   color: #323330;
 }
 
-.nav-main .nav-site a:hover {
-  color: #323330;
-}
-
+.nav-main .nav-site a:hover,
 .nav-main .nav-site a.active {
   color: #323330;
   border-bottom: 1px solid #323330;


### PR DESCRIPTION
Right now, main `nav` looks quite dead because there are no interactions on hover.
I added a border so that there's at least some visual feedback.

An alternative would be to set `color: white` on hover instead (adding both is perhaps too much).