### PR TITLE
Giving up on the distinction of "::global" as a special thing vs

### DIFF
--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -24,7 +24,7 @@ export default function(opts: RealmOptions = {}): Realm {
   initializeIntrinsics(i, r);
   // TODO: Find a way to let different environments initialize their own global
   // object for special magic host objects such as the window object in the DOM.
-  r.$GlobalObject = new ObjectValue(r, i.ObjectPrototype, "::global");
+  r.$GlobalObject = new ObjectValue(r, i.ObjectPrototype, "global");
   initializeGlobal(r);
   for (let name in evaluators) r.evaluators[name] = evaluators[name];
   for (let name in partialEvaluators) r.partialEvaluators[name] = partialEvaluators[name];

--- a/src/intrinsics/dom/global.js
+++ b/src/intrinsics/dom/global.js
@@ -49,7 +49,7 @@ export default function(realm: Realm): void {
   });
 
   global.$DefineOwnProperty("setTimeout", {
-    value: new NativeFunctionValue(realm, "::global.setTimeout", "", 2, (context, args) => {
+    value: new NativeFunctionValue(realm, "global.setTimeout", "", 2, (context, args) => {
       let callback = args[0].throwIfNotConcrete();
       if (!(callback instanceof FunctionValue))
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "callback arguments must be function");
@@ -59,7 +59,7 @@ export default function(realm: Realm): void {
       return generator.emitCallAndCaptureResult(
         TypesDomain.topVal,
         ValuesDomain.topVal,
-        () => generator.preludeGenerator.memoizeReference("::global.setTimeout"),
+        () => generator.preludeGenerator.memoizeReference("global.setTimeout"),
         args
       );
     }),
@@ -69,11 +69,11 @@ export default function(realm: Realm): void {
   });
 
   global.$DefineOwnProperty("clearTimeout", {
-    value: new NativeFunctionValue(realm, "::global.clearTimeout", "", 2, (context, args) => {
+    value: new NativeFunctionValue(realm, "global.clearTimeout", "", 2, (context, args) => {
       if (!realm.useAbstractInterpretation) throw new Error("TODO: implement global.clearTimeout");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
-      generator.emitCall(() => generator.preludeGenerator.memoizeReference("::global.clearTimeout"), args);
+      generator.emitCall(() => generator.preludeGenerator.memoizeReference("global.clearTimeout"), args);
       return realm.intrinsics.undefined;
     }),
     writable: true,
@@ -82,7 +82,7 @@ export default function(realm: Realm): void {
   });
 
   global.$DefineOwnProperty("setInterval", {
-    value: new NativeFunctionValue(realm, "::global.setInterval", "", 2, (context, args) => {
+    value: new NativeFunctionValue(realm, "global.setInterval", "", 2, (context, args) => {
       if (!realm.useAbstractInterpretation) throw new Error("TODO: implement global.setInterval");
       let callback = args[0].throwIfNotConcrete();
       if (!(callback instanceof FunctionValue))
@@ -92,7 +92,7 @@ export default function(realm: Realm): void {
       return generator.emitCallAndCaptureResult(
         TypesDomain.topVal,
         ValuesDomain.topVal,
-        () => generator.preludeGenerator.memoizeReference("::global.setInterval"),
+        () => generator.preludeGenerator.memoizeReference("global.setInterval"),
         args
       );
     }),
@@ -102,11 +102,11 @@ export default function(realm: Realm): void {
   });
 
   global.$DefineOwnProperty("clearInterval", {
-    value: new NativeFunctionValue(realm, "::global.clearInterval", "", 2, (context, args) => {
+    value: new NativeFunctionValue(realm, "global.clearInterval", "", 2, (context, args) => {
       if (!realm.useAbstractInterpretation) throw new Error("TODO: implement global.clearInterval");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
-      generator.emitCall(() => generator.preludeGenerator.memoizeReference("::global.clearInterval"), args);
+      generator.emitCall(() => generator.preludeGenerator.memoizeReference("global.clearInterval"), args);
       return realm.intrinsics.undefined;
     }),
     writable: true,

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -20,7 +20,7 @@ export default function buildExpressionTemplate(code: string): (void | PreludeGe
     if (preludeGenerator !== undefined && code.includes("global"))
       obj = Object.assign(
         {
-          global: preludeGenerator.memoizeReference("::global"),
+          global: preludeGenerator.memoizeReference("global"),
         },
         obj
       );

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -380,7 +380,7 @@ export class PreludeGenerator {
     return str
       .split(".")
       .map(name => {
-        if (name === "::global") {
+        if (name === "global") {
           this.usesThis = true;
           return t.thisExpression();
         } else {
@@ -393,7 +393,7 @@ export class PreludeGenerator {
   globalReference(key: string, globalScope: boolean = false) {
     if (globalScope && t.isValidIdentifier(key)) return t.identifier(key);
     let keyNode = t.isValidIdentifier(key) ? t.identifier(key) : t.stringLiteral(key);
-    return t.memberExpression(this.memoizeReference("::global"), keyNode, !t.isIdentifier(keyNode));
+    return t.memberExpression(this.memoizeReference("global"), keyNode, !t.isIdentifier(keyNode));
   }
 
   memoizeReference(key: string): BabelNodeIdentifier | BabelNodeMemberExpression | BabelNodeThisExpression {


### PR DESCRIPTION
"global" as an identifier when naming intrinsic things.