### PR TITLE
Don't expand occurrences of 'undefined' in residual functions.

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1130,6 +1130,12 @@ export class Serializer {
 
   _serializeGlobalBinding(boundName: string, visitedBinding: VisitedBinding, functionName: string, reasons: Array<string>): SerializedBinding {
     invariant(!visitedBinding.declarativeEnvironmentRecord);
+    if (boundName === "undefined") {
+      // The global 'undefined' property is not writable and not configurable, and thus we can just use 'undefined' here,
+      // encoded as 'void 0' to avoid the possibility of interference with local variables named 'undefined'.
+      return { serializedValue: t.unaryExpression("void", t.numericLiteral(0), true), value: undefined, modified: true, referentialized: true };
+    }
+
     let value = this.realm.getGlobalLetBinding(boundName);
     // Check for let binding vs global property
     if (value) {

--- a/test/serializer/basic/UndefinedInResidualFunction.js
+++ b/test/serializer/basic/UndefinedInResidualFunction.js
@@ -1,0 +1,2 @@
+// does not contain:undefined
+global.inspect = function() { return undefined; }


### PR DESCRIPTION
We used to turn
```js
global.residual = function() { return undefined; }
```
into
```js
(function () {
  var _$0 = this;

  function _0() {
    return _$0.undefined;
  }

  residual = _0;
}).call(this);
```

Correct, but very annoying. No more!
(Motivated while working on #699 and realizing that when pushing more code into residual functions, strange things happen.)