### PR TITLE
Fixing regression around delaying of "referentialization"

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1180,7 +1180,8 @@ export class Serializer {
       let serializedBindings = instance.serializedBindings;
 
       for (let name in names) {
-        let serializedBinding : SerializedBinding = serializedBindings[name];
+        let serializedBinding = serializedBindings[name];
+        invariant(serializedBinding !== undefined);
         if (serializedBinding.modified) {
 
           // Initialize captured scope at function call instead of globally
@@ -1328,6 +1329,7 @@ export class Serializer {
 
             for (let functionInstance of batch) {
               let serializedBinding = functionInstance.serializedBindings[name];
+              invariant(serializedBinding !== undefined);
               let found = false;
               for (let [binding, group] of bindingLookup.entries()) {
                 if (AreSameSerializedBindings(this.realm, serializedBinding, binding)) {

--- a/test/serializer/basic/ReferentializeBug.js
+++ b/test/serializer/basic/ReferentializeBug.js
@@ -1,0 +1,10 @@
+(function() {
+  function f() {
+    let obj = { x: 0 };
+    function g() { return function() { obj = { x: obj.x+1 }; /* This comment makes this function too big to be inlined. */ } }
+    function h() { return obj.x; }
+    return [g(), g(), g(), h];
+  }
+  a = f();
+  inspect = function() { return a[3](); }
+})();


### PR DESCRIPTION
We recently added a feature that delays "referentialization" (#643),
which is the allocation of mutable slots for captured variables.
However, this caused a regression when the same captured variable
gets involved in multiple functions, with the delaying logic kicking
in for some functions but not others.

This change ensures that referentialization is always delayed in a
uniform way.

This doesn't always produce optimal code, but that's for another pull request.

Added regression test.