### PR TITLE
Always throw new FatalError()

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -16,7 +16,7 @@ import type { SourceMap, SourceType } from "./types.js";
 import { AbruptCompletion, Completion, JoinedAbruptCompletions, NormalCompletion, PossiblyNormalCompletion, ThrowCompletion } from "./completions.js";
 import { ExecutionContext } from "./realm.js";
 import { Value } from "./values/index.js";
-import { AbstractValue, NullValue, SymbolValue, BooleanValue, FunctionValue, ObjectValue, AbstractObjectValue, UndefinedValue } from "./values/index.js";
+import { AbstractValue, NullValue, SymbolValue, BooleanValue, FunctionValue, NumberValue, ObjectValue, AbstractObjectValue, StringValue, UndefinedValue } from "./values/index.js";
 import generate from "babel-generator";
 import parse from "./utils/parse.js";
 import invariant from "./invariant.js";
@@ -1127,16 +1127,30 @@ export class LexicalEnvironment {
 
 }
 
-//
+// ECMA262 6.2.3
+// A Reference is a resolved name or property binding. A Reference consists of three components, the base value,
+// the referenced name and the Boolean valued strict reference flag. The base value is either undefined, an Object,
+// a Boolean, a String, a Symbol, a Number, or an Environment Record. A base value of undefined indicates that the
+// Reference could not be resolved to a binding. The referenced name is a String or Symbol value.
+export type BaseValue = void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord;
+export type ReferenceName = string | SymbolValue;
+
+export function canBecomeAnObject(base: Value): boolean {
+  let type = base.getType();
+  return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
+}
+
 export class Reference {
-  base: void | Value | EnvironmentRecord;
-  referencedName: AbstractValue | string | SymbolValue;
+  base: BaseValue | AbstractValue;
+  referencedName: ReferenceName | AbstractValue;
   strict: boolean;
   thisValue: void | Value;
 
-  constructor(base: void | Value | EnvironmentRecord,
-      refName: AbstractValue | string | SymbolValue,
+  constructor(base: BaseValue | AbstractValue,
+      refName: ReferenceName | AbstractValue,
       strict: boolean, thisValue?: void | Value) {
+    invariant(base instanceof AbstractObjectValue || base === undefined || base instanceof ObjectValue ||
+      base instanceof EnvironmentRecord || canBecomeAnObject(base));
     this.base = base;
     this.referencedName = refName;
     invariant(!(refName instanceof AbstractValue) || !refName.mightNotBeString());

--- a/src/errors.js
+++ b/src/errors.js
@@ -42,6 +42,4 @@ export function FatalError() {
 Object.setPrototypeOf(FatalError, Error);
 Object.setPrototypeOf(FatalError.prototype, Error.prototype);
 
-export const fatalError = new FatalError();
-
 export type ErrorHandler = (error: CompilerDiagnostics) => ErrorHandlerResult;

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { CompilerDiagnostics, fatalError } from "../errors.js";
+import { CompilerDiagnostics, FatalError } from "../errors.js";
 import { Value, AbstractValue, AbstractObjectValue, ConcreteValue, UndefinedValue, NullValue, BooleanValue, NumberValue, ObjectValue, StringValue } from "../values/index.js";
 import { GetValue } from "../methods/index.js";
 import { HasProperty, HasSomeCompatibleType } from "../methods/index.js";
@@ -50,7 +50,7 @@ export function getPureBinaryOperationResultType(
       // Assume that an unknown value is actually a primitive or otherwise a well behaved object.
       return typeIfPure;
     }
-    throw fatalError;
+    throw new FatalError();
   }
   if (op === "+") {
     let ltype = GetToPrimitivePureResultType(realm, lval);
@@ -66,7 +66,7 @@ export function getPureBinaryOperationResultType(
         if (ltype === NumberValue && rtype === NumberValue) return NumberValue;
         return Value;
       }
-     throw fatalError;
+     throw new FatalError();
     }
     if (ltype === StringValue || rtype === StringValue) return StringValue;
     return NumberValue;
@@ -85,7 +85,7 @@ export function getPureBinaryOperationResultType(
         // Assume that the object is actually a well behaved object.
         return BooleanValue;
       }
-      throw fatalError;
+      throw new FatalError();
     }
     if (rval instanceof ObjectValue || rval instanceof AbstractObjectValue) {
        // Simple object won't throw here, aren't proxy objects or typed arrays and do not have @@hasInstance properties.
@@ -97,7 +97,7 @@ export function getPureBinaryOperationResultType(
       // Assume that the object is actually a well behaved object.
       return BooleanValue;
     }
-    throw fatalError;
+    throw new FatalError();
   }
   invariant(false, "unimplemented " + op);
 }

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -91,7 +91,7 @@ function EvaluateCall(
     let args =
       [func].concat(ArgumentListEvaluation(realm, strictCode, env, ((ast.arguments: any): Array<BabelNode>)));
     return realm.deriveAbstract(
-      new TypesDomain(AbstractValue),
+      TypesDomain.topVal,
       ValuesDomain.topVal,
       args,
       (nodes) => {

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { CompilerDiagnostics, fatalError } from "../errors.js";
+import { CompilerDiagnostics, FatalError } from "../errors.js";
 import { AbruptCompletion, Completion, NormalCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
@@ -104,7 +104,7 @@ function EvaluateCall(
     if (func.getType() !== FunctionValue) {
       let loc = ast.callee.type === "MemberExpression" ? ast.callee.property.loc : ast.callee.loc;
       let error = new CompilerDiagnostics("might not be a function", loc, 'PP0005', 'RecoverableError');
-      if (realm.handleError(error) === 'Fail') throw fatalError;
+      if (realm.handleError(error) === 'Fail') throw new FatalError();
     } else if (func.kind === "conditional") {
       return callBothFunctionsAndJoinTheirEffects(func.args, ast, strictCode, env, realm);
     } else {
@@ -132,7 +132,7 @@ function EvaluateCall(
       if (evalText instanceof AbstractValue) {
         let loc = ast.arguments[0].loc;
         let error = new CompilerDiagnostics("eval argument must be a known value", loc, 'PP0006', 'RecoverableError');
-        if (realm.handleError(error) === 'Fail') throw fatalError;
+        if (realm.handleError(error) === 'Fail') throw new FatalError();
         // Assume that it is a safe eval with no visible heap changes or abrupt control flow.
         return generateRuntimeCall();
       }

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment, Reference } from "../environment.js";
 import { AbstractValue, Value } from "../values/index.js";
-import { CompilerDiagnostics, fatalError } from "../errors.js";
+import { CompilerDiagnostics, FatalError } from "../errors.js";
 import { NullValue, EmptyValue, ObjectValue } from '../values/index.js';
 import type { BabelNodeClassDeclaration, BabelNodeExpression, BabelNodeClassMethod } from "babel-types";
 import parse from "../utils/parse.js";
@@ -42,7 +42,7 @@ function EvaluateClassHeritage(realm: Realm, ClassHeritage: BabelNodeExpression,
   if (val instanceof AbstractValue) {
     let error = new CompilerDiagnostics(
       "unknown super class", ClassHeritage.loc, 'PP0009', 'RecoverableError');
-    if (realm.handleError(error) === 'Fail') throw fatalError;
+    if (realm.handleError(error) === 'Fail') throw new FatalError();
   }
   if (!(val instanceof ObjectValue)) {
     return null;
@@ -116,7 +116,7 @@ function ClassDefinitionEvaluation(realm: Realm, ast: BabelNodeClassDeclaration,
         if (protoParent instanceof AbstractValue) {
           let error = new CompilerDiagnostics(
             "unknown super class prototype", ClassHeritage.loc, 'PP0010', 'RecoverableError');
-          if (realm.handleError(error) === 'Fail') throw fatalError;
+          if (realm.handleError(error) === 'Fail') throw new FatalError();
           protoParent = realm.intrinsics.ObjectPrototype;
         } else {
           throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, 'protoParent must be an instance of Object or Null');

--- a/src/evaluators/MemberExpression.js
+++ b/src/evaluators/MemberExpression.js
@@ -38,7 +38,7 @@ export default function (ast: BabelNodeMemberExpression, strictCode: boolean, en
   }
 
   // 5. Let bv be ? RequireObjectCoercible(baseValue).
-  let bv = RequireObjectCoercible(realm, baseValue);
+  let bv = RequireObjectCoercible(realm, baseValue, ast.object.loc);
 
   // 6. Let propertyKey be ? ToPropertyKey(propertyNameValue).
   let propertyKey = ToPropertyKeyPartial(realm, propertyNameValue);

--- a/src/evaluators/ObjectExpression.js
+++ b/src/evaluators/ObjectExpression.js
@@ -14,7 +14,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
 import type { Value } from "../values/index.js";
 import type { Reference } from "../environment.js";
-import { CompilerDiagnostics, fatalError } from "../errors.js";
+import { CompilerDiagnostics, FatalError } from "../errors.js";
 import { AbstractValue, ConcreteValue, ObjectValue, StringValue } from "../values/index.js";
 import {
   ObjectCreate,
@@ -93,7 +93,7 @@ export default function (ast: BabelNodeObjectExpression, strictCode: boolean, en
         if (propKey.mightNotBeString()) {
           let error = new CompilerDiagnostics(
             "property key value is unknown", prop.loc, 'PP0011', 'FatalError');
-          if (realm.handleError(error) === 'Fail') throw fatalError;
+          if (realm.handleError(error) === 'Fail') throw new FatalError();
           continue; // recover by ignoring the property, which is only ever safe to do if the property is dead,
           // which is assuming a bit much, hence the designation as a FatalError.
         }

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { CompilerDiagnostics, fatalError } from "../errors.js";
+import { CompilerDiagnostics, FatalError } from "../errors.js";
 import { AbstractObjectValue, Value, BooleanValue, ConcreteValue, NumberValue, StringValue, UndefinedValue, NullValue, SymbolValue, ObjectValue, AbstractValue } from "../values/index.js";
 import { Reference, EnvironmentRecord } from "../environment.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -48,7 +48,7 @@ export default function (ast: BabelNodeUnaryExpression, strictCode: boolean, env
     let error = new CompilerDiagnostics(
       "might be a symbol or an object with an unknown valueOf or toString or Symbol.toPrimitive method",
       ast.argument.loc, 'PP0008', 'RecoverableError');
-    if (realm.handleError(error) === 'Fail') throw fatalError;
+    if (realm.handleError(error) === 'Fail') throw new FatalError();
   }
 
   let expr = env.evaluate(ast.argument, strictCode);

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -13,7 +13,7 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import type { Reference } from "../environment.js";
-import { CompilerDiagnostics, fatalError } from "../errors.js";
+import { CompilerDiagnostics, FatalError } from "../errors.js";
 import { Add, GetValue, ToNumber, PutValue, IsToNumberPure } from "../methods/index.js";
 import { AbstractValue, NumberValue } from "../values/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -34,7 +34,7 @@ export default function (ast: BabelNodeUpdateExpression, strictCode: boolean, en
       let error = new CompilerDiagnostics(
         "might be a symbol or an object with an unknown valueOf or toString or Symbol.toPrimitive method",
         ast.argument.loc, 'PP0008', 'RecoverableError');
-      if (realm.handleError(error) === 'Fail') throw fatalError;
+      if (realm.handleError(error) === 'Fail') throw new FatalError();
     }
     invariant(ast.operator === '++' || ast.operator === '--'); // As per BabelNodeUpdateExpression
     let op = ast.operator === '++' ? '+' : '-';

--- a/src/evaluators/WithStatement.js
+++ b/src/evaluators/WithStatement.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import { LexicalEnvironment, ObjectEnvironmentRecord } from "../environment.js";
-import { CompilerDiagnostics, fatalError } from "../errors.js";
+import { CompilerDiagnostics, FatalError } from "../errors.js";
 import { AbruptCompletion } from "../completions.js";
 import { AbstractValue, Value } from "../values/index.js";
 import type { Reference } from "../environment.js";
@@ -29,7 +29,7 @@ export default function (ast: BabelNodeWithStatement, strictCode: boolean, env: 
   if (val instanceof AbstractValue) {
     let loc = ast.object.loc;
     let error = new CompilerDiagnostics("with object must be a known value", loc, 'PP0007', 'RecoverableError');
-    if (realm.handleError(error) === "Fail") throw fatalError;
+    if (realm.handleError(error) === "Fail") throw new FatalError();
   }
   let obj = ToObjectPartial(realm, val);
 

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -86,7 +86,7 @@ export default function (realm: Realm): void {
       let types = new TypesDomain(type);
       let values = template ? new ValuesDomain(new Set([template])) : ValuesDomain.topVal;
       let result = realm.createAbstract(types, values, [], buildNode, undefined, nameString);
-      if (template) {
+      if (template && !(template instanceof FunctionValue)) { // why exclude functions?
         template.makePartial();
         if (nameString) realm.rebuildNestedProperties(result, nameString);
       }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -77,7 +77,11 @@ export function IsSuperReference(realm: Realm, V: Reference): boolean {
 // HasPrimitiveBase(V). Returns true if Type(base) is Boolean, String, Symbol, or Number.
 export function HasPrimitiveBase(realm: Realm, V: Reference): boolean {
   let base = GetBase(realm, V);
-  return base instanceof Value && HasSomeCompatibleType(base, BooleanValue, StringValue, SymbolValue, NumberValue);
+  // void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord | AbstractValue;
+  if (!base || base instanceof EnvironmentRecord) return false;
+  if (base instanceof ObjectValue || base instanceof AbstractObjectValue) return false;
+  let type = base.getType();
+  return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
 }
 
 // ECMA262 6.2.3
@@ -132,7 +136,7 @@ export function GetValue(realm: Realm, V: Reference | Value): Value {
     return base.GetBindingValue(referencedName, IsStrictReference(realm, V));
   }
 
-  throw new Error("unknown reference type");
+  invariant(false);
 }
 
 // ECMA262 6.2.3
@@ -144,8 +148,8 @@ export function IsStrictReference(realm: Realm, V: Reference): boolean {
 // ECMA262 6.2.3
 // IsPropertyReference(V). Returns true if either the base value is an object or HasPrimitiveBase(V) is true; otherwise returns false.
 export function IsPropertyReference(realm: Realm, V: Reference): boolean {
-  return V.base instanceof ObjectValue || V.base instanceof AbstractObjectValue ||
-    V.base instanceof AbstractObjectValue || HasPrimitiveBase(realm, V);
+  // V.base is AbstractValue | void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord;
+  return V.base instanceof AbstractValue || V.base instanceof ObjectValue || HasPrimitiveBase(realm, V);
 }
 
 // ECMA262 6.2.3

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -794,7 +794,7 @@ export function PutValue(realm: Realm, V: Value | Reference, W: Value) {
     return base.SetMutableBinding(referencedName, W, IsStrictReference(realm, V));
   }
 
-  throw new Error("unknown reference type");
+  invariant(false);
 }
 
 // ECMA262 9.4.2.4

--- a/src/prepack-node-environment.js
+++ b/src/prepack-node-environment.js
@@ -17,7 +17,7 @@ import { Value } from "./values";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
 import { getRealmOptions, getSerializerOptions } from "./options";
-import { fatalError } from "./errors.js";
+import { FatalError } from "./errors.js";
 import initializeBootstrap from "./intrinsics/node/bootstrap.js";
 import initializeProcess from "./intrinsics/node/process.js";
 
@@ -108,7 +108,7 @@ export function prepackNodeCLISync(filename: string, options: Options = defaultO
   // Serialize
   let serialized = serializer.init("", "", "", options.sourceMaps);
   if (!serialized) {
-    throw fatalError;
+    throw new FatalError();
   }
   return serialized;
 }

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -14,7 +14,7 @@ import initializeGlobals from "./globals.js";
 import fs from "fs";
 import { AbruptCompletion } from "./completions.js";
 import { getRealmOptions, getSerializerOptions } from "./options";
-import { fatalError } from "./errors.js";
+import { FatalError } from "./errors.js";
 import { prepackNodeCLI, prepackNodeCLISync } from "./prepack-node-environment";
 
 import type { Options } from "./options";
@@ -41,7 +41,7 @@ export function prepackString(filename: string, code: string, sourceMap: string,
        options.sourceMaps
      );
      if (!serialized) {
-       throw fatalError;
+       throw new FatalError();
      }
      if (!options.residual) return serialized;
      let result = realm.$GlobalEnv.executePartialEvaluator(

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -12,9 +12,8 @@ import Serializer from "./serializer/index.js";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
 import * as t from "babel-types";
-import { FatalError } from "./errors.js";
 import { getRealmOptions, getSerializerOptions } from "./options";
-import { type ErrorHandler, fatalError } from "./errors.js";
+import { type ErrorHandler, FatalError } from "./errors.js";
 
 import type { Options } from "./options";
 import { defaultOptions } from "./options";
@@ -42,7 +41,7 @@ export function prepack(code: string, options: Options = defaultOptions, errorHa
   let serializer = new Serializer(realm, getSerializerOptions(options));
   let serialized = serializer.init(filename, code, "", options.sourceMaps);
   if (!serialized) {
-    throw fatalError;
+    throw new FatalError();
   }
   return serialized;
 }
@@ -62,7 +61,7 @@ export function prepackFromAst(ast: BabelNodeFile | BabelNodeProgram, code: stri
   let serializer = new Serializer(realm, getSerializerOptions(options));
   let serialized = serializer.init("", code, "", options.sourceMaps);
   if (!serialized) {
-    throw fatalError;
+    throw new FatalError();
   }
   return serialized;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -560,7 +560,7 @@ export class Realm {
   // NOTE: `buildNode` MUST NOT create an AST which may mutate or access mutable state! Use `deriveAbstract` for that purpose.
   createAbstract(types: TypesDomain, values: ValuesDomain, args: Array<Value>, buildNode: (Array<BabelNodeExpression> => BabelNodeExpression) | BabelNodeExpression, kind?: string, intrinsicName?: string) {
     invariant(this.useAbstractInterpretation);
-    let Constructor = types.getType() === ObjectValue ? AbstractObjectValue : AbstractValue;
+    let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;
     return new Constructor(this, types, values, args, buildNode, kind, intrinsicName);
   }
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -33,7 +33,7 @@ export default class AbstractValue extends Value {
       intrinsicName?: string) {
     invariant(realm.useAbstractInterpretation);
     super(realm, intrinsicName);
-    invariant(types.getType() !== ObjectValue || this instanceof AbstractObjectValue);
+    invariant(!Value.isTypeCompatibleWith(types.getType(), ObjectValue) || this instanceof AbstractObjectValue);
     invariant(types.getType() !== NullValue && types.getType() !== UndefinedValue);
     this.types = types;
     this.values = values;
@@ -141,6 +141,14 @@ export default class AbstractValue extends Value {
     if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return true;
     if (this.values.isTop()) return true;
     return this.values.mightNotBeFalse();
+  }
+
+  mightBeNull(): boolean {
+    let valueType = this.getType();
+    if (valueType === NullValue) return true;
+    if (valueType !== Value) return false;
+    if (this.values.isTop()) return true;
+    return this.values.includesValueOfType(NullValue);
   }
 
   mightBeNumber(): boolean {

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import { EmptyValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "./index.js";
+import { EmptyValue, NullValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "./index.js";
 import invariant from "../invariant.js";
 
 export default class ConcreteValue extends Value {
@@ -21,6 +21,10 @@ export default class ConcreteValue extends Value {
 
   mightNotBeFalse(): boolean {
     return !this.mightBeFalse();
+  }
+
+  mightBeNull(): boolean {
+    return this instanceof NullValue;
   }
 
   mightBeNumber(): boolean {

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -66,6 +66,10 @@ export default class Value {
     throw new Error("abstract method; please override");
   }
 
+  mightBeNull(): boolean {
+    throw new Error("abstract method; please override");
+  }
+
   mightBeNumber(): boolean {
     throw new Error("abstract method; please override");
   }

--- a/test/error-handler/member.js
+++ b/test/error-handler/member.js
@@ -1,0 +1,8 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":8,"column":0},"end":{"line":8,"column":2},"identifierName":"oq","source":"test/error-handler/member.js"},"severity":"FatalError","errorCode":"PP0012"}]
+
+var b = global.__abstract ? __abstract("boolean", true) : true;
+var o = global.__abstract ? __abstract({}, "({})") : {};
+var oq = b ? o : null;
+
+oq.foo = 123;

--- a/test/error-handler/member2.js
+++ b/test/error-handler/member2.js
@@ -1,0 +1,8 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":8,"column":4},"end":{"line":8,"column":6},"identifierName":"oq","source":"test/error-handler/member2.js"},"severity":"FatalError","errorCode":"PP0012"}]
+
+var b = global.__abstract ? __abstract("boolean", true) : true;
+var o = global.__abstract ? __abstract({}, "({})") : {};
+var oq = b ? o : null;
+
+x = oq.foo;


### PR DESCRIPTION
Since the constructor captures the stack trace each throw statement should construct its own instance of FatalError.