### PR TITLE
Rename Realm methods dealing with effects tracking

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -54,10 +54,10 @@ function callBothFunctionsAndJoinTheirEffects(args: Array<Value>, ast: BabelNode
   invariant(func2.getType() === FunctionValue);
 
   let [compl1, gen1, bindings1, properties1, createdObj1] =
-    realm.partially_evaluate(() => EvaluateCall(func1, func1, ast, strictCode, env, realm));
+    realm.evaluateForEffects(() => EvaluateCall(func1, func1, ast, strictCode, env, realm));
 
   let [compl2, gen2, bindings2, properties2, createdObj2] =
-    realm.partially_evaluate(() => EvaluateCall(func2, func2, ast, strictCode, env, realm));
+    realm.evaluateForEffects(() => EvaluateCall(func2, func2, ast, strictCode, env, realm));
 
   let joinedEffects =
     joinEffects(realm, cond,
@@ -69,12 +69,12 @@ function callBothFunctionsAndJoinTheirEffects(args: Array<Value>, ast: BabelNode
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    realm.capture_effects();
+    realm.captureEffects();
   }
 
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.
-  realm.apply_effects(joinedEffects);
+  realm.applyEffects(joinedEffects);
 
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;

--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -80,7 +80,7 @@ function emitResidualLoopIfSafe(ast: BabelNodeForInStatement, strictCode: boolea
       envRec.InitializeBinding(n, absStr);
     }
     let [compl, gen, bindings, properties, createdObj] =
-      realm.partially_evaluate_node(body, strictCode, blockEnv);
+      realm.evaluateNodeForEffects(body, strictCode, blockEnv);
     if (compl instanceof Value && gen.body.length === 0 && bindings.size === 0 &&
         properties.size === 1) {
       invariant(createdObj.size === 0); // or there will be more than one property

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -63,11 +63,11 @@ export function evaluateWithAbstractConditional(condValue: AbstractValue,
     env: LexicalEnvironment, realm: Realm): NormalCompletion | Value | Reference {
   // Evaluate consequent and alternate in sandboxes and get their effects.
   let [compl1, gen1, bindings1, properties1, createdObj1] =
-    realm.partially_evaluate_node(consequent, strictCode, env);
+    realm.evaluateNodeForEffects(consequent, strictCode, env);
 
   let [compl2, gen2, bindings2, properties2, createdObj2] =
     alternate ?
-      realm.partially_evaluate_node(alternate, strictCode, env) :
+      realm.evaluateNodeForEffects(alternate, strictCode, env) :
       construct_empty_effects(realm);
 
   // Join the effects, creating an abstract view of what happened, regardless
@@ -82,11 +82,11 @@ export function evaluateWithAbstractConditional(condValue: AbstractValue,
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    realm.capture_effects();
+    realm.captureEffects();
   }
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.
-  realm.apply_effects(joinedEffects);
+  realm.applyEffects(joinedEffects);
 
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -55,7 +55,7 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean,
 
   // Evaluate ast.right in a sandbox to get its effects
   let [compl2, gen2, bindings2, properties2, createdObj2] =
-    realm.partially_evaluate_node(ast.right, strictCode, env);
+    realm.evaluateNodeForEffects(ast.right, strictCode, env);
 
   // Join the effects, creating an abstract view of what happened, regardless
   // of the actual value of lval.
@@ -77,11 +77,11 @@ export default function (ast: BabelNodeLogicalExpression, strictCode: boolean,
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    realm.capture_effects();
+    realm.captureEffects();
   }
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.
-  realm.apply_effects(joinedEffects);
+  realm.applyEffects(joinedEffects);
 
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -299,16 +299,16 @@ export function OrdinaryCallEvaluateBody(realm: Realm, F: FunctionValue, argumen
     let code = F.$ECMAScriptCode;
     invariant(code !== undefined);
     let c = realm.getRunningContext().lexicalEnvironment.evaluateAbstractCompletion(code, F.$Strict);
-    let e = realm.get_captured_effects();
+    let e = realm.getCapturedEffects();
     if (e !== undefined) {
-      realm.stop_effect_capture();
+      realm.stopEffectCapture();
       let [_c, _g, b, p, _o] = e;
       _c; _g; _o;
       realm.restoreBindings(b);
       realm.restoreProperties(p);
     }
     if (c instanceof JoinedAbruptCompletions) {
-      if (e !== undefined) realm.apply_effects(e);
+      if (e !== undefined) realm.applyEffects(e);
       throw AbstractValue.createIntrospectionErrorThrowCompletion(c.joinCondition);
     } else if (c instanceof PossiblyNormalCompletion) {
       // If the abrupt part of the completion is a return completion, then the
@@ -317,12 +317,12 @@ export function OrdinaryCallEvaluateBody(realm: Realm, F: FunctionValue, argumen
       // in the realm.
       invariant(e !== undefined);
       let joinedEffects = joinEffectsAndRemoveNestedReturnCompletions(realm, c, e);
-      realm.apply_effects(joinedEffects);
+      realm.applyEffects(joinedEffects);
       invariant(joinedEffects[0] instanceof ReturnCompletion);
       return joinedEffects[0];
     } else {
       invariant(c instanceof Value || c instanceof AbruptCompletion);
-      if (e !== undefined) realm.apply_effects(e);
+      if (e !== undefined) realm.applyEffects(e);
       return c;
     }
   }

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1025,21 +1025,21 @@ export function EvaluateStatements(
         } else {
           invariant(blockValue instanceof PossiblyNormalCompletion);
           if (res instanceof AbruptCompletion) {
-            let e = realm.get_captured_effects();
+            let e = realm.getCapturedEffects();
             invariant(e !== undefined);
-            realm.stop_effect_capture();
+            realm.stopEffectCapture();
             let [_c, _g, b, p, _o] = e;
             _c; _g; _o;
             realm.restoreBindings(b);
             realm.restoreProperties(p);
             if (res instanceof IntrospectionThrowCompletion) {
-              realm.apply_effects(e);
+              realm.applyEffects(e);
               throw res;
             }
             invariant(blockValue instanceof PossiblyNormalCompletion);
             e[0] = res;
             let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, blockValue, res, e);
-            realm.apply_effects(joined_effects);
+            realm.applyEffects(joined_effects);
             throw joined_effects[0];
           } else {
             if (res instanceof Value)

--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -38,7 +38,7 @@ export class Logger {
     // We use partial evaluation so that we can throw away any state mutations
     try {
       let result;
-      let effects = realm.partially_evaluate(() => {
+      let effects = realm.evaluateForEffects(() => {
         try {
           result = f();
         } catch (e) {

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -74,7 +74,7 @@ class ModuleTracer extends Tracer {
         this.requireStack.push(moduleIdValue);
         let requireSequenceStart = this.requireSequence.length;
         this.requireSequence.push(moduleIdValue);
-        let effects = realm.partially_evaluate(() => {
+        let effects = realm.evaluateForEffects(() => {
           try {
             return performCall();
           } catch (e) {
@@ -113,7 +113,7 @@ class ModuleTracer extends Tracer {
             ValuesDomain.topVal, [],
              ([]) => t.callExpression(t.identifier("require"), [t.valueToNode(moduleIdValue)]));
         } else {
-          realm.apply_effects(effects, `initialization of module ${moduleIdValue}`);
+          realm.applyEffects(effects, `initialization of module ${moduleIdValue}`);
         }
       } finally {
         let popped = this.requireStack.pop();
@@ -276,11 +276,11 @@ export class Modules {
     try {
       let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
 
-      let effects = realm.partially_evaluate_node(node, true, env);
+      let effects = realm.evaluateNodeForEffects(node, true, env);
       let result = effects[0];
       if (result instanceof IntrospectionThrowCompletion) return effects;
 
-      realm.apply_effects(effects, message);
+      realm.applyEffects(effects, message);
       if (result instanceof Completion) {
         console.log(`=== UNEXPECTED ERROR during ${message} ===`);
         this.logger.logCompletion(result);
@@ -347,7 +347,7 @@ export class Modules {
         let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
 
         let [compl, generator, bindings, properties, createdObjects] =
-          realm.partially_evaluate_node(node, true, env);
+          realm.evaluateNodeForEffects(node, true, env);
         // for lint unused
         invariant(bindings);
 


### PR DESCRIPTION
partially_evaluate is a bit of a misnomer, so renamed it to evaluateForEffects. While at it, also renamed all of the related methods to follow camlCase conventions.