### PR TITLE
Doing the right thing for "global." in __abstract names.

### DIFF
--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -19,7 +19,7 @@ import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import seedrandom from "seedrandom";
 
-let buildDateNow = buildExpressionTemplate("Date.now()");
+let buildDateNow = buildExpressionTemplate("global.Date.now()");
 
 export default function (realm: Realm): NativeFunctionValue {
   let lastNow;
@@ -27,7 +27,7 @@ export default function (realm: Realm): NativeFunctionValue {
   function getCurrentTime(): AbstractValue | NumberValue {
     if (realm.useAbstractInterpretation) {
       let dummyArg = new StringValue(realm, "__Date.now()");
-      let tmp = realm.deriveAbstract(new TypesDomain(NumberValue), ValuesDomain.topVal, [dummyArg], buildDateNow);
+      let tmp = realm.deriveAbstract(new TypesDomain(NumberValue), ValuesDomain.topVal, [dummyArg], buildDateNow(realm.preludeGenerator));
       invariant(tmp instanceof AbstractValue, "getCurrentTime() should always return and abstract value");
       return tmp;
     } else {

--- a/src/intrinsics/ecma262/NumberPrototype.js
+++ b/src/intrinsics/ecma262/NumberPrototype.js
@@ -88,7 +88,7 @@ export default function (realm: Realm, obj: ObjectValue): void {
     let x = thisNumberValue(realm, context);
     if (realm.useAbstractInterpretation) {
       // The locale is environment-dependent
-      return realm.deriveAbstract(new TypesDomain(StringValue), ValuesDomain.topVal, [x], ([n]) => buildToLocaleString({
+      return realm.deriveAbstract(new TypesDomain(StringValue), ValuesDomain.topVal, [x], ([n]) => buildToLocaleString(realm.preludeGenerator)({
         VALUE: n
       }));
     } else {

--- a/src/intrinsics/node/fs.js
+++ b/src/intrinsics/node/fs.js
@@ -82,7 +82,7 @@ export default function (realm: Realm): ObjectValue {
 
   let types = new TypesDomain(ObjectValue);
   let values = new ValuesDomain(new Set([new ObjectValue(realm)]));
-  let buildNode = buildExpressionTemplate(`${intrinsicName}.FSReqWrap`);
+  let buildNode = buildExpressionTemplate(`${intrinsicName}.FSReqWrap`)(realm.preludeGenerator);
   let FSReqWrap = realm.createAbstract(types, values, [], buildNode, undefined, `${intrinsicName}.FSReqWrap`);
   DefinePropertyOrThrow(realm, obj, "FSReqWrap", {
     value: FSReqWrap,

--- a/src/intrinsics/node/process.js
+++ b/src/intrinsics/node/process.js
@@ -112,7 +112,7 @@ function initializeTTYWrap(realm) {
     // ]));
     // let buildNode = buildExpressionTemplate(
     //   `(process.binding('tty_wrap').guessHandleType(${fd}))`
-    // );
+    // )(this.realm.preludeGenerator);
     // return realm.createAbstract(types, values, [], buildNode, undefined, `(process.binding('tty_wrap').guessHandleType(${fd}))`);
   });
   obj.defineNativeMethod("isTTY", 0, (context, args) => {
@@ -124,7 +124,7 @@ function initializeTTYWrap(realm) {
     ]));
     let buildNode = buildExpressionTemplate(
       `(process.binding('tty_wrap').isTTY(${fd}))`
-    );
+    )(realm.preludeGenerator);
     return realm.createAbstract(types, values, [], buildNode, undefined, `(process.binding('tty_wrap').isTTY(${fd}))`);
   });
   // TODO: Implement the rest of this protocol.
@@ -248,7 +248,7 @@ function initializeUtil(realm) {
 function createAbstractValue(realm, type, intrinsicName) {
   let types = new TypesDomain(type);
   let values = type === ObjectValue ? new ValuesDomain(new Set([new ObjectValue(realm)])) : ValuesDomain.topVal;
-  let buildNode = buildExpressionTemplate(intrinsicName);
+  let buildNode = buildExpressionTemplate(intrinsicName)(realm.preludeGenerator);
   return realm.createAbstract(types, values, [], buildNode, undefined, intrinsicName);
 }
 

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -20,7 +20,7 @@ import type { BabelNodeExpression, BabelNodeSpreadElement, BabelNodeIdentifier }
 import invariant from "../../invariant.js";
 import { describeLocation } from "../ecma262/Error.js";
 
-let buildThrowErrorAbstractValue = buildExpressionTemplate("(function(){throw new Error('abstract value defined at ' + LOCATION);})()");
+let buildThrowErrorAbstractValue = buildExpressionTemplate("(function(){throw new global.Error('abstract value defined at ' + LOCATION);})()");
 
 export default function (realm: Realm): void {
   let global = realm.$GlobalObject;
@@ -78,9 +78,9 @@ export default function (realm: Realm): void {
           if (locString !== undefined) break;
         }
 
-        buildNode = () => buildThrowErrorAbstractValue({ LOCATION: t.stringLiteral(locString || "(unknown location)") });
+        buildNode = () => buildThrowErrorAbstractValue(realm.preludeGenerator)({ LOCATION: t.stringLiteral(locString || "(unknown location)") });
       } else {
-        buildNode = buildExpressionTemplate(nameString);
+        buildNode = buildExpressionTemplate(nameString)(realm.preludeGenerator);
       }
 
       let types = new TypesDomain(type);

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -11,11 +11,16 @@
 
 import buildTemplate from "babel-template";
 import type { BabelNodeExpression } from "babel-types";
+import type { PreludeGenerator } from "./generator.js";
 
-export default function buildExpressionTemplate(code: string): (any => BabelNodeExpression) {
+export default function buildExpressionTemplate(code: string): (void | PreludeGenerator) => (any => BabelNodeExpression) {
   let template;
-  return function (obj: any): BabelNodeExpression {
+  return (preludeGenerator: void | PreludeGenerator) => (obj: any): BabelNodeExpression => {
     if (template === undefined) template = buildTemplate(code);
+    if (preludeGenerator !== undefined && code.includes("global"))
+      obj = Object.assign({
+        global: preludeGenerator.memoizeReference("::global")
+      }, obj);
     let result = template(obj).expression;
     if (result === undefined) throw new Error("Code does not represent an expression: " + code);
     return result;

--- a/test/serializer/abstract/GlobalAbstractName.js
+++ b/test/serializer/abstract/GlobalAbstractName.js
@@ -1,0 +1,6 @@
+// does not contain:global
+(function() {
+    global.x = 42;
+    global.y = global.__abstract ? __abstract("number", "global.x") : 42;
+    inspect = function() { return y; }
+})();


### PR DESCRIPTION
The `global` identifier isn't always defined in JavaScript. In Prepack, it is meant to refer to the global `this` object. Now, when referencing `global.` in the given expression for an abstract value, the appropriate transformation is done.

Besides enabling this for the `__abstract` function, this pull request also updates other existing references such as `Date.now()` to explicitly refer to `global.Date.now()`.