### PR TITLE
__residual requires making all dependencies explicit. Have variant that infers them! #622

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -132,6 +132,8 @@ export default function (realm: Realm): void {
     configurable: true
   });
 
+  // Helper function that identifies a variant of the residual function that has implicit dependencies. This version of residual will infer the dependencies
+  // and rewrite the function body to do the same thing as the orignal residual function.
   global.$DefineOwnProperty("__residual_unsafe", {
     value: new NativeFunctionValue(realm, "global.__residual", "__residual", 2, (context, [typeNameOrTemplate, f, ...args]) => {
       if (!realm.useAbstractInterpretation) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -364,7 +364,9 @@ export class ResidualHeapVisitor {
       );
 
       if (val.isResidual && Object.keys(functionInfo.names).length) {
-        this.logger.logError(val, `residual function ${describeLocation(this.realm, val, undefined, code.loc) || "(unknown)"} refers to the following identifiers defined outside of the local scope: ${Object.keys(functionInfo.names).join(", ")}`);
+        if (!val.isUnsafeResidual) {
+          this.logger.logError(val, `residual function ${describeLocation(this.realm, val, undefined, code.loc) || "(unknown)"} refers to the following identifiers defined outside of the local scope: ${Object.keys(functionInfo.names).join(", ")}`);
+        }
       }
     }
 

--- a/src/values/FunctionValue.js
+++ b/src/values/FunctionValue.js
@@ -38,6 +38,9 @@ export default class FunctionValue extends ObjectValue {
   // identifiers defined outside of the local scope.
   isResidual: void | true;
 
+  //Added functinality
+  isUnsafeResidual: void | true;
+
   getKind(): ObjectKind {
     return "Function";
   }

--- a/src/values/FunctionValue.js
+++ b/src/values/FunctionValue.js
@@ -38,7 +38,7 @@ export default class FunctionValue extends ObjectValue {
   // identifiers defined outside of the local scope.
   isResidual: void | true;
 
-  //Added functinality
+  // Allows for residual function with inference of parameters
   isUnsafeResidual: void | true;
 
   getKind(): ObjectKind {

--- a/test/serializer/abstract/ResidualExplicitParameters.js
+++ b/test/serializer/abstract/ResidualExplicitParameters.js
@@ -1,0 +1,5 @@
+(function() {
+  let x = 42;
+  let y = global.__residual ? __residual("number", function () { return x; }) : 42; // this variant takes no further arguments
+  inspect = function() { return y; }
+})();

--- a/test/serializer/abstract/ResidualExplicitParameters.js
+++ b/test/serializer/abstract/ResidualExplicitParameters.js
@@ -1,5 +1,5 @@
 (function() {
   let x = 42;
-  let y = global.__residual ? __residual("number", function () { return x; }) : 42; // this variant takes no further arguments
+  let y = global.__residual_unsafe ? __residual_unsafe("number", function () { return x; }) : 42; // this variant takes no further arguments
   inspect = function() { return y; }
 })();

--- a/test/serializer/abstract/ResidualExplicitParameters2.js
+++ b/test/serializer/abstract/ResidualExplicitParameters2.js
@@ -1,0 +1,6 @@
+// cannot serialize
+(function() {
+  let x = 42;
+  let y = global.__residual ? __residual("number", function () { return x; }) : 42; // this variant takes no further arguments
+  inspect = function() { return y; }
+})();


### PR DESCRIPTION
Added a simple implementation of __residual_unsafe that allows for implicit dependencies for residual functions. I have also added a test case that validates this new feature.