### PR TITLE
Tighten up test for pure binary expressions

### DIFF
--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -514,9 +514,9 @@ export function ToPrimitive(realm: Realm, input: ConcreteValue, hint?: "default"
 
 // Returns result type of ToPrimitive if it is pure (terminates, does not throw exception, does not read or write heap), otherwise undefined.
 export function GetToPrimitivePureResultType(realm: Realm, input: Value): void | typeof Value {
-  // This carefully abstracts the behavior of ToPrimitive.
-  if (input instanceof PrimitiveValue || input instanceof AbstractValue) return input.getType();
-  invariant(input instanceof ObjectValue);
+  let type = input.getType();
+  if (input instanceof PrimitiveValue) return type;
+  if (input instanceof AbstractValue && Value.isTypeCompatibleWith(type, PrimitiveValue)) return type;
   return undefined;
 }
 

--- a/test/serializer/abstract/BinaryExpression2.js
+++ b/test/serializer/abstract/BinaryExpression2.js
@@ -1,0 +1,15 @@
+// throws introspection error
+
+var b = global.__abstract ? __abstract("boolean", true) : true;
+var x = global.__abstract ? __abstract("number", 123) : 123;
+var badOb = { valueOf: function() { throw 13;} }
+var ob = global.__abstract ? __abstract("object", "({ valueOf: function() { throw 13;} })") : badOb;
+var y = b ? ob : x;
+
+try {
+  z = 100 + y;
+} catch (err) {
+  z = 200 + err;
+}
+
+inspect = function() { return "" + z; }


### PR DESCRIPTION
Abstract values might be objects, in which case GetToPrimitivePureResultType must return undefined.