### PR TITLE
Error message for unknown name in object pattern

### DIFF
--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -16,7 +16,7 @@ import { Reference } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
 import { Value, ObjectValue, UndefinedValue } from "../values/index.js";
 import { NormalCompletion, AbruptCompletion } from "../completions.js";
-import { EvalPropertyNamePartial } from "../evaluators/ObjectExpression.js";
+import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   RequireObjectCoercible,
   GetIterator,
@@ -52,7 +52,7 @@ export function DestructuringAssignmentEvaluation(
 
     for (let property of pattern.properties) {
       // 1. Let name be the result of evaluating PropertyName.
-      let name = EvalPropertyNamePartial(property, env, realm, strictCode);
+      let name = EvalPropertyName(property, env, realm, strictCode);
 
       // 2. ReturnIfAbrupt(name).
 

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -36,7 +36,7 @@ import {
   LexicalEnvironment,
 } from "../environment.js";
 import { NormalCompletion, AbruptCompletion, ThrowCompletion } from "../completions.js";
-import { EvalPropertyNamePartial } from "../evaluators/ObjectExpression.js";
+import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   GetV,
   GetThisValue,
@@ -565,7 +565,7 @@ export function BindingInitialization(
       let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
 
       // 1. Let P be the result of evaluating PropertyName.
-      let P = EvalPropertyNamePartial(property, env, realm, strictCode);
+      let P = EvalPropertyName(property, env, realm, strictCode);
 
       // 2. ReturnIfAbrupt(P).
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -54,7 +54,7 @@ import {
   UpdateEmpty,
 } from "../methods/index.js";
 import { CreateListIterator } from "../methods/iterator.js";
-import { EvalPropertyNamePartial } from "../evaluators/ObjectExpression.js";
+import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import traverse from "../traverse.js";
 import invariant from "../invariant.js";
 import parse from "../utils/parse.js";
@@ -1537,7 +1537,7 @@ export function DefineMethod(
   functionPrototype?: ObjectValue
 ) {
   // 1. Let propKey be the result of evaluating PropertyName.
-  let propKey = EvalPropertyNamePartial(prop, env, realm, strictCode);
+  let propKey = EvalPropertyName(prop, env, realm, strictCode);
 
   // 2. ReturnIfAbrupt(propKey).
 

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -25,7 +25,7 @@ import {
   AbstractValue,
   AbstractObjectValue,
 } from "../values/index.js";
-import { EvalPropertyNamePartial } from "../evaluators/ObjectExpression";
+import { EvalPropertyName } from "../evaluators/ObjectExpression";
 import { EnvironmentRecord, Reference } from "../environment.js";
 import { CreateIterResultObject } from "../methods/create.js";
 import invariant from "../invariant.js";
@@ -1170,7 +1170,7 @@ export function PropertyDefinitionEvaluation(
     // See 14.4.
     // ECMA 14.4.13
     // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyNamePartial(MethodDefinition, env, realm, strictCode);
+    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
 
     // 2. ReturnIfAbrupt(propKey).
     // 3. If the function code for this GeneratorMethod is strict mode code, let strict be true. Otherwise let strict be false.
@@ -1209,7 +1209,7 @@ export function PropertyDefinitionEvaluation(
     return DefinePropertyOrThrow(realm, object, propKey, desc);
   } else if (MethodDefinition.kind === "get") {
     // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyNamePartial(MethodDefinition, env, realm, strictCode);
+    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
 
     // 2. ReturnIfAbrupt(propKey).
 
@@ -1242,7 +1242,7 @@ export function PropertyDefinitionEvaluation(
     DefinePropertyOrThrow(realm, object, propKey, desc);
   } else if (MethodDefinition.kind === "set") {
     // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyNamePartial(MethodDefinition, env, realm, strictCode);
+    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
 
     // 2. ReturnIfAbrupt(propKey).
 

--- a/test/error-handler/objectExpression2.js
+++ b/test/error-handler/objectExpression2.js
@@ -1,0 +1,6 @@
+// expected errors: [{"location":{"start":{"line":6,"column":11},"end":{"line":6,"column":30},"source":"test/error-handler/objectExpression2.js"},"severity":"FatalError","errorCode":"PP0011"}]
+
+let x = __abstract("number");
+let y = __abstract("number");
+
+let ob = { [x]: function () {}, [y]: 2 };

--- a/test/error-handler/objectpattern.js
+++ b/test/error-handler/objectpattern.js
@@ -1,0 +1,7 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":7,"column":3},"end":{"line":7,"column":10},"source":"test/error-handler/objectpattern.js"},"severity":"FatalError","errorCode":"PP0014"}]
+
+let p = __abstract("string", "foo");
+let foo = "foo";
+({ [foo]: q1 } = { foo: "bar" });
+({ [p]: q2 } = { foo: "bar" });


### PR DESCRIPTION
Give an error message if a computed property used in an object pattern is not known at prepack time. Add some more test cases to get to 100% coverage (and also tweak the code to not include impossible branches).