### PR TITLE
Test separate model file and fix source maps for comments

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { BabelNode, BabelNodeFile, BabelNodeStatement } from "babel-types";
+import type { BabelNode, BabelNodeComment, BabelNodeFile, BabelNodeStatement } from "babel-types";
 import type { Realm } from "./realm.js";
 import type { SourceFile, SourceMap, SourceType } from "./types.js";
 
@@ -1152,8 +1152,29 @@ export class LexicalEnvironment {
   fixup_filenames(ast: BabelNode) {
     traverse(ast, function(node) {
       let loc = node.loc;
-      if (!!loc && !!loc.source) (loc: any).filename = loc.source;
+      if (!loc || !loc.source) {
+        node.leadingComments = null;
+        node.innerComments = null;
+        node.trailingComments = null;
+        node.loc = null;
+      } else {
+        let filename = loc.source;
+        (loc: any).filename = filename;
+        fixup_comments(node.leadingComments, filename);
+        fixup_comments(node.innerComments, filename);
+        fixup_comments(node.trailingComments, filename);
+      }
       return false;
+
+      function fixup_comments(comments: ?Array<BabelNodeComment>, filename: string) {
+        if (!comments) return;
+        for (let c of comments) {
+          if (c.loc) {
+            (c.loc: any).filename = filename;
+            c.loc.source = filename;
+          }
+        }
+      }
     });
   }
 


### PR DESCRIPTION
Adapt the test-internal script to combine separate files containing a model, a source bundle and a source map.

Also extend fixup_filenames to explicitly traverse comments because the default traverser does not do so.