### PR TITLE
First bit of support for error recovery

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -69,8 +69,10 @@ function runTest(name: string, code: string): boolean {
       speculate: true,
     },
     errorHandler.bind(null, recover ? 'RecoverIfPossible' : 'Fail', errors));
-    console.log(chalk.red("Serialization succeeded though it should have failed"));
-    return false;
+    if (!recover) {
+      console.log(chalk.red("Serialization succeeded though it should have failed"));
+      return false;
+    }
   } catch (e) {
     // We expect serialization to fail, so catch the error and continue
   }
@@ -81,8 +83,14 @@ function runTest(name: string, code: string): boolean {
 
   for (let i = 0; i < expectedErrors.length; ++i) {
     for (let prop in expectedErrors[i]) {
-      if (expectedErrors[i][prop] !== errors[i][prop]) {
-        console.log(chalk.red(`Error ${i}: Expected ${expectedErrors[i][prop]} errors, but found ${errors[i][prop]}`));
+      let expected = expectedErrors[i][prop];
+      let actual = (errors[i]: any)[prop];
+      if (prop === "location") {
+        actual = JSON.stringify(actual);
+        expected = JSON.stringify(expected);
+      }
+      if (expected !== actual) {
+        console.log(chalk.red(`Error ${i + 1}: Expected ${expected} errors, but found ${actual}`));
         return false;
       }
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -32,7 +32,3 @@ export class CompilerDiagnostics extends Error {
 }
 
 export type ErrorHandler = (error: CompilerDiagnostics) => ErrorHandlerResult;
-
-export const errorDetails: {[ErrorCode]: string} = {
-  'PP0001': 'Array size must be a concrete number',
-};

--- a/src/evaluators/AssignmentExpression.js
+++ b/src/evaluators/AssignmentExpression.js
@@ -101,7 +101,7 @@ export default function (ast: BabelNodeAssignmentExpression, strictCode: boolean
   // 5. Let op be the @ where AssignmentOperator is @=.
   let op  = ((AssignmentOperator.slice(0, -1): any): BabelBinaryOperator);
   // 6. Let r be the result of applying op to lval and rval as if evaluating the expression lval op rval.
-  let r = GetValue(realm, computeBinary(realm, op, lval, rval));
+  let r = GetValue(realm, computeBinary(realm, op, lval, rval, ast.left.loc, ast.right.loc));
   // 7. Perform ? PutValue(lref, r).
   PutValue(realm, lref, r);
   // 8. Return r.

--- a/src/partial-evaluators/AssignmentExpression.js
+++ b/src/partial-evaluators/AssignmentExpression.js
@@ -130,5 +130,6 @@ export default function (
   if (resultAst === undefined) {
     resultAst = t.assignmentExpression(ast.operator, (last: any), (rast: any));
   }
-  return createAbstractValueForBinary(op, resultAst, lval, rval, leftCompletion, rightCompletion, resultValue, io, realm);
+  return createAbstractValueForBinary(op, resultAst, lval, rval, last.loc, rast.loc,
+     leftCompletion, rightCompletion, resultValue, io, realm);
 }

--- a/src/partial-evaluators/BinaryExpression.js
+++ b/src/partial-evaluators/BinaryExpression.js
@@ -9,7 +9,8 @@
 
 /* @flow */
 
-import type { BabelBinaryOperator, BabelNodeBinaryExpression, BabelNodeExpression, BabelNodeStatement } from "babel-types";
+import type { BabelBinaryOperator, BabelNodeBinaryExpression, BabelNodeExpression, BabelNodeStatement,
+   BabelNodeSourceLocation } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 
@@ -61,16 +62,18 @@ export default function (
   if (resultAst === undefined) {
     resultAst = t.binaryExpression(op, (leftAst: any), (rightAst: any));
   }
-  return createAbstractValueForBinary(op, resultAst, lval, rval, leftCompletion, rightCompletion, resultValue, io, realm);
+  return createAbstractValueForBinary(op, resultAst, lval, rval, leftAst.loc, rightAst.loc,
+     leftCompletion, rightCompletion, resultValue, io, realm);
 }
 
 export function createAbstractValueForBinary(
     op: BabelBinaryOperator, ast: BabelNodeExpression, lval: Value, rval: Value,
+    lloc: ?BabelNodeSourceLocation, rloc: ?BabelNodeSourceLocation,
     leftCompletion: void | NormalCompletion, rightCompletion: void | NormalCompletion,
     resultValue: void | Value, io: Array<BabelNodeStatement>, realm: Realm
 ): [Completion | Value, BabelNodeExpression, Array<BabelNodeStatement>] {
   if (resultValue === undefined) {
-    let resultType = getPureBinaryOperationResultType(realm, op, lval, rval);
+    let resultType = getPureBinaryOperationResultType(realm, op, lval, rval, lloc, rloc);
     if (resultType === undefined) {
       // The operation may result in side effects that we cannot track.
       // Since we have no idea what those effects are, we can either forget

--- a/src/realm.js
+++ b/src/realm.js
@@ -655,10 +655,10 @@ export class Realm {
   // Pass the error to the realm's error-handler
   // Return value indicates whether the caller should try to recover from the
   // error or not ('true' means recover if possible).
-  handleError(error: CompilerDiagnostics): ErrorHandlerResult {
+  handleError(diagnostic: CompilerDiagnostics): ErrorHandlerResult {
     // Default behaviour is to bail on the first error
     let errorHandler = this.errorHandler;
     if (!errorHandler) return 'Fail';
-    return errorHandler(error);
+    return errorHandler(diagnostic);
   }
 }

--- a/test/error-handler/BinaryExpression.js
+++ b/test/error-handler/BinaryExpression.js
@@ -1,0 +1,16 @@
+// recover-from-errors
+// expected errors: [{location: {"start":{"line":11,"column":12},"end":{"line":11,"column":13},"identifierName":"y","source":"test/error-handler/BinaryExpression.js"}, errorCode: "PP0002", severity: "Error", message: "might be an object with an unknown valueOf or toString method"}]
+
+var b = global.__abstract ? __abstract("boolean", true) : true;
+var x = global.__abstract ? __abstract("number", 123) : 123;
+var badOb = { valueOf: function() { throw 13;} }
+var ob = global.__abstract ? __abstract("object", "({ valueOf: function() { throw 13;} })") : badOb;
+var y = b ? ob : x;
+
+try {
+  z = 100 + y;
+} catch (err) {
+  z = 200 + err;
+}
+
+inspect = function() { return "" + z; }


### PR DESCRIPTION
Produce a nicer error message for + operator with abstract values that might be objects of unknown type. Carry on if the error handler requests it (this is useful to point out more than one error at a time).

Tweak the error handler test runner to deal with recoverable errors and provide a way to specify more expected values for error messages.