### PR TITLE
Set up binding identity before starting to serialize value.

### DIFF
--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -33,7 +33,8 @@ export type FunctionInfo = {
 
 export type SerializedBindings = { [key: string]: SerializedBinding };
 export type SerializedBinding = {
-  serializedValue: BabelNodeExpression;
+  // The serializedValue is only not yet present during the initialization of a binding that involves recursive dependencies.
+  serializedValue?: BabelNodeExpression;
   value?: Value;
   referentialized?: boolean;
   modified?: boolean;

--- a/test/serializer/basic/RecursiveMutatedFunctionIdentifier.js
+++ b/test/serializer/basic/RecursiveMutatedFunctionIdentifier.js
@@ -1,0 +1,13 @@
+(function() {
+    let v;
+    function init() {
+        init = function() {};
+        v = {};
+    }
+    function work() {
+        let a = (init(), v);
+        let b = (init(), v);
+        return a == b;
+    }
+    global.inspect = work;
+})();


### PR DESCRIPTION
This is needed in case of recursive dependencies.
Adding test.

This addresses #570.