### PR TITLE
Add optional limit on context stack depth

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -31,6 +31,7 @@ export type Options = {|
   residual?: boolean,
   serialize?: boolean,
   strictlyMonotonicDateNow?: boolean,
+  maxStackDepth?: number
 |};
 
 export const defaultOptions = {};
@@ -44,6 +45,7 @@ export function getRealmOptions({
   residual,
   serialize = !residual,
   strictlyMonotonicDateNow,
+  maxStackDepth,
 }: Options): RealmOptions {
   return {
     compatibility,
@@ -54,6 +56,7 @@ export function getRealmOptions({
     residual,
     serialize,
     strictlyMonotonicDateNow,
+    maxStackDepth,
   };
 }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -116,6 +116,8 @@ export class Realm {
     this.start = Date.now();
     this.compatibility = opts.compatibility || "browser";
 
+    this.maxStackDepth = opts.maxStackDepth || 0;
+
 
     this.$TemplateMap  = [];
 
@@ -142,6 +144,7 @@ export class Realm {
   timeout: void | number;
   mathRandomGenerator: void | () => number;
   strictlyMonotonicDateNow: boolean;
+  maxStackDepth: void | number;
 
   modifiedBindings: void | Bindings;
   modifiedProperties: void | PropertyBindings;
@@ -225,6 +228,9 @@ export class Realm {
   }
 
   pushContext(context: ExecutionContext): void {
+    if (this.maxStackDepth && this.contextStack.length >= this.maxStackDepth) {
+      throw new Error("Maximum context stack size exceeded");
+    }
     this.contextStack.push(context);
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -58,6 +58,7 @@ export type RealmOptions = {
   mathRandomSeed?: string,
   strictlyMonotonicDateNow?: boolean,
   errorHandler?: ErrorHandler,
+  maxStackDepth?: number,
 };
 
 export type AbstractTime = "early" | "late";

--- a/test/serializer/basic/LimitedStack.js
+++ b/test/serializer/basic/LimitedStack.js
@@ -1,0 +1,18 @@
+// limit stack depth: 100
+// exceeds stack depth limit
+
+(function() {
+  let immediate = function(future) {
+    if (Date.now() > future) {
+      return "exit value";
+    }
+
+    return immediate(future);
+  };
+
+  let n = immediate(Date.now() - 1);
+})();
+
+inspect = function() {
+  return false;
+};

--- a/test/serializer/basic/LimitedStack2.js
+++ b/test/serializer/basic/LimitedStack2.js
@@ -1,0 +1,18 @@
+// limit stack depth: 3
+// exceeds stack depth limit
+
+(function a() {
+  return b();
+})();
+
+function b() {
+  return c();
+}
+
+function c() {
+  return 0;
+}
+
+inspect = function() {
+  return false;
+};

--- a/test/serializer/basic/LimitedStack3.js
+++ b/test/serializer/basic/LimitedStack3.js
@@ -1,0 +1,18 @@
+// limit stack depth: 10
+// does not exceed stack depth limit
+
+(function a() {
+  return b();
+})();
+
+function b() {
+  return c();
+}
+
+function c() {
+  return 0;
+}
+
+inspect = function() {
+  return true;
+};


### PR DESCRIPTION
Partially addresses #520 as per @NTillmann’s suggestion in https://github.com/facebook/prepack/issues/520#issuecomment-299068188.

Feedback welcome - I’m especially unsure of my testing approach here as it relates to the wider setup of the repo, but did not want to submit this without test coverage. Happy to polish / move things around as needed to get this merged.

Also, I’m not sure whether #520 should be closed, strictly speaking, following this work. Leaving this decision to the maintainers.