### PR TITLE
Dealing with conditional require calls

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -35,8 +35,8 @@ export type CreatedObjects = Set<ObjectValue | AbstractObjectValue>;
 export type Effects = [EvaluationResult, Generator, Bindings, PropertyBindings, CreatedObjects];
 
 export class Tracer {
-  beginPartialEvaluation() {}
-  endPartialEvaluation(effects: void | Effects) {}
+  beginEvaluateForEffects(state: any) {}
+  endEvaluateForEffects(state: any, effects: void | Effects) {}
   detourCall(F: FunctionValue, thisArgument: void | Value, argumentsList: Array<Value>, newTarget: void | ObjectValue, performCall: () => Value): void | Value {}
   beforeCall(F: FunctionValue, thisArgument: void | Value, argumentsList: Array<Value>, newTarget: void | ObjectValue) {}
   afterCall(F: FunctionValue, thisArgument: void | Value, argumentsList: Array<Value>, newTarget: void | ObjectValue, result: void | Reference | Value | AbruptCompletion) {}
@@ -263,7 +263,7 @@ export class Realm {
     return [effects, nodeAst, nodeIO];
   }
 
-  evaluateForEffects(f: () => Completion | Value | Reference): Effects {
+  evaluateForEffects(f: () => Completion | Value | Reference, state: any): Effects {
     // Save old state and set up empty state for ast
     let context = this.getRunningContext();
     let savedContextEffects = context.savedEffects;
@@ -274,7 +274,7 @@ export class Realm {
     this.generator = new Generator(this);
     this.createdObjects = new Set();
 
-    for (let t1 of this.tracers) t1.beginPartialEvaluation();
+    for (let t1 of this.tracers) t1.beginEvaluateForEffects(state);
 
     let c;
     let result;
@@ -316,7 +316,7 @@ export class Realm {
       this.modifiedProperties = savedProperties;
       this.createdObjects = saved_createdObjects;
 
-      for (let t2 of this.tracers) t2.endPartialEvaluation(result);
+      for (let t2 of this.tracers) t2.endEvaluateForEffects(state, result);
     }
   }
 

--- a/src/serializer/LoggingTracer.js
+++ b/src/serializer/LoggingTracer.js
@@ -42,15 +42,15 @@ export class LoggingTracer extends Tracer {
     console.log(`[calls] ${this.nesting.map(_ => "  ").join("")}${message}`);
   }
 
-  beginPartialEvaluation() {
-    this.log(`>partial evaluation`);
-    this.nesting.push("(partial evaluation)");
+  beginEvaluateForEffects(state: any) {
+    this.log(`>evaluate for effects`);
+    this.nesting.push("(evaluate for effects)");
   }
 
-  endPartialEvaluation(effects: void | Effects) {
+  endEvaluateForEffects(state: any, effects: void | Effects) {
     let name = this.nesting.pop();
-    invariant(name === "(partial evaluation)");
-    this.log(`<partial evaluation`);
+    invariant(name === "(evaluate for effects)");
+    this.log(`<evaluate for effects`);
   }
 
   beforeCall(F: FunctionValue, thisArgument: void | Value, argumentsList: Array<Value>, newTarget: void | ObjectValue) {

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -333,6 +333,7 @@ export class Modules {
       return effects;
     } catch (err) {
       if (err instanceof FatalError) return undefined;
+      throw err;
     } finally {
       realm.popContext(context);
       this.delayUnsupportedRequires = oldDelayUnsupportedRequires;
@@ -364,6 +365,7 @@ export class Modules {
       count++;
       this.initializedModules.set(moduleId, result);
     }
+    // TODO: How do FatalError / Realm.handleError participate in these statistics?
     if (count > 0) console.log(`=== speculatively initialized ${count} additional modules`);
     let a = [];
     for (let key in introspectionErrors) a.push([introspectionErrors[key], key]);

--- a/test/serializer/optimizations/require_accelerate.js
+++ b/test/serializer/optimizations/require_accelerate.js
@@ -1,0 +1,109 @@
+// delay unsupported requires
+
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+      try {
+
+   var _moduleObject = { exports: exports };
+
+   factory(global, require, _moduleObject, exports, dependencyMap);
+
+      module.factory = undefined;
+
+   return module.exports = _moduleObject.exports;
+ } catch (e) {
+   module.hasError = true;
+   module.isInitialized = false;
+   module.exports = undefined;
+   throw e;
+ }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+define(function(global, require, module, exports) {
+  var nondet = global.__abstract ? __abstract("boolean", "true") : true;
+  if (nondet) {
+    require(1);
+  }
+}, 0, null);
+
+define(function(global, require, module, exports) {
+}, 1, null);
+
+var f = require(0);
+require(1); // without accelerating requires (and without refinement), Prepack can't handle this.
+
+inspect = function() { 42; }


### PR DESCRIPTION
When require calls are encountered within a evaluate-for-effects context
that isn't trigger by the delaying-require-calls logic,
accelerate the likely conditional require call, effectively making it unconditional.

Completely untested, but I am looking for early feedback or validation...