### PR TITLE
Error messages for object expressions

### DIFF
--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -16,7 +16,7 @@ import { Reference } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
 import { Value, ObjectValue, UndefinedValue } from "../values/index.js";
 import { NormalCompletion, AbruptCompletion } from "../completions.js";
-import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
+import { EvalPropertyNamePartial } from "../evaluators/ObjectExpression.js";
 import {
   RequireObjectCoercible,
   GetIterator,
@@ -50,7 +50,7 @@ export function DestructuringAssignmentEvaluation(realm: Realm, pattern: BabelNo
 
     for (let property of pattern.properties) {
       // 1. Let name be the result of evaluating PropertyName.
-      let name = EvalPropertyName(property, env, realm, strictCode);
+      let name = EvalPropertyNamePartial(property, env, realm, strictCode);
 
       // 2. ReturnIfAbrupt(name).
 

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -36,7 +36,7 @@ import {
   LexicalEnvironment
 } from "../environment.js";
 import { NormalCompletion, AbruptCompletion, ThrowCompletion } from "../completions.js";
-import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
+import { EvalPropertyNamePartial } from "../evaluators/ObjectExpression.js";
 import {
   GetV,
   GetThisValue,
@@ -529,7 +529,7 @@ export function BindingInitialization(realm: Realm, node: BabelNodeLVal, value: 
       let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
 
       // 1. Let P be the result of evaluating PropertyName.
-      let P = EvalPropertyName(property, env, realm, strictCode);
+      let P = EvalPropertyNamePartial(property, env, realm, strictCode);
 
       // 2. ReturnIfAbrupt(P).
 

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding, PropertyKeyValue } from "../types.js";
 import { ArrayValue, UndefinedValue, NumberValue, SymbolValue, NullValue, BooleanValue, ObjectValue, StringValue, Value, ConcreteValue, AbstractValue, AbstractObjectValue } from "../values/index.js";
-import { EvalPropertyName } from '../evaluators/ObjectExpression';
+import { EvalPropertyNamePartial } from '../evaluators/ObjectExpression';
 import { EnvironmentRecord, Reference } from "../environment.js";
 import { CreateIterResultObject } from "../methods/create.js";
 import invariant from "../invariant.js";
@@ -1104,7 +1104,7 @@ export function PropertyDefinitionEvaluation(realm: Realm, MethodDefinition: Bab
     // See 14.4.
     // ECMA 14.4.13
     // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
+    let propKey = EvalPropertyNamePartial(MethodDefinition, env, realm, strictCode);
 
     // 2. ReturnIfAbrupt(propKey).
     // 3. If the function code for this GeneratorMethod is strict mode code, let strict be true. Otherwise let strict be false.
@@ -1136,7 +1136,7 @@ export function PropertyDefinitionEvaluation(realm: Realm, MethodDefinition: Bab
     return DefinePropertyOrThrow(realm, object, propKey, desc);
   } else if (MethodDefinition.kind === "get") {
     // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
+    let propKey = EvalPropertyNamePartial(MethodDefinition, env, realm, strictCode);
 
     // 2. ReturnIfAbrupt(propKey).
 
@@ -1169,7 +1169,7 @@ export function PropertyDefinitionEvaluation(realm: Realm, MethodDefinition: Bab
     DefinePropertyOrThrow(realm, object, propKey, desc);
   } else if (MethodDefinition.kind === 'set') {
     // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
+    let propKey = EvalPropertyNamePartial(MethodDefinition, env, realm, strictCode);
 
     // 2. ReturnIfAbrupt(propKey).
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -107,6 +107,11 @@ export class ResidualHeapVisitor {
 
       if (key === "name") {
         // TODO #474: Make sure that we retain original function names. Or set name property. Or ensure that nothing references the name property.
+        // For now don't ignore the property if it is different from the function name.
+        // I.e. if it was set explicitly in the code, retain it.
+        if (desc.value !== undefined && (desc.value instanceof AbstractValue ||
+          val.__originalName && val.__originalName !== "" && desc.value.value !== val.__originalName))
+            return false;
         return true;
       }
 

--- a/test/error-handler/objectExpression.js
+++ b/test/error-handler/objectExpression.js
@@ -1,0 +1,7 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":7,"column":11},"end":{"line":7,"column":30},"source":"test/error-handler/objectExpression.js"},"severity":"FatalError","errorCode":"PP0011"}, {"location":{"start":{"line":7,"column":32},"end":{"line":7,"column":38},"source":"test/error-handler/objectExpression.js"},"severity":"FatalError","errorCode":"PP0011"}]
+
+let x = __abstract("number");
+let y = __abstract("number");
+
+let ob = { [x]: function () {}, [y]: 2 };

--- a/test/serializer/abstract/ObjectExpression.js
+++ b/test/serializer/abstract/ObjectExpression.js
@@ -1,0 +1,9 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let p = x ? "x" : "y";
+let q = x ? "y" : "z";
+let r = x ? "f" : "g";
+
+ob = { [p]: 1, [q]: 2 };
+ob2 = { [r]: function(){ } };
+
+inspect = function() { return ob.x + " " + ob.y + " " + ob2.f.name; }


### PR DESCRIPTION
Generalize object expressions to allow abstract values as property names, since it is already possible to use abstract property names via `ob[absPropName] = val`.

In the case where the abstract value is not known to be a string value, give an error message since this case is not supported by either syntax (and is quite a bit more complicated to support).

[PP0011 property key value is unknown](https://github.com/facebook/prepack/wiki/PP0011)