### PR TITLE
Make IsNumberPure safer

### DIFF
--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -460,14 +460,21 @@ export function ToNumber(realm: Realm, val: numberOrValue): number {
     return val.value;
   } else if (val instanceof StringValue) {
     return Number(val.value);
+  } else if (val instanceof SymbolValue) {
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
   } else {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to a number");
+    invariant(false, "unexpected type of value");
   }
 }
 
 export function IsToNumberPure(realm: Realm, val: numberOrValue): boolean {
-  // This carefully abstracts the behavior of IsToNumberSideEffectFree.
-  if (val instanceof ObjectValue) return IsToPrimitivePure(realm, val);
+  if (val instanceof Value) {
+    if (IsToPrimitivePure(realm, val)) {
+      let type = val.getType();
+      return (type !== SymbolValue && type !== PrimitiveValue && type !== Value);
+    }
+    return false;
+  }
   return true;
 }
 

--- a/test/serializer/abstract/UnaryExpression2.js
+++ b/test/serializer/abstract/UnaryExpression2.js
@@ -1,0 +1,15 @@
+// throws introspection error
+
+var b = global.__abstract ? __abstract("boolean", true) : true;
+var x = global.__abstract ? __abstract("number", 123) : 123;
+var badOb = { valueOf: function() { throw 13;} }
+var ob = global.__abstract ? __abstract("object", "({ valueOf: function() { throw 13;} })") : badOb;
+var y = b ? ob : x;
+
+try {
+  z = -y;
+} catch (err) {
+  z = -err;
+}
+
+inspect = function() { return "" + z; }


### PR DESCRIPTION
ToNumberPure returned true for all abstract values, including ones that might be objects or symbols. This is obviously not safe, so I made things stricter.