### PR TITLE
Allow more than one input file for Prepack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ npm-debug.log
 build/
 coverage*/
 .vscode
-test/internal
+facebook/test
 prepack.min.js

--- a/scripts/generate-sourcemaps-test.js
+++ b/scripts/generate-sourcemaps-test.js
@@ -69,7 +69,6 @@ function generateTest(name: string, test_path: string, code: string): boolean {
     fs.writeFileSync(name + ".new1.js.map", JSON.stringify(newMap1));
     s = prepackFileSync(name + ".new1.js", {
       compatibility: "node-source-maps",
-      filename: test_path,
       inputSourceMapFilename: name + ".new1.js.map",
       internalDebug: true,
       onError: errorHandler,
@@ -99,6 +98,7 @@ function generateTest(name: string, test_path: string, code: string): boolean {
   console.log(newCode2);
   console.log(chalk.underline("newMap 2"));
   console.log(newMap2);
+
   return false;
 }
 

--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -84,6 +84,7 @@ function runTest(name: string, code: string): boolean {
       let expected = expectedErrors[i][prop];
       let actual = (errors[i]: any)[prop];
       if (prop === "location") {
+        delete actual.filename;
         actual = JSON.stringify(actual);
         expected = JSON.stringify(expected);
       }

--- a/scripts/test-residual.js
+++ b/scripts/test-residual.js
@@ -78,12 +78,13 @@ function exec(code) {
 
 function runTest(name, code) {
   let realmOptions = { residual: true };
+  let sources = [{ filePath: name, fileContents: code }];
   console.log(chalk.inverse(name));
   if (code.includes("// throws introspection error")) {
     try {
       let realm = construct_realm(realmOptions);
       initializeGlobals(realm);
-      let result = realm.$GlobalEnv.executePartialEvaluator(name, code);
+      let result = realm.$GlobalEnv.executePartialEvaluator(sources);
       if (result instanceof IntrospectionThrowCompletion) return true;
       if (result instanceof ThrowCompletion) throw result.value;
     } catch (err) {
@@ -111,7 +112,7 @@ return __result; }).call(this);`);
       for (; i < max; i++) {
         let realm = construct_realm(realmOptions);
         initializeGlobals(realm);
-        let result = realm.$GlobalEnv.executePartialEvaluator(name, code);
+        let result = realm.$GlobalEnv.executePartialEvaluator(sources);
         if (result instanceof ThrowCompletion) throw result.value;
         if (result instanceof AbruptCompletion) throw result;
         let newCode = result.code;

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -90,7 +90,6 @@ function runTest(name, code, args) {
   let delayUnsupportedRequires = code.includes("// delay unsupported requires");
   let functionCloneCountMatch = code.match(/\/\/ serialized function clone count: (\d+)/);
   let options = {
-    filename: name,
     compatibility,
     speculate,
     delayUnsupportedRequires,
@@ -109,7 +108,8 @@ function runTest(name, code, args) {
       initializeGlobals(realm);
       let serializerOptions = { initializeMoreModules: speculate, delayUnsupportedRequires, internalDebug: true };
       let serializer = new Serializer(realm, serializerOptions);
-      let serialized = serializer.init(name, code, "", false, onError);
+      let sources = [{ filePath: name, fileContents: code }];
+      let serialized = serializer.init(sources, false, onError);
       if (!serialized) {
         console.log(chalk.red("Error during serialization"));
       } else {

--- a/src/benchmarker.js
+++ b/src/benchmarker.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { Compatibility } from "./types.js";
+import type { Compatibility } from "./options.js";
 import Serializer from "./serializer/index.js";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
@@ -135,7 +135,8 @@ function dump(name: string, raw: string, min: string = raw, compatibility?: "bro
   let realm = construct_realm({ serialize: true, compatibility });
   initializeGlobals(realm);
   let serializer = new Serializer(realm);
-  let serialized = serializer.init(name, raw);
+  let sources = [{ filePath: name, fileContents: raw }];
+  let serialized = serializer.init(sources);
   if (!serialized) {
     process.exit(1);
     invariant(false);

--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -12,7 +12,7 @@
 import { Realm } from "./realm.js";
 import { initialize as initializeIntrinsics } from "./intrinsics/index.js";
 import initializeGlobal from "./intrinsics/ecma262/global.js";
-import type { RealmOptions } from "./types.js";
+import type { RealmOptions } from "./options.js";
 import * as evaluators from "./evaluators/index.js";
 import * as partialEvaluators from "./partial-evaluators/index.js";
 import { NewGlobalEnvironment } from "./methods/index.js";

--- a/src/options.js
+++ b/src/options.js
@@ -10,12 +10,44 @@
 /* @flow */
 
 import type { ErrorHandler } from "./errors.js";
-import type { RealmOptions, Compatibility } from "./types";
-import type { SerializerOptions } from "./serializer/types";
+
+export type Compatibility =
+  | "browser"
+  | "jsc-600-1-4-17"
+  | "node-source-maps"
+  | "node-cli";
+export const CompatibilityValues = [
+  "browser",
+   "jsc-600-1-4-17",
+  "node-source-maps",
+  "node-cli"
+];
+
+export type RealmOptions = {
+  residual?: boolean,
+  serialize?: boolean,
+  debugNames?: boolean,
+  uniqueSuffix?: string,
+  timeout?: number,
+  compatibility?: Compatibility,
+  mathRandomSeed?: string,
+  strictlyMonotonicDateNow?: boolean,
+  errorHandler?: ErrorHandler,
+};
+
+export type SerializerOptions = {
+  initializeMoreModules?: boolean;
+  internalDebug?: boolean;
+  trace?: boolean;
+  singlePass?: boolean;
+  logStatistics?: boolean;
+  logModules?: boolean;
+  delayUnsupportedRequires?: boolean;
+}
 
 export type Options = {|
   onError?: ErrorHandler,
-  filename?: string,
+  outputFilename?: string,
   inputSourceMapFilename?: string,
   sourceMaps?: boolean,
   compatibility?: Compatibility,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -12,8 +12,8 @@
 /* eslint-disable no-shadow */
 
 import { CompilerDiagnostics, type ErrorHandlerResult, FatalError } from "./errors.js";
+import { type Compatibility, CompatibilityValues } from "./options.js";
 import { prepackStdin, prepackFileSync } from "./prepack-node.js";
-import { CompatibilityValues, type Compatibility } from './types.js';
 import type { BabelNodeSourceLocation } from "babel-types";
 import fs from "fs";
 

--- a/src/prepack-node-environment.js
+++ b/src/prepack-node-environment.js
@@ -108,7 +108,8 @@ export function prepackNodeCLISync(filename: string, options: Options = defaultO
   tickDomainCallback.intrinsicName = 'process._tickDomainCallback';
 
   // Serialize
-  let serialized = serializer.init("", "", "", options.sourceMaps);
+  let sources = [{ filePath: "", fileContents: "" }];
+  let serialized = serializer.init(sources, options.sourceMaps);
   if (!serialized) {
     throw new FatalError("serializer failed");
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { RealmOptions, Intrinsics, Compatibility, PropertyBinding, Descriptor } from "./types.js";
+import type { Intrinsics, PropertyBinding, Descriptor } from "./types.js";
 import { CompilerDiagnostics, type ErrorHandlerResult, type ErrorHandler } from "./errors.js";
 import type { NativeFunctionValue, FunctionValue } from "./values/index.js";
 import { Value, ObjectValue, AbstractValue, AbstractObjectValue, StringValue, ConcreteValue, UndefinedValue } from "./values/index.js";
@@ -19,6 +19,7 @@ import type { Binding } from "./environment.js";
 import { cloneDescriptor, GetValue, Construct, ThrowIfMightHaveBeenDeleted } from "./methods/index.js";
 import type { NormalCompletion } from "./completions.js";
 import { Completion, IntrospectionThrowCompletion, ThrowCompletion, AbruptCompletion, PossiblyNormalCompletion } from "./completions.js";
+import type { Compatibility, RealmOptions } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
 import { Generator, PreludeGenerator } from "./utils/generator.js";

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -80,16 +80,6 @@ export class BodyReference {
   index: number;
 }
 
-export type SerializerOptions = {
-  initializeMoreModules?: boolean;
-  internalDebug?: boolean;
-  trace?: boolean;
-  singlePass?: boolean;
-  logStatistics?: boolean;
-  logModules?: boolean;
-  delayUnsupportedRequires?: boolean;
-}
-
 export class SerializerStatistics {
   constructor() {
     this.objects = 0;

--- a/src/types.js
+++ b/src/types.js
@@ -11,7 +11,6 @@
 
 import type { NumberValue, AbstractValue, BooleanValue, NativeFunctionValue, FunctionValue, StringValue, SymbolValue, UndefinedValue, NullValue, EmptyValue, Value, AbstractObjectValue } from "./values/index.js";
 import { ObjectValue } from "./values/index.js";
-import type { ErrorHandler } from "./errors.js";
 
 export const ElementSize = {
   Float32: 4,
@@ -29,35 +28,17 @@ export type IterationKind = "key+value" | "value" | "key";
 
 export type SourceType = "module" | "script";
 
+export type SourceFile = {
+  filePath: string,
+  fileContents: string,
+  sourceMapContents?: string
+}
+
 export type SourceMap = {
   sources: Array<string>,
   names: Array<string>,
   mappings: string,
   sourcesContent: Array<string>
-};
-
-export type Compatibility =
-  | "browser"
-  | "jsc-600-1-4-17"
-  | "node-source-maps"
-  | "node-cli";
-export const CompatibilityValues = [
-  "browser",
-   "jsc-600-1-4-17",
-  "node-source-maps",
-  "node-cli"
-];
-
-export type RealmOptions = {
-  residual?: boolean,
-  serialize?: boolean,
-  debugNames?: boolean,
-  uniqueSuffix?: string,
-  timeout?: number,
-  compatibility?: Compatibility,
-  mathRandomSeed?: string,
-  strictlyMonotonicDateNow?: boolean,
-  errorHandler?: ErrorHandler,
 };
 
 export type AbstractTime = "early" | "late";


### PR DESCRIPTION
We usually need at least two files: 1) the environmental model and 2) the bundle to be Prepacked. 
In general, there is no good reason to not allow as many files as the caller wants.

To make this not be a breaking chance, I've added a new API for this: prepackSources.

Further complications result from working around a bug in Babel and not increasing the module cycle length for Flow.