### PR TITLE
Implement Date.parse

### DIFF
--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -906,7 +906,10 @@ function prepareTest(
 
 function createRealm(timeout: number): { realm: Realm, $: ObjectValue } {
   // Create a new realm.
-  let realm = construct_realm({ timeout: timeout * 1000 });
+  let realm = construct_realm({
+    strictlyMonotonicDateNow: true,
+    timeout: timeout * 1000,
+  });
   initializeGlobals(realm);
   let executionContext = new ExecutionContext();
   executionContext.realm = realm;

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -1101,7 +1101,9 @@ function testFilterByMetadata(
   if (test.location.includes("Simd")) return false;
 
   // temporarily disable intl402 tests (ES5)
-  if (test.location.includes("intl402")) return false;
+  if (test.location.includes("intl402") && !test.location.includes('/Date/')) {
+    return false;
+  }
 
   // temporarily disable tests which use realm.
   if (test.location.includes("realm")) return false;

--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -189,7 +189,8 @@ export default function (realm: Realm): NativeFunctionValue {
 
   // ECMA262 20.3.3.2
   func.defineNativeMethod("parse", 1, (context, [string]) => {
-    throw new Error("TODO: Implement Date.parse");
+    const parsedDate = Date.parse(string.value);
+    return new NumberValue(realm, parsedDate);
   });
 
   // ECMA262 20.3.3.4

--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { NativeFunctionValue, NumberValue, StringValue, ObjectValue } from "../../values/index.js";
+import { AbstractValue, NativeFunctionValue, NumberValue, StringValue, ObjectValue } from "../../values/index.js";
 import { ToInteger, ToNumber, ToPrimitive } from "../../methods/to.js";
 import { OrdinaryCreateFromConstructor } from "../../methods/create.js";
 import { MakeTime, MakeDate, MakeDay, TimeClip, UTC, ToDateString, thisTimeValue } from "../../methods/date.js";
@@ -189,8 +189,12 @@ export default function (realm: Realm): NativeFunctionValue {
 
   // ECMA262 20.3.3.2
   func.defineNativeMethod("parse", 1, (context, [string]) => {
-    const parsedDate = Date.parse(string.value);
-    return new NumberValue(realm, parsedDate);
+    if (realm.useAbstractInterpretation) {
+      throw AbstractValue.createIntrospectionErrorThrowCompletion(string);
+    } else {
+      const parsedDate = Date.parse(string.value);
+      return new NumberValue(realm, parsedDate);
+    }
   });
 
   // ECMA262 20.3.3.4


### PR DESCRIPTION
Implement most basic Date.parse by using underlying runtime's Date.parse method