### PR TITLE
Partial evaluator for if statement

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint src scripts",
     "flow": "flow check",
     "test-residual": "node scripts/test-residual.js",
+    "test-residual-with-coverage": "./node_modules/.bin/istanbul cover ./scripts/test-residual.js && ./node_modules/.bin/remap-istanbul -i coverage/coverage.json -o coverage-sourcemapped -t html && echo You can find coverage reports here: && echo   coverage/lcov-report/index.html && echo   coverage-sourcemapped/index.html",
     "test-serializer": "node scripts/test-runner.js",
     "test-serializer-with-coverage": "./node_modules/.bin/istanbul cover ./scripts/test-runner.js && ./node_modules/.bin/remap-istanbul -i coverage/coverage.json -o coverage-sourcemapped -t html && echo You can find coverage reports here: && echo   coverage/lcov-report/index.html && echo   coverage-sourcemapped/index.html",
     "test-sourcemaps": "babel-node scripts/generate-sourcemaps-test.js && bash < scripts/test-sourcemaps.sh",

--- a/scripts/test-residual.js
+++ b/scripts/test-residual.js
@@ -78,11 +78,11 @@ function exec(code) {
 
 function runTest(name, code) {
   let realmOptions = { residual: true };
-  let realm = construct_realm(realmOptions);
-  initializeGlobals(realm);
   console.log(chalk.inverse(name));
   if (code.includes("// throws introspection error")) {
     try {
+      let realm = construct_realm(realmOptions);
+      initializeGlobals(realm);
       let result = realm.$GlobalEnv.executePartialEvaluator(name, code);
       if (result instanceof IntrospectionThrowCompletion) return true;
       if (result instanceof ThrowCompletion) throw result.value;
@@ -109,6 +109,8 @@ return __result; }).call(this);`);
       let max = 4;
       let oldCode = code;
       for (; i < max; i++) {
+        let realm = construct_realm(realmOptions);
+        initializeGlobals(realm);
         let result = realm.$GlobalEnv.executePartialEvaluator(name, code);
         if (result instanceof ThrowCompletion) throw result.value;
         if (result instanceof AbruptCompletion) throw result;

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -622,7 +622,7 @@ function handleFinished(
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 22817 || numPassedES6 < 7402 || numTimeouts > 0)) {
+  if (!args.filterString && (numPassedES5 < 22823 || numPassedES6 < 7402 || numTimeouts > 0)) {
     console.log(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {

--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -58,6 +58,22 @@ export default class ValuesDomain {
     return false;
   }
 
+  mightBeFalse(): boolean {
+    invariant(!this.isTop());
+    for (let cval of this.getElements()) {
+      if (cval.mightBeFalse()) return true;
+    }
+    return false;
+  }
+
+  mightNotBeFalse(): boolean {
+    invariant(!this.isTop());
+    for (let cval of this.getElements()) {
+      if (cval.mightNotBeFalse()) return true;
+    }
+    return false;
+  }
+
   static joinValues(realm: Realm, v1: void | Value, v2: void | Value): ValuesDomain {
     if (v1 === undefined) v1 = realm.intrinsics.undefined;
     if (v2 === undefined) v2 = realm.intrinsics.undefined;

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -301,11 +301,7 @@ export function OrdinaryCallEvaluateBody(realm: Realm, F: FunctionValue, argumen
     let c = realm.getRunningContext().lexicalEnvironment.evaluateAbstractCompletion(code, F.$Strict);
     let e = realm.getCapturedEffects();
     if (e !== undefined) {
-      realm.stopEffectCapture();
-      let [_c, _g, b, p, _o] = e;
-      _c; _g; _o;
-      realm.restoreBindings(b);
-      realm.restoreProperties(p);
+      realm.stopEffectCaptureAndUndoEffects();
     }
     if (c instanceof JoinedAbruptCompletions) {
       if (e !== undefined) realm.applyEffects(e);

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1027,11 +1027,7 @@ export function EvaluateStatements(
           if (res instanceof AbruptCompletion) {
             let e = realm.getCapturedEffects();
             invariant(e !== undefined);
-            realm.stopEffectCapture();
-            let [_c, _g, b, p, _o] = e;
-            _c; _g; _o;
-            realm.restoreBindings(b);
-            realm.restoreProperties(p);
+            realm.stopEffectCaptureAndUndoEffects();
             if (res instanceof IntrospectionThrowCompletion) {
               realm.applyEffects(e);
               throw res;
@@ -1081,11 +1077,7 @@ export function PartiallyEvaluateStatements(
           if (res instanceof AbruptCompletion) {
             let e = realm.getCapturedEffects();
             invariant(e !== undefined);
-            realm.stopEffectCapture();
-            let [_c, _g, b, p, _o] = e;
-            _c; _g; _o;
-            realm.restoreBindings(b);
-            realm.restoreProperties(p);
+            realm.stopEffectCaptureAndUndoEffects();
             if (res instanceof IntrospectionThrowCompletion) {
               realm.applyEffects(e);
               throw res;

--- a/src/partial-evaluators/BlockStatement.js
+++ b/src/partial-evaluators/BlockStatement.js
@@ -46,7 +46,8 @@ export default function (
       }
     }
 
-    let [res, bAst] = PartiallyEvaluateStatements(ast.body, blockValue, strictCode, blockEnv, realm);
+    let [res, bAst] =
+      PartiallyEvaluateStatements(ast.body, blockValue, strictCode, blockEnv, realm);
     invariant(bAst.length > 0 || res instanceof EmptyValue);
     if (bAst.length === 0) return [res, t.emptyStatement(), []];
     let rAst = t.blockStatement(bAst, ast.directives);

--- a/src/partial-evaluators/Identifier.js
+++ b/src/partial-evaluators/Identifier.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { BabelNodeIdentifier, BabelNodeStatement } from "babel-types";
-import type { LexicalEnvironment } from "../environment.js";
+import type { LexicalEnvironment, Reference } from "../environment.js";
 import type { Realm } from "../realm.js";
 
 import { AbruptCompletion } from "../completions.js";
@@ -19,7 +19,7 @@ import { Value } from "../values/index.js";
 // ECMA262 12.1.6
 export default function (
   ast: BabelNodeIdentifier, strictCode: boolean, env: LexicalEnvironment, realm: Realm
-): [AbruptCompletion | Value, BabelNodeIdentifier, Array<BabelNodeStatement>] {
-  let result = env.evaluateCompletionDeref(ast, strictCode);
+): [AbruptCompletion | Reference | Value, BabelNodeIdentifier, Array<BabelNodeStatement>] {
+  let result = env.evaluateCompletion(ast, strictCode);
   return [result, ast, []];
 }

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -13,12 +13,103 @@ import type { BabelNodeIfStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 
-import { AbruptCompletion } from "../completions.js";
-import { Value } from "../values/index.js";
+import { AbruptCompletion, Completion, NormalCompletion } from "../completions.js";
+import { Reference } from "../environment.js";
+import { joinEffects, UpdateEmpty } from "../methods/index.js";
+import { AbstractValue, Value } from "../values/index.js";
+import { construct_empty_effects } from "../realm.js";
+
+import * as t from "babel-types";
+import invariant from "../invariant.js";
 
 export default function (
   ast: BabelNodeIfStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm
-): [AbruptCompletion | Value, BabelNodeIfStatement, Array<BabelNodeStatement>] {
-  let result = env.evaluateCompletionDeref(ast, strictCode);
-  return [result, ast, []];
+): [Completion | Value, BabelNodeStatement, Array<BabelNodeStatement>] {
+  let [exprValue, exprAst, exprIO] = env.partiallyEvaluateCompletionDeref(ast.test, strictCode);
+  if (exprValue instanceof AbruptCompletion)
+    return [exprValue, t.expressionStatement((exprAst: any)), exprIO];
+  let completion;
+  if (exprValue instanceof NormalCompletion) {
+    completion = exprValue;
+    exprValue = completion.value;
+  }
+  invariant(exprValue instanceof Value);
+
+  if (!exprValue.mightNotBeTrue()) {
+    // 3.a. Let stmtCompletion be the result of evaluating the first Statement
+    let [stmtCompletion, stmtAst, stmtIO] = env.partiallyEvaluateCompletionDeref(ast.consequent, strictCode);
+
+    // 5. Return Completion(UpdateEmpty(stmtCompletion, undefined)
+    stmtCompletion = UpdateEmpty(realm, stmtCompletion, realm.intrinsics.undefined);
+    return [stmtCompletion, (stmtAst: any), exprIO.concat(stmtIO)];
+  } else if (!exprValue.mightNotBeFalse()) {
+    let stmtCompletion, stmtAst, stmtIO;
+    if (ast.alternate)
+      // 4.a. Let stmtCompletion be the result of evaluating the second Statement
+      [stmtCompletion, stmtAst, stmtIO] = env.partiallyEvaluateCompletionDeref(ast.alternate, strictCode);
+    else {
+      // 3 (of the if only statement). Return NormalCompletion(undefined)
+      stmtCompletion = realm.intrinsics.undefined;
+      stmtAst = t.emptyStatement();
+      stmtIO = [];
+    }
+    // 5. Return Completion(UpdateEmpty(stmtCompletion, undefined)
+    stmtCompletion = UpdateEmpty(realm, stmtCompletion, realm.intrinsics.undefined);
+    return [stmtCompletion, (stmtAst: any), exprIO.concat(stmtIO)];
+  }
+  invariant(exprValue instanceof AbstractValue);
+
+  // Evaluate consequent and alternate in sandboxes and get their effects.
+  realm.captureEffects();
+  let [conCompl, conAst, conIO] =
+    env.partiallyEvaluateCompletionDeref(ast.consequent, strictCode);
+  let consequentEffects = realm.getCapturedEffects();
+  invariant(consequentEffects !== undefined);
+  let [compl1, gen1, bindings1, properties1, createdObj1] = consequentEffects;
+  compl1;
+  realm.stopEffectCaptureAndUndoEffects();
+  let consequentAst = (conAst: any);
+  if (conIO.length > 0)
+    consequentAst = t.blockStatement(conIO.concat(consequentAst));
+
+  let altCompl, altAst, altIO;
+  let alternateEffects;
+  if (ast.alternate) {
+    realm.captureEffects();
+    invariant(ast.alternate);
+    [altCompl, altAst, altIO] = env.partiallyEvaluateCompletionDeref(ast.alternate, strictCode);
+    alternateEffects = realm.getCapturedEffects();
+    realm.stopEffectCaptureAndUndoEffects();
+  } else {
+    alternateEffects = construct_empty_effects(realm);
+    [altCompl, altAst, altIO] = [alternateEffects[0], undefined, []];
+  }
+  let alternateAst = (altAst: any);
+  if (altIO.length > 0)
+    alternateAst = t.blockStatement(altIO.concat(alternateAst));
+  invariant(alternateEffects !== undefined);
+  let [compl2, gen2, bindings2, properties2, createdObj2] = alternateEffects;
+  compl2;
+
+  // Join the effects, creating an abstract view of what happened, regardless
+  // of the actual value of exprValue.
+  let joinedEffects =
+    joinEffects(realm, exprValue,
+      [conCompl, gen1, bindings1, properties1, createdObj1],
+      [altCompl, gen2, bindings2, properties2, createdObj2]);
+  completion = joinedEffects[0];
+  if (completion instanceof NormalCompletion) {
+    // in this case one of the branches may complete abruptly, which means that
+    // not all control flow branches join into one flow at this point.
+    // Consequently we have to continue tracking changes until the point where
+    // all the branches come together into one.
+    realm.captureEffects();
+  }
+  // Note that the effects of (non joining) abrupt branches are not included
+  // in joinedEffects, but are tracked separately inside completion.
+  realm.applyEffects(joinedEffects);
+
+  let resultAst = t.ifStatement((exprAst: any), (consequentAst: any), (alternateAst: any));
+  invariant(!(completion instanceof Reference));
+  return [completion, resultAst, exprIO];
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -353,7 +353,12 @@ export class Realm {
        this.modifiedProperties, this.createdObjects];
   }
 
-  stopEffectCapture() {
+  stopEffectCaptureAndUndoEffects() {
+    // Roll back the state changes
+    this.restoreBindings(this.modifiedBindings);
+    this.restoreProperties(this.modifiedProperties);
+
+    // Restore saved state
     let context = this.getRunningContext();
     if (context.savedEffects !== undefined) {
       let [c, g, b, p, o] = context.savedEffects;
@@ -603,10 +608,13 @@ export class Realm {
   }
 
   appendGenerator(generator: Generator, leadingComment: string = ""): void {
-    let realmGenerator = this.generator;
-    invariant(realmGenerator);
-    let realmGeneratorBody = realmGenerator.body;
     let generatorBody = generator.body;
+    let realmGenerator = this.generator;
+    if (realmGenerator === undefined) {
+      invariant(generatorBody.length === 0);
+      return;
+    }
+    let realmGeneratorBody = realmGenerator.body;
     let i = 0;
     if (generatorBody.length > 0 && leadingComment.length > 0) {
       let firstEntry = generatorBody[i++];

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -79,6 +79,14 @@ export default class AbstractObjectValue extends AbstractValue {
     return result;
   }
 
+  mightBeFalse(): boolean {
+    return false;
+  }
+
+  mightNotBeFalse(): boolean {
+    return true;
+  }
+
   makeNotPartial(): void {
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -123,6 +123,26 @@ export default class AbstractValue extends Value {
     add_args(this.args);
   }
 
+  mightBeFalse(): boolean {
+    let valueType = this.getType();
+    if (valueType === UndefinedValue) return true;
+    if (valueType === NullValue) return true;
+    if (valueType === SymbolValue) return false;
+    if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return false;
+    if (this.values.isTop()) return true;
+    return this.values.mightBeFalse();
+  }
+
+  mightNotBeFalse(): boolean {
+    let valueType = this.getType();
+    if (valueType === UndefinedValue) return false;
+    if (valueType === NullValue) return false;
+    if (valueType === SymbolValue) return true;
+    if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return true;
+    if (this.values.isTop()) return true;
+    return this.values.mightNotBeFalse();
+  }
+
   mightBeNumber(): boolean {
     let valueType = this.getType();
     if (valueType === NumberValue) return true;

--- a/src/values/BooleanValue.js
+++ b/src/values/BooleanValue.js
@@ -23,6 +23,10 @@ export default class BooleanValue extends PrimitiveValue {
 
   value: boolean;
 
+  mightBeFalse(): boolean {
+    return !this.value;
+  }
+
   _serialize(): boolean {
     return this.value;
   }

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -19,6 +19,10 @@ export default class ConcreteValue extends Value {
     super(realm, intrinsicName);
   }
 
+  mightNotBeFalse(): boolean {
+    return !this.mightBeFalse();
+  }
+
   mightBeNumber(): boolean {
     return this instanceof NumberValue;
   }

--- a/src/values/NullValue.js
+++ b/src/values/NullValue.js
@@ -15,4 +15,9 @@ export default class NullValue extends PrimitiveValue {
   _serialize(): null {
     return null;
   }
+
+  mightBeFalse(): boolean {
+    return true;
+  }
+
 }

--- a/src/values/NumberValue.js
+++ b/src/values/NumberValue.js
@@ -21,6 +21,10 @@ export default class NumberValue extends PrimitiveValue {
 
   value: number;
 
+  mightBeFalse(): boolean {
+    return this.value === 0 || isNaN(this.value);
+  }
+
   throwIfNotConcreteNumber(): NumberValue {
     return this;
   }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -168,6 +168,10 @@ export default class ObjectValue extends ConcreteValue {
   symbols: Map<SymbolValue, PropertyBinding>;
   unknownProperty: void | PropertyBinding;
 
+  mightBeFalse(): boolean {
+    return false;
+  }
+
   mightNotBeObject(): boolean {
     return false;
   }

--- a/src/values/StringValue.js
+++ b/src/values/StringValue.js
@@ -20,6 +20,10 @@ export default class StringValue extends PrimitiveValue {
 
   value: string;
 
+  mightBeFalse(): boolean {
+    return this.value.length === 0;
+  }
+
   _serialize(): string {
     return this.value;
   }

--- a/src/values/SymbolValue.js
+++ b/src/values/SymbolValue.js
@@ -20,6 +20,10 @@ export default class SymbolValue extends PrimitiveValue {
 
   $Description: ?string;
 
+  mightBeFalse(): boolean {
+    return false;
+  }
+
   _serialize(): Symbol {
     return Symbol(this.$Description);
   }

--- a/src/values/UndefinedValue.js
+++ b/src/values/UndefinedValue.js
@@ -15,4 +15,9 @@ export default class UndefinedValue extends PrimitiveValue {
   _serialize() {
     return undefined;
   }
+
+  mightBeFalse(): boolean {
+    return true;
+  }
+
 }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -58,6 +58,14 @@ export default class Value {
     return !!this.intrinsicName;
   }
 
+  mightBeFalse(): boolean {
+    throw new Error("abstract method; please override");
+  }
+
+  mightNotBeFalse(): boolean {
+    throw new Error("abstract method; please override");
+  }
+
   mightBeNumber(): boolean {
     throw new Error("abstract method; please override");
   }
@@ -76,6 +84,14 @@ export default class Value {
 
   mightNotBeString(): boolean {
     throw new Error("abstract method; please override");
+  }
+
+  mightBeTrue(): boolean {
+    return this.mightNotBeFalse();
+  }
+
+  mightNotBeTrue(): boolean {
+    return this.mightBeFalse();
   }
 
   mightBeUndefined(): boolean {

--- a/test/residual/If.js
+++ b/test/residual/If.js
@@ -1,0 +1,32 @@
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+
+let x;
+let y = 1;
+if (b) {
+  x = true;
+  y = false;
+} else {
+  x = [];
+  y = null;
+}
+
+let z = 1;
+if (b) {
+  z = 2;
+}
+
+if (x) {
+  z = 3;
+}
+
+if (y) {
+  z = 4;
+}
+
+if (y) {
+  z = 5;
+} else {
+  z = 6;
+}
+
+let __result = y + "" + z;


### PR DESCRIPTION
This adds a partial evaluator for if statements. To support this, AbstractValue now has helper methods for determining if ToBoolean(absvalue) is known to always result in false or always result in true. To make it painfully clear that this is 3-valued logic, the pattern of "!mightNotBeTrue" is preferred over the simpler "isTrue".

Realm.stopEffectCapture now also becomes stopEffectCaptureAndUndoEffects because the latter bit is always connected to it anyways.
