### PR TITLE
add mobile navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,72 +101,232 @@ header, .repl-container {
   background-color: #f7f7f7;
 }
 
-.nav-main {
-  *zoom: 1;
-  background: #f5da55;
-  position: fixed;
-  top: 0;
-  height: 60px;
-  width: 100%;
-  z-index: 100;
-  border-bottom: solid 1px #ddd;
+/* NAV */
+
+.nav-toggle {
+  cursor: pointer;
+  display: block;
+  height: 3.25rem;
+  position: relative;
+  width: 3.25rem;
 }
 
-.nav-main:before, .nav-main:after {
-  content: " ";
-  display: table;
+.nav-toggle span {
+  background-color: #323330;
+  display: block;
+  height: 1px;
+  left: 50%;
+  margin-left: -7px;
+  position: absolute;
+  top: 50%;
+  -webkit-transition: none 86ms ease-out;
+  transition: none 86ms ease-out;
+  -webkit-transition-property: background, left, opacity, -webkit-transform;
+  transition-property: background, left, opacity, -webkit-transform;
+  transition-property: background, left, opacity, transform;
+  transition-property: background, left, opacity, transform, -webkit-transform;
+  width: 15px;
 }
 
-.nav-main:after {
-  clear: both;
+.nav-toggle span:nth-child(1) {
+  margin-top: -6px;
 }
 
-.nav-main a {
-  color: #323330;
+.nav-toggle span:nth-child(2) {
+  margin-top: -1px;
+}
+
+.nav-toggle span:nth-child(3) {
+  margin-top: 4px;
+}
+
+.nav-toggle:hover {
+  background-color: #f5da55;
+}
+
+.nav-toggle.is-active span {
+  background-color: #323330;
+}
+
+.nav-toggle.is-active span:nth-child(1) {
+  margin-left: -5px;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+  -webkit-transform-origin: left top;
+  transform-origin: left top;
+}
+
+.nav-toggle.is-active span:nth-child(2) {
+  opacity: 0;
+}
+
+.nav-toggle.is-active span:nth-child(3) {
+  margin-left: -5px;
+  -webkit-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+  -webkit-transform-origin: left bottom;
+  transform-origin: left bottom;
+}
+
+@media screen and (min-width: 769px), print {
+  .nav-toggle {
+    display: none;
+  }
+}
+
+.nav-item {
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  font-size: 1rem;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
   text-decoration: none;
+  margin: 0 1px;
 }
 
-.nav-main .nav-site {
-  float: right;
-  margin: 0;
+.nav-item a {
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
-.nav-main .nav-site li {
-  margin: 0;
+@media screen and (max-width: 768px) {
+  .nav-item {
+    -webkit-box-pack: start;
+    -ms-flex-pack: start;
+    justify-content: flex-start;
+  }
 }
 
-.nav-main .nav-site a {
-  padding: 0 8px;
-  text-transform: uppercase;
+a.nav-item {
+  color: #323330;
+}
+
+@media screen and (max-width: 768px) {
+  a.nav-item {
+    margin: 0;
+  }
+}
+
+a.nav-item:not(.is-brand) {
   letter-spacing: 1px;
-  line-height: 60px;
-  display: inline-block;
-  height: 60px;
-  color: #323330;
+  text-transform: uppercase;
 }
 
-.nav-main .nav-site a:hover,
-.nav-main .nav-site a.active {
-  color: #323330;
+a.nav-item:hover:not(.is-brand) {
+  color: #363636;
   border-bottom: 1px solid #323330;
 }
 
-.nav-main .nav-home {
+a.nav-item.is-active {
+  color: #363636;
+  border-bottom: 1px solid #323330;
+}
+
+a.nav-item.is-brand {
   color: #323330;
   font-size: 24px;
-  line-height: 60px;
 }
 
-.nav-home a {
-  color: #323330;
+@media screen and (min-width: 1000px) {
+  a.nav-item.is-brand {
+    padding-left: 0;
+  }
 }
 
-.nav-main ul {
-  display: inline;
+.nav-left,
+.nav-right {
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-flex: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  max-width: 100%;
+  overflow: auto;
 }
 
-.nav-main li {
-  display: inline;
+.nav-left {
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  white-space: nowrap;
+}
+
+.nav-right {
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+@media screen and (max-width: 768px) {
+  .nav-menu.nav-right {
+    background-color: white;
+    -webkit-box-shadow: 0 4px 7px rgba(10, 10, 10, 0.1);
+    box-shadow: 0 4px 7px rgba(10, 10, 10, 0.1);
+    left: 0;
+    display: none;
+    right: 0;
+    top: 100%;
+    position: absolute;
+  }
+
+  .nav-menu.nav-right .nav-item {
+    padding: 0.75rem;
+  }
+
+  .nav-menu.nav-right .nav-item:hover {
+    padding: 0.75rem;
+    background-color: #f5da55;
+  }
+
+  .nav-menu.nav-right.is-active {
+    display: block;
+  }
+}
+
+.nav {
+  margin: 0 auto;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  background-color: #f5da55;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  text-align: center;
+  z-index: 10;
+}
+
+.nav > .content-container {
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  min-height: 3.25rem;
+  width: 100%;
 }
 
 /* CONTENT */
@@ -179,7 +339,7 @@ header, .repl-container {
 }
 
 .content {
-  margin-top: 60px;
+  /*margin-top: 60px;*/
   /*padding: 20px 0;*/
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -29,7 +29,7 @@ header, .repl-container {
 
 .record-container{
   height: 60px;
-  margin-top:60px;
+  /*margin-top:60px;*/
   padding-top: 8px;
   /*line-height: 40px;*/
   background: #1c1c1c;

--- a/frequently-asked-questions.html
+++ b/frequently-asked-questions.html
@@ -16,24 +16,31 @@
   </head>
   <body>
 
-    <div class="nav-main">
+    <nav class="nav">
       <div class="content-container">
-        <a class="nav-home" href="./">
-          Prepack
-        </a>
-        <ul class="nav-site">
-          <li>
-            <a href="./">About</a>
-            <a href="getting-started.html">Getting Started</a>
-            <a href="frequently-asked-questions.html" class="active">FAQs</a>
-            <a href="repl.html">Try It Out</a>
-          </li>
-          <li>
-            <a href="https://github.com/facebook/prepack" class="">GitHub</a>
-          </li>
-        </ul>
+
+        <div class="nav-left">
+          <a class="nav-item is-brand" href="./">
+            Prepack
+          </a>
+        </div>
+
+        <span id="nav-toggle" class="nav-toggle">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+
+        <div id="nav-menu" class="nav-right nav-menu">
+          <a href="./" class="nav-item">About</a>
+          <a href="getting-started.html" class="nav-item">Getting Started</a>
+          <a href="frequently-asked-questions.html" class="nav-item is-active">FAQs</a>
+          <a href="repl.html" class="nav-item">Try It Out</a>
+          <a href="https://github.com/facebook/prepack" class="nav-item">GitHub</a>
+        </div>
+
       </div>
-    </div>
+    </nav>
 
     <div class="content">
       <div class="section">
@@ -41,10 +48,10 @@
           <h2>Why do I get a <code>ReferenceError</code> when trying to prepack my code?</h2>
 
           <p class="align-left">
-            Trying to prepack a seemlingly simple program such as <code>global.result = UnknownProperty;</code> will cause a 
+            Trying to prepack a seemlingly simple program such as <code>global.result = UnknownProperty;</code> will cause a
             <code>ReferenceError</code>. The reason is that Prepack actually runs the global code, not knowing anything else
             about the environment. And the semantics of JavaScript is that an unknown identifier that cannot be resolved
-            causes a <code>ReferenceError</code>. You might want to invest into modeling your environment. 
+            causes a <code>ReferenceError</code>. You might want to invest into modeling your environment.
             Check out the section <i>The Environment matters!</i> on the landing page.
           </p>
 
@@ -52,17 +59,17 @@
 
           <p class="align-left">
             Prepack actually runs the global code, and by default, any accesses to unknown properties of an object result in
-            <code>undefined</code>. Thus, <code>global.UnknownProperty</code> prepacks to <code>undefined</code>. 
-            You might want to invest into modeling your environment. 
+            <code>undefined</code>. Thus, <code>global.UnknownProperty</code> prepacks to <code>undefined</code>.
+            You might want to invest into modeling your environment.
             Check out the section <i>The Environment matters!</i> on the landing page.
           </p>
 
           <h2>What is an <code>__IntrospectionError</code>?</h2>
 
           <p class="align-left">
-            Prepack actually runs the global code. 
+            Prepack actually runs the global code.
             When functions such as <code>Date.now</code> or <code>Math.random</code> are invoked,
-            their behavior is <i>non-deterministic</i>. Prepack doesn't know which exact value they will return 
+            their behavior is <i>non-deterministic</i>. Prepack doesn't know which exact value they will return
             when the resulting prepacked code will run again later in the real run-time environment.
             (You can also directly inject such non-deterministic values using Prepack's <code>__abstract</code> built-in, or
             other modeling built-ins described in the section <i>The Environment matters!</i> on the landing page.)
@@ -70,14 +77,14 @@
           <p class="align-left">
             When the global code branches over such values,
             it is not clear at prepack-time which branch will be taken later in the real run-time environment.
-            Therefore, Prepack tries to explore all possible behaviors, and summarize them. 
+            Therefore, Prepack tries to explore all possible behaviors, and summarize them.
             However, Prepack is still limited in its abilities, and sometimes it just won't ever make sense to explore all possible behaviors.
             In those cases, Prepack throws a <code>__IntrospectionError</code>.
-            This is not a user error, but a Prepack limitation. 
+            This is not a user error, but a Prepack limitation.
             It is sometimes possible to work around these limitations by changing your code. The easiest way to work around the limitation is to move the problematic code out of the global code path into a callback that's only invoked later, or by making the problematic part of the initialization phase lazy.
           </p>
           <p class="align-left">
-            If you get such an error while using <code>Math.random</code>, 
+            If you get such an error while using <code>Math.random</code>,
             consider setting the <code>mathRandomSeed</code> option to make all random numbers queries along the global code path deterministic.
           </p>
 
@@ -103,9 +110,9 @@
           <h2>Has Prepack been integrated with other tools?</h2>
 
           <p class="align-left">
-            The following are a few plugins to other tools. 
+            The following are a few plugins to other tools.
             They have been created and are maintained separately from Prepack itself.
-            If you run into any issues with those plugins, 
+            If you run into any issues with those plugins,
             please ask the plugin maintainers for support.
           </p>
           <p class="align-left">
@@ -148,5 +155,7 @@
         </div>
       </div>
     </div>
+
+    <script src="js/toggle_menu.js"></script>
   </body>
 </html>

--- a/getting-started.html
+++ b/getting-started.html
@@ -16,24 +16,31 @@
   </head>
   <body>
 
-    <div class="nav-main">
+    <nav class="nav">
       <div class="content-container">
-        <a class="nav-home" href="./">
-          Prepack
-        </a>
-        <ul class="nav-site">
-          <li>
-            <a href="./">About</a>
-            <a href="getting-started.html" class="active">Getting Started</a>
-            <a href="frequently-asked-questions.html">FAQs</a>
-            <a href="repl.html">Try It Out</a>
-          </li>
-          <li>
-            <a href="https://github.com/facebook/prepack" class="">GitHub</a>
-          </li>
-        </ul>
+
+        <div class="nav-left">
+          <a class="nav-item is-brand" href="./">
+            Prepack
+          </a>
+        </div>
+
+        <span id="nav-toggle" class="nav-toggle">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+
+        <div id="nav-menu" class="nav-right nav-menu">
+          <a href="./" class="nav-item">About</a>
+          <a href="getting-started.html" class="nav-item is-active">Getting Started</a>
+          <a href="frequently-asked-questions.html" class="nav-item">FAQs</a>
+          <a href="repl.html" class="nav-item">Try It Out</a>
+          <a href="https://github.com/facebook/prepack" class="nav-item">GitHub</a>
+        </div>
+
       </div>
-    </div>
+    </nav>
 
     <div class="content">
       <div class="section">
@@ -250,5 +257,7 @@ import * as Prepack from 'prepack';</code></pre>
         </div>
       </div>
     </div>
+
+    <script src="js/toggle_menu.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -16,24 +16,31 @@
   </head>
   <body>
 
-    <div class="nav-main">
+    <nav class="nav">
       <div class="content-container">
-        <a class="nav-home" href="./">
-          Prepack
-        </a>
-        <ul class="nav-site">
-          <li>
-            <a href="./" class="active">About</a>
-            <a href="getting-started.html">Getting Started</a>
-            <a href="frequently-asked-questions.html">FAQs</a>
-            <a href="repl.html">Try It Out</a>
-          </li>
-          <li>
-            <a href="https://github.com/facebook/prepack" class="">GitHub</a>
-          </li>
-        </ul>
+
+        <div class="nav-left">
+          <a class="nav-item is-brand" href="./">
+            Prepack
+          </a>
+        </div>
+
+        <span id="nav-toggle" class="nav-toggle">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+
+        <div id="nav-menu" class="nav-right nav-menu">
+          <a href="./" class="nav-item is-active">About</a>
+          <a href="getting-started.html" class="nav-item">Getting Started</a>
+          <a href="frequently-asked-questions.html" class="nav-item">FAQs</a>
+          <a href="repl.html" class="nav-item">Try It Out</a>
+          <a href="https://github.com/facebook/prepack" class="nav-item">GitHub</a>
+        </div>
+
       </div>
-    </div>
+    </nav>
 
     <div class="content">
       <div class="hero">
@@ -379,5 +386,7 @@ __residual("object", function(delay) {
         </div>
       </div>
     </div>
+
+    <script src="js/toggle_menu.js"></script>
   </body>
 </html>

--- a/js/toggle_menu.js
+++ b/js/toggle_menu.js
@@ -1,0 +1,12 @@
+var toggle = document.getElementById("nav-toggle");
+var menu = document.getElementById("nav-menu");
+
+toggle.addEventListener("click", function() {
+  if (this.className === "nav-toggle") {
+    this.className = "nav-toggle is-active";
+    menu.classList.add("is-active");
+  } else {
+    this.className = "nav-toggle";
+    menu.classList.remove("is-active");
+  }
+});

--- a/repl.html
+++ b/repl.html
@@ -16,24 +16,32 @@
   </head>
   <body>
 
-    <div class="nav-main">
+    <nav class="nav">
       <div class="content-container">
-        <a class="nav-home" href="/">
-          Prepack
-        </a>
-        <ul class="nav-site">
-          <li>
-            <a href="./">About</a>
-            <a href="getting-started.html">Getting Started</a>
-            <a href="frequently-asked-questions.html">FAQs</a>
-            <a href="repl.html" class="active">Try It Out</a>
-          </li>
-          <li>
-            <a href="https://github.com/facebook/prepack" class="">GitHub</a>
-          </li>
-        </ul>
+
+        <div class="nav-left">
+          <a class="nav-item is-brand" href="./">
+            Prepack
+          </a>
+        </div>
+
+        <span id="nav-toggle" class="nav-toggle">
+          <span></span>
+          <span></span>
+          <span></span>
+        </span>
+
+        <div id="nav-menu" class="nav-right nav-menu">
+          <a href="./" class="nav-item">About</a>
+          <a href="getting-started.html" class="nav-item">Getting Started</a>
+          <a href="frequently-asked-questions.html" class="nav-item">FAQs</a>
+          <a href="repl.html" class="nav-item is-active">Try It Out</a>
+          <a href="https://github.com/facebook/prepack" class="nav-item">GitHub</a>
+        </div>
+
       </div>
-    </div>
+    </nav>
+
     <div class="record-container">
       <select class="select-record">
         <option>1</option>
@@ -63,5 +71,6 @@
     <script src="js/tether.min.js"></script>
     <script src="js/select.min.js"></script>
     <script src="js/repl.js"></script>
+    <script src="js/toggle_menu.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Hello,

This is my first pull request, if I did something wrong please say it to me !

I add a basic mobile navigation to the website to access easily all the html pages.

I change all the nav part in style.css, add a toggle-menu.js where I have an eventListener to click on a hamburger menu icon, add the html part in each html file and add the script src at the bottom.

//edit
The second commit correct a display error in repl.html (the record container was hidden outside an element)
And of course I only see after doing this pull request that the navigation on mobile is good. It's just a little buggy when you resize on a browser (or using sizzy app)