### PR TITLE
Implement ES6 destructuring bindings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -192,6 +192,7 @@
 
   // Flow
     "flowtype/boolean-style": [2, "boolean"], // a problem is raised when using bool instead of boolean
+    "flowtype/define-flow-type": 2,
     "flowtype/generic-spacing": [2, "never"],
     "flowtype/space-before-type-colon": [2, "never"],
     "flowtype/space-before-generic-bracket": [2, "never"],

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -1196,7 +1196,6 @@ function filterFeatures(data: BannerData): boolean {
   let features = data.features;
   if (features.includes("class")) return false;
   if (features.includes("default-parameters")) return false;
-  if (features.includes("destructuring-binding")) return false;
   if (features.includes("generators")) return false;
   return true;
 }

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -1198,8 +1198,7 @@ function filterFeatures(data: BannerData): boolean {
   if (features.includes("default-parameters")) return false;
   if (features.includes("generators")) return false;
   if (features.includes("generator")) return false;
-  return features.includes('destructuring-binding');
-  // return true;
+  return true;
 }
 
 function filterIncludes(data: BannerData): boolean {

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -1226,10 +1226,11 @@ function filterCircleCI(data: BannerData): boolean {
 }
 
 function filterSneakyGenerators(data: BannerData, testFileContents: string) {
-  // The sneaky generator tests mostly appear when the `destructuring-binding`
-  // feature is enabled.
+  // There are some sneaky tests that use generators but are not labeled with
+  // the "generators" or "generator" feature tag. Here we use a simple heuristic
+  // to filter out tests with sneaky generators.
   if (data.features.includes('destructuring-binding')) {
-    return !/function\*/.test(testFileContents) && !/\*method\(/.test(testFileContents);
+    return !testFileContents.includes("function*") && !testFileContents.includes("*method");
   }
   return true;
 }

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -1197,7 +1197,9 @@ function filterFeatures(data: BannerData): boolean {
   if (features.includes("class")) return false;
   if (features.includes("default-parameters")) return false;
   if (features.includes("generators")) return false;
-  return true;
+  if (features.includes("generator")) return false;
+  return features.includes('destructuring-binding');
+  // return true;
 }
 
 function filterIncludes(data: BannerData): boolean {

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -790,8 +790,8 @@ function handleTest(
     } else {
       invariant(testFileContents, "testFileContents should not be null if banners are not None");
       // filter out by flags, features, and includes
-      let keepThisTest = filterFeatures(banners) && filterFlags(banners) &&
-        filterIncludes(banners) && filterDescription(banners) && filterCircleCI(banners);
+      let keepThisTest = filterFeatures(banners) && filterFlags(banners) && filterIncludes(banners) &&
+        filterDescription(banners) && filterCircleCI(banners) && filterSneakyGenerators(banners, testFileContents);
       let testResults = [];
       if (keepThisTest) {
         // now run the test
@@ -1225,6 +1225,16 @@ function filterCircleCI(data: BannerData): boolean {
   return (!!process.env.NIGHTLY_BUILD ||
       (skipTests.indexOf(data.es5id) < 0 && skipTests6.indexOf(data.es6id) < 0));
 }
+
+function filterSneakyGenerators(data: BannerData, testFileContents: string) {
+  // The sneaky generator tests mostly appear when the `destructuring-binding`
+  // feature is enabled.
+  if (data.features.includes('destructuring-binding')) {
+    return !/function\*/.test(testFileContents) && !/\*method\(/.test(testFileContents);
+  }
+  return true;
+}
+
 /**
  * Run a given ${test} whose file contents are ${testFileContents} and return
  * a list of results, one for each strictness level (strict or not).

--- a/src/evaluators/AssignmentExpression.js
+++ b/src/evaluators/AssignmentExpression.js
@@ -14,14 +14,14 @@ import type { LexicalEnvironment } from "../environment.js";
 import { Value, ObjectValue } from "../values/index.js";
 import { Reference } from "../environment.js";
 import {
+  DestructuringAssignmentEvaluation,
+  GetReferencedName,
   GetValue,
-  PutValue,
-  SetFunctionName,
+  HasOwnProperty,
   IsAnonymousFunctionDefinition,
   IsIdentifierRef,
-  HasOwnProperty,
-  GetReferencedName,
-  DestructuringAssignmentEvaluation,
+  PutValue,
+  SetFunctionName,
 } from "../methods/index.js";
 import invariant from "../invariant.js";
 import type { BabelNodeAssignmentExpression, BabelBinaryOperator } from "babel-types";

--- a/src/evaluators/AssignmentExpression.js
+++ b/src/evaluators/AssignmentExpression.js
@@ -12,10 +12,17 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { Value, ObjectValue } from "../values/index.js";
-import { GetValue } from "../methods/index.js";
 import { Reference } from "../environment.js";
-import { PutValue, SetFunctionName, IsAnonymousFunctionDefinition, HasOwnProperty, GetReferencedName } from "../methods/index.js";
-import { IsIdentifierRef } from "../methods/is.js";
+import {
+  GetValue,
+  PutValue,
+  SetFunctionName,
+  IsAnonymousFunctionDefinition,
+  IsIdentifierRef,
+  HasOwnProperty,
+  GetReferencedName,
+  DestructuringAssignmentEvaluation,
+} from "../methods/index.js";
 import invariant from "../invariant.js";
 import type { BabelNodeAssignmentExpression, BabelBinaryOperator } from "babel-types";
 import { computeBinary } from "./BinaryExpression.js";
@@ -32,7 +39,12 @@ export default function (ast: BabelNodeAssignmentExpression, strictCode: boolean
   // AssignmentExpression : LeftHandSideExpression = AssignmentExpression
   if (AssignmentOperator === "="){
     // 1. If LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral, then
-    if (LeftHandSideExpression.type !== "ObjectLiteral" && LeftHandSideExpression.type !== "ArrayLiteral") {
+    //
+    // The spec assumes we haven't yet distinguished between literals and
+    // patterns, but our parser does that work for us. That means we check for
+    // "*Pattern" instead of "*Literal" like the spec text suggests.
+    if (LeftHandSideExpression.type !== "ObjectPattern" &&
+        LeftHandSideExpression.type !== "ArrayPattern") {
       // a. Let lref be the result of evaluating LeftHandSideExpression.
       let lref = env.evaluate(LeftHandSideExpression, strictCode);
       // b. ReturnIfAbrupt(lref). -- Not neccessary
@@ -57,13 +69,23 @@ export default function (ast: BabelNodeAssignmentExpression, strictCode: boolean
       // g. Return rval.
       return rval;
     }
-    throw new Error("Patterns aren't supported yet");
+
     // 2. Let assignmentPattern be the parse of the source text corresponding to LeftHandSideExpression using AssignmentPattern[?Yield] as the goal symbol.
+    let assignmentPattern = LeftHandSideExpression;
+
     // 3. Let rref be the result of evaluating AssignmentExpression.
+    let rref = env.evaluate(AssignmentExpression, strictCode);
+
     // 4. Let rval be ? GetValue(rref).
+    let rval = GetValue(realm, rref);
+
     // 5. Let status be the result of performing DestructuringAssignmentEvaluation of assignmentPattern using rval as the argument.
+    DestructuringAssignmentEvaluation(realm, assignmentPattern, rval, strictCode, env);
+
     // 6. ReturnIfAbrupt(status).
+
     // 7. Return rval.
+    return rval;
   }
 
   // AssignmentExpression : LeftHandSideExpression AssignmentOperator AssignmentExpression

--- a/src/evaluators/CatchClause.js
+++ b/src/evaluators/CatchClause.js
@@ -42,7 +42,7 @@ export default function (ast: BabelNodeCatchClause, strictCode: boolean, env: Le
 
   try {
     // 6. Let status be the result of performing BindingInitialization for CatchParameter passing thrownValue and catchEnv as arguments.
-    BindingInitialization(realm, ast.param, thrownValue.value, catchEnv);
+    BindingInitialization(realm, ast.param, thrownValue.value, strictCode, catchEnv);
 
     // 7. If status is an abrupt completion, then
       // a. Set the running execution context's LexicalEnvironment to oldEnv.

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -178,6 +178,7 @@ export function ForInOfBodyEvaluation(realm: Realm, env: LexicalEnvironment, lhs
   // 4. If destructuring is true and if lhsKind is assignment, then
   if (destructuring && lhsKind === "assignment") {
     // a. Assert: lhs is a LeftHandSideExpression.
+    invariant(lhs.type !== "VariableDeclaration");
 
     // b. Let assignmentPattern be the parse of the source text corresponding to lhs using AssignmentPattern as the goal symbol.
   }
@@ -254,21 +255,28 @@ export function ForInOfBodyEvaluation(realm: Realm, env: LexicalEnvironment, lhs
       } else { // g. Else,
         // i. If lhsKind is assignment, then
         if (lhsKind === "assignment") {
+          // This should have been asserted in step 4.a, but we repeat the
+          // assertion here for Flow.
+          invariant(lhs.type !== "VariableDeclaration");
+
           // 1. Let status be the result of performing DestructuringAssignmentEvaluation of assignmentPattern using nextValue as the argument.
+          BindingInitialization(realm, lhs, nextValue, strictCode, iterationEnv);
         } else if (lhsKind === "varBinding") { // ii. Else if lhsKind is varBinding, then
           // 1. Assert: lhs is a ForBinding.
+          invariant(lhs.type !== "VariableDeclaration");
 
           // 2. Let status be the result of performing BindingInitialization for lhs passing nextValue and undefined as the arguments.
-          status = BindingInitialization(realm, lhs, nextValue, undefined);
+          status = BindingInitialization(realm, lhs, nextValue, strictCode, undefined);
         } else { // iii. Else,
           // 1. Assert: lhsKind is lexicalBinding.
           invariant(lhsKind === "lexicalBinding");
 
           // 2. Assert: lhs is a ForDeclaration.
+          invariant(lhs.type !== "VariableDeclaration");
 
           // 3. Let status be the result of performing BindingInitialization for lhs passing nextValue and iterationEnv as arguments.
           invariant(iterationEnv !== undefined);
-          status = BindingInitialization(realm, lhs, nextValue, iterationEnv);
+          status = BindingInitialization(realm, lhs, nextValue, strictCode, iterationEnv);
         }
       }
     } catch (e) {

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -196,7 +196,7 @@ export function ForInOfBodyEvaluation(realm: Realm, env: LexicalEnvironment, lhs
     let nextValue = IteratorValue(realm, nextResult);
 
     // d. If lhsKind is either assignment or varBinding, then
-    let iterationEnv : LexicalEnvironment | void;
+    let iterationEnv : void | LexicalEnvironment;
     let lhsRef;
     if (lhsKind === "assignment" || lhsKind === "varBinding") {
       // i. If destructuring is false, then

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -30,6 +30,7 @@ import {
   UpdateEmpty,
   BoundNames,
   BindingInitialization,
+  DestructuringAssignmentEvaluation,
   GetIterator,
   IsDestructuring,
   HasSomeCompatibleType
@@ -255,12 +256,12 @@ export function ForInOfBodyEvaluation(realm: Realm, env: LexicalEnvironment, lhs
       } else { // g. Else,
         // i. If lhsKind is assignment, then
         if (lhsKind === "assignment") {
-          // This should have been asserted in step 4.a, but we repeat the
-          // assertion here for Flow.
-          invariant(lhs.type !== "VariableDeclaration");
+          // This should be true given the algorithm. We add a check here mostly
+          // for Flow.
+          invariant(lhs.type === "ArrayPattern" || lhs.type === "ObjectPattern");
 
           // 1. Let status be the result of performing DestructuringAssignmentEvaluation of assignmentPattern using nextValue as the argument.
-          BindingInitialization(realm, lhs, nextValue, strictCode, iterationEnv);
+          status = DestructuringAssignmentEvaluation(realm, lhs, nextValue, strictCode, iterationEnv || env);
         } else if (lhsKind === "varBinding") { // ii. Else if lhsKind is varBinding, then
           // 1. Assert: lhs is a ForBinding.
           invariant(lhs.type !== "VariableDeclaration");

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -256,8 +256,6 @@ export function ForInOfBodyEvaluation(realm: Realm, env: LexicalEnvironment, lhs
       } else { // g. Else,
         // i. If lhsKind is assignment, then
         if (lhsKind === "assignment") {
-          // This should be true given the algorithm. We add a check here mostly
-          // for Flow.
           invariant(lhs.type === "ArrayPattern" || lhs.type === "ObjectPattern");
 
           // 1. Let status be the result of performing DestructuringAssignmentEvaluation of assignmentPattern using nextValue as the argument.

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -196,7 +196,7 @@ export function ForInOfBodyEvaluation(realm: Realm, env: LexicalEnvironment, lhs
     let nextValue = IteratorValue(realm, nextResult);
 
     // d. If lhsKind is either assignment or varBinding, then
-    let iterationEnv : LexicalEnvironment;
+    let iterationEnv : LexicalEnvironment | void;
     let lhsRef;
     if (lhsKind === "assignment" || lhsKind === "varBinding") {
       // i. If destructuring is false, then

--- a/src/evaluators/ObjectExpression.js
+++ b/src/evaluators/ObjectExpression.js
@@ -33,7 +33,7 @@ import invariant from "../invariant.js";
 import type { BabelNodeObjectExpression, BabelNodeObjectProperty, BabelNodeObjectMethod } from "babel-types";
 
 // Returns the result of evaluating PropertyName.
-function EvalPropertyName(prop: BabelNodeObjectProperty | BabelNodeObjectMethod, env: LexicalEnvironment, realm: Realm, strictCode: boolean): PropertyKeyValue {
+export function EvalPropertyName(prop: BabelNodeObjectProperty | BabelNodeObjectMethod, env: LexicalEnvironment, realm: Realm, strictCode: boolean): PropertyKeyValue {
   if (prop.computed) {
     let propertyKeyName = GetValue(realm, env.evaluate(prop.key, strictCode)).throwIfNotConcrete();
     return ToPropertyKey(realm, propertyKeyName);

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -23,7 +23,6 @@ import {
   SetFunctionName,
   BindingInitialization,
 } from "../methods/index.js";
-import { ThrowCompletion } from "../completions.js";
 import invariant from "../invariant.js";
 import type { BabelNodeVariableDeclaration } from "babel-types";
 
@@ -130,7 +129,7 @@ export default function (ast: BabelNodeVariableDeclaration, strictCode: boolean,
       // 3. Return the result of performing BindingInitialization for BindingPattern passing rval and undefined as arguments.
       BindingInitialization(realm, declar.id, rval, strictCode, undefined);
     } else {
-      throw new ThrowCompletion(new StringValue(realm, "unrecognized declaration"));
+      invariant(false, "unrecognized declaration");
     }
   }
 

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -10,9 +10,8 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import type { LexicalEnvironment } from "../environment.js";
+import type { LexicalEnvironment, Reference } from "../environment.js";
 import type { Value } from "../values/index.js";
-import type { Reference } from "../environment.js";
 import { ObjectValue, StringValue } from "../values/index.js";
 import {
   PutValue,
@@ -22,7 +21,9 @@ import {
   IsAnonymousFunctionDefinition,
   HasOwnProperty,
   SetFunctionName,
+  BindingInitialization,
 } from "../methods/index.js";
+import { ThrowCompletion } from "../completions.js";
 import invariant from "../invariant.js";
 import type { BabelNodeVariableDeclaration } from "babel-types";
 
@@ -83,39 +84,54 @@ export default function (ast: BabelNodeVariableDeclaration, strictCode: boolean,
   }
 
   for (let declar of ast.declarations) {
-    if (declar.id.type !== "Identifier") {
-      throw new Error("TODO: Patterns aren't supported yet");
-    }
-
     let Initializer = declar.init;
-    if (!Initializer) continue;
 
-    // 1. Let bindingId be StringValue of BindingIdentifier.
-    let bindingId = declar.id.name;
+    if (declar.id.type === "Identifier" && !Initializer) {
+      // VariableDeclaration : BindingIdentifier
 
-    // 2. Let lhs be ? ResolveBinding(bindingId).
-    let lhs = ResolveBinding(realm, bindingId, strictCode);
+      // 1. Return NormalCompletion(empty).
+      continue;
+    } else if (declar.id.type === "Identifier" && Initializer) {
+      // VariableDeclaration : BindingIdentifier Initializer
 
-    // 3. Let rhs be the result of evaluating Initializer.
-    let rhs = env.evaluate(Initializer, strictCode);
+      // 1. Let bindingId be StringValue of BindingIdentifier.
+      let bindingId = declar.id.name;
 
-    // 4. Let value be ? GetValue(rhs).
-    let value = GetValue(realm, rhs);
-    if (declar.id && declar.id.name) value.__originalName = bindingId;
+      // 2. Let lhs be ? ResolveBinding(bindingId).
+      let lhs = ResolveBinding(realm, bindingId, strictCode);
 
-    // 5. If IsAnonymousFunctionDefinition(Initializer) is true, then
-    if (IsAnonymousFunctionDefinition(realm, Initializer)) {
-      invariant(value instanceof ObjectValue);
+      // 3. Let rhs be the result of evaluating Initializer.
+      let rhs = env.evaluate(Initializer, strictCode);
 
-      // a. Let hasNameProperty be ? HasOwnProperty(value, "name").
-      let hasNameProperty = HasOwnProperty(realm, value, "name");
+      // 4. Let value be ? GetValue(rhs).
+      let value = GetValue(realm, rhs);
+      if (declar.id && declar.id.name) value.__originalName = bindingId;
 
-      // b. If hasNameProperty is false, perform SetFunctionName(value, bindingId).
-      if (!hasNameProperty) SetFunctionName(realm, value, new StringValue(realm, bindingId));
+      // 5. If IsAnonymousFunctionDefinition(Initializer) is true, then
+      if (IsAnonymousFunctionDefinition(realm, Initializer)) {
+        invariant(value instanceof ObjectValue);
+
+        // a. Let hasNameProperty be ? HasOwnProperty(value, "name").
+        let hasNameProperty = HasOwnProperty(realm, value, "name");
+
+        // b. If hasNameProperty is false, perform SetFunctionName(value, bindingId).
+        if (!hasNameProperty) SetFunctionName(realm, value, new StringValue(realm, bindingId));
+      }
+
+      // 6. Return ? PutValue(lhs, value).
+      PutValue(realm, lhs, value);
+    } else if ((declar.id.type === "ObjectPattern" || declar.id.type === "ArrayPattern") && Initializer) {
+      // 1. Let rhs be the result of evaluating Initializer.
+      let rhs = env.evaluate(Initializer, strictCode);
+
+      // 2. Let rval be ? GetValue(rhs).
+      let rval = GetValue(realm, rhs);
+
+      // 3. Return the result of performing BindingInitialization for BindingPattern passing rval and undefined as arguments.
+      BindingInitialization(realm, declar.id, rval, strictCode, undefined);
+    } else {
+      throw new ThrowCompletion(new StringValue(realm, "unrecognized declaration"));
     }
-
-    // 6. Return ? PutValue(lhs, value).
-    PutValue(realm, lhs, value);
   }
 
   return realm.intrinsics.empty;

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -541,6 +541,26 @@ export function CreateDataProperty(realm: Realm, O: ObjectValue, P: PropertyKeyV
   return O.$DefineOwnProperty(P, newDesc);
 }
 
+// ECMA262 7.3.5
+export function CreateMethodProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value): boolean {
+  // 1. Assert: Type(O) is Object.
+  invariant(O instanceof ObjectValue, "Not an object value");
+
+  // 2. Assert: IsPropertyKey(P) is true.
+  invariant(IsPropertyKey(realm, P), "Not a property key");
+
+  // 3. Let newDesc be the PropertyDescriptor{[[Value]]: V, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}.
+  let newDesc = {
+    value: V,
+    writable: true,
+    enumerable: false,
+    configurable: true
+  };
+
+  // 4. Return ? O.[[DefineOwnProperty]](P, newDesc).
+  return O.$DefineOwnProperty(P, newDesc);
+}
+
 // ECMA262 7.3.6
 export function CreateDataPropertyOrThrow(realm: Realm, O: Value, P: PropertyKeyValue, V: Value): boolean {
   // 1. Assert: Type(O) is Object.

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -15,7 +15,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { Reference } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
 import { Value, ObjectValue, UndefinedValue } from "../values/index.js";
-import { AbruptCompletion } from "../completions.js";
+import { Completion, AbruptCompletion } from "../completions.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   RequireObjectCoercible,
@@ -80,12 +80,10 @@ export function DestructuringAssignmentEvaluation(realm: Realm, pattern: BabelNo
     }
 
     // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
-    // TODO: Why does this work?
     if (iteratorRecord.$Done === false) {
-      let completion = new AbruptCompletion(new UndefinedValue(realm));
-      let actualCompletion = IteratorClose(realm, iterator, completion);
-      if (actualCompletion !== completion) {
-        throw actualCompletion;
+      let completion = IteratorClose(realm, iterator, new Completion(realm.intrinsics.undefined));
+      if (completion instanceof AbruptCompletion) {
+        throw completion;
       }
     }
 

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -95,18 +95,17 @@ export function DestructuringAssignmentEvaluation(realm: Realm, pattern: BabelNo
 }
 
 // ECMA262 12.15.5.3
-export function IteratorDestructuringAssignmentEvaluation(realm: Realm, elements: Array<BabelNodeLVal | null>, iteratorRecord: {$Iterator: ObjectValue, $Done: boolean}, strictCode: boolean, env: LexicalEnvironment) {
-  // Check if the last formal is a rest element. If so then we want to save the
+export function IteratorDestructuringAssignmentEvaluation(realm: Realm, elements: $ReadOnlyArray<BabelNodeLVal | null>, iteratorRecord: {$Iterator: ObjectValue, $Done: boolean}, strictCode: boolean, env: LexicalEnvironment) {
+  // Check if the last element is a rest element. If so then we want to save the
   // element and handle it separately after we iterate through the other
   // formals. This also enforces that a rest element may only ever be in the
   // last position.
   let restEl;
   if (elements.length > 0) {
-    let lastEl = elements.pop();
+    let lastEl = elements[elements.length - 1];
     if (lastEl !== null && lastEl.type === "RestElement") {
       restEl = lastEl;
-    } else {
-      elements.push(lastEl);
+      elements = elements.slice(0, -1);
     }
   }
 

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -183,7 +183,7 @@ export function IteratorDestructuringAssignmentEvaluation(realm: Realm, elements
         iteratorRecord.$Done = true;
         // Normally this assignment would be done in step 3, but we do it
         // here so that Flow knows `value` will always be initialized by step 4.
-        value = new UndefinedValue(realm);
+        value = realm.intrinsics.undefined;
       } else { // e. Else,
         // i. Let value be IteratorValue(next).
         try {
@@ -198,7 +198,7 @@ export function IteratorDestructuringAssignmentEvaluation(realm: Realm, elements
         }
       }
     } else { // 3. If iteratorRecord.[[Done]] is true, let value be undefined.
-      value = new UndefinedValue(realm);
+      value = realm.intrinsics.undefined;
     }
 
     let v;

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -13,8 +13,8 @@ import invariant from "../invariant.js";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
-import { Value, StringValue, ObjectValue, UndefinedValue } from "../values/index.js";
-import { AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { Value, ObjectValue, UndefinedValue } from "../values/index.js";
+import { AbruptCompletion } from "../completions.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   RequireObjectCoercible,
@@ -29,9 +29,7 @@ import {
   SetFunctionName,
   GetReferencedName,
   PutValue,
-  ResolveBinding,
   ArrayCreate,
-  InitializeReferencedBinding,
   CreateDataProperty,
   GetV,
 } from "./index.js";

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -1,0 +1,420 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import invariant from "../invariant.js";
+import type { Realm } from "../realm.js";
+import type { LexicalEnvironment } from "../environment.js";
+import type { PropertyKeyValue } from "../types.js";
+import { Value, StringValue, ObjectValue, UndefinedValue } from "../values/index.js";
+import { AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
+import {
+  RequireObjectCoercible,
+  GetIterator,
+  IteratorClose,
+  IteratorStep,
+  IteratorValue,
+  GetValue,
+  IsAnonymousFunctionDefinition,
+  IsIdentifierRef,
+  HasOwnProperty,
+  SetFunctionName,
+  GetReferencedName,
+  PutValue,
+  ResolveBinding,
+  ArrayCreate,
+  InitializeReferencedBinding,
+  CreateDataProperty,
+  GetV,
+} from "./index.js";
+import type {
+  BabelNodeLVal,
+  BabelNodeArrayPattern,
+  BabelNodeObjectPattern,
+} from "babel-types";
+
+// ECMA262 12.15.5.2
+export function DestructuringAssignmentEvaluation(realm: Realm, pattern: BabelNodeArrayPattern | BabelNodeObjectPattern, value: Value, strictCode: boolean, env: LexicalEnvironment) {
+  if (pattern.type === "ObjectPattern") {
+    // 1. Perform ? RequireObjectCoercible(value).
+    RequireObjectCoercible(realm, value);
+
+    // 2. Return the result of performing DestructuringAssignmentEvaluation for AssignmentPropertyList using value as the argument.
+
+    for (let property of pattern.properties) {
+      // 1. Let name be the result of evaluating PropertyName.
+      let name = EvalPropertyName(property, env, realm, strictCode);
+
+      // 2. ReturnIfAbrupt(name).
+
+      // 3. Return the result of performing KeyedDestructuringAssignmentEvaluation of AssignmentElement with value and name as the arguments.
+      KeyedDestructuringAssignmentEvaluation(realm, property.value, value, name, strictCode, env);
+    }
+  } else if (pattern.type === "ArrayPattern") {
+    // 1. Let iterator be ? GetIterator(value).
+    let iterator = GetIterator(realm, value);
+
+    // 2. Let iteratorRecord be Record {[[Iterator]]: iterator, [[Done]]: false}.
+    let iteratorRecord = {
+      $Iterator: iterator,
+      $Done: false,
+    };
+
+    // 3. Let result be the result of performing IteratorDestructuringAssignmentEvaluation of AssignmentElementList using iteratorRecord as the argument.
+    let result;
+    try {
+      result = IteratorDestructuringAssignmentEvaluation(realm, pattern.elements, iteratorRecord, strictCode, env);
+    } catch (error) {
+      // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
+      if (iteratorRecord.$Done === false && error instanceof AbruptCompletion) {
+        throw IteratorClose(realm, iterator, error);
+      }
+      throw error;
+    }
+
+    // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
+    // TODO: Why does this work?
+    if (iteratorRecord.$Done === false) {
+      let completion = new AbruptCompletion(new UndefinedValue(realm));
+      let actualCompletion = IteratorClose(realm, iterator, completion);
+      if (actualCompletion !== completion) {
+        throw actualCompletion;
+      }
+    }
+
+    // 5. Return result.
+    return result;
+  }
+}
+
+// ECMA262 12.15.5.3
+export function IteratorDestructuringAssignmentEvaluation(realm: Realm, elements: Array<BabelNodeLVal | null>, iteratorRecord: {$Iterator: ObjectValue, $Done: boolean}, strictCode: boolean, env: LexicalEnvironment) {
+  // Check if the last formal is a rest element. If so then we want to save the
+  // element and handle it separately after we iterate through the other
+  // formals. This also enforces that a rest element may only ever be in the
+  // last position.
+  let restEl;
+  if (elements.length > 0) {
+    let lastEl = elements.pop();
+    if (lastEl !== null && lastEl.type === "RestElement") {
+      restEl = lastEl;
+    } else {
+      elements.push(lastEl);
+    }
+  }
+
+  for (let element of elements) {
+    if (element === null) {
+      // Elision handling
+
+      // 1. If iteratorRecord.[[Done]] is false, then
+      if (iteratorRecord.$Done === false) {
+        // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+        let next;
+        try {
+          next = IteratorStep(realm, iteratorRecord.$Iterator);
+        } catch (e) {
+          // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+          if (e instanceof AbruptCompletion) {
+            iteratorRecord.$Done = true;
+          }
+          // c. ReturnIfAbrupt(next).
+          throw e;
+        }
+        // d. If next is false, set iteratorRecord.[[Done]] to true.
+        if (next === false) {
+          iteratorRecord.$Done = true;
+        }
+      }
+      // 2. Return NormalCompletion(empty).
+      continue;
+    }
+
+    // AssignmentElement : DestructuringAssignmentTarget Initializer
+
+    let DestructuringAssignmentTarget;
+    let Initializer;
+
+    if (element.type === "AssignmentPattern") {
+      Initializer = element.right;
+      DestructuringAssignmentTarget = element.left;
+    } else {
+      DestructuringAssignmentTarget = element;
+    }
+
+    let lref;
+
+    // 1. If DestructuringAssignmentTarget is neither an ObjectLiteral nor an ArrayLiteral, then
+    //
+    // The spec assumes we haven't yet distinguished between literals and
+    // patterns, but our parser does that work for us. That means we check for
+    // "*Pattern" instead of "*Literal" like the spec text suggests.
+    if (DestructuringAssignmentTarget.type !== "ObjectPattern" &&
+        DestructuringAssignmentTarget.type !== "ArrayPattern") {
+      // a. Let lref be the result of evaluating DestructuringAssignmentTarget.
+      lref = env.evaluate(DestructuringAssignmentTarget, strictCode);
+
+      // b. ReturnIfAbrupt(lref).
+    }
+
+    let value;
+
+    // 2. If iteratorRecord.[[Done]] is false, then
+    if (iteratorRecord.$Done === false) {
+      // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+      let next;
+      try {
+        next = IteratorStep(realm, iteratorRecord.$Iterator);
+      } catch (e) {
+        // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        if (e instanceof AbruptCompletion) {
+          iteratorRecord.$Done = true;
+        }
+        // c. ReturnIfAbrupt(next).
+        throw e;
+      }
+
+      // d. If next is false, set iteratorRecord.[[Done]] to true.
+      if (next === false) {
+        iteratorRecord.$Done = true;
+        // Normally this assignment would be done in step 3, but we do it
+        // here so that Flow knows `value` will always be initialized by step 4.
+        value = new UndefinedValue(realm);
+      } else { // e. Else,
+        // i. Let value be IteratorValue(next).
+        try {
+          value = IteratorValue(realm, next);
+        } catch (e) {
+          // ii. If value is an abrupt completion, set iteratorRecord.[[Done]] to true.
+          if (e instanceof AbruptCompletion) {
+            iteratorRecord.$Done = true;
+          }
+          // iii. ReturnIfAbrupt(v).
+          throw e;
+        }
+      }
+    } else { // 3. If iteratorRecord.[[Done]] is true, let value be undefined.
+      value = new UndefinedValue(realm);
+    }
+
+    let v;
+
+    // 4. If Initializer is present and value is undefined, then
+    if (Initializer && value instanceof UndefinedValue) {
+      // a. Let defaultValue be the result of evaluating Initializer.
+      let defaultValue = env.evaluate(Initializer, strictCode);
+
+      // b. Let v be ? GetValue(defaultValue).
+      v = GetValue(realm, defaultValue);
+    } else { // 5. Else, let v be value.
+      v = value;
+    }
+
+    // 6. If DestructuringAssignmentTarget is an ObjectLiteral or an ArrayLiteral, then
+    //
+    // The spec assumes we haven't yet distinguished between literals and
+    // patterns, but our parser does that work for us. That means we check for
+    // "*Pattern" instead of "*Literal" like the spec text suggests.
+    if (DestructuringAssignmentTarget.type === "ObjectPattern" ||
+        DestructuringAssignmentTarget.type === "ArrayPattern") {
+      // a. Let nestedAssignmentPattern be the parse of the source text corresponding to DestructuringAssignmentTarget using either AssignmentPattern or AssignmentPattern[Yield] as the goal symbol depending upon whether this AssignmentElement has the [Yield] parameter.
+      let nestedAssignmentPattern = DestructuringAssignmentTarget;
+
+      // b. Return the result of performing DestructuringAssignmentEvaluation of nestedAssignmentPattern with v as the argument.
+      DestructuringAssignmentEvaluation(realm, nestedAssignmentPattern, v, strictCode, env);
+      continue;
+    }
+
+    // We know `lref` exists because of how the algorithm is setup, but tell
+    // Flow that `lref` exists with an `invariant()`.
+    invariant(lref);
+
+    // 7. If Initializer is present and value is undefined and IsAnonymousFunctionDefinition(Initializer) and IsIdentifierRef of DestructuringAssignmentTarget are both true, then
+    if (Initializer &&
+        value instanceof UndefinedValue &&
+        IsAnonymousFunctionDefinition(realm, Initializer) &&
+        IsIdentifierRef(realm, DestructuringAssignmentTarget) &&
+        v instanceof ObjectValue) {
+      // a. Let hasNameProperty be ? HasOwnProperty(v, "name").
+      let hasNameProperty = HasOwnProperty(realm, v, "name");
+
+      // b. If hasNameProperty is false, perform SetFunctionName(v, GetReferencedName(lref)).
+      if (hasNameProperty === false) {
+        SetFunctionName(realm, v, GetReferencedName(realm, lref));
+      }
+    }
+
+    // 8. Return ? PutValue(lref, v).
+    PutValue(realm, lref, v);
+    continue;
+  }
+
+  // Handle the rest element if we have one.
+  if (restEl) {
+    // AssignmentRestElement : ...DestructuringAssignmentTarget
+    let DestructuringAssignmentTarget = restEl.argument;
+
+    let lref;
+
+    // 1. If DestructuringAssignmentTarget is neither an ObjectLiteral nor an ArrayLiteral, then
+    //
+    // The spec assumes we haven't yet distinguished between literals and
+    // patterns, but our parser does that work for us. That means we check for
+    // "*Pattern" instead of "*Literal" like the spec text suggests.
+    if (DestructuringAssignmentTarget.type !== "ObjectPattern" &&
+        DestructuringAssignmentTarget.type !== "ArrayPattern") {
+      // a. Let lref be the result of evaluating DestructuringAssignmentTarget.
+      lref = env.evaluate(DestructuringAssignmentTarget, strictCode);
+
+      // b. ReturnIfAbrupt(lref).
+    }
+
+    // 2. Let A be ArrayCreate(0).
+    let A = ArrayCreate(realm, 0);
+
+    // 3. Let n be 0.
+    let n = 0;
+
+    // 4. Repeat while iteratorRecord.[[Done]] is false,
+    while (iteratorRecord.$Done === false) {
+      // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+      let next;
+      try {
+        next = IteratorStep(realm, iteratorRecord.$Iterator);
+      } catch (e) {
+        // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        if (e instanceof AbruptCompletion) {
+          iteratorRecord.$Done = true;
+        }
+        // c. ReturnIfAbrupt(next).
+        throw e;
+      }
+
+      // d. If next is false, set iteratorRecord.[[Done]] to true.
+      if (next === false) {
+        iteratorRecord.$Done = true;
+      } else { // e. Else,
+        // i. Let nextValue be IteratorValue(next).
+        let nextValue;
+        try {
+          nextValue = IteratorValue(realm, next);
+        } catch (e) {
+          // ii. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
+          if (e instanceof AbruptCompletion) {
+            iteratorRecord.$Done = true;
+          }
+          // iii. ReturnIfAbrupt(nextValue).
+          throw e;
+        }
+
+        // iv. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
+        let status = CreateDataProperty(realm, A, n.toString(), nextValue);
+
+        // v. Assert: status is true.
+        invariant(status, "expected to create data property");
+
+        // vi. Increment n by 1.
+        n += 1;
+      }
+    }
+
+    // 5. If DestructuringAssignmentTarget is neither an ObjectLiteral nor an ArrayLiteral, then
+    if (DestructuringAssignmentTarget.type !== "ObjectPattern" &&
+        DestructuringAssignmentTarget.type !== "ArrayPattern") {
+      // `lref` will always be defined at this point. Let Flow know with an
+      // invariant.
+      invariant(lref);
+
+      // a. Return ? PutValue(lref, A).
+      PutValue(realm, lref, A);
+    } else {
+      // 6. Let nestedAssignmentPattern be the parse of the source text corresponding to DestructuringAssignmentTarget using either AssignmentPattern or AssignmentPattern[Yield] as the goal symbol depending upon whether this AssignmentElement has the [Yield] parameter.
+      let nestedAssignmentPattern = DestructuringAssignmentTarget;
+
+      // 7. Return the result of performing DestructuringAssignmentEvaluation of nestedAssignmentPattern with A as the argument.
+      DestructuringAssignmentEvaluation(realm, nestedAssignmentPattern, A, strictCode, env);
+    }
+  }
+}
+
+// ECMA262 12.15.5.4
+export function KeyedDestructuringAssignmentEvaluation(realm: Realm, node: BabelNodeLVal, value: Value, propertyName: PropertyKeyValue, strictCode: boolean, env: LexicalEnvironment) {
+  let DestructuringAssignmentTarget;
+  let Initializer;
+
+  if (node.type === "AssignmentPattern") {
+    Initializer = node.right;
+    DestructuringAssignmentTarget = node.left;
+  } else {
+    DestructuringAssignmentTarget = node;
+  }
+
+  let lref;
+
+  // 1. If DestructuringAssignmentTarget is neither an ObjectLiteral nor an ArrayLiteral, then
+  //
+  // The spec assumes we haven't yet distinguished between literals and
+  // patterns, but our parser does that work for us. That means we check for
+  // "*Pattern" instead of "*Literal" like the spec text suggests.
+  if (DestructuringAssignmentTarget.type !== "ObjectPattern" &&
+      DestructuringAssignmentTarget.type !== "ArrayPattern") {
+    // a. Let lref be the result of evaluating DestructuringAssignmentTarget.
+    lref = env.evaluate(DestructuringAssignmentTarget, strictCode);
+
+    // b. ReturnIfAbrupt(lref).
+  }
+
+  let rhsValue;
+
+  // 2. Let v be ? GetV(value, propertyName).
+  let v = GetV(realm, value, propertyName);
+
+  // 3. If Initializer is present and v is undefined, then
+  if (Initializer && v instanceof UndefinedValue) {
+    // a. Let defaultValue be the result of evaluating Initializer.
+    let defaultValue = env.evaluate(Initializer, strictCode);
+
+    // b. Let rhsValue be ? GetValue(defaultValue).
+    rhsValue = GetValue(realm, defaultValue);
+  } else { // 4. Else, let rhsValue be v.
+    rhsValue = v;
+  }
+
+  // 5. If DestructuringAssignmentTarget is an ObjectLiteral or an ArrayLiteral, then
+  //
+  // The spec assumes we haven't yet distinguished between literals and
+  // patterns, but our parser does that work for us. That means we check for
+  // "*Pattern" instead of "*Literal" like the spec text suggests.
+  if (DestructuringAssignmentTarget.type === "ObjectPattern" || DestructuringAssignmentTarget.type === "ArrayPattern") {
+    // a. Let assignmentPattern be the parse of the source text corresponding to DestructuringAssignmentTarget using either AssignmentPattern or AssignmentPattern[Yield] as the goal symbol depending upon whether this AssignmentElement has the [Yield] parameter.
+    let assignmentPattern = DestructuringAssignmentTarget;
+
+    // b. Return the result of performing DestructuringAssignmentEvaluation of assignmentPattern with rhsValue as the argument.
+    return DestructuringAssignmentEvaluation(realm, assignmentPattern, rhsValue, strictCode, env);
+  }
+
+  // 6. If Initializer is present and v is undefined and IsAnonymousFunctionDefinition(Initializer) and IsIdentifierRef of DestructuringAssignmentTarget are both true, then
+  if (Initializer &&
+      v instanceof UndefinedValue &&
+      IsAnonymousFunctionDefinition(realm, Initializer) &&
+      IsIdentifierRef(realm, DestructuringAssignmentTarget)) {
+    // a. Let hasNameProperty be ? HasOwnProperty(rhsValue, "name").
+    let hasNameProperty = HasOwnProperty(realm, rhsValue, "name");
+
+    // b. If hasNameProperty is false, perform SetFunctionName(rhsValue, GetReferencedName(lref)).
+    if (hasNameProperty === false) {
+      SetFunctionName(realm, rhsValue, GetReferencedName(realm, lref));
+    }
+  }
+
+  // 7. Return ? PutValue(lref, rhsValue).
+  return PutValue(realm, lref, rhsValue);
+}

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -15,7 +15,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { Reference } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
 import { Value, ObjectValue, UndefinedValue } from "../values/index.js";
-import { Completion, AbruptCompletion } from "../completions.js";
+import { NormalCompletion, AbruptCompletion } from "../completions.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   RequireObjectCoercible,
@@ -81,7 +81,7 @@ export function DestructuringAssignmentEvaluation(realm: Realm, pattern: BabelNo
 
     // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
     if (iteratorRecord.$Done === false) {
-      let completion = IteratorClose(realm, iterator, new Completion(realm.intrinsics.undefined));
+      let completion = IteratorClose(realm, iterator, new NormalCompletion(realm.intrinsics.undefined));
       if (completion instanceof AbruptCompletion) {
         throw completion;
       }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -634,7 +634,7 @@ export function IteratorBindingInitialization(realm: Realm, formals: $ReadOnlyAr
           iteratorRecord.$Done = true;
           // Normally this assignment would be done in step 4, but we do it
           // here so that Flow knows `v` will always be initialized by step 5.
-          v = new UndefinedValue(realm);
+          v = realm.intrinsics.undefined;
         } else { // e. Else,
           // i. Let v be IteratorValue(next).
           try {
@@ -649,7 +649,7 @@ export function IteratorBindingInitialization(realm: Realm, formals: $ReadOnlyAr
           }
         }
       } else { // 4. If iteratorRecord.[[Done]] is true, let v be undefined.
-        v = new UndefinedValue(realm);
+        v = realm.intrinsics.undefined;
       }
 
       // 5. If Initializer is present and v is undefined, then
@@ -708,7 +708,7 @@ export function IteratorBindingInitialization(realm: Realm, formals: $ReadOnlyAr
           iteratorRecord.$Done = true;
           // Normally this assignment would be done in step 2, but we do it
           // here so that Flow knows `v` will always be initialized by step 3.
-          v = new UndefinedValue(realm);
+          v = realm.intrinsics.undefined;
         } else { // e. Else,
           // i. Let v be IteratorValue(next).
           try {
@@ -723,7 +723,7 @@ export function IteratorBindingInitialization(realm: Realm, formals: $ReadOnlyAr
           }
         }
       } else { // 2. If iteratorRecord.[[Done]] is true, let v be undefined.
-        v = new UndefinedValue(realm);
+        v = realm.intrinsics.undefined;
       }
 
       // 3. If Initializer is present and v is undefined, then

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -12,6 +12,7 @@
 import type { Realm } from "../realm.js";
 import * as t from "babel-types";
 import invariant from "../invariant.js";
+import { PropertyKeyValue } from "../types.js";
 import {
   AbstractValue,
   UndefinedValue,
@@ -35,15 +36,24 @@ import {
   LexicalEnvironment
 } from "../environment.js";
 import { AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   GetV,
   GetThisValue,
   ToObjectPartial,
   PutValue,
   RequireObjectCoercible,
-  HasSomeCompatibleType
+  HasSomeCompatibleType,
+  GetIterator,
+  IteratorStep,
+  IteratorValue,
+  IteratorClose,
+  CreateDataProperty,
+  ArrayCreate,
+  IsAnonymousFunctionDefinition,
+  HasOwnProperty,
+  SetFunctionName,
 } from "./index.js";
-import { IteratorStep, IteratorValue } from "./iterator.js";
 import type {
   BabelNode,
   BabelNodeVariableDeclaration,
@@ -53,6 +63,7 @@ import type {
   BabelNodeArrayPattern,
   BabelNodeStatement,
   BabelNodeLVal,
+  BabelNodePattern,
 } from "babel-types";
 
 
@@ -172,7 +183,10 @@ export function BoundNames(realm: Realm, node: BabelNode): Array<string> {
 }
 
 // ECMA262 13.3.3.2
-export function ContainsExpression(realm: Realm, node: BabelNode): boolean {
+export function ContainsExpression(realm: Realm, node: ?BabelNode): boolean {
+  if (!node) {
+    return false;
+  }
   switch (node.type) {
     case "ObjectPattern":
       for (let prop of ((node: any): BabelNodeObjectPattern).properties) {
@@ -470,47 +484,135 @@ export function ResolveThisBinding(realm: Realm): NullValue | ObjectValue | Abst
   return envRec.GetThisBinding();
 }
 
-export function BindingInitialization(realm: Realm, node: BabelNode, value: Value, environment: void | LexicalEnvironment) {
+export function BindingInitialization(realm: Realm, node: BabelNodeLVal, value: Value, strictCode: boolean, environment: void | LexicalEnvironment) {
   if (node.type === "ArrayPattern") { // ECMA262 13.3.3.5
     // 1. Let iterator be ? GetIterator(value).
+    let iterator = GetIterator(realm, value);
+
     // 2. Let iteratorRecord be Record {[[Iterator]]: iterator, [[Done]]: false}.
+    let iteratorRecord = {
+      $Iterator: iterator,
+      $Done: false,
+    };
+
     // 3. Let result be IteratorBindingInitialization for ArrayBindingPattern using iteratorRecord and environment as arguments.
+    try {
+      IteratorBindingInitialization(realm, node.elements, iteratorRecord, strictCode, environment);
+    } catch (error) {
+      // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
+      if (iteratorRecord.$Done === false && error instanceof AbruptCompletion) {
+        throw IteratorClose(realm, iterator, error);
+      }
+      throw error;
+    }
+
     // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
+    // TODO: Why does this work?
+    if (iteratorRecord.$Done === false) {
+      let completion = new AbruptCompletion(new UndefinedValue(realm));
+      let actualCompletion = IteratorClose(realm, iterator, completion);
+      if (actualCompletion !== completion) {
+        throw actualCompletion;
+      }
+    }
+
     // 5. Return result.
-    throw new Error("TODO: Patterns aren't supported yet");
+    return;
   } else if (node.type === "ObjectPattern") { // ECMA262 13.3.3.5
+    // BindingPattern : ObjectBindingPattern
+
     // 1. Perform ? RequireObjectCoercible(value).
     RequireObjectCoercible(realm, value);
 
     // 2. Return the result of performing BindingInitialization for ObjectBindingPattern using value and environment as arguments.
-    throw new Error("TODO: Patterns aren't supported yet");
+
+    for (let property of node.properties) {
+      let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
+
+      // 1. Let P be the result of evaluating PropertyName.
+      let P = EvalPropertyName(property, env, realm, strictCode);
+
+      // 2. ReturnIfAbrupt(P).
+
+      // 3. Return the result of performing KeyedBindingInitialization for BindingElement using value, environment, and P as arguments.
+      KeyedBindingInitialization(realm, property.value, value, strictCode, environment, P);
+    }
   } else if (node.type === "Identifier") { // ECMA262 12.1.5
     // 1. Let name be StringValue of Identifier.
     let name = ((node: any): BabelNodeIdentifier).name;
 
     // 2. Return ? InitializeBoundName(name, value, environment).
-    return InitializeBoundName(realm, name, value, environment);
+    InitializeBoundName(realm, name, value, environment);
+    return;
   } else if (node.type === "VariableDeclaration") { // ECMA262 13.7.5.9
     for (let decl of ((node: any): BabelNodeVariableDeclaration).declarations) {
-      BindingInitialization(realm, decl.id, value, environment);
+      BindingInitialization(realm, decl.id, value, strictCode, environment);
+    }
+  } else {
+    throw new Error("Unknown node " + node.type);
+  }
+}
+
+// ECMA262 13.3.3.6
+// ECMA262 14.1.19
+export function IteratorBindingInitialization(realm: Realm, formals: Array<BabelNodeLVal>, iteratorRecord: {$Iterator: ObjectValue, $Done: boolean}, strictCode: boolean, environment: void | LexicalEnvironment) {
+  let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
+
+  // Check if the last formal is a rest element. If so then we want to save the
+  // element and handle it separately after we iterate through the other
+  // formals. This also enforces that a rest element may only ever be in the
+  // last position.
+  let restEl;
+  if (formals.length > 0) {
+    let lastFormal = formals.pop();
+    if (lastFormal.type === 'RestElement') {
+      restEl = lastFormal;
+    } else {
+      formals.push(lastFormal);
     }
   }
 
-  throw new Error("Unknown node " + node.type);
-}
-
-export function IteratorBindingInitialization(realm: Realm, formals: Array<BabelNodeLVal>, iteratorRecord: {$Iterator: ObjectValue, $Done: boolean}, strict: boolean, environment: void | LexicalEnvironment) {
   for (let param of formals) {
-    switch (param.type) {
-    // ECMA262 13.3.3.6
+    if (param === null) {
+      // Elision handling in IteratorDestructuringAssignmentEvaluation
 
-    // SingleNameBinding : BindingIdentifier Initializer
-    case 'Identifier': {
+      // 1. If iteratorRecord.[[Done]] is false, then
+      if (iteratorRecord.$Done === false) {
+        // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+        let next;
+        try {
+          next = IteratorStep(realm, iteratorRecord.$Iterator);
+        } catch (e) {
+          // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+          if (e instanceof AbruptCompletion) {
+            iteratorRecord.$Done = true;
+          }
+          // c. ReturnIfAbrupt(next).
+          throw e;
+        }
+        // d. If next is false, set iteratorRecord.[[Done]] to true.
+        if (next === false) {
+          iteratorRecord.$Done = true;
+        }
+      }
+      // 2. Return NormalCompletion(empty).
+      continue;
+    }
+
+    let Initializer;
+    if (param.type === "AssignmentPattern") {
+      Initializer = param.right;
+      param = param.left;
+    }
+
+    if (param.type === 'Identifier') {
+      // SingleNameBinding : BindingIdentifier Initializer
+
       // 1. Let bindingId be StringValue of BindingIdentifier.
       let bindingId = param.name;
 
       // 2. Let lhs be ? ResolveBinding(bindingId, environment).
-      let lhs = ResolveBinding(realm, param.name, strict, environment);
+      let lhs = ResolveBinding(realm, param.name, strictCode, environment);
 
       // Initialized later in the algorithm.
       let v;
@@ -553,28 +655,38 @@ export function IteratorBindingInitialization(realm: Realm, formals: Array<Babel
         v = new UndefinedValue(realm);
       }
 
-      // TODO:
       // 5. If Initializer is present and v is undefined, then
+      if (Initializer && v instanceof UndefinedValue) {
         // a. Let defaultValue be the result of evaluating Initializer.
+        let defaultValue = env.evaluate(Initializer, strictCode);
+
         // b. Let v be ? GetValue(defaultValue).
+        v = GetValue(realm, defaultValue);
+
         // c. If IsAnonymousFunctionDefinition(Initializer) is true, then
+        if (IsAnonymousFunctionDefinition(realm, Initializer)) {
           // i. Let hasNameProperty be ? HasOwnProperty(v, "name").
+          let hasNameProperty = HasOwnProperty(realm, v, "name");
+
           // ii. If hasNameProperty is false, perform SetFunctionName(v, bindingId).
+          if (hasNameProperty === false) {
+            SetFunctionName(realm, v, bindingId);
+          }
+        }
+      }
 
       // 6. If environment is undefined, return ? PutValue(lhs, v).
       if (!environment) {
         PutValue(realm, lhs, v);
-        break;
+        continue;
       }
 
       // 7. Return InitializeReferencedBinding(lhs, v).
       InitializeReferencedBinding(realm, lhs, v);
-      break;
-    }
+      continue;
+    } else if (param.type === 'ObjectPattern' || param.type === 'ArrayPattern') {
+      // BindingElement : BindingPatternInitializer
 
-    // BindingElement : BindingPatternInitializer
-    case 'ObjectPattern':
-    case 'ArrayPattern': {
       // Initialized later in the algorithm.
       let v;
 
@@ -616,19 +728,97 @@ export function IteratorBindingInitialization(realm: Realm, formals: Array<Babel
         v = new UndefinedValue(realm);
       }
 
-      // TODO:
       // 3. If Initializer is present and v is undefined, then
+      if (Initializer && v instanceof UndefinedValue) {
         // a. Let defaultValue be the result of evaluating Initializer.
+        let defaultValue = env.evaluate(Initializer, strictCode);
+
         // b. Let v be ? GetValue(defaultValue).
+        v = GetValue(realm, defaultValue);
+      }
 
       // 4. Return the result of performing BindingInitialization of BindingPattern with v and environment as the arguments.
-      BindingInitialization(realm, param, v, environment);
-      break;
+      BindingInitialization(realm, param, v, strictCode, environment);
+      continue;
+    } else {
+      throw new ThrowCompletion(new StringValue(realm, "unrecognized element"));
     }
+  }
 
-    default:
-      throw new ThrowCompletion(new StringValue(realm, `unrecognized parameter of type '${param.type}'`));
+  // Handle the rest element if we have one.
+  if (restEl && restEl.argument.type === 'Identifier') {
+    // BindingRestElement : ...BindingIdentifier
+
+    // 1. Let lhs be ? ResolveBinding(StringValue of BindingIdentifier, environment).
+    let lhs = ResolveBinding(realm, restEl.argument.name, strictCode, environment);
+
+    // 2. Let A be ArrayCreate(0).
+    let A = ArrayCreate(realm, 0);
+
+    // 3. Let n be 0.
+    let n = 0;
+
+    // 4. Repeat,
+    while (true) {
+      // Initialized later in the algorithm.
+      let next;
+
+      // a. If iteratorRecord.[[Done]] is false, then
+      if (iteratorRecord.$Done === false) {
+        // i. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+        try {
+          next = IteratorStep(realm, iteratorRecord.$Iterator);
+        } catch (e) {
+          // ii. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+          if (e instanceof AbruptCompletion) {
+            iteratorRecord.$Done = true;
+          }
+          // iii. ReturnIfAbrupt(next).
+          throw e;
+        }
+        // iv. If next is false, set iteratorRecord.[[Done]] to true.
+        if (next === false) {
+          iteratorRecord.$Done = true;
+        }
+      }
+
+      // b. If iteratorRecord.[[Done]] is true, then
+      if (iteratorRecord.$Done === true) {
+        // i. If environment is undefined, return ? PutValue(lhs, A).
+        if (!environment) {
+          PutValue(realm, lhs, A);
+          break;
+        }
+
+        // ii. Return InitializeReferencedBinding(lhs, A).
+        InitializeReferencedBinding(realm, lhs, A);
+        break;
+      }
+
+      // c. Let nextValue be IteratorValue(next).
+      let nextValue;
+      try {
+        nextValue = IteratorValue(realm, next);
+      } catch (e) {
+        // d. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
+        if (e instanceof AbruptCompletion) {
+          iteratorRecord.$Done = true;
+        }
+        // e. ReturnIfAbrupt(nextValue).
+        throw e;
+      }
+
+      // f. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
+      let status = CreateDataProperty(realm, A, n.toString(), nextValue);
+
+      // g. Assert: status is true.
+      invariant(status, "expected to create data property");
+
+      // h. Increment n by 1.
+      n += 1;
     }
+  } else if (restEl) {
+    throw new ThrowCompletion(new StringValue(realm, "unrecognized rest argument"));
   }
 }
 
@@ -681,39 +871,77 @@ export function IsDestructuring(ast: BabelNode) {
     case "ArrayLiteral":
     case "ObjectLiteral":
       return true;
+    case "ArrayPattern":
+    case "ObjectPattern":
+      return true;
     default:
       return false;
   }
 }
 
 // ECMA262 13.3.3.7
-export function KeyedBindingInitialization(realm: Realm, value: Value, environment: ?LexicalEnvironment, propertyName: string) {
-  // 1. Let bindingId be StringValue of BindingIdentifier.
-  let bindingId = propertyName;
+export function KeyedBindingInitialization(realm: Realm, node: BabelNodeIdentifier | BabelNodePattern, value: Value, strictCode: boolean, environment: ?LexicalEnvironment, propertyName: PropertyKeyValue) {
+  let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
 
-  // if environment is undefined, the calling context is not strict
-  let strict = environment !== undefined;
-
-  // 2. Let lhs be ? ResolveBinding(bindingId, environment).
-  let lhs = ResolveBinding(realm, bindingId, strict, environment);
-
-  // 3. Let v be ? GetV(value, propertyName).
-  let v = GetV(realm, value, propertyName);
-
-  // 4. If Initializer is present and v is undefined, then
-  if (false) {
-    // a. Let defaultValue be the result of evaluating Initializer.
-    // b. Let v be ? GetValue(defaultValue).
-    // c. If IsAnonymousFunctionDefinition(Initializer) is true, then
-      // i. Let hasNameProperty be ? HasOwnProperty(v, "name").
-      // ii. If hasNameProperty is false, perform SetFunctionName(v, bindingId).
+  let Initializer;
+  if (node.type === "AssignmentPattern") {
+    Initializer = node.right;
+    node = node.left;
   }
 
-  // 5. If environment is undefined, return ? PutValue(lhs, v).
-  if (!environment) return PutValue(realm, lhs, v);
+  if (node.type === 'Identifier') {
+    // SingleNameBinding : BindingIdentifier Initializer
 
-  console.log(lhs, v);
+    // 1. Let bindingId be StringValue of BindingIdentifier.
+    let bindingId = node.name;
 
-  // 6. Return InitializeReferencedBinding(lhs, v).
-  return InitializeReferencedBinding(realm, lhs, v);
+    // 2. Let lhs be ? ResolveBinding(bindingId, environment).
+    let lhs = ResolveBinding(realm, bindingId, strictCode, environment);
+
+    // 3. Let v be ? GetV(value, propertyName).
+    let v = GetV(realm, value, propertyName);
+
+    // 4. If Initializer is present and v is undefined, then
+    if (Initializer && v instanceof UndefinedValue) {
+      // a. Let defaultValue be the result of evaluating Initializer.
+      let defaultValue = env.evaluate(Initializer, strictCode);
+
+      // b. Let v be ? GetValue(defaultValue).
+      v = GetValue(realm, defaultValue);
+
+      // c. If IsAnonymousFunctionDefinition(Initializer) is true, then
+      if (IsAnonymousFunctionDefinition(realm, Initializer)) {
+        // i. Let hasNameProperty be ? HasOwnProperty(v, "name").
+        let hasNameProperty = HasOwnProperty(realm, v, "name");
+
+        // ii. If hasNameProperty is false, perform SetFunctionName(v, bindingId).
+        if (hasNameProperty === false) {
+          SetFunctionName(realm, v, bindingId);
+        }
+      }
+    }
+
+    // 5. If environment is undefined, return ? PutValue(lhs, v).
+    if (!environment) return PutValue(realm, lhs, v);
+
+    // 6. Return InitializeReferencedBinding(lhs, v).
+    return InitializeReferencedBinding(realm, lhs, v);
+  } else if (node.type === "ObjectPattern" || node.type === "ArrayPattern") {
+    // BindingElement : BindingPattern Initializer
+
+    // 1. Let v be ? GetV(value, propertyName).
+    let v = GetV(realm, value, propertyName);
+
+    // 2. If Initializer is present and v is undefined, then
+    if (Initializer && v instanceof UndefinedValue) {
+      // a. Let defaultValue be the result of evaluating Initializer.
+      let defaultValue = env.evaluate(Initializer, strictCode);
+
+      // b. Let v be ? GetValue(defaultValue).
+      v = GetValue(realm, defaultValue);
+    }
+
+    // 3. Return the result of performing BindingInitialization for BindingPattern passing v and environment as arguments.
+    return BindingInitialization(realm, node, v, strictCode, environment);
+  }
 }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -35,7 +35,7 @@ import {
   Reference,
   LexicalEnvironment
 } from "../environment.js";
-import { Completion, AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { NormalCompletion, AbruptCompletion, ThrowCompletion } from "../completions.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   GetV,
@@ -510,7 +510,7 @@ export function BindingInitialization(realm: Realm, node: BabelNodeLVal, value: 
 
     // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
     if (iteratorRecord.$Done === false) {
-      let completion = IteratorClose(realm, iterator, new Completion(realm.intrinsics.undefined));
+      let completion = IteratorClose(realm, iterator, new NormalCompletion(realm.intrinsics.undefined));
       if (completion instanceof AbruptCompletion) {
         throw completion;
       }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -627,7 +627,7 @@ export function IteratorBindingInitialization(realm: Realm, formals: Array<Babel
     }
 
     default:
-      throw new ThrowCompletion(new StringValue(realm, `unrecognized parameter of kind '${param.kind}'`));
+      throw new ThrowCompletion(new StringValue(realm, `unrecognized parameter of type '${param.type}'`));
     }
   }
 }

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -16,7 +16,7 @@ import { ThrowCompletion, ReturnCompletion, AbruptCompletion, NormalCompletion, 
 import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord, Reference } from "../environment.js";
 import { Value, BoundFunctionValue, EmptyValue, FunctionValue, ObjectValue, StringValue, SymbolValue, NumberValue } from "../values/index.js";
-import { DefinePropertyOrThrow, NewDeclarativeEnvironment, ResolveBinding } from "./index.js";
+import { DefinePropertyOrThrow, NewDeclarativeEnvironment } from "./index.js";
 import { OrdinaryCreateFromConstructor, CreateUnmappedArgumentsObject, CreateMappedArgumentsObject } from "./create.js";
 import { OrdinaryCallEvaluateBody, OrdinaryCallBindThis, PrepareForOrdinaryCall, Call } from "./call.js";
 import { SameValue } from "../methods/abstract.js";
@@ -25,7 +25,6 @@ import { IteratorBindingInitialization } from "../methods/environment.js";
 import { joinPossiblyNormalCompletionWithAbruptCompletion, composePossiblyNormalCompletions,
   BoundNames, ContainsExpression, GetActiveScriptOrModule, UpdateEmpty } from "../methods/index.js";
 import { CreateListIterator } from "../methods/iterator.js";
-import { PutValue } from "./properties.js";
 import traverse from "../traverse.js";
 import invariant from "../invariant.js";
 import parse from "../utils/parse.js";

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -26,6 +26,7 @@ export * from "./iterator.js";
 export * from "./join.js";
 export * from "./own.js";
 export * from "./properties.js";
+export * from "./destructuring.js";
 export * from "./regexp.js";
 export * from "./promise.js";
 export * from "./arraybuffer.js";

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -11,22 +11,22 @@
 
 import type { Realm } from "../realm.js";
 import type { CallableObjectValue } from "../types.js";
-import { ThrowCompletion, AbruptCompletion } from "../completions.js";
+import { Completion, ThrowCompletion } from "../completions.js";
 import {
-  NumberValue,
-  StringValue,
-  ObjectValue,
-  UndefinedValue,
   NativeFunctionValue,
+  NumberValue,
+  ObjectValue,
+  StringValue,
+  UndefinedValue,
   Value,
 } from "../values/index.js";
 import {
-  GetMethod,
   Call,
   Get,
-  ToBooleanPartial,
+  GetMethod,
   Invoke,
   ObjectCreate,
+  ToBooleanPartial,
 } from "./index.js";
 import invariant from "../invariant.js";
 import type { IterationKind } from "../types.js";
@@ -255,12 +255,12 @@ export function CreateSetIterator(realm: Realm, set: Value, kind: IterationKind)
 }
 
 // ECMA262 7.4.6
-export function IteratorClose(realm: Realm, iterator: ObjectValue, completion: AbruptCompletion): AbruptCompletion {
+export function IteratorClose(realm: Realm, iterator: ObjectValue, completion: Completion): Completion {
   // 1. Assert: Type(iterator) is Object.
   invariant(iterator instanceof ObjectValue, "expected object");
 
   // 2. Assert: completion is a Completion Record.
-  invariant(completion instanceof AbruptCompletion, "expected completion record");
+  invariant(completion instanceof Completion, "expected completion record");
 
   // 3. Let return be ? GetMethod(iterator, "return").
   let ret = GetMethod(realm, iterator, "return");
@@ -284,7 +284,7 @@ export function IteratorClose(realm: Realm, iterator: ObjectValue, completion: A
 
   // 8. If Type(innerResult.[[Value]]) is not Object, throw a TypeError exception.
   if (!(innerResult instanceof ObjectValue)) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    return realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
   }
 
   // 9. Return Completion(completion).

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -273,6 +273,7 @@ export function IteratorClose(realm: Realm, iterator: ObjectValue, completion: A
   if (completion instanceof ThrowCompletion) return completion;
 
   // 7. If innerResult.[[Type]] is throw, return Completion(innerResult).
+  if (innerResult instanceof ThrowCompletion) return innerResult;
 
   // 8. If Type(innerResult.[[Value]]) is not Object, throw a TypeError exception.
   if (!(innerResult instanceof ObjectValue)) {

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -167,9 +167,11 @@ function ListIterator_next(realm: Realm): NativeFunctionValue {
     // 7. Let list be the value of the [[IteratedList]] internal slot of O.
     let list = O.$IteratedList;
 
+    invariant(typeof O.$ListIteratorNextIndex === "number");
+
     // 8. Let index be the value of the [[ListIteratorNextIndex]] internal slot of O.
     // Default to 0 for Flow.
-    let index = O.$ListIteratorNextIndex || 0;
+    let index = O.$ListIteratorNextIndex;
 
     // 9. Let len be the number of elements of list.
     let len = list.length;

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -137,7 +137,9 @@ export function CreateListIterator(realm: Realm, list: Array<Value>): ObjectValu
 
 // ECMA262 7.4.8.1
 function ListIterator_next(realm: Realm): NativeFunctionValue {
-  let func = new NativeFunctionValue(realm, undefined, "next", 0, (context: ObjectValue) => {
+  let func = new NativeFunctionValue(realm, undefined, "next", 0, context => {
+    invariant(context instanceof ObjectValue);
+
     // 1. Let O be the this value.
     let O = context;
 

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { CallableObjectValue } from "../types.js";
-import { Completion, ThrowCompletion } from "../completions.js";
+import { Completion, AbruptCompletion, ThrowCompletion } from "../completions.js";
 import {
   NativeFunctionValue,
   NumberValue,
@@ -177,7 +177,7 @@ function ListIterator_next(realm: Realm): NativeFunctionValue {
     // 10. If index ≥ len, then
     if (index >= len) {
       // a. Return CreateIterResultObject(undefined, true).
-      return CreateIterResultObject(realm, new UndefinedValue(realm), true);
+      return CreateIterResultObject(realm, realm.intrinsics.undefined, true);
     }
 
     // 11. Set the value of the [[ListIteratorNextIndex]] internal slot of O to index+1.
@@ -273,7 +273,11 @@ export function IteratorClose(realm: Realm, iterator: ObjectValue, completion: C
   try {
     innerResult = Call(realm, ret.throwIfNotConcrete(), iterator, []);
   } catch (error) {
-    innerResult = error;
+    if (error instanceof AbruptCompletion) {
+      innerResult = error;
+    } else {
+      throw error;
+    }
   }
 
   // 6. If completion.[[Type]] is throw, return Completion(completion).

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -267,7 +267,12 @@ export function IteratorClose(realm: Realm, iterator: ObjectValue, completion: A
   if (ret instanceof UndefinedValue) return completion;
 
   // 5. Let innerResult be Call(return, iterator, « »).
-  let innerResult = Call(realm, ret.throwIfNotConcrete(), iterator, []);
+  let innerResult;
+  try {
+    innerResult = Call(realm, ret.throwIfNotConcrete(), iterator, []);
+  } catch (error) {
+    innerResult = error;
+  }
 
   // 6. If completion.[[Type]] is throw, return Completion(completion).
   if (completion instanceof ThrowCompletion) return completion;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -100,6 +100,11 @@ export default class ObjectValue extends ConcreteValue {
   $Capabilities: void | PromiseCapability;
   $RemainingElements: void | { value: number };
 
+  // iterator
+  $IteratedList: void | Array<Value>;
+  $ListIteratorNextIndex: void | number;
+  $IteratorNext: void | NativeFunctionValue;
+
   // set
   $SetIterationKind: void | IterationKind;
   $SetNextIndex: void | number;


### PR DESCRIPTION
This implements the runtime semantics to get all the tests for the `destructuring-binding` feature to pass. At first that was only sections [13.3.3.5](http://www.ecma-international.org/ecma-262/7.0/#sec-destructuring-binding-patterns-runtime-semantics-bindinginitialization) and [13.3.3.6](http://www.ecma-international.org/ecma-262/7.0/#sec-destructuring-binding-patterns-runtime-semantics-iteratorbindinginitialization) along with other unimplemented supporting sections. However, what I learned is that there are actually two ways to destructure in the spec. One for the variable and argument definitions people are familiar with:

```js
const { x } = { x: 5 };
```

…and another for destructuring an expression which can lead to interesting code which I first did not believe was JavaScript:

```js
const x = {};

0, { xy: x.y } = { xy: 23 };

console.log(x.y); // Logs "23"
```

So that meant sections [12.15.5.2](http://www.ecma-international.org/ecma-262/7.0/#sec-runtime-semantics-destructuringassignmentevaluation), [12.15.5.3](http://www.ecma-international.org/ecma-262/7.0/#sec-runtime-semantics-iteratordestructuringassignmentevaluation), and [12.15.5.4](http://www.ecma-international.org/ecma-262/7.0/#sec-runtime-semantics-keyeddestructuringassignmentevaluation) also needed to be implemented along with their supporting methods to get the tests with the `destructuring-binding` feature to pass.

When enabling the `destructuring-binding` tests I also found some tests which contained generators which were not labeled with the `generators` feature flag. Some instead had a `generator` feature flag, and others had no indication that they were using generators. For these “sneaky generator” tests I added a couple other filters to `scripts/test262-runner.js` in development and decided to leave them in when opening this PR. If you want the filters removed or refactored let me know.

I want to draw your attention to a couple of specific areas in the diff where I could use some guidance on the proper styles and organization of this codebase:

- In general in the code I preferred visually following the flow of the specification to DRYness in places where code may have been reusable. I assume this is generally the approach that makes the most sense for this codebase, but there are a lot of places in this diff where code is internally duplicated, or duplicated from previous implementations.
- The `EvalPropertyName()` function in `evaluators/ObjectExpression.js` is not formally defined in the specification (at least anywhere I could find), but implements the same procedure for evaluating property names when it comes to destructuring. Specifically in cases like this: `const { [a + b]: x } = ...` . Is there a better way to expose this logic, or should this logic be copied to the callsites where this logic is needed?
- I made a lot of changes to [`methods/environment.js`](https://github.com/facebook/prepack/compare/master...calebmer:es6-destructuring-bindings#diff-d224ad787c05488da66b128e046fbf62R12) to completely implement `BindingInitilization` and then `IteratorBindingInitilization` which shares a similar mandate. That *doubled* the size of the file. (Previously [575 lines](https://github.com/calebmer/prepack/blob/a127d6224851884be454b98ae94901673144f7ee/src/methods/environment.js), now [1018](https://github.com/calebmer/prepack/blob/e9d6364b475b70c521cd7137d2f22a045c180386/src/methods/environment.js) lines.) Is this to much scope creep? How do you recommend extracting some of the logic? (If at all.)
- There is some logic around calling `IteratorClose` that I don’t fully understand. It gets the tests to pass, but the code itself is a little hacky and does not entirely make sense. I get the feeling that `IteratorClose` is improperly implemented, but I didn’t spend a lot of time verifying that and fixing it. The two callsites are [here](https://github.com/facebook/prepack/compare/master...calebmer:es6-destructuring-bindings#diff-1f9be20197695c39b4e93e761c0dec7cR83) and [here](https://github.com/facebook/prepack/compare/master...calebmer:es6-destructuring-bindings#diff-d224ad787c05488da66b128e046fbf62R510).

There may be other stylistic issues, let me know! 😊