### PR TITLE
Fix callback to fit node.js conventions

### DIFF
--- a/src/prepack-node-environment.js
+++ b/src/prepack-node-environment.js
@@ -23,10 +23,11 @@ import initializeProcess from "./intrinsics/node/process.js";
 
 import type { Options } from "./options";
 import { defaultOptions } from "./options";
+import type { SourceMap } from "./types.js";
 
 declare var process: any;
 
-export function prepackNodeCLI(filename: string, options: Options = defaultOptions, callback: Function) {
+export function prepackNodeCLI(filename: string, options: Options = defaultOptions, callback: (any, ?{code: string, map?: SourceMap})=>void) {
   let serialized;
   try {
     serialized = prepackNodeCLISync(filename, options);

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -58,7 +58,7 @@ export function prepackString(filename: string, code: string, sourceMap: string,
 
 export function prepackStdin(
     options: Options = defaultOptions,
-    callback: ({code: string, map?: SourceMap})=>void) {
+    callback: (any, ?{code: string, map?: SourceMap})=>void) {
   let sourceMapFilename = options.inputSourceMapFilename || '';
   process.stdin.setEncoding('utf8');
   process.stdin.resume();
@@ -73,10 +73,10 @@ export function prepackStdin(
       try {
         serialized = prepackString(filename, code, sourceMap, options);
       } catch (err) {
-        callback(err);
+        callback(err, null);
         return;
       }
-      callback(serialized);
+      callback(null, serialized);
     });
   });
 }
@@ -84,7 +84,7 @@ export function prepackStdin(
 export function prepackFile(
     filename: string,
     options: Options = defaultOptions,
-    callback: ({code: string, map?: SourceMap})=>void,
+    callback: (any, ?{code: string, map?: SourceMap})=>void,
     errorHandler?: (err: ?Error)=>void) {
   if (options.compatibility === 'node-cli') {
     prepackNodeCLI(filename, options, callback);
@@ -105,10 +105,10 @@ export function prepackFile(
       try {
         serialized = prepackString(filename, code, sourceMap, options);
       } catch (err) {
-        callback(err);
+        callback(err, null);
         return;
       }
-      callback(serialized);
+      callback(null, serialized);
     });
   });
 }


### PR DESCRIPTION
See discussion in #691 - apparently the previous change was not taking into account node.js conventions and needs to be reverted.
This change is to revert to the correct calling convention + introduce proper flow-typing for the function signature