### PR TITLE
Making Prettier a check-in gate

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 .*/node_modules/.*\.json
 .*/lib/.*
 .*/test/serializer/.*
+.*/scripts/prettier.js
 
 [include]
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ dependencies:
 
 test:
   override:
+    - yarn prettier-ci-check
     - yarn lint
     - yarn flow
     - yarn depcheck

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "validate": "npm run build && npm run build-scripts && npm run lint && npm run depcheck && npm run flow && npm test",
     "prepublish": "npm run build",
     "depcheck": "babel-node scripts/detect_bad_deps.js",
-    "prettier": "prettier --write --trailing-comma es5 --print-width 120 \"+(src|scripts)/**/*.js\""
+    "prettier": "node ./scripts/prettier.js write",
+    "prettier-ci-check": "node ./scripts/prettier.js"
   },
   "dependencies": {
     "babel-core": "^6.8.0",
@@ -85,7 +86,7 @@
     "kcheck": "^2.0.0",
     "madge": "^1.6.0",
     "minimist": "^1.2.0",
-    "prettier": "^1.4.2",
+    "prettier": "^1.5.1",
     "remap-istanbul": "^0.9.1",
     "source-map-support": "^0.4.6",
     "uglify-js": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "validate": "npm run build && npm run build-scripts && npm run lint && npm run depcheck && npm run flow && npm test",
     "prepublish": "npm run build",
     "depcheck": "babel-node scripts/detect_bad_deps.js",
-    "prettier": "node ./scripts/prettier.js write",
+    "prettier": "node ./scripts/prettier.js write-changed",
+    "prettier-all": "node ./scripts/prettier.js write",
     "prettier-ci-check": "node ./scripts/prettier.js"
   },
   "dependencies": {
@@ -86,7 +87,7 @@
     "kcheck": "^2.0.0",
     "madge": "^1.6.0",
     "minimist": "^1.2.0",
-    "prettier": "^1.5.1",
+    "prettier": "1.5.2",
     "remap-istanbul": "^0.9.1",
     "source-map-support": "^0.4.6",
     "uglify-js": "^2.6.2",

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+// Mostly taken from a script in React
+// https://github.com/facebook/react/blob/master/scripts/prettier/index.js
+
+const chalk = require("chalk");
+const glob = require("glob");
+const path = require("path");
+const execFileSync = require("child_process").execFileSync;
+
+const mode = process.argv[2] || "check";
+const shouldWrite = mode === "write" || mode === "write-changed";
+const onlyChanged = mode === "check-changed" || mode === "write-changed";
+
+const isWindows = process.platform === "win32";
+const prettier = isWindows ? "prettier.cmd" : "prettier";
+const prettierCmd = path.resolve(__dirname, "../node_modules/.bin/" + prettier);
+const defaultOptions = {
+  "trailing-comma": "es5",
+  "print-width": 120,
+};
+const config = {
+  default: {
+    patterns: ["src/**/*.js"],
+  },
+  scripts: {
+    patterns: ["scripts/**/*.js"],
+  },
+};
+
+function exec(command, args) {
+  console.log("> " + [command].concat(args).join(" "));
+  const options = {};
+  return execFileSync(command, args, options).toString();
+}
+
+const mergeBase = exec("git", ["merge-base", "HEAD", "master"]).trim();
+const changedFiles = new Set(
+  exec("git", ["diff", "-z", "--name-only", "--diff-filter=ACMRTUB", mergeBase]).match(/[^\0]+/g)
+);
+
+Object.keys(config).forEach(key => {
+  const patterns = config[key].patterns;
+  const options = config[key].options;
+  const ignore = config[key].ignore;
+
+  const globPattern = patterns.length > 1 ? `{${patterns.join(",")}}` : `${patterns.join(",")}`;
+  const files = glob.sync(globPattern, { ignore }).filter(f => !onlyChanged || changedFiles.has(f));
+
+  if (!files.length) {
+    return;
+  }
+
+  const args = Object.keys(defaultOptions).map(k => `--${k}=${(options && options[k]) || defaultOptions[k]}`);
+  args.push(`--${shouldWrite ? "write" : "l"}`);
+
+  try {
+    exec(prettierCmd, [...args, ...files]);
+  } catch (e) {
+    if (!shouldWrite) {
+      console.log(
+        "\n" +
+          chalk.red(`  This project uses prettier to format all JavaScript code.\n`) +
+          chalk.dim(`    Please run `) +
+          chalk.reset("yarn prettier") +
+          chalk.dim(` and add changes to files listed above to your commit.`) +
+          `\n`
+      );
+      process.exit(1);
+    }
+    throw e;
+  }
+});

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -37,9 +37,8 @@ const config = {
   },
 };
 
-function exec(command, args) {
+function exec(command, args, options = {}) {
   console.log("> " + [command].concat(args).join(" "));
-  const options = {};
   return execFileSync(command, args, options).toString();
 }
 
@@ -63,8 +62,9 @@ Object.keys(config).forEach(key => {
   const args = Object.keys(defaultOptions).map(k => `--${k}=${(options && options[k]) || defaultOptions[k]}`);
   args.push(`--${shouldWrite ? "write" : "l"}`);
 
+  let result;
   try {
-    exec(prettierCmd, [...args, ...files]);
+    result = exec(prettierCmd, [...args, ...files]);
   } catch (e) {
     if (!shouldWrite) {
       console.log(
@@ -81,4 +81,5 @@ Object.keys(config).forEach(key => {
     }
     throw e;
   }
+  console.log("\n" + result);
 });

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -69,6 +69,8 @@ Object.keys(config).forEach(key => {
     if (!shouldWrite) {
       console.log(
         "\n" +
+          e.output[1] +
+          "\n" +
           chalk.red(`  This project uses prettier to format all JavaScript code.\n`) +
           chalk.dim(`    Please run `) +
           chalk.reset("yarn prettier") +

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -630,9 +630,8 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let lengthA = 0;
 
     // 6. If limit is undefined, let lim be 232-1; else let lim be ? ToUint32(limit).
-    let lim = !limit || limit instanceof UndefinedValue
-      ? Math.pow(2, 32) - 1
-      : ToUint32(realm, limit.throwIfNotConcrete());
+    let lim =
+      !limit || limit instanceof UndefinedValue ? Math.pow(2, 32) - 1 : ToUint32(realm, limit.throwIfNotConcrete());
 
     // 7. Let s be the number of elements in S.
     let s = S.length;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3916,9 +3916,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.1.tgz#3d6e60e5e7078ec218fe32867a3a66e946c01938"
+prettier@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.2.tgz#7ea0751da27b93bfb6cecfcec509994f52d83bb3"
 
 pretty-ms@2.1.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3916,9 +3916,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.4.2.tgz#bcdd95ed1eca434ac7f98ca26ea4d25a2af6a2ac"
+prettier@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.1.tgz#3d6e60e5e7078ec218fe32867a3a66e946c01938"
 
 pretty-ms@2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This builds on top #760, making it ready to land.

Additional changes over #760:
Pinning Prettier version to get some formatting always. (Different prettier versions were responsible for the observed flip-flopping of StringPrototype.js.)
Print output of prettier in wrapper script for better diagnosis / experience. (TODO: How to just pipe through console output? Couldn't get it to work.)
Updating problematic .js file for the last time.

