### PR TITLE
Never emit 'undefined' literal.

### DIFF
--- a/test/serializer/basic/Undefined.js
+++ b/test/serializer/basic/Undefined.js
@@ -1,0 +1,5 @@
+// does not contain:undefined
+(function() {
+  x = undefined;
+  inspect = function() { return x; }
+})();

--- a/test/serializer/basic/UndefinedAsLocalVariableName.js
+++ b/test/serializer/basic/UndefinedAsLocalVariableName.js
@@ -1,0 +1,7 @@
+(function() {
+    let x = undefined;
+    inspect = function() {
+        let undefined = 42;
+        return undefined === x;
+    }
+})();


### PR DESCRIPTION
Similarly to the previous change that resolved 'undefined' in residual functions to 'void 0',
serialize all 'undefined' values as 'void 0' (and avoid using Babel's valueToNode which produces the
ambiguous 'undefined' literal).
Add test case that ensures that we never emit 'undefined',
and another regression test case that used to fail the serializer when using the local variable name 'undefined'.