### PR TITLE
Better delayed values

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -170,12 +170,12 @@ function runTest(name, code, args) {
       let i = 0;
       let max = 4;
       let oldCode = code;
-      let anyIndexedVars = false;
+      let anyDelayedValues = false;
       for (; i < max; i++) {
         let newUniqueSuffix = `_unique${unique++}`;
         options.uniqueSuffix = newUniqueSuffix;
         let serialized = prepack(oldCode, options);
-        if (serialized.statistics.indexedVars > 0) anyIndexedVars = true;
+        if (serialized.statistics.delayedValues > 0) anyDelayedValues = true;
         if (!serialized) {
           console.log(chalk.red("Error during serialization!"));
           break;
@@ -212,7 +212,7 @@ function runTest(name, code, args) {
         oldCode = newCode;
         oldUniqueSuffix = newUniqueSuffix;
       }
-      if (anyIndexedVars) {
+      if (anyDelayedValues) {
         // TODO: Make delayed initializations logic more sophisticated in order to still reach a fixed point.
         return true;
       } else if (i === max) {

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -112,7 +112,6 @@ export class Serializer {
     this.declaredDerivedIds = new Set();
     this.descriptors = new Map();
     this.needsEmptyVar = false;
-    this.needsVars = false;
     this.needsAuxiliaryConstructor = false;
     this.valueNameGenerator = this.preludeGenerator.createNameGenerator("_");
     this.descriptorNameGenerator = this.preludeGenerator.createNameGenerator("$$");
@@ -126,9 +125,6 @@ export class Serializer {
     this.serializedValues = new Set();
     this.functionInitializerInfos = new Map();
     this.initializers = new Map();
-    this.varsExpression = t.identifier(this.scopeNameGenerator.generate("vars"));
-    this.nextVarsIndex = 0;
-    this.availableVars = [];
     this.collectValToRefCountOnly = collectValToRefCountOnly;
     if (collectValToRefCountOnly) this.valToRefCount = new Map();
   }
@@ -158,7 +154,6 @@ export class Serializer {
   generator: Generator;
   descriptors: Map<string, BabelNodeIdentifier>;
   needsEmptyVar: boolean;
-  needsVars: boolean;
   needsAuxiliaryConstructor: boolean;
   valueNameGenerator: NameGenerator;
   descriptorNameGenerator: NameGenerator;
@@ -181,20 +176,6 @@ export class Serializer {
   serializedValues: Set<Value>;
   serializedScopes: Map<DeclarativeEnvironmentRecord, ScopeBinding>;
   capturedScopeInstanceIdx: number;
-  varsExpression: BabelNodeIdentifier;
-  nextVarsIndex: number;
-  availableVars: Array<BabelNodeMemberExpression>;
-
-  allocateIndexedVar(): BabelNodeMemberExpression {
-    if (this.availableVars.length > 0) {
-      return this.availableVars.pop();
-    }
-    return t.memberExpression(this.varsExpression, t.numericLiteral(this.nextVarsIndex++), true);
-  }
-
-  releaseIndexedVar(indexedVar: BabelNodeMemberExpression) {
-    this.availableVars.push(indexedVar);
-  }
 
   _getBodyReference() {
     return new BodyReference(this.body, this.body.length);
@@ -581,16 +562,7 @@ export class Serializer {
     this.body = target.body;
 
     let name = this.valueNameGenerator.generate(val.__originalName || "");
-    let id;
-    if (target.usedBySingleFunctionValue) {
-      // The visitor ensures that all function values are always associated with the
-      // realm generator scope, so they are never just used by a single function scope.
-      invariant(!(val instanceof FunctionValue));
-      this.needsVars = true;
-      id = this.allocateIndexedVar();
-    } else {
-      id = t.identifier(name);
-    }
+    let id = t.identifier(name);
     this.refs.set(val, id);
     this.serializationStack.push(val);
     let init = this._serializeValue(name, val, reasons);
@@ -610,6 +582,10 @@ export class Serializer {
       if (init) {
         if (init !== id) {
           if (target.usedBySingleFunctionValue) {
+            let declar = t.variableDeclaration((bindingType ? bindingType : "var"), [
+              t.variableDeclarator(id)
+            ]);
+            this.mainBody.push(declar);
             let assignment = t.expressionStatement(t.assignmentExpression("=", id, init));
             this.body.push(assignment);
           } else {
@@ -620,20 +596,9 @@ export class Serializer {
           }
         }
         this.statistics.valueIds++;
-        if (target.usedBySingleFunctionValue) this.statistics.indexedVars++;
+        if (target.usedBySingleFunctionValue) this.statistics.delayedValues++;
       }
     } else {
-      if (target.usedBySingleFunctionValue) {
-        // When `target.usedBySingleFunctionValue` is true, then according to the
-        // control-flow above, `id` must have been created by a call to
-        // `allocateIndexedVar`, which always returns a member expression.
-        invariant(id.type === "MemberExpression");
-        // We inlined this value, so the indexed variable we allocated earlier is
-        // not actually needed, so we release it back to a pool of indexed vars
-        // that can be re-used.
-        this.releaseIndexedVar(((id: any): BabelNodeMemberExpression));
-      }
-
       if (init) {
         this.refs.delete(val);
         result = init;
@@ -1629,24 +1594,27 @@ export class Serializer {
 
       let location;
       for (let value of initializedValues) {
-        location = this.refs.get(value);
-        if (location !== undefined) break;
+        if (!value.mightBeUndefined()) {
+          location = this.refs.get(value);
+          if (location !== undefined) break;
+        }
       }
       if (location === undefined) {
         // Take care of side-effecting code that is associated with an inlined value
-        location = this.allocateIndexedVar();
+        location = t.identifier(this.valueNameGenerator.generate("initialized"));
+        this.mainBody.push(t.variableDeclaration("var", [t.variableDeclarator(location)]));
         initializationStatements.unshift(
           t.expressionStatement(
             t.assignmentExpression(
               "=",
               location,
-              Serializer.voidExpression
+              t.nullLiteral()
             )
           )
         );
       }
       return t.ifStatement(
-        t.binaryExpression("===", location, this.varsExpression),
+        t.binaryExpression("===", location, Serializer.voidExpression),
         t.blockStatement(initializationStatements));
     };
     for (let [functionValue, funcNode] of funcNodes) {
@@ -1834,26 +1802,6 @@ export class Serializer {
         ),
       ]));
     }
-    if (this.needsVars) {
-      // We need to allocate an array which holds indexed variables,
-      // representing values that are not needed along the main initialization path,
-      // and whose initialization is getting delaying until a later point, e.g.
-      // within a residual function.
-      // We know that we need up to `nextVarsIndex` many slots in the array,
-      // so we allocate an array of that size.
-      // We fill the with references to itself, representing uninitialized values.
-      // This is to enables efficient checks of the following form:
-      // `if (vars[someIndex] === vars) { /* initialize vars[someIndex] */ }`
-      body.push(t.variableDeclaration("var", [
-        t.variableDeclarator(
-          this.varsExpression,
-          t.newExpression(t.identifier("Array"), [t.numericLiteral(this.nextVarsIndex)])
-        ),
-      ]));
-      body.push(t.expressionStatement(t.callExpression(
-        t.memberExpression(this.varsExpression, t.identifier("fill")), [this.varsExpression]
-      )));
-    }
     if (this.needsAuxiliaryConstructor) {
       body.push(t.functionDeclaration(
         Serializer.constructorExpression, [], t.blockStatement([])));
@@ -1946,7 +1894,7 @@ export class Serializer {
 
       for (let declar of node.declarations) {
         let { init } = declar;
-        invariant(init);
+        if (!init) continue;
         if (init.type !== "ObjectExpression") continue;
 
         let keys = this.getObjectKeys(init);

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -99,7 +99,7 @@ export class SerializerStatistics {
     this.referentialized = 0;
     this.valueIds = 0;
     this.valuesInlined = 0;
-    this.indexedVars = 0;
+    this.delayedValues = 0;
   }
   objects: number;
   objectProperties: number;
@@ -108,11 +108,11 @@ export class SerializerStatistics {
   referentialized: number;
   valueIds: number;
   valuesInlined: number;
-  indexedVars: number;
+  delayedValues: number;
   log() {
     console.log(`=== serialization statistics`);
     console.log(`${this.objects} objects with ${this.objectProperties} properties`);
     console.log(`${this.functions} functions plus ${this.functionClones} clones due to captured variables; ${this.referentialized} captured mutable variables`);
-    console.log(`${this.valueIds} value ids and ${this.indexedVars} indexed variables generated, and ${this.valuesInlined} values inlined`);
+    console.log(`${this.valueIds} eager and ${this.delayedValues} delayed value ids generated, and ${this.valuesInlined} values inlined`);
   }
 }


### PR DESCRIPTION
Don't create an array to hold delayed values. 
Instead, just allocate local variables in the main scope.
This change reflects discussions with JavaScript compiler / VM people.
Remove remnants from earlier generalization where refs could not only be ids but also member expressions.