### PR TITLE
Make serialize the default option

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -33,7 +33,7 @@ export type Options = {|
   strictlyMonotonicDateNow?: boolean,
 |};
 
-export const defaultOptions = { };
+export const defaultOptions = {};
 
 export function getRealmOptions({
   compatibility = "browser",

--- a/src/options.js
+++ b/src/options.js
@@ -33,7 +33,7 @@ export type Options = {|
   strictlyMonotonicDateNow?: boolean,
 |};
 
-export const defaultOptions = {};
+export const defaultOptions = { };
 
 export function getRealmOptions({
   compatibility = "browser",
@@ -42,7 +42,7 @@ export function getRealmOptions({
   uniqueSuffix,
   timeout,
   residual,
-  serialize,
+  serialize = !residual,
   strictlyMonotonicDateNow
 }: Options): RealmOptions {
   return {


### PR DESCRIPTION
Calling a Prepack method without supplying the options parameter should default to running the serializer.