### PR TITLE
Support throw completions that escape functions bodies

### DIFF
--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -630,9 +630,8 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let lengthA = 0;
 
     // 6. If limit is undefined, let lim be 232-1; else let lim be ? ToUint32(limit).
-    let lim = !limit || limit instanceof UndefinedValue
-      ? Math.pow(2, 32) - 1
-      : ToUint32(realm, limit.throwIfNotConcrete());
+    let lim =
+      !limit || limit instanceof UndefinedValue ? Math.pow(2, 32) - 1 : ToUint32(realm, limit.throwIfNotConcrete());
 
     // 7. Let s be the number of elements in S.
     let s = S.length;

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -18,6 +18,7 @@ import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { EnvironmentRecord, Reference } from "../environment.js";
 import {
   composeNormalCompletions,
+  composePossiblyNormalCompletions,
   EvaluateDirectCallWithArgList,
   GetBase,
   GetReferencedName,
@@ -30,6 +31,7 @@ import {
   SameValue,
   stopEffectCaptureAndJoinCompletions,
   unbundleNormalCompletion,
+  updatePossiblyNormalCompletionWithValue,
 } from "../methods/index.js";
 import { AbstractValue, BooleanValue, FunctionValue, Value } from "../values/index.js";
 
@@ -84,6 +86,20 @@ export default function(
   }
 
   let callResult = EvaluateCall(ref, func, ast, argVals, strictCode, env, realm);
+  let context = realm.getRunningContext();
+  let savedCompletion = context.savedCompletion;
+  if (savedCompletion !== undefined) {
+    if (completion instanceof Value) {
+      updatePossiblyNormalCompletionWithValue(realm, savedCompletion, completion);
+      completion = savedCompletion;
+    } else if (completion instanceof PossiblyNormalCompletion) {
+      completion = composePossiblyNormalCompletions(realm, savedCompletion, completion);
+    } else {
+      invariant(completion === undefined);
+      completion = savedCompletion;
+    }
+    context.savedCompletion = undefined;
+  }
   if (callResult instanceof AbruptCompletion) {
     if (completion instanceof PossiblyNormalCompletion)
       completion = stopEffectCaptureAndJoinCompletions(completion, callResult, realm);

--- a/src/realm.js
+++ b/src/realm.js
@@ -84,6 +84,7 @@ export class ExecutionContext {
   lexicalEnvironment: LexicalEnvironment;
   isReadOnly: boolean;
   savedEffects: void | Effects;
+  savedCompletion: void | PossiblyNormalCompletion;
 
   setCaller(context: ExecutionContext): void {
     this.caller = context;

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -14,7 +14,13 @@ import { FatalError } from "../errors.js";
 import { Realm, ExecutionContext, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
 import { IsUnresolvableReference, ResolveBinding, ToStringPartial, Get } from "../methods/index.js";
-import { Completion, AbruptCompletion, IntrospectionThrowCompletion, ThrowCompletion } from "../completions.js";
+import {
+  AbruptCompletion,
+  Completion,
+  IntrospectionThrowCompletion,
+  PossiblyNormalCompletion,
+  ThrowCompletion,
+} from "../completions.js";
 import { Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import * as t from "babel-types";
@@ -152,7 +158,7 @@ class ModuleTracer extends Tracer {
           } else {
             [result] = effects;
             invariant(result instanceof Value || result instanceof Completion);
-            if (result instanceof IntrospectionThrowCompletion) {
+            if (result instanceof IntrospectionThrowCompletion || result instanceof PossiblyNormalCompletion) {
               let [message, stack] = this.modules.getMessageAndStack(effects);
               console.log(`delaying require(${moduleIdValue}): ${message} ${stack}`);
               effects = undefined;
@@ -196,7 +202,7 @@ class ModuleTracer extends Tracer {
           invariant(popped === moduleIdValue);
           let message = "";
           invariant(!(result instanceof IntrospectionThrowCompletion));
-          if (result instanceof ThrowCompletion) (" threw an error");
+          if (result instanceof ThrowCompletion) message = " threw an error";
           this.log(`<require(${moduleIdValue})${message}`);
           realm.errorHandler = oldErrorHandler;
         }

--- a/test/serializer/abstract/Return8.js
+++ b/test/serializer/abstract/Return8.js
@@ -1,0 +1,15 @@
+// throws introspection error
+let x = __abstract("boolean", "true");
+
+y = 1;
+
+function f(b) {
+  if (b) throw 1;
+  y = 2;
+}
+
+function g(b) {
+  f(b);
+}
+
+z = g(x);


### PR DESCRIPTION
The code for throwing an introspection error if an conditional throw completion occurs, kicks in too late for one of the invariants. This invariant now fails for one of our scenarios because of the inclusion of the invariant module.

Fixing this so that the invariant is preserved turns out to be tricky, so I've had to implement more of use cases for PossiblyNormalCompletions. Calls that return the latter (because of a conditional, uncaught throw in the body), now no longer terminate Prepack immediately, but execution proceeds until the end of the statement containing the call. When the completion resulting from that statement is inspected and found to be a PossiblyNormalCompletion, an IntrospectionError is thrown.

When running the partial evaluator, things carry on.
