### PR TITLE
Avoid setting __proto__ directly when possible

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -100,7 +100,7 @@ export class Serializer {
     this.declaredDerivedIds = new Set();
     this.descriptors = new Map();
     this.needsEmptyVar = false;
-    this.needsAuxiliaryConstructor = [];
+    this.needsAuxiliaryConstructor = false;
     this.valueNameGenerator = this.preludeGenerator.createNameGenerator("_");
     this.referentializedNameGenerator = this.preludeGenerator.createNameGenerator("$");
     this.descriptorNameGenerator = this.preludeGenerator.createNameGenerator("$$");
@@ -1079,11 +1079,10 @@ export class Serializer {
   }
 
   _findLastObjectPrototype(obj: ObjectValue): ObjectValue {
-    while (true) {
-      if (obj.$Prototype instanceof ObjectValue) obj = obj.$Prototype;
-      else return obj;
-    }
+    while (obj.$Prototype instanceof ObjectValue) obj = obj.$Prototype;
+    return obj;
   }
+
   _serializeValueObject(name: string, val: ObjectValue, reasons: Array<string>): BabelNodeExpression {
     // If this object is a prototype object that was implicitly created by the runtime
     // for a constructor, then we can obtain a reference to this object

--- a/test/serializer/basic/EfficientPrototypeSetting.js
+++ b/test/serializer/basic/EfficientPrototypeSetting.js
@@ -1,0 +1,10 @@
+// does not contain:__proto__ =
+(function() {
+    var x = {};
+    var proto = {};
+    x.__proto__ = proto;
+    inspect = function() {
+        let p = x.__proto__;
+        return p === proto;
+    }
+})();

--- a/test/serializer/basic/NonObjectPrototypes.js
+++ b/test/serializer/basic/NonObjectPrototypes.js
@@ -1,0 +1,5 @@
+(function() {
+    var x = {};
+    x.__proto__ = 42;
+    inspect = function() { return x.__proto__; }
+})();

--- a/test/serializer/basic/NullPrototype.js
+++ b/test/serializer/basic/NullPrototype.js
@@ -1,0 +1,5 @@
+(function() {
+    var x = {};
+    x.__proto__ = null;
+    inspect = function() { x.__proto__ === null; }
+})();


### PR DESCRIPTION
When an object of kind Object needs its __proto__ property configured, don't set it directly; instead, use an auxiliary constructor.
Adding test.

This addresses #574.