### PR TITLE
Make error handler test less verbose

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -62,7 +62,7 @@ function runTest(name: string, code: string): boolean {
   try {
     prepack(code, {
       filename: name,
-      internalDebug: true,
+      internalDebug: false,
       compatibility: "jsc-600-1-4-17",
       mathRandomSeed: "0",
       serialize: true,


### PR DESCRIPTION
This test spews a lot of useless information to the console. Reduce it.