### PR TITLE
Add ClassExpression to IsFunctionDefinition.

### DIFF
--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -263,6 +263,9 @@ export function IsFunctionDefinition(realm: Realm, node: BabelNodeExpression): b
     case "ArrowFunctionExpression":
     case "FunctionExpression":
       return true;
+    // 14.5.8 Static Semantics: IsFunctionDefinition
+    case 'ClassExpression':
+        return true;
     default:
       throw Error("Unexpected AST form : " + node.type);
   }


### PR DESCRIPTION
Because I saw a ton of failing test262 tests on another one of my PRs, related to the ClassExpression change I made:
```
		Error: Unexpected AST form : ClassExpression
		    at IsFunctionDefinition (/home/ubuntu/prepack/lib/methods/is.js:295:13)
		    at IsAnonymousFunctionDefinition (/home/ubuntu/prepack/lib/methods/is.js:302:8)
		    at exports.default (/home/ubuntu/prepack/lib/evaluators/VariableDeclaration.js:44:13)
		    at LexicalEnvironment.evaluateAbstract (/home/ubuntu/prepack/lib/environment.js:1311:16)
		    at LexicalEnvironment.evaluate (/home/ubuntu/prepack/lib/environment.js:1298:22)
		    at exports.default (/home/ubuntu/prepack/lib/evaluators/Program.js:24:32)
		    at LexicalEnvironment.evaluateAbstract (/home/ubuntu/prepack/lib/environment.js:1311:16)
		    at LexicalEnvironment.evaluate (/home/ubuntu/prepack/lib/environment.js:1298:22)
		    at exports.default (/home/ubuntu/prepack/lib/evaluators/File.js:8:14)
		    at LexicalEnvironment.evaluateAbstract (/home/ubuntu/prepack/lib/environment.js:1311:16)
		    at LexicalEnvironment.evaluate (/home/ubuntu/prepack/lib/environment.js:1298:22)
```