### PR TITLE
Delay serialization of any value that is only referenced from residual functions

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -170,10 +170,12 @@ function runTest(name, code, args) {
       let i = 0;
       let max = 4;
       let oldCode = code;
+      let anyIndexedVars = false;
       for (; i < max; i++) {
         let newUniqueSuffix = `_unique${unique++}`;
         options.uniqueSuffix = newUniqueSuffix;
         let serialized = prepack(oldCode, options);
+        if (serialized.statistics.indexedVars > 0) anyIndexedVars = true;
         if (!serialized) {
           console.log(chalk.red("Error during serialization!"));
           break;
@@ -210,7 +212,10 @@ function runTest(name, code, args) {
         oldCode = newCode;
         oldUniqueSuffix = newUniqueSuffix;
       }
-      if (i === max) {
+      if (anyIndexedVars) {
+        // TODO: Make delayed initializations logic more sophisticated in order to still reach a fixed point.
+        return true;
+      } else if (i === max) {
         console.log(chalk.red(`Code generation did not reach fixed point after ${max} iterations!`));
       }
     } catch (err) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -383,6 +383,7 @@ export class ResidualHeapVisitor {
 
     let visitedBindings = Object.create(null);
     this.withScope(val, () => {
+      invariant(functionInfo);
       for (let innerName in functionInfo.names) {
         let visitedBinding;
         let doesNotMatter = true;

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -524,7 +524,7 @@ export class ResidualHeapVisitor {
     } else if (val instanceof SymbolValue) {
       if (this._mark(val)) this.visitValueSymbol(val);
     } else if (val instanceof ObjectValue) {
-      // Prototypes are reachable via function declarations, and those get hoised, so we need to move
+      // Prototypes are reachable via function declarations, and those get hoisted, so we need to move
       // prototype initialization to the global code as well.
       if (val.originalConstructor !== undefined) {
         this._withScope(this.realmGenerator, () => {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -25,7 +25,7 @@ import { ClosureRefVisitor } from "./visitors.js";
 import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
 
-class GlobalScope {}
+export class GlobalScope {}
 
 /* This class visits all values that are reachable in the residual heap.
    In particular, this "filters out" values that are...

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -16,10 +16,11 @@ import { ToLength, IsArray, Get } from "../methods/index.js";
 import { Completion } from "../completions.js";
 import { BoundFunctionValue, ProxyValue, SymbolValue, AbstractValue, EmptyValue, FunctionValue, Value, ObjectValue, NativeFunctionValue, UndefinedValue } from "../values/index.js";
 import * as t from "babel-types";
-import type { BabelNodeExpression, BabelNodeStatement, BabelNodeIdentifier, BabelNodeBlockStatement, BabelNodeObjectExpression, BabelNodeStringLiteral, BabelNodeLVal, BabelNodeSpreadElement, BabelVariableKind, BabelNodeFunctionDeclaration, BabelNodeIfStatement } from "babel-types";
+import type { BabelNodeExpression, BabelNodeStatement, BabelNodeIdentifier, BabelNodeBlockStatement, BabelNodeObjectExpression, BabelNodeStringLiteral, BabelNodeLVal, BabelNodeSpreadElement, BabelVariableKind, BabelNodeFunctionDeclaration, BabelNodeIfStatement, BabelNodeMemberExpression, BabelNodeVariableDeclaration } from "babel-types";
 import { Generator, PreludeGenerator, NameGenerator } from "../utils/generator.js";
 import type { SerializationContext } from "../utils/generator.js";
 import generate from "babel-generator";
+import type SourceMap from "babel-generator";
 // import { transform } from "babel-core";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";
@@ -88,17 +89,16 @@ export class Serializer {
     this.preludeGenerator = realmPreludeGenerator;
 
     this.options = serializerOptions;
-    this._resetSerializeStates();
   }
 
-  _resetSerializeStates() {
+  _init(detectValuesUsedBySingleFunctionValue: boolean, collectValToRefCountOnly: boolean) {
     this.declarativeEnvironmentRecordsBindings = new Map();
     this.serializationStack = [];
     this.delayedSerializations = [];
     this.delayedKeyedSerializations = new Map();
     this.globalReasons = {};
     this.prelude = [];
-    this.body = [];
+    this.body = this.mainBody = [];
 
     this.serializedScopes = new Map();
     this.capturedScopeInstanceIdx = 0;
@@ -112,6 +112,7 @@ export class Serializer {
     this.declaredDerivedIds = new Set();
     this.descriptors = new Map();
     this.needsEmptyVar = false;
+    this.needsVars = false;
     this.needsAuxiliaryConstructor = false;
     this.valueNameGenerator = this.preludeGenerator.createNameGenerator("_");
     this.descriptorNameGenerator = this.preludeGenerator.createNameGenerator("$$");
@@ -122,6 +123,13 @@ export class Serializer {
     this.firstFunctionUsages = new Map();
     this.functionPrototypes = new Map();
     this.serializedValues = new Set();
+    this.functionInitializers = new Map();
+    this.varsExpression = t.identifier(this.scopeNameGenerator.generate("vars"));
+    this.nextVarsIndex = 0;
+    this.availableVars = [];
+    this.detectValuesUsedBySingleFunctionValue = detectValuesUsedBySingleFunctionValue;
+    this.collectValToRefCountOnly = collectValToRefCountOnly;
+    if (collectValToRefCountOnly) this.valToRefCount = new Map();
   }
 
   globalReasons: {
@@ -137,17 +145,19 @@ export class Serializer {
   functions: Map<BabelNodeBlockStatement, Array<FunctionInstance>>;
   functionInstances: Array<FunctionInstance>;
   //value to intermediate references generated like $0, $1, $2,...
-  refs: Map<Value, BabelNodeIdentifier>;
+  refs: Map<Value, BabelNodeIdentifier | BabelNodeMemberExpression>;
   collectValToRefCountOnly: boolean;
   valToRefCount: Map<Value, number>;
   prelude: Array<BabelNodeStatement>;
   body: Array<BabelNodeStatement>;
+  mainBody: Array<BabelNodeStatement>;
   realm: Realm;
   declaredDerivedIds: Set<BabelNodeIdentifier>;
   preludeGenerator: PreludeGenerator;
   generator: Generator;
   descriptors: Map<string, BabelNodeIdentifier>;
   needsEmptyVar: boolean;
+  needsVars: boolean;
   needsAuxiliaryConstructor: boolean;
   valueNameGenerator: NameGenerator;
   descriptorNameGenerator: NameGenerator;
@@ -164,13 +174,24 @@ export class Serializer {
   residualValues: Map<Value, Set<Scope>>;
   residualFunctionBindings: Map<FunctionValue, VisitedBindings>;
   residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>;
+  functionInitializers: Map<FunctionValue, { body: Array<BabelNodeStatement>, values: Array<Value> }>;
   serializedValues: Set<Value>;
   serializedScopes: Map<DeclarativeEnvironmentRecord, ScopeBinding>;
   capturedScopeInstanceIdx: number;
+  varsExpression: BabelNodeIdentifier;
+  nextVarsIndex: number;
+  availableVars: Array<BabelNodeMemberExpression>;
+  detectValuesUsedBySingleFunctionValue: boolean;
 
+  allocateIndexedVar(): BabelNodeMemberExpression {
+    if (this.availableVars.length > 0) {
+      return this.availableVars.pop();
+    }
+    return t.memberExpression(this.varsExpression, t.numericLiteral(this.nextVarsIndex++), true);
+  }
 
-  _getBodyReference() {
-    return new BodyReference(this.body, this.body.length);
+  releaseIndexedVar(indexedVar: BabelNodeMemberExpression) {
+    this.availableVars.push(indexedVar);
   }
 
   execute(filename: string, code: string, map: string,
@@ -408,7 +429,7 @@ export class Serializer {
         descriptorId = t.identifier(this.descriptorNameGenerator.generate(descriptorsKey));
         let declar = t.variableDeclaration("var", [
           t.variableDeclarator(descriptorId, t.objectExpression(descProps))]);
-        this.body.push(declar);
+        this.prelude.push(declar);
         this.descriptors.set(descriptorsKey, descriptorId);
       }
       invariant(descriptorId !== undefined);
@@ -462,15 +483,15 @@ export class Serializer {
     return serializedBinding;
   }
 
-  _getValIdForReference(val: Value): BabelNodeIdentifier {
+  _getValIdForReference(val: Value): BabelNodeIdentifier | BabelNodeMemberExpression {
     let id = this._getValIdForReferenceOptional(val);
-    invariant(id, "Value Id cannot be null or undefined");
+    invariant(id !== undefined, "Value Id cannot be null or undefined");
     return id;
   }
 
-  _getValIdForReferenceOptional(val: Value): ?BabelNodeIdentifier {
+  _getValIdForReferenceOptional(val: Value): void | BabelNodeIdentifier | BabelNodeMemberExpression{
     let id = this.refs.get(val);
-    if (id) {
+    if (id !== undefined) {
       this._incrementValToRefCount(val);
     }
     return id;
@@ -488,8 +509,37 @@ export class Serializer {
     }
   }
 
+  _getTarget(val: Value, scopes: Set<Scope>): { body: Array<BabelNodeStatement>, usedBySingleFunctionValue?: true } {
+    let functionValues = [];
+    let generators = [];
+    for (let scope of scopes) {
+      if (scope instanceof FunctionValue) functionValues.push(scope);
+      else {
+        invariant(scope instanceof Generator);
+        if (scope === this.realm.generator) return { body: this.mainBody };
+        generators.push(scope);
+      }
+    }
+
+    if (generators.length === 0) {
+      if (functionValues.length === 1 && this.detectValuesUsedBySingleFunctionValue) {
+        let initializer = this.functionInitializers.get(functionValues[0]);
+        if (initializer === undefined) this.functionInitializers.set(functionValues[0], initializer = { body: [], values: [] });
+        initializer.values.push(val);
+        return { body: initializer.body, usedBySingleFunctionValue: true };
+      }
+      return { body: this.mainBody };
+    }
+
+    // TODO: What does this mean? Where should the code go? Figure this out.
+    // TODO #482: If there's more than one generator involved, We should walk up the generator chain, and find the first common generator, and then choose a body that will be emitted just before that common generator.
+    // For now, stick to historical behavior.
+    return { body: this.body };
+  }
+
   serializeValue(val: Value, reasons?: Array<string>, referenceOnly?: boolean, bindingType?: BabelVariableKind): BabelNodeExpression {
-    invariant(this.residualValues.has(val));
+    let scopes = this.residualValues.get(val);
+    invariant(scopes !== undefined);
 
     let ref = this._getValIdForReferenceOptional(val);
     if (ref) {
@@ -504,8 +554,19 @@ export class Serializer {
       return res;
     }
 
+    let oldBody = this.body;
+    let target = this._getTarget(val, scopes);
+    this.body = target.body;
+
     let name = this.valueNameGenerator.generate(val.__originalName || "");
-    let id = t.identifier(name);
+    let id;
+    if (target.usedBySingleFunctionValue) {
+      invariant(!(val instanceof FunctionValue));
+      this.needsVars = true;
+      id = this.allocateIndexedVar();
+    } else {
+      id = t.identifier(name);
+    }
     this.refs.set(val, id);
     this.serializationStack.push(val);
     let init = this._serializeValue(name, val, reasons);
@@ -522,36 +583,45 @@ export class Serializer {
     invariant(refCount !== undefined && refCount > 0);
     if (this.collectValToRefCountOnly ||
       refCount !== 1) {
-       if (init) {
-         if (init !== id) {
-           let declar = t.variableDeclaration((bindingType ? bindingType : "var"), [
-             t.variableDeclarator(id, init)
-           ]);
+      if (init) {
+        if (init !== id) {
+          if (target.usedBySingleFunctionValue) {
+            let assignment = t.expressionStatement(t.assignmentExpression("=", id, init));
+            this.body.push(assignment);
+          } else {
+            let declar = t.variableDeclaration((bindingType ? bindingType : "var"), [
+              t.variableDeclarator(id, init)
+            ]);
+            this.body.push(declar);
+          }
+        }
+        this.statistics.valueIds++;
+        if (target.usedBySingleFunctionValue) this.statistics.indexedVars++;
+      }
+    } else {
+      if (target.usedBySingleFunctionValue) {
+        invariant(id.type === "MemberExpression");
+        this.releaseIndexedVar(((id: any): BabelNodeMemberExpression));
+      }
 
-           this.body.push(declar);
-         }
-         this.statistics.valueIds++;
-       }
-     } else {
-       if (init) {
-         this.refs.delete(val);
-         result = init;
-         this.statistics.valueIdsElided++;
-       }
-     }
+      if (init) {
+        this.refs.delete(val);
+        result = init;
+        this.statistics.valuesInlined++;
+      }
+    }
 
     this.serializationStack.pop();
     if (this.serializationStack.length === 0) {
-      let oldBody = this.body;
       while (this.delayedSerializations.length) {
         invariant(this.serializationStack.length === 0);
         let delayed = this.delayedSerializations.shift();
         this.body = delayed.body;
         delayed.func();
       }
-      this.body = oldBody;
     }
 
+    this.body = oldBody;
     return result;
   }
 
@@ -605,7 +675,7 @@ export class Serializer {
         if (delayReason) return delayReason;
       }
     } else if (val instanceof FunctionValue) {
-      if (!this.firstFunctionUsages.has(val)) this.firstFunctionUsages.set(val, this._getBodyReference());
+      if (!this.firstFunctionUsages.has(val)) this.firstFunctionUsages.set(val, new BodyReference(this.body, this.body.length));
       return false;
     } else if (val instanceof AbstractValue) {
       if (val.hasIdentifier() && !this.declaredDerivedIds.has(val.getIdentifier())) return val.getIdentifier();
@@ -904,7 +974,7 @@ export class Serializer {
     let delayed = 1;
     let undelay = () => {
       if (--delayed === 0) {
-        instance.insertionPoint = this._getBodyReference();
+        instance.insertionPoint = new BodyReference(this.body, this.body.length);
         this.functionInstances.push(instance);
 
         let code = val.$ECMAScriptCode;
@@ -944,7 +1014,7 @@ export class Serializer {
   _canEmbedProperty(obj: ObjectValue, key: string, prop: Descriptor): boolean {
     if ((obj instanceof FunctionValue && key === "prototype") ||
         (obj.getKind() === "RegExp" && key === "lastIndex"))
-    return !!prop.writable && !prop.configurable && !prop.enumerable && !prop.set && !prop.get;
+      return !!prop.writable && !prop.configurable && !prop.enumerable && !prop.set && !prop.get;
     else
       return !!prop.writable && !!prop.configurable && !!prop.enumerable && !prop.set && !prop.get;
   }
@@ -967,7 +1037,8 @@ export class Serializer {
         invariant(prototypeId !== undefined);
         this.serializeValue(constructor, reasons.concat(`Constructor of object ${name}`));
         this.addProperties(name, val, reasons);
-        this.functionPrototypes.set(constructor, prototypeId);
+        invariant(prototypeId.type === "Identifier");
+        this.functionPrototypes.set(constructor, ((prototypeId: any): BabelNodeIdentifier));
       });
       return prototypeId;
     }
@@ -1253,6 +1324,7 @@ export class Serializer {
     let functionEntries: Array<[BabelNodeBlockStatement, Array<FunctionInstance>]> = Array.from(this.functions.entries());
     this.statistics.functions = functionEntries.length;
     let hoistedBody = [];
+    let funcNodes: Map<FunctionValue, BabelNodeFunctionDeclaration | BabelNodeVariableDeclaration> = new Map();
 
     for (let [funcBody, instances] of functionEntries) {
       let functionInfo = this.residualFunctionInfos.get(funcBody);
@@ -1283,6 +1355,7 @@ export class Serializer {
               t.memberExpression(id, t.identifier("prototype")))
           ]));
         }
+        funcNodes.set(functionValue, funcNode);
       };
 
       if (shouldInline || instances.length === 1 || usesArguments) {
@@ -1291,6 +1364,7 @@ export class Serializer {
         for (let instance of instances) {
           let { functionValue, serializedBindings, scopeInstances } = instance;
           let id = this._getValIdForReference(functionValue);
+          invariant(id.type === "Identifier");
           let funcParams = params.slice();
           let funcNode = t.functionDeclaration(id, funcParams, ((t.cloneDeep(funcBody): any): BabelNodeBlockStatement));
           let scopeInitialization = [];
@@ -1424,6 +1498,7 @@ export class Serializer {
           for (let instance of instances) {
             let { functionValue, serializedBindings, insertionPoint } = instance;
             let functionId = this._getValIdForReference(functionValue);
+            invariant(functionId.type === "Identifier");
             let flatArgs: Array<BabelNodeExpression> = factoryNames.map((name) => {
               let serializedValue = serializedBindings[name].serializedValue;
               invariant(serializedValue);
@@ -1492,6 +1567,40 @@ export class Serializer {
         let insertionPoint = instance.insertionPoint;
         invariant(insertionPoint instanceof BodyReference);
         Array.prototype.splice.apply(insertionPoint.body, ([insertionPoint.index, 0]: Array<any>).concat((functionBody: Array<any>)));
+      }
+    }
+
+    for (let [functionValue, funcNode] of funcNodes) {
+      let scopeInitializer = this.functionInitializers.get(functionValue);
+      if (scopeInitializer !== undefined) {
+        let scopeInitializerBody = scopeInitializer.body;
+        if (scopeInitializerBody.length === 0) {
+          this.functionInitializers.delete(functionValue);
+          continue;
+        }
+        let location;
+        for (let value of scopeInitializer.values) {
+          location = this.refs.get(value);
+          if (location !== undefined) break;
+        }
+        if (location === undefined) {
+          location = this.allocateIndexedVar();
+          scopeInitializerBody.unshift(
+            t.expressionStatement(
+              t.assignmentExpression(
+                "=",
+                location,
+                Serializer.voidExpression
+              )
+            )
+          );
+        }
+        let initializerStatement = t.ifStatement(
+          t.binaryExpression("===", location, this.varsExpression),
+          t.blockStatement(scopeInitializerBody));
+        invariant(funcNode.type === "FunctionDeclaration");
+        let blockStatement: BabelNodeBlockStatement = ((funcNode: any): BabelNodeFunctionDeclaration).body;
+        blockStatement.body = [initializerStatement].concat(blockStatement.body);
       }
     }
 
@@ -1620,6 +1729,17 @@ export class Serializer {
           t.objectExpression([])
         ),
       ]));
+    }
+    if (this.needsVars) {
+      body.push(t.variableDeclaration("var", [
+        t.variableDeclarator(
+          this.varsExpression,
+          t.newExpression(t.identifier("Array"), [t.numericLiteral(this.nextVarsIndex)])
+        ),
+      ]));
+      body.push(t.expressionStatement(t.callExpression(
+        t.memberExpression(this.varsExpression, t.identifier("fill")), [this.varsExpression]
+      )));
     }
     if (this.needsAuxiliaryConstructor) {
       body.push(t.functionDeclaration(
@@ -1843,7 +1963,11 @@ export class Serializer {
   }
 
   init(filename: string, code: string, map?: string = "",
-      sourceMaps?: boolean = false, onError?: (Realm, Value) => void) {
+      sourceMaps?: boolean = false, onError?: (Realm, Value) => void): void | {
+    code: string,
+    map: void | SourceMap,
+    statistics: SerializerStatistics
+  } {
     // Phase 1: Let's interpret.
     if (this.options.profile) console.time("[Profiling] Interpreting Global Code");
     this.execute(filename, code, map, onError);
@@ -1874,16 +1998,21 @@ export class Serializer {
     // Serialize for the first time in order to gather reference counts
     if (!this.options.singlePass) {
       if (this.options.profile) console.time("[Profiling] Reference Counts Pass");
-      this.collectValToRefCountOnly = true;
-      this.valToRefCount = new Map();
+      this._init(
+        /*detectValuesUsedBySingleFunctionValue*/true,
+        /*collectValToRefCountOnly*/true);
       this.serialize();
       if (this.logger.hasErrors()) return undefined;
       if (this.options.profile) console.timeEnd("[Profiling] Reference Counts Pass");
     }
+
     // Serialize for a second time, using reference counts to minimize number of generated identifiers
-    this._resetSerializeStates();
-    this.collectValToRefCountOnly = false;
     if (this.options.profile) console.time("[Profiling] Serialize Pass");
+    // To reach a fixed point in testing, disable optimization to detect and optimize values used by single functions
+    // in case there is just one function with an initializer
+    this._init(
+      /*detectValuesUsedBySingleFunctionValue*/!this.functionInitializers || this.functionInitializers.size !== 1,
+      /*collectValToRefCountOnly*/false);
     let ast = this.serialize();
     let generated = generate(
         ast,

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -580,7 +580,7 @@ export class Serializer {
     let name = this.valueNameGenerator.generate(val.__originalName || "");
     let id;
     if (target.usedBySingleFunctionValue) {
-      // The visitor ensures that all function values are alwauys associated with the
+      // The visitor ensures that all function values are always associated with the
       // realm generator scope, so they are never just used by a single function scope.
       invariant(!(val instanceof FunctionValue));
       this.needsVars = true;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -29,7 +29,8 @@ import { ClosureRefReplacer, IdentifierCollector } from "./visitors.js";
 import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
 import { LoggingTracer } from "./LoggingTracer.js";
-import { ResidualHeapVisitor, GlobalScope } from "./ResidualHeapVisitor.js";
+import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
+import type { Scope } from "./ResidualHeapVisitor.js";
 
 const GLOBAL_CAPTURED_SCOPE_NAME = "__captured_scopes";
 
@@ -160,7 +161,7 @@ export class Serializer {
   firstFunctionUsages: Map<FunctionValue, BodyReference>;
   functionPrototypes: Map<FunctionValue, BabelNodeIdentifier>;
   ignoredProperties: Map<ObjectValue, Set<string>>;
-  residualValues: Map<Value, Set<GlobalScope | FunctionValue>>;
+  residualValues: Map<Value, Set<Scope>>;
   residualFunctionBindings: Map<FunctionValue, VisitedBindings>;
   residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>;
   serializedValues: Set<Value>;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1675,7 +1675,7 @@ export class Serializer {
             initializedValues = initializer.values;
           }
           if (initializer === ownInitializer) {
-            initializationStatements = initializationStatements.concat(ownInitializer.body);
+            initializationStatements = initializationStatements.concat(initializer.body);
           } else {
             let ast = sharedInitializers.get(initializer.id);
             if (ast === undefined) {
@@ -1690,7 +1690,7 @@ export class Serializer {
                 enter(path) {
                   count++;
                 }
-              });
+              }, null, {});
               if (count > 24) {
                 let id = t.identifier(this.initializerNameGenerator.generate());
                 this.prelude.push(t.functionDeclaration(id, [], t.blockStatement([ast])));

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1858,7 +1858,7 @@ export class Serializer {
     residualHeapVisitor.visitRoots();
     if (this.logger.hasErrors()) return undefined;
     this.ignoredProperties = residualHeapVisitor.ignoredProperties;
-    this.residualValues = residualHeapVisitor.values;
+    this.residualValues = new Set(residualHeapVisitor.values.keys());
     this.residualFunctionBindings = residualHeapVisitor.functionBindings;
     this.residualFunctionInfos = residualHeapVisitor.functionInfos;
     if (this.options.profile) console.timeEnd("[Profiling] Deep Traversal of Heap");

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -98,7 +98,8 @@ export class SerializerStatistics {
     this.functionClones = 0;
     this.referentialized = 0;
     this.valueIds = 0;
-    this.valueIdsElided = 0;
+    this.valuesInlined = 0;
+    this.indexedVars = 0;
   }
   objects: number;
   objectProperties: number;
@@ -106,11 +107,12 @@ export class SerializerStatistics {
   functionClones: number;
   referentialized: number;
   valueIds: number;
-  valueIdsElided: number;
+  valuesInlined: number;
+  indexedVars: number;
   log() {
     console.log(`=== serialization statistics`);
     console.log(`${this.objects} objects with ${this.objectProperties} properties`);
     console.log(`${this.functions} functions plus ${this.functionClones} clones due to captured variables; ${this.referentialized} captured mutable variables`);
-    console.log(`${this.valueIds} value ids generated and ${this.valueIdsElided} elided`);
+    console.log(`${this.valueIds} value ids and ${this.indexedVars} indexed variables generated, and ${this.valuesInlined} values inlined`);
   }
 }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -263,13 +263,13 @@ export class Generator {
     }
   }
 
-  visit(visitValue: Value => void) {
+  visit(visitValue: Value => void, visitGenerator: Generator => void) {
     for (let bodyEntry of this.body) {
       for (let boundArg of bodyEntry.args)
         visitValue(boundArg);
       if (bodyEntry.dependencies)
         for (let dependency of bodyEntry.dependencies)
-          dependency.visit(visitValue);
+          visitGenerator(dependency);
     }
   }
 }

--- a/test/serializer/basic/CapturedScopesAndIndexedVars.js
+++ b/test/serializer/basic/CapturedScopesAndIndexedVars.js
@@ -1,0 +1,23 @@
+(function() {
+let f = function() {
+  var o = { };
+  return function(replace) {
+    if (replace) o = { };
+    return o;
+  }
+}
+
+let g1 = f();
+let g2 = f();
+let g3 = f();
+let g4 = f();
+
+inspect = function() { 
+  return 
+    g1(false) === g1(false)
+    g2(false) !== g2(true)
+    g3(true) !== g1(true)
+    g4(true) !== g1(true);
+}
+
+})();

--- a/test/serializer/basic/ReferentializeInitializer.js
+++ b/test/serializer/basic/ReferentializeInitializer.js
@@ -1,0 +1,10 @@
+(function() {
+  function f() {
+    let obj = { count: 0 };
+    return function(reset) { if (reset) obj = { count: 0 }; return obj.count++; }
+  }
+  g = f();
+  inspect = function() {
+    return "" + g(false) + g(true) + g(false);
+  }
+})();

--- a/test/serializer/basic/ResidualIdentityObservation2.js
+++ b/test/serializer/basic/ResidualIdentityObservation2.js
@@ -1,0 +1,7 @@
+(function() {
+    var a = {x: 4};
+    function f() {
+        return a;
+    }
+    inspect = function() { return f() === f(); }
+})();


### PR DESCRIPTION
This will address #496.

Done so far: Keep track of the scopes (in terms of functions) in which values are needed.
Still to be done: Use that information in the serializer to move initialization of values only used by single residual function into a separate block that run once inside of the residual function.