### PR TITLE
Check that abstract reference base objects are coercible to objects

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -16,7 +16,7 @@ import type { SourceMap, SourceType } from "./types.js";
 import { AbruptCompletion, Completion, JoinedAbruptCompletions, NormalCompletion, PossiblyNormalCompletion, ThrowCompletion } from "./completions.js";
 import { ExecutionContext } from "./realm.js";
 import { Value } from "./values/index.js";
-import { AbstractValue, NullValue, SymbolValue, BooleanValue, FunctionValue, ObjectValue, AbstractObjectValue, UndefinedValue } from "./values/index.js";
+import { AbstractValue, NullValue, SymbolValue, BooleanValue, FunctionValue, NumberValue, ObjectValue, AbstractObjectValue, StringValue, UndefinedValue } from "./values/index.js";
 import generate from "babel-generator";
 import parse from "./utils/parse.js";
 import invariant from "./invariant.js";
@@ -1127,16 +1127,30 @@ export class LexicalEnvironment {
 
 }
 
-//
+// ECMA262 6.2.3
+// A Reference is a resolved name or property binding. A Reference consists of three components, the base value,
+// the referenced name and the Boolean valued strict reference flag. The base value is either undefined, an Object,
+// a Boolean, a String, a Symbol, a Number, or an Environment Record. A base value of undefined indicates that the
+// Reference could not be resolved to a binding. The referenced name is a String or Symbol value.
+export type BaseValue = void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord;
+export type ReferenceName = string | SymbolValue;
+
+export function canBecomeAnObject(base: Value): boolean {
+  let type = base.getType();
+  return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
+}
+
 export class Reference {
-  base: void | Value | EnvironmentRecord;
-  referencedName: AbstractValue | string | SymbolValue;
+  base: BaseValue | AbstractValue;
+  referencedName: ReferenceName | AbstractValue;
   strict: boolean;
   thisValue: void | Value;
 
-  constructor(base: void | Value | EnvironmentRecord,
-      refName: AbstractValue | string | SymbolValue,
+  constructor(base: BaseValue | AbstractValue,
+      refName: ReferenceName | AbstractValue,
       strict: boolean, thisValue?: void | Value) {
+    invariant(base instanceof AbstractObjectValue || base === undefined || base instanceof ObjectValue ||
+      base instanceof EnvironmentRecord || canBecomeAnObject(base));
     this.base = base;
     this.referencedName = refName;
     invariant(!(refName instanceof AbstractValue) || !refName.mightNotBeString());

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -91,7 +91,7 @@ function EvaluateCall(
     let args =
       [func].concat(ArgumentListEvaluation(realm, strictCode, env, ((ast.arguments: any): Array<BabelNode>)));
     return realm.deriveAbstract(
-      new TypesDomain(AbstractValue),
+      TypesDomain.topVal,
       ValuesDomain.topVal,
       args,
       (nodes) => {

--- a/src/evaluators/MemberExpression.js
+++ b/src/evaluators/MemberExpression.js
@@ -38,7 +38,7 @@ export default function (ast: BabelNodeMemberExpression, strictCode: boolean, en
   }
 
   // 5. Let bv be ? RequireObjectCoercible(baseValue).
-  let bv = RequireObjectCoercible(realm, baseValue);
+  let bv = RequireObjectCoercible(realm, baseValue, ast.object.loc);
 
   // 6. Let propertyKey be ? ToPropertyKey(propertyNameValue).
   let propertyKey = ToPropertyKeyPartial(realm, propertyNameValue);

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -86,7 +86,7 @@ export default function (realm: Realm): void {
       let types = new TypesDomain(type);
       let values = template ? new ValuesDomain(new Set([template])) : ValuesDomain.topVal;
       let result = realm.createAbstract(types, values, [], buildNode, undefined, nameString);
-      if (template) {
+      if (template && !(template instanceof FunctionValue)) { // why exclude functions?
         template.makePartial();
         if (nameString) realm.rebuildNestedProperties(result, nameString);
       }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -77,7 +77,11 @@ export function IsSuperReference(realm: Realm, V: Reference): boolean {
 // HasPrimitiveBase(V). Returns true if Type(base) is Boolean, String, Symbol, or Number.
 export function HasPrimitiveBase(realm: Realm, V: Reference): boolean {
   let base = GetBase(realm, V);
-  return base instanceof Value && HasSomeCompatibleType(base, BooleanValue, StringValue, SymbolValue, NumberValue);
+  // void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord | AbstractValue;
+  if (!base || base instanceof EnvironmentRecord) return false;
+  if (base instanceof ObjectValue || base instanceof AbstractObjectValue) return false;
+  let type = base.getType();
+  return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
 }
 
 // ECMA262 6.2.3
@@ -132,7 +136,7 @@ export function GetValue(realm: Realm, V: Reference | Value): Value {
     return base.GetBindingValue(referencedName, IsStrictReference(realm, V));
   }
 
-  throw new Error("unknown reference type");
+  invariant(false);
 }
 
 // ECMA262 6.2.3
@@ -144,8 +148,8 @@ export function IsStrictReference(realm: Realm, V: Reference): boolean {
 // ECMA262 6.2.3
 // IsPropertyReference(V). Returns true if either the base value is an object or HasPrimitiveBase(V) is true; otherwise returns false.
 export function IsPropertyReference(realm: Realm, V: Reference): boolean {
-  return V.base instanceof ObjectValue || V.base instanceof AbstractObjectValue ||
-    V.base instanceof AbstractObjectValue || HasPrimitiveBase(realm, V);
+  // V.base is AbstractValue | void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord;
+  return V.base instanceof AbstractValue || V.base instanceof ObjectValue || HasPrimitiveBase(realm, V);
 }
 
 // ECMA262 6.2.3

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -794,7 +794,7 @@ export function PutValue(realm: Realm, V: Value | Reference, W: Value) {
     return base.SetMutableBinding(referencedName, W, IsStrictReference(realm, V));
   }
 
-  throw new Error("unknown reference type");
+  invariant(false);
 }
 
 // ECMA262 9.4.2.4

--- a/src/realm.js
+++ b/src/realm.js
@@ -560,7 +560,7 @@ export class Realm {
   // NOTE: `buildNode` MUST NOT create an AST which may mutate or access mutable state! Use `deriveAbstract` for that purpose.
   createAbstract(types: TypesDomain, values: ValuesDomain, args: Array<Value>, buildNode: (Array<BabelNodeExpression> => BabelNodeExpression) | BabelNodeExpression, kind?: string, intrinsicName?: string) {
     invariant(this.useAbstractInterpretation);
-    let Constructor = types.getType() === ObjectValue ? AbstractObjectValue : AbstractValue;
+    let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;
     return new Constructor(this, types, values, args, buildNode, kind, intrinsicName);
   }
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -33,7 +33,7 @@ export default class AbstractValue extends Value {
       intrinsicName?: string) {
     invariant(realm.useAbstractInterpretation);
     super(realm, intrinsicName);
-    invariant(types.getType() !== ObjectValue || this instanceof AbstractObjectValue);
+    invariant(!Value.isTypeCompatibleWith(types.getType(), ObjectValue) || this instanceof AbstractObjectValue);
     invariant(types.getType() !== NullValue && types.getType() !== UndefinedValue);
     this.types = types;
     this.values = values;
@@ -141,6 +141,14 @@ export default class AbstractValue extends Value {
     if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return true;
     if (this.values.isTop()) return true;
     return this.values.mightNotBeFalse();
+  }
+
+  mightBeNull(): boolean {
+    let valueType = this.getType();
+    if (valueType === NullValue) return true;
+    if (valueType !== Value) return false;
+    if (this.values.isTop()) return true;
+    return this.values.includesValueOfType(NullValue);
   }
 
   mightBeNumber(): boolean {

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import { EmptyValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "./index.js";
+import { EmptyValue, NullValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "./index.js";
 import invariant from "../invariant.js";
 
 export default class ConcreteValue extends Value {
@@ -21,6 +21,10 @@ export default class ConcreteValue extends Value {
 
   mightNotBeFalse(): boolean {
     return !this.mightBeFalse();
+  }
+
+  mightBeNull(): boolean {
+    return this instanceof NullValue;
   }
 
   mightBeNumber(): boolean {

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -66,6 +66,10 @@ export default class Value {
     throw new Error("abstract method; please override");
   }
 
+  mightBeNull(): boolean {
+    throw new Error("abstract method; please override");
+  }
+
   mightBeNumber(): boolean {
     throw new Error("abstract method; please override");
   }

--- a/test/error-handler/member.js
+++ b/test/error-handler/member.js
@@ -1,0 +1,8 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":8,"column":0},"end":{"line":8,"column":2},"identifierName":"oq","source":"test/error-handler/member.js"},"severity":"FatalError","errorCode":"PP0012"}]
+
+var b = global.__abstract ? __abstract("boolean", true) : true;
+var o = global.__abstract ? __abstract({}, "({})") : {};
+var oq = b ? o : null;
+
+oq.foo = 123;

--- a/test/error-handler/member2.js
+++ b/test/error-handler/member2.js
@@ -1,0 +1,8 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":8,"column":4},"end":{"line":8,"column":6},"identifierName":"oq","source":"test/error-handler/member2.js"},"severity":"FatalError","errorCode":"PP0012"}]
+
+var b = global.__abstract ? __abstract("boolean", true) : true;
+var o = global.__abstract ? __abstract({}, "({})") : {};
+var oq = b ? o : null;
+
+x = oq.foo;


### PR DESCRIPTION
The base value of a Reference is an abstract value that is not known to be an object or one of a set of objects, then the effects of an assignment to the reference is unknown to the extent that Prepack cannot continue. It also had the effect that an invariant was violated, leading to issue #750.

We now give a error message that is contextualized to the member expression (if any) that created  the Reference.

[PP0012 reference base value is unknown](https://github.com/facebook/prepack/wiki/PP0012)

