### PR TITLE
Fixing recently introduced bug which declares and binds arguments in the wrong order.

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1391,13 +1391,14 @@ export class Serializer {
           for (let key of factoryNames) {
             factoryParams.push(t.identifier(key));
           }
-          factoryParams = factoryParams.concat(params).slice();
 
           let scopeInitialization = [];
           for (let scope of instances[0].scopeInstances) {
             factoryParams.push(t.identifier(scope.name));
             scopeInitialization.push(this._getReferentializedScopeInitialization(scope));
           }
+
+          factoryParams = factoryParams.concat(params).slice();
 
           // The Replacer below mutates the AST, so let's clone the original AST to avoid modifying it
           let factoryNode = t.functionDeclaration(factoryId, factoryParams, ((t.cloneDeep(funcBody): any): BabelNodeBlockStatement));
@@ -1425,6 +1426,9 @@ export class Serializer {
               invariant(serializedValue);
               return serializedValue;
             });
+            for (let { id } of instance.scopeInstances) {
+              flatArgs.push(t.numericLiteral(id));
+            }
             let node;
             let firstUsage = this.firstFunctionUsages.get(functionValue);
             invariant(insertionPoint !== undefined);
@@ -1440,10 +1444,6 @@ export class Serializer {
                 callArgs.push(((param: any): BabelNodeIdentifier));
               }
 
-              for (let { id } of instance.scopeInstances) {
-                callArgs.push(t.numericLiteral(id));
-              }
-
               let callee = t.memberExpression(factoryId, t.identifier("call"));
 
               let childBody = t.blockStatement([
@@ -1452,10 +1452,6 @@ export class Serializer {
 
               node = t.functionDeclaration(functionId, params, childBody);
             } else {
-              for (let { id } of instance.scopeInstances) {
-                flatArgs.push(t.numericLiteral(id));
-              }
-
               node = t.variableDeclaration("var", [
                 t.variableDeclarator(functionId, t.callExpression(
                   t.memberExpression(factoryId, t.identifier("bind")),

--- a/test/serializer/basic/CapturedScopeParameterOrdering.js
+++ b/test/serializer/basic/CapturedScopeParameterOrdering.js
@@ -1,0 +1,11 @@
+(function() {
+    function f() {
+        let x = 0;
+        function g() {
+            return function(p) { return [p, x++]; /* This comment makes this function too big for inlining */ }
+        }
+        return [g(), g(), g()];
+    }
+    let a = f();
+    inspect = function() { return a[0](42)[0]; }
+})();


### PR DESCRIPTION
Since recently, we lazily allocate space for mutable captured variable slots used by residual functions. The slots are identified by an index representing different indices. If the same function code is involved in multiple residual function instances, then we try to share the function body, and use a `.bind(...)` call to create multiple instances, also binding the particular index arguments. However, the ordering was wrong. This pull request fixes that.

Adding test case that represents residual functions
which capture and mutate variables
and have a non-empty argument list.