### PR TITLE
Use ReferenceError in correct places to pass additional test262 tests

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -377,7 +377,7 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
       if (!S) {
         return realm.intrinsics.undefined;
       } else {
-        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+        throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError);
       }
     }
 
@@ -441,7 +441,7 @@ export class FunctionEnvironmentRecord extends DeclarativeEnvironmentRecord {
 
     // 3. If envRec.[[ThisBindingStatus]] is "initialized", throw a ReferenceError exception.
     if (envRec.$ThisBindingStatus === "initialized") {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+      throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError);
     }
 
     // 4. Set envRec.[[ThisValue]] to V.


### PR DESCRIPTION
Fixes two tests in `prepack/test/test262/test/language/expressions/arrow-function` that were returning `Expected a ReferenceError but got a TypeError`:

```
	✗ (es6) (strict): lexical-super-call-from-within-constructor.js
		Got an error, but was not expecting one:
		Interpreter: Expected a ReferenceError but got a TypeError
		Native: Error
		    at new ThrowCompletion (/home/ubuntu/prepack/lib/completions.js:74:41)
		    at exports.default (/home/ubuntu/prepack/lib/evaluators/ThrowStatement.js:10:9)
		    at LexicalEnvironment.evaluateAbstract (/home/ubuntu/prepack/lib/environment.js:1312:16)
		    at LexicalEnvironment.evaluateAbstractCompletion (/home/ubuntu/prepack/lib/environment.js:1199:21)
		    at EvaluateStatements (/home/ubuntu/prepack/lib/methods/function.js:1481:28)
		    at exports.default (/home/ubuntu/prepack/lib/evaluators/BlockStatement.js:51:12)
		    at LexicalEnvironment.evaluateAbstract (/home/ubuntu/prepack/lib/environment.js:1312:16)
		    at LexicalEnvironment.evaluateAbstractCompletion (/home/ubuntu/prepack/lib/environment.js:1199:21)
		    at OrdinaryCallEvaluateBody (/home/ubuntu/prepack/lib/methods/call.js:346:58)
		    at InternalCall (/home/ubuntu/prepack/lib/methods/function.js:971:14)

	✗ (es6) (nostrict): lexical-super-call-from-within-constructor.js
		Got an error, but was not expecting one:
		Interpreter: Expected a ReferenceError but got a TypeError
		Native: Error
		    at new ThrowCompletion (/home/ubuntu/prepack/lib/completions.js:74:41)
		    at exports.default (/home/ubuntu/prepack/lib/evaluators/ThrowStatement.js:10:9)
		    at LexicalEnvironment.evaluateAbstract (/home/ubuntu/prepack/lib/environment.js:1312:16)
		    at LexicalEnvironment.evaluateAbstractCompletion (/home/ubuntu/prepack/lib/environment.js:1199:21)
		    at EvaluateStatements (/home/ubuntu/prepack/lib/methods/function.js:1481:28)
		    at exports.default (/home/ubuntu/prepack/lib/evaluators/BlockStatement.js:51:12)
		    at LexicalEnvironment.evaluateAbstract (/home/ubuntu/prepack/lib/environment.js:1312:16)
		    at LexicalEnvironment.evaluateAbstractCompletion (/home/ubuntu/prepack/lib/environment.js:1199:21)
		    at OrdinaryCallEvaluateBody (/home/ubuntu/prepack/lib/methods/call.js:346:58)
		    at InternalCall (/home/ubuntu/prepack/lib/methods/function.js:971:14)
```