### PR TITLE
Little serializer refactoring, pulling out the management of residual function initializers

### DIFF
--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { FunctionValue, Value } from "../values/index.js";
+import * as t from "babel-types";
+import type { BabelNodeStatement, BabelNodeIdentifier } from "babel-types";
+import { NameGenerator } from "../utils/generator.js";
+import traverse from "babel-traverse";
+import invariant from "../invariant.js";
+import { voidExpression, nullExpression } from "../utils/internalizer.js";
+
+export type LocationService = {
+  getLocation: Value => void | BabelNodeIdentifier,
+  createLocation: () => BabelNodeIdentifier
+};
+
+// This class manages information about values
+// which are only referenced by residual functions,
+// and it provides the ability to generate initialization code for those values that
+// can be placed into the residual functions.
+export class ResidualFunctionInitializers {
+  constructor(
+    locationService: LocationService,
+    prelude: Array<BabelNodeStatement>,
+    initializerNameGenerator: NameGenerator
+  ) {
+    this.functionInitializerInfos = new Map();
+    this.initializers = new Map();
+    this.sharedInitializers = new Map();
+    this.locationService = locationService;
+    this.initializerNameGenerator = initializerNameGenerator;
+    this.prelude = prelude;
+  }
+
+  functionInitializerInfos: Map<FunctionValue, { ownId: string, initializerIds: Set<string> }>;
+  initializers: Map<string, { id: string, order: number, body: Array<BabelNodeStatement>, values: Array<Value> }>;
+  sharedInitializers: Map<string, BabelNodeStatement>;
+  locationService: LocationService;
+  prelude: Array<BabelNodeStatement>;
+  initializerNameGenerator: NameGenerator;
+
+  registerValueOnlyReferencedByResidualFunctions(functionValues: Array<FunctionValue>, val: Value): Array<BabelNodeStatement> {
+    invariant(functionValues.length >= 1);
+    let infos = [];
+    for (let functionValue of functionValues) {
+      let info = this.functionInitializerInfos.get(functionValue);
+      if (info === undefined) this.functionInitializerInfos.set(functionValue, info = { ownId: this.functionInitializerInfos.size.toString(), initializerIds: new Set() });
+      infos.push(info);
+    }
+    let id = infos.map(info => info.ownId).sort().join();
+    for (let info of infos) info.initializerIds.add(id);
+    let initializer = this.initializers.get(id);
+    if (initializer === undefined) this.initializers.set(id, initializer = { id, order: infos.length, values: [], body: [] });
+    initializer.values.push(val);
+    return initializer.body;
+  }
+
+  scrubFunctionInitializers() {
+    // Deleting trivial entries in order to avoid creating empty initialization functions that serve no purpose.
+    for (let initializer of this.initializers.values())
+      if (initializer.body.length === 0) this.initializers.delete(initializer.id);
+    for (let [functionValue, info] of this.functionInitializerInfos) {
+      for (let id of info.initializerIds) {
+        let initializer = this.initializers.get(id);
+        if (initializer === undefined) {
+          info.initializerIds.delete(id);
+        }
+      }
+      if (info.initializerIds.size === 0) this.functionInitializerInfos.delete(functionValue);
+    }
+  }
+
+  _conditionalInitialization(initializedValues: Array<Value>, initializationStatements: Array<BabelNodeStatement>): BabelNodeStatement  {
+    if (initializationStatements.length === 1 && t.isIfStatement(initializationStatements[0])) {
+      return initializationStatements[0];
+    }
+
+    // We have some initialization code, and it should only get executed once,
+    // so we are going to guard it.
+    // First, let's see if one of the initialized values is guaranteed to not
+    // be undefined after initialization. In that case, we can use that state-change
+    // to figure out if initialization needs to run.
+    let location;
+    for (let value of initializedValues) {
+      if (!value.mightBeUndefined()) {
+        location = this.locationService.getLocation(value);
+        if (location !== undefined) break;
+      }
+    }
+    if (location === undefined) {
+      // Second, if we didn't find a non-undefined value, let's make one up.
+      // It will transition from `undefined` to `null`.
+      location = this.locationService.createLocation();
+      initializationStatements.unshift(
+        t.expressionStatement(
+          t.assignmentExpression(
+            "=",
+            location,
+            nullExpression
+          )
+        )
+      );
+    }
+    return t.ifStatement(
+      t.binaryExpression("===", location, voidExpression),
+      t.blockStatement(initializationStatements));
+  }
+
+  hasInitializerStatement(functionValue: FunctionValue): boolean {
+    return !!this.functionInitializerInfos.get(functionValue);
+  }
+
+  getInitializerStatement(functionValue: FunctionValue): void | BabelNodeStatement {
+    let initializerInfo = this.functionInitializerInfos.get(functionValue);
+    if (initializerInfo === undefined) return undefined;
+
+    invariant(initializerInfo.initializerIds.size > 0);
+    let ownInitializer = this.initializers.get(initializerInfo.ownId);
+    let initializedValues;
+    let initializationStatements = [];
+    let initializers = [];
+    for (let initializerId of initializerInfo.initializerIds) {
+      let initializer = this.initializers.get(initializerId);
+      invariant(initializer !== undefined);
+      invariant(initializer.body.length > 0);
+      initializers.push(initializer);
+    }
+    // Sorting initializers by the number of scopes they are required by.
+    // Note that the scope sets form a lattice, and this sorting effectively
+    // ensures that value initializers that depend on other value initializers
+    // get called in the right order.
+    initializers.sort((i, j) => j.order - i.order);
+    for (let initializer of initializers) {
+      if (initializerInfo.initializerIds.size === 1 || initializer === ownInitializer) {
+        initializedValues = initializer.values;
+      }
+      if (initializer === ownInitializer) {
+        initializationStatements = initializationStatements.concat(initializer.body);
+      } else {
+        let ast = this.sharedInitializers.get(initializer.id);
+        if (ast === undefined) {
+          ast = this._conditionalInitialization(initializer.values, initializer.body);
+          // We inline compact initializers, as calling a function would introduce too much
+          // overhead. To determine if an initializer is compact, we count the number of
+          // nodes in the AST, and check if it exceeds a certain threshold.
+          // TODO: Study in more detail which threshold is the best compromise in terms of
+          // code size and performance.
+          let count = 0;
+          traverse(t.file(t.program([ast])), {
+            enter(path) {
+              count++;
+            }
+          }, null, {});
+          if (count > 24) {
+            let id = t.identifier(this.initializerNameGenerator.generate());
+            this.prelude.push(t.functionDeclaration(id, [], t.blockStatement([ast])));
+            ast = t.expressionStatement(t.callExpression(id, []));
+          }
+          this.sharedInitializers.set(initializer.id, ast);
+        }
+        initializationStatements.push(ast);
+      }
+    }
+
+    return this._conditionalInitialization(initializedValues || [], initializationStatements);
+  }
+}

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -31,8 +31,10 @@ import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
 import { LoggingTracer } from "./LoggingTracer.js";
 import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
+import { ResidualFunctionInitializers } from "./ResidualFunctionInitializers.js";
 import type { Scope } from "./ResidualHeapVisitor.js";
 import { factorifyObjects } from "./factorify.js";
+import { voidExpression, nullExpression, emptyExpression, constructorExpression, protoExpression } from "../utils/internalizer.js";
 
 type AbstractSyntaxTree = {
   type: string,
@@ -43,11 +45,6 @@ type AbstractSyntaxTree = {
 };
 
 export class Serializer {
-  static voidExpression = t.unaryExpression("void", t.numericLiteral(0), true);
-  static emptyExpression = t.identifier("__empty");
-  static constructorExpression = t.identifier("__constructor");
-  static protoExpression = t.identifier("__proto__");
-
   constructor(realm: Realm, serializerOptions: SerializerOptions = {}) {
     invariant(realm.useAbstractInterpretation);
     // Start tracking mutations
@@ -94,14 +91,19 @@ export class Serializer {
     this.descriptorNameGenerator = this.preludeGenerator.createNameGenerator("$$");
     this.factoryNameGenerator = this.preludeGenerator.createNameGenerator("$_");
     this.scopeNameGenerator = this.preludeGenerator.createNameGenerator("__scope_");
-    this.initializerNameGenerator = this.preludeGenerator.createNameGenerator("__init_");
     this.requireReturns = new Map();
     this.statistics = new SerializerStatistics();
     this.firstFunctionUsages = new Map();
     this.functionPrototypes = new Map();
     this.serializedValues = new Set();
-    this.functionInitializerInfos = new Map();
-    this.initializers = new Map();
+    this.residualFunctionInitializers = new ResidualFunctionInitializers({
+      getLocation: (value) => this.refs.get(value),
+      createLocation: () => {
+        let location = t.identifier(this.valueNameGenerator.generate("initialized"));
+        this.mainBody.push(t.variableDeclaration("var", [t.variableDeclarator(location)]));
+        return location;
+      }
+    }, this.prelude, this.preludeGenerator.createNameGenerator("__init_"));
     this.collectValToRefCountOnly = collectValToRefCountOnly;
     if (collectValToRefCountOnly) this.valToRefCount = new Map();
     this.capturedScopesArray = t.identifier(this.scopeNameGenerator.generate("main"));
@@ -137,7 +139,6 @@ export class Serializer {
   descriptorNameGenerator: NameGenerator;
   factoryNameGenerator: NameGenerator;
   scopeNameGenerator: NameGenerator;
-  initializerNameGenerator: NameGenerator;
   logger: Logger;
   modules: Modules;
   requireReturns: Map<number | string, BabelNodeExpression>;
@@ -149,12 +150,11 @@ export class Serializer {
   residualValues: Map<Value, Set<Scope>>;
   residualFunctionBindings: Map<FunctionValue, VisitedBindings>;
   residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>;
-  functionInitializerInfos: Map<FunctionValue, { ownId: string, initializerIds: Set<string> }>;
-  initializers: Map<string, { id: string, order: number, body: Array<BabelNodeStatement>, values: Array<Value> }>;
   serializedValues: Set<Value>;
   serializedScopes: Map<DeclarativeEnvironmentRecord, ScopeBinding>;
   capturedScopeInstanceIdx: number;
   capturedScopesArray: BabelNodeIdentifier;
+  residualFunctionInitializers: ResidualFunctionInitializers;
 
   _getBodyReference() {
     return new BodyReference(this.body, this.body.length);
@@ -234,7 +234,7 @@ export class Serializer {
         invariant(proto);
         let serializedProto = this.serializeValue(proto, reasons.concat(`Referred to as the prototype for ${name}`));
         let uid = this._getValIdForReference(obj);
-        let condition = t.binaryExpression("!==", t.memberExpression(uid, Serializer.protoExpression), serializedProto);
+        let condition = t.binaryExpression("!==", t.memberExpression(uid, protoExpression), serializedProto);
         let throwblock = t.blockStatement([
           t.throwStatement(
             t.newExpression(
@@ -259,7 +259,7 @@ export class Serializer {
       else {
         this.body.push(t.expressionStatement(t.assignmentExpression(
           "=",
-          t.memberExpression(uid, Serializer.protoExpression),
+          t.memberExpression(uid, protoExpression),
           serializedProto
         )));
       }
@@ -477,7 +477,7 @@ export class Serializer {
   }
 
   // Determine whether initialization code for a value should go into the main body, or a more specific initialization body.
-  _getTarget(val: Value, scopes: Set<Scope>): { body: Array<BabelNodeStatement>, usedBySingleFunctionValue?: true } {
+  _getTarget(val: Value, scopes: Set<Scope>): { body: Array<BabelNodeStatement>, usedOnlyByResidualFunctions?: true } {
     // All relevant values were visited in at least one scope.
     invariant(scopes.size >= 1);
 
@@ -498,19 +498,8 @@ export class Serializer {
     }
 
     if (generators.length === 0) {
-      invariant(functionValues.length >= 1);
-      let infos = [];
-      for (let functionValue of functionValues) {
-        let info = this.functionInitializerInfos.get(functionValue);
-        if (info === undefined) this.functionInitializerInfos.set(functionValue, info = { ownId: this.functionInitializerInfos.size.toString(), initializerIds: new Set() });
-        infos.push(info);
-      }
-      let id = infos.map(info => info.ownId).sort().join();
-      for (let info of infos) info.initializerIds.add(id);
-      let initializer = this.initializers.get(id);
-      if (initializer === undefined) this.initializers.set(id, initializer = { id, order: infos.length, values: [], body: [] });
-      initializer.values.push(val);
-      return { body: initializer.body, usedBySingleFunctionValue: true };
+      let body = this.residualFunctionInitializers.registerValueOnlyReferencedByResidualFunctions(functionValues, val);
+      return { body: body, usedOnlyByResidualFunctions: true };
     }
 
     // TODO: What does this mean? Where should the code go? Figure this out.
@@ -560,7 +549,7 @@ export class Serializer {
       refCount !== 1) {
       if (init) {
         if (init !== id) {
-          if (target.usedBySingleFunctionValue) {
+          if (target.usedOnlyByResidualFunctions) {
             let declar = t.variableDeclaration((bindingType ? bindingType : "var"), [
               t.variableDeclarator(id)
             ]);
@@ -575,7 +564,7 @@ export class Serializer {
           }
         }
         this.statistics.valueIds++;
-        if (target.usedBySingleFunctionValue) this.statistics.delayedValues++;
+        if (target.usedOnlyByResidualFunctions) this.statistics.delayedValues++;
       }
     } else {
       if (init) {
@@ -1124,9 +1113,9 @@ export class Serializer {
           return t.sequenceExpression([
             t.assignmentExpression(
               "=",
-              t.memberExpression(Serializer.constructorExpression, t.identifier("prototype")),
+              t.memberExpression(constructorExpression, t.identifier("prototype")),
               serializedProto),
-            t.newExpression(Serializer.constructorExpression, [])
+            t.newExpression(constructorExpression, [])
           ]);
         } else {
           return t.objectExpression(props);
@@ -1166,9 +1155,9 @@ export class Serializer {
       return this._serializeValueIntrinsic(val);
     } else if (val instanceof EmptyValue) {
       this.needsEmptyVar = true;
-      return Serializer.emptyExpression;
+      return emptyExpression;
     } else if (val instanceof UndefinedValue) {
-      return Serializer.voidExpression;
+      return voidExpression;
     } else if (ResidualHeapVisitor.isLeaf(val)) {
       return t.valueToNode(val.serialize());
     } else if (IsArray(this.realm, val)) {
@@ -1192,7 +1181,7 @@ export class Serializer {
     if (boundName === "undefined") {
       // The global 'undefined' property is not writable and not configurable, and thus we can just use 'undefined' here,
       // encoded as 'void 0' to avoid the possibility of interference with local variables named 'undefined'.
-      return { serializedValue: Serializer.voidExpression, value: undefined, modified: true, referentialized: true };
+      return { serializedValue: voidExpression, value: undefined, modified: true, referentialized: true };
     }
 
     let value = this.realm.getGlobalLetBinding(boundName);
@@ -1285,21 +1274,6 @@ export class Serializer {
               this.capturedScopesArray, t.identifier(scope.name), true),
             t.objectExpression(properties)
           )));
-  }
-
-  _scrubFunctionInitializers() {
-    // Deleting trivial entries in order to avoid creating empty initialization functions that serve no purpose.
-    for (let initializer of this.initializers.values())
-      if (initializer.body.length === 0) this.initializers.delete(initializer.id);
-    for (let [functionValue, info] of this.functionInitializerInfos) {
-      for (let id of info.initializerIds) {
-        let initializer = this.initializers.get(id);
-        if (initializer === undefined) {
-          info.initializerIds.delete(id);
-        }
-      }
-      if (info.initializerIds.size === 0) this.functionInitializerInfos.delete(functionValue);
-    }
   }
 
   _spliceFunctions() {
@@ -1505,8 +1479,7 @@ export class Serializer {
             let node;
             let firstUsage = this.firstFunctionUsages.get(functionValue);
             invariant(insertionPoint !== undefined);
-            let initializerInfo = this.functionInitializerInfos.get(functionValue);
-            if (initializerInfo !== undefined ||
+            if (this.residualFunctionInitializers.hasInitializerStatement(functionValue) ||
                 usesThis ||
                 firstUsage !== undefined && !firstUsage.isNotEarlierThan(insertionPoint) ||
                 this.functionPrototypes.get(functionValue) !== undefined) {
@@ -1530,7 +1503,7 @@ export class Serializer {
               node = t.variableDeclaration("var", [
                 t.variableDeclarator(functionId, t.callExpression(
                   t.memberExpression(factoryId, t.identifier("bind")),
-                  [t.nullLiteral()].concat(flatArgs)
+                  [nullExpression].concat(flatArgs)
                 ))
               ]);
             }
@@ -1564,95 +1537,9 @@ export class Serializer {
     }
 
     // Inject initializer code for indexed vars into functions
-    let sharedInitializers = new Map();
-    let conditionalInitialization = (initializedValues, initializationStatements) => {
-      if (initializationStatements.length === 1 && t.isIfStatement(initializationStatements[0])) {
-        return initializationStatements[0];
-      }
-
-      // We have some initialization code, and it should only get executed once,
-      // so we are going to guard it.
-      // First, let's see if one of the initialized values is guaranteed to not
-      // be undefined after initialization. In that case, we can use that state-change
-      // to figure out if initialization needs to run.
-      let location;
-      for (let value of initializedValues) {
-        if (!value.mightBeUndefined()) {
-          location = this.refs.get(value);
-          if (location !== undefined) break;
-        }
-      }
-      if (location === undefined) {
-        // Second, if we didn't find a non-undefined value, let's make one up.
-        // It will transition from `undefined` to `null`.
-        location = t.identifier(this.valueNameGenerator.generate("initialized"));
-        this.mainBody.push(t.variableDeclaration("var", [t.variableDeclarator(location)]));
-        initializationStatements.unshift(
-          t.expressionStatement(
-            t.assignmentExpression(
-              "=",
-              location,
-              t.nullLiteral()
-            )
-          )
-        );
-      }
-      return t.ifStatement(
-        t.binaryExpression("===", location, Serializer.voidExpression),
-        t.blockStatement(initializationStatements));
-    };
     for (let [functionValue, funcNode] of funcNodes) {
-      let initializerInfo = this.functionInitializerInfos.get(functionValue);
-      if (initializerInfo !== undefined) {
-        invariant(initializerInfo.initializerIds.size > 0);
-        let ownInitializer = this.initializers.get(initializerInfo.ownId);
-        let initializedValues;
-        let initializationStatements = [];
-        let initializers = [];
-        for (let initializerId of initializerInfo.initializerIds) {
-          let initializer = this.initializers.get(initializerId);
-          invariant(initializer !== undefined);
-          invariant(initializer.body.length > 0);
-          initializers.push(initializer);
-        }
-        // Sorting initializers by the number of scopes they are required by.
-        // Note that the scope sets form a lattice, and this sorting effectively
-        // ensures that value initializers that depend on other value initializers
-        // get called in the right order.
-        initializers.sort((i, j) => j.order - i.order);
-        for (let initializer of initializers) {
-          if (initializerInfo.initializerIds.size === 1 || initializer === ownInitializer) {
-            initializedValues = initializer.values;
-          }
-          if (initializer === ownInitializer) {
-            initializationStatements = initializationStatements.concat(initializer.body);
-          } else {
-            let ast = sharedInitializers.get(initializer.id);
-            if (ast === undefined) {
-              ast = conditionalInitialization(initializer.values, initializer.body);
-              // We inline compact initializers, as calling a function would introduce too much
-              // overhead. To determine if an initializer is compact, we count the number of
-              // nodes in the AST, and check if it exceeds a certain threshold.
-              // TODO: Study in more detail which threshold is the best compromise in terms of
-              // code size and performance.
-              let count = 0;
-              traverse(t.file(t.program([ast])), {
-                enter(path) {
-                  count++;
-                }
-              }, null, {});
-              if (count > 24) {
-                let id = t.identifier(this.initializerNameGenerator.generate());
-                this.prelude.push(t.functionDeclaration(id, [], t.blockStatement([ast])));
-                ast = t.expressionStatement(t.callExpression(id, []));
-              }
-              sharedInitializers.set(initializer.id, ast);
-            }
-            initializationStatements.push(ast);
-          }
-        }
-
-        let initializerStatement = conditionalInitialization(initializedValues || [], initializationStatements);
+      let initializerStatement = this.residualFunctionInitializers.getInitializerStatement(functionValue);
+      if (initializerStatement !== undefined) {
         invariant(funcNode.type === "FunctionDeclaration");
         let blockStatement: BabelNodeBlockStatement = ((funcNode: any): BabelNodeFunctionDeclaration).body;
         blockStatement.body.unshift(initializerStatement);
@@ -1750,7 +1637,7 @@ export class Serializer {
     for (let [moduleId, moduleValue] of this.modules.initializedModules)
       this.requireReturns.set(moduleId, this.serializeValue(moduleValue));
 
-    this._scrubFunctionInitializers();
+    this.residualFunctionInitializers.scrubFunctionInitializers();
     let hoistedBody = this._spliceFunctions();
 
     // add strict modes
@@ -1781,14 +1668,14 @@ export class Serializer {
     if (this.needsEmptyVar) {
       body.push(t.variableDeclaration("var", [
         t.variableDeclarator(
-          Serializer.emptyExpression,
+          emptyExpression,
           t.objectExpression([])
         ),
       ]));
     }
     if (this.needsAuxiliaryConstructor) {
       body.push(t.functionDeclaration(
-        Serializer.constructorExpression, [], t.blockStatement([])));
+        constructorExpression, [], t.blockStatement([])));
     }
     body = body.concat(this.prelude, hoistedBody, this.body);
     factorifyObjects(body, this.factoryNameGenerator);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -18,6 +18,7 @@ import * as base62 from "base62";
 import * as t from "babel-types";
 import invariant from "../invariant.js";
 import type { BabelNodeExpression, BabelNodeIdentifier, BabelNodeStatement, BabelNodeMemberExpression, BabelNodeThisExpression } from "babel-types";
+import { nullExpression } from "./internalizer.js";
 
 export type SerializationContext = {
   reasons: Array<string>;
@@ -244,7 +245,7 @@ export class Generator {
                   t.unaryExpression("typeof", nodes[0]), t.stringLiteral("function")));
             condition =
               t.logicalExpression("||", condition,
-                t.binaryExpression("===", nodes[0], t.nullLiteral()));
+                t.binaryExpression("===", nodes[0], nullExpression));
           }
           return condition;
         },

--- a/src/utils/internalizer.js
+++ b/src/utils/internalizer.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { BabelNodeExpression } from "babel-types";
+import * as t from "babel-types";
+
+export const voidExpression: BabelNodeExpression = t.unaryExpression("void", t.numericLiteral(0), true);
+export const nullExpression: BabelNodeExpression = t.nullLiteral();
+export const emptyExpression: BabelNodeIdentifier = t.identifier("__empty");
+export const constructorExpression: BabelNodeIdentifier = t.identifier("__constructor");
+export const protoExpression: BabelNodeIdentifier = t.identifier("__proto__");

--- a/test/serializer/basic/LargeDelayedValue.js
+++ b/test/serializer/basic/LargeDelayedValue.js
@@ -1,0 +1,8 @@
+(function() {
+    let obj = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11, l: 12 };
+    global.a = [
+                function() { return obj; },
+                function() { return obj; }
+                ];
+    inspect = function() { global.a[0]().length + global.a[1]().length; }
+})();


### PR DESCRIPTION
The serializer identifies which values are only referenced by
residual functions, and then moves out the initialization of
those values into guarded code blocks in the residual functions.

This functionality has now been extracted from the core serializer.