### PR TITLE
Partial evaluator for calls

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -970,7 +970,7 @@ export class LexicalEnvironment {
     try {
       return this.partiallyEvaluate(ast, strictCode, metadata);
     } catch (err) {
-      if (err instanceof AbruptCompletion)
+      if (err instanceof Completion)
         return [err, ast, []];
       if (err instanceof Error)
         // rethrowing Error should preserve stack trace

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -305,7 +305,7 @@ export function OrdinaryCallEvaluateBody(realm: Realm, F: FunctionValue, argumen
     }
     if (c instanceof JoinedAbruptCompletions) {
       if (e !== undefined) realm.applyEffects(e);
-      throw AbstractValue.createIntrospectionErrorThrowCompletion(c.joinCondition);
+      return c;
     } else if (c instanceof PossiblyNormalCompletion) {
       // If the abrupt part of the completion is a return completion, then the
       // effects of its independent control path must be joined with the effects
@@ -325,10 +325,19 @@ export function OrdinaryCallEvaluateBody(realm: Realm, F: FunctionValue, argumen
 }
 
 // ECMA262 12.3.4.3
-export function EvaluateDirectCall(realm: Realm, strictCode: boolean, env: LexicalEnvironment, ref: Value | Reference, func: Value, thisValue: Value, args: Array<BabelNode> | BabelNodeTemplateLiteral, tailPosition?: boolean): Value {
+export function EvaluateDirectCall(realm: Realm, strictCode: boolean, env: LexicalEnvironment, ref: Value | Reference,
+   func: Value, thisValue: Value, args: Array<BabelNode> | BabelNodeTemplateLiteral, tailPosition?: boolean
+ ): Value {
   // 1. Let argList be ? ArgumentListEvaluation(arguments).
   let argList = ArgumentListEvaluation(realm, strictCode, env, args);
 
+  return EvaluateDirectCallWithArgList(realm, strictCode, env, ref, func, thisValue, argList, tailPosition);
+}
+
+export function EvaluateDirectCallWithArgList(
+  realm: Realm, strictCode: boolean, env: LexicalEnvironment, ref: Value | Reference,
+  func: Value, thisValue: Value, argList: Array<Value>, tailPosition?: boolean
+): Value {
   if (func instanceof AbstractValue && func.getType() === FunctionValue) {
     let fullArgs = [func].concat(argList);
     return realm.deriveAbstract(

--- a/src/partial-evaluators/BinaryExpression.js
+++ b/src/partial-evaluators/BinaryExpression.js
@@ -33,6 +33,7 @@ export default function (
   let [rval, rightAst, rightIO] = env.partiallyEvaluateCompletionDeref(ast.right, strictCode);
   let io = leftIO.concat(rightIO);
   if (rval instanceof AbruptCompletion) {
+    // todo: if leftCompletion is a PossiblyNormalCompletion, compose
     return [rval, t.binaryExpression(ast.operator, (leftAst: any), (rightAst: any)), io];
   }
   let rightCompletion; [rightCompletion, rval] = unbundleNormalCompletion(rval);

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -9,16 +9,199 @@
 
 /* @flow */
 
-import type { BabelNodeCallExpression, BabelNodeStatement } from "babel-types";
+import type { BabelNodeCallExpression, BabelNodeExpression, BabelNodeStatement } from "babel-types";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
-import { AbruptCompletion } from "../completions.js";
-import { Value } from "../values/index.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
+import { TypesDomain, ValuesDomain } from "../domains/index.js";
+import { EnvironmentRecord, Reference } from "../environment.js";
+import { composeNormalCompletions, EvaluateDirectCallWithArgList,
+   GetBase, GetReferencedName, GetThisValue, GetValue,
+   IsInTailPosition, IsPropertyReference,
+   joinEffects, PerformEval,
+   SameValue, stopEffectCaptureAndJoinCompletions, unbundleNormalCompletion } from "../methods/index.js";
+import { AbstractValue, BooleanValue, FunctionValue, Value } from "../values/index.js";
 
+import * as t from "babel-types";
+import invariant from "../invariant.js";
+
+// ECMA262 12.3.4.1
 export default function (
   ast: BabelNodeCallExpression, strictCode: boolean, env: LexicalEnvironment, realm: Realm
-): [AbruptCompletion | Value, BabelNodeCallExpression, Array<BabelNodeStatement>] {
-  let result = env.evaluateCompletionDeref(ast, strictCode);
-  return [result, ast, []];
+): [Completion | Value, BabelNodeExpression, Array<BabelNodeStatement>] {
+  realm.setNextExecutionContextLocation(ast.loc);
+
+  // 1. Let ref be the result of evaluating MemberExpression.
+  let [ref, calleeAst, calleeIO] = env.partiallyEvaluateCompletion(ast.callee, strictCode);
+  if (ref instanceof AbruptCompletion)
+    return [ref, (calleeAst: any), calleeIO];
+  let completion;
+  if (ref instanceof PossiblyNormalCompletion) {
+    completion = ref;
+    ref = completion.value;
+  }
+  invariant(ref instanceof Value || ref instanceof Reference);
+
+  // 2. Let func be ? GetValue(ref).
+  let func = GetValue(realm, ref);
+
+  let io = calleeIO;
+  let partialArgs = [];
+  let argVals = [];
+  for (let arg of ast.arguments) {
+    let [argValue, argAst, argIO] = env.partiallyEvaluateCompletionDeref(arg, strictCode);
+    io = io.concat(argIO);
+    partialArgs.push((argAst: any));
+    if (argValue instanceof AbruptCompletion) {
+      if (completion instanceof PossiblyNormalCompletion)
+        completion = stopEffectCaptureAndJoinCompletions(completion, argValue, realm);
+      else
+        completion = argValue;
+      let resultAst = t.callExpression((calleeAst: any), partialArgs);
+      return [completion, resultAst, io];
+    }
+    if (argValue instanceof PossiblyNormalCompletion) {
+      argVals.push(argValue.value);
+      if (completion instanceof PossiblyNormalCompletion)
+        completion = composeNormalCompletions(completion, argValue, argValue.value, realm);
+      else
+        completion = argValue;
+    } else  {
+      invariant(argValue instanceof Value);
+      argVals.push(argValue);
+    }
+  }
+
+  let callResult = EvaluateCall(ref, func, ast, argVals, strictCode, env, realm);
+  if (callResult instanceof AbruptCompletion) {
+    if (completion instanceof PossiblyNormalCompletion)
+      completion = stopEffectCaptureAndJoinCompletions(completion, callResult, realm);
+    else
+      completion = callResult;
+    let resultAst = t.callExpression((calleeAst: any), partialArgs);
+    return [completion, resultAst, io];
+  }
+  let callCompletion; [callCompletion, callResult] = unbundleNormalCompletion(callResult);
+  invariant(callResult instanceof Value);
+  invariant(completion === undefined || completion instanceof PossiblyNormalCompletion);
+  completion = composeNormalCompletions(completion, callCompletion, callResult, realm);
+  if (completion instanceof PossiblyNormalCompletion) {
+    realm.captureEffects();
+  }
+  return [completion, t.callExpression((calleeAst: any), partialArgs), io];
+}
+
+function callBothFunctionsAndJoinTheirEffects(
+  funcs: Array<Value>, ast: BabelNodeCallExpression, argVals: Array<Value>, strictCode: boolean, env: LexicalEnvironment, realm: Realm
+): Completion | Value {
+  let [cond, func1, func2] = funcs;
+  invariant(cond instanceof AbstractValue && cond.getType() === BooleanValue);
+  invariant(func1.getType() === FunctionValue);
+  invariant(func2.getType() === FunctionValue);
+
+  let [compl1, gen1, bindings1, properties1, createdObj1] =
+    realm.evaluateForEffects(() => EvaluateCall(func1, func1, ast, argVals, strictCode, env, realm));
+
+  let [compl2, gen2, bindings2, properties2, createdObj2] =
+    realm.evaluateForEffects(() => EvaluateCall(func2, func2, ast, argVals, strictCode, env, realm));
+
+  let joinedEffects =
+    joinEffects(realm, cond,
+      [compl1, gen1, bindings1, properties1, createdObj1],
+      [compl2, gen2, bindings2, properties2, createdObj2]);
+  let joinedCompletion = joinedEffects[0];
+  if (joinedCompletion instanceof PossiblyNormalCompletion) {
+    // in this case one of the branches may complete abruptly, which means that
+    // not all control flow branches join into one flow at this point.
+    // Consequently we have to continue tracking changes until the point where
+    // all the branches come together into one.
+    realm.captureEffects();
+  }
+
+  // Note that the effects of (non joining) abrupt branches are not included
+  // in joinedEffects, but are tracked separately inside joinedCompletion.
+  realm.applyEffects(joinedEffects);
+
+  // return or throw completion
+  invariant(joinedCompletion instanceof Completion || joinedCompletion instanceof Value);
+  return joinedCompletion;
+}
+
+function EvaluateCall(
+  ref: Value | Reference, func: Value, ast: BabelNodeCallExpression,
+  argList: Array<Value>, strictCode: boolean, env: LexicalEnvironment, realm: Realm
+): Completion | Value {
+  if (func instanceof AbstractValue && func.getType() === FunctionValue) {
+    if (func.kind === "conditional")
+      return callBothFunctionsAndJoinTheirEffects(func.args, ast, argList, strictCode, env, realm);
+
+    // The called function comes from the environmental model and we require that
+    // such functions have no visible side-effects. Hence we can carry on
+    // by returning a call node with the arguments updated with their partial counterparts.
+    // TODO: obtain the type of the return value from the abstract function.
+    return realm.createAbstract(
+      TypesDomain.topVal, ValuesDomain.topVal, [], t.identifier("never used"));
+  }
+  // If func is abstract and not known to be a safe function, we can't safely continue.
+  func = func.throwIfNotConcrete();
+
+  // 3. If Type(ref) is Reference and IsPropertyReference(ref) is false and GetReferencedName(ref) is "eval", then
+  if (ref instanceof Reference && !IsPropertyReference(realm, ref) && GetReferencedName(realm, ref) === "eval") {
+    // a. If SameValue(func, %eval%) is true, then
+    if (SameValue(realm, func, realm.intrinsics.eval)) {
+      // i. Let argList be ? ArgumentListEvaluation(Arguments).
+
+      // ii. If argList has no elements, return undefined.
+      if (argList.length === 0) return realm.intrinsics.undefined;
+
+      // iii. Let evalText be the first element of argList.
+      let evalText = argList[0];
+
+      // iv. If the source code matching this CallExpression is strict code, let strictCaller be true. Otherwise let strictCaller be false.
+      let strictCaller = strictCode;
+
+      // v. Let evalRealm be the current Realm Record.
+      let evalRealm = realm;
+
+      // vi. Return ? PerformEval(evalText, evalRealm, strictCaller, true).
+      return PerformEval(realm, evalText, evalRealm, strictCaller, true);
+    }
+  }
+
+  let thisValue;
+
+  // 4. If Type(ref) is Reference, then
+  if (ref instanceof Reference) {
+    // a. If IsPropertyReference(ref) is true, then
+    if (IsPropertyReference(realm, ref)) {
+      // i. Let thisValue be GetThisValue(ref).
+      thisValue = GetThisValue(realm, ref);
+    } else { // b. Else, the base of ref is an Environment Record
+      // i. Let refEnv be GetBase(ref).
+      let refEnv = GetBase(realm, ref);
+      invariant(refEnv instanceof EnvironmentRecord);
+
+      // ii. Let thisValue be refEnv.WithBaseObject().
+      thisValue = refEnv.WithBaseObject();
+    }
+  } else { // 5. Else Type(ref) is not Reference,
+    // a. Let thisValue be undefined.
+    thisValue = realm.intrinsics.undefined;
+  }
+
+  // 6. Let thisCall be this CallExpression.
+  let thisCall = ast;
+
+  // 7. Let tailCall be IsInTailPosition(thisCall). (See 14.6.1)
+  let tailCall = IsInTailPosition(realm, thisCall);
+
+  // 8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
+
+  try {
+    return EvaluateDirectCallWithArgList(realm, strictCode, env, ref, func, thisValue, argList, tailCall);
+  } catch (err) {
+    if (err instanceof Completion) return err;
+    throw err;
+  }
 }

--- a/src/partial-evaluators/MemberExpression.js
+++ b/src/partial-evaluators/MemberExpression.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { BabelNodeMemberExpression, BabelNodeStatement } from "babel-types";
-import type { LexicalEnvironment } from "../environment.js";
+import type { LexicalEnvironment, Reference } from "../environment.js";
 import type { Realm } from "../realm.js";
 
 import { AbruptCompletion } from "../completions.js";
@@ -19,7 +19,7 @@ import { Value } from "../values/index.js";
 // ECMA262 12.3.2.1
 export default function (
   ast: BabelNodeMemberExpression, strictCode: boolean, env: LexicalEnvironment, realm: Realm
-): [AbruptCompletion | Value, BabelNodeMemberExpression, Array<BabelNodeStatement>] {
-  let result = env.evaluateCompletionDeref(ast, strictCode);
+): [AbruptCompletion | Reference | Value, BabelNodeMemberExpression, Array<BabelNodeStatement>] {
+  let result = env.evaluateCompletion(ast, strictCode);
   return [result, ast, []];
 }

--- a/src/partial-evaluators/Program.js
+++ b/src/partial-evaluators/Program.js
@@ -38,8 +38,8 @@ export default function (
       partialBody.push((partialAst: any));
       if (!(potentialVal instanceof EmptyValue)) val = potentialVal;
     } else {
-      throw realm.createIntrospectionErrorThrowCompletion(
-        "function declarations are not yet supported");
+      // TODO: this goes away once residual functions are partially evaluated.
+      partialBody.push(node);
     }
   }
 

--- a/test/residual/call.js
+++ b/test/residual/call.js
@@ -1,0 +1,55 @@
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+
+let y = 1;
+
+function foo(x) {
+  if (b)
+    y += x;
+  else
+    throw x;
+}
+
+foo(2);
+
+function bar(x) {
+  if (x)
+    return foo;
+  else
+    throw foo;
+}
+
+if (b)
+  bar(b)(3);
+else
+  bar(false)(4);
+
+if (b) {
+
+} else {
+  bar(b)(bar(false));
+}
+
+function alwaysThrow() {
+  throw "always";
+}
+
+if (b) {
+} else {
+  bar(alwaysThrow());
+}
+bar(bar(b));
+
+if (b) {
+} else {
+  alwaysThrow(bar(b), bar(b));
+}
+
+function plain() {
+  y += 3;
+}
+plain();
+
+var ob = { p: plain };
+ob.p();
+
+__result = y;

--- a/test/residual/call2.js
+++ b/test/residual/call2.js
@@ -1,0 +1,3 @@
+function f() { return 123; }
+var g = global.__abstract ? global.__abstract(f, "f") : f;
+__result = g();

--- a/test/residual/call3.js
+++ b/test/residual/call3.js
@@ -1,0 +1,13 @@
+var o = global.__abstract ? global.__abstract('number', '1') : 1;
+var obj = {};
+function bar(x) {
+  if (o > 1) {
+    obj.foo = function() { return 1 + x; }
+  } else if (o > 2) {
+    obj.foo = function() { return 2 + x; }
+  } else {
+    obj.foo = function() { return 3 + x; }
+  }
+}
+bar(5);
+__result = obj.foo();

--- a/test/residual/call4.js
+++ b/test/residual/call4.js
@@ -1,0 +1,13 @@
+var o = global.__abstract ? global.__abstract('number', '1') : 1;
+var obj = {};
+function bar(x) {
+  if (o > 1) {
+    obj.foo = function() { return 1 + x; }
+  } else if (o > 2) {
+    obj.foo = function() { return 2 + x; }
+  } else {
+    obj.foo = function() { return 3 + x; }
+  }
+}
+bar(5);
+__result = obj.foo();

--- a/test/residual/call5.js
+++ b/test/residual/call5.js
@@ -1,0 +1,18 @@
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+
+function foo() {
+  return 1;
+}
+
+function bar() {
+  throw 2;
+}
+
+let fooBar;
+if (b) {
+  fooBar = foo;
+} else {
+  fooBar = bar;
+}
+
+__result = fooBar();

--- a/test/residual/call6.js
+++ b/test/residual/call6.js
@@ -1,0 +1,5 @@
+eval("var ohSo = 'evil';");
+evil = eval();
+eval = function () { return " very "; };
+very = eval();
+__result = ohSo + very + evil;


### PR DESCRIPTION
Partially evaluate the function expression and arguments expressions and deal with all the different kinds of abrupt and possibly abrupt completions when determining the abstract state that results from the function.

At this stage, function calls are not inlined in the residual code.