### PR TITLE
Fix bug in referentialization

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1376,11 +1376,15 @@ export class Serializer {
     for (let [funcBody, instances] of functionEntries) {
       let functionInfo = this.residualFunctionInfos.get(funcBody);
       invariant(functionInfo);
+      this._referentialize(functionInfo.names, instances);
+    }
+
+    for (let [funcBody, instances] of functionEntries) {
+      let functionInfo = this.residualFunctionInfos.get(funcBody);
+      invariant(functionInfo);
       let { names, modified, usesThis, usesArguments } = functionInfo;
       let params = instances[0].functionValue.$FormalParameters;
       invariant(params !== undefined);
-
-      this._referentialize(names, instances);
 
       let shouldInline = !funcBody;
       if (!shouldInline && funcBody.start && funcBody.end) {

--- a/test/serializer/basic/CapturedScope7.js
+++ b/test/serializer/basic/CapturedScope7.js
@@ -1,0 +1,15 @@
+(function() {
+    function f() {
+        let a = 1;
+        let b = 2;
+        return [
+                function() { return a++; /* This comment makes this function too big to be inlined. */ },
+                function() { return b++; /* This comment makes this function too big to be inlined. */ },
+                ];
+    }
+    F = f();
+    inspect = function() {
+        F[0]();
+        return F[1]();
+    }
+})();


### PR DESCRIPTION
It's important to first referentialize all mutated captured variables, before starting to emit any residual function.
Otherwise, earlier emitted functions may initialize captured scopes without taking into
account all relevant mutated captured variables.
Add test case.