### PR TITLE
Bug fix: Callback invocation in prepackFile args

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -113,25 +113,24 @@ function run(Object, Array, console, JSON, process, prepackStdin, prepackFileSyn
   );
 
   if (!inputFilename) {
-    prepackStdin(resolvedOptions, function (serialized) {
-      processSerializedCode(serialized);
-    });
-  } else {
-    try {
-      let serialized = prepackFileSync(
-        inputFilename,
-        resolvedOptions
-      );
-      processSerializedCode(serialized);
-    } catch (x) {
-      if (x instanceof InitializationError) {
-        // Ignore InitializationError since they have already logged
-        // their errors to the console, but exit with an error code.
-        process.exit(1);
-      }
-      // For any other type of error, rethrow.
-      throw x;
+    prepackStdin(resolvedOptions, processSerializedCode);
+    return;
+  }
+
+  try {
+    let serialized = prepackFileSync(
+      inputFilename,
+      resolvedOptions
+    );
+    processSerializedCode(serialized);
+  } catch (x) {
+    if (x instanceof InitializationError) {
+      // Ignore InitializationError since they have already logged
+      // their errors to the console, but exit with an error code.
+      process.exit(1);
     }
+    // For any other type of error, rethrow.
+    throw x;
   }
 
   function processSerializedCode(serialized) {

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -50,7 +50,9 @@ export function prepackString(filename: string, code: string, sourceMap: string,
    }
 }
 
-export function prepackStdin(options: Options = defaultOptions, callback: Function) {
+export function prepackStdin(
+    options: Options = defaultOptions,
+    callback: ({code: string, map?: SourceMap})=>void) {
   let sourceMapFilename = options.inputSourceMapFilename || '';
   process.stdin.setEncoding('utf8');
   process.stdin.resume();
@@ -73,7 +75,11 @@ export function prepackStdin(options: Options = defaultOptions, callback: Functi
   });
 }
 
-export function prepackFile(filename: string, options: Options = defaultOptions, callback: Function) {
+export function prepackFile(
+    filename: string,
+    options: Options = defaultOptions,
+    callback: ({code: string, map?: SourceMap})=>void,
+    errorHandler?: (err: ?Error)=>void) {
   if (options.compatibility === 'node-cli') {
     prepackNodeCLI(filename, options, callback);
     return;
@@ -81,7 +87,7 @@ export function prepackFile(filename: string, options: Options = defaultOptions,
   let sourceMapFilename = options.inputSourceMapFilename || (filename + ".map");
   fs.readFile(filename, "utf8", function(fileErr, code) {
     if (fileErr) {
-      callback(fileErr);
+      if (errorHandler) errorHandler(fileErr);
       return;
     }
     fs.readFile(sourceMapFilename, "utf8", function(mapErr, sourceMap) {
@@ -96,7 +102,7 @@ export function prepackFile(filename: string, options: Options = defaultOptions,
         callback(err);
         return;
       }
-      callback(null, serialized);
+      callback(serialized);
     });
   });
 }


### PR DESCRIPTION
The callback invocation in prepackFile was passing a redundant 'null' as
the first argument of the invocation rather than passing the serialized
data as the sole argument, which is what the callback expects.
As a result, calling prepackFile would fail with an exception.

Solution: remove the leading 'null' argument