### PR TITLE
No Need To Generate Source Code On First Serialize Pass

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -33,7 +33,7 @@ import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
 
 const GLOBAL_CAPTURED_SCOPE_NAME = "__captured_scopes";
 
-type SerializedOutput = {
+type AbstractSyntaxTree = {
   type: string,
   program: {
     type: string,
@@ -1573,7 +1573,7 @@ export class Serializer {
     return false;
   }
 
-  serialize(): { ast?: SerializedOutput} {
+  serialize(): AbstractSyntaxTree {
     this._emitGenerator(this.generator);
     invariant(this.declaredDerivedIds.size <= this.preludeGenerator.derivedIds.size);
 


### PR DESCRIPTION
Refactored code to avoid unnecessary source code generation. I noticed that the parsing ast into code generation takes about 2000ms so the updated profiling stats are:
[Profiling] Interpreting Global Code: 12133.150ms
[Profiling] Resolving Initial Modules: 2006.665ms
[Profiling] Deep Traversal of Heap: 5004.448ms
[Profiling] Reference Counts Pass: 8972.274ms
[Profiling] Serialize Pass: 10276.123ms

The Reference Counts Pass is much faster without generating code