### PR TITLE
Eliminate resolveInitializedModules pass

### DIFF
--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -37,6 +37,7 @@ class ModuleTracer extends Tracer {
     this.requireSequence = [];
     this.logModules = logModules;
     this.uninitializedModuleIdsRequiredInEvaluateForEffects = new Set();
+    this.nestedRequiredModulesAndValues = [];
   }
 
   modules: Modules;
@@ -44,6 +45,9 @@ class ModuleTracer extends Tracer {
   requireStack: Array<number | string | void>;
   requireSequence: Array<number | string>;
   uninitializedModuleIdsRequiredInEvaluateForEffects: Set<number | string>;
+  // We can't say that a module has been initialized if it was initialized in a
+  // evaluate for effects context until we know the effects are applied.
+  nestedRequiredModulesAndValues: Array<{| id: number | string, value: Value |}> = [];
   logModules: boolean;
 
   log(message: string) {
@@ -75,18 +79,47 @@ class ModuleTracer extends Tracer {
     performCall: () => Value
   ): void | Value {
     let realm = this.modules.realm;
-    if (F === this.modules.getRequire() && this.modules.delayUnsupportedRequires && argumentsList.length === 1) {
+    if (
+      F === this.modules.getRequire() &&
+      !this.modules.disallowDelayingRequiresOverride &&
+      argumentsList.length === 1
+    ) {
       let moduleId = argumentsList[0];
       let moduleIdValue;
       if (moduleId instanceof NumberValue || moduleId instanceof StringValue) {
         moduleIdValue = moduleId.value;
-        if (!this.modules.moduleIds.has(moduleIdValue)) {
+        if (!this.modules.moduleIds.has(moduleIdValue) && this.modules.delayUnsupportedRequires) {
           this.modules.logger.logError(moduleId, "Module referenced by require call has not been defined.");
         }
       } else {
-        this.modules.logger.logError(moduleId, "First argument to require function is not a number or string value.");
+        if (this.modules.delayUnsupportedRequires) {
+          this.modules.logger.logError(moduleId, "First argument to require function is not a number or string value.");
+        }
         return undefined;
       }
+
+      // Even if we're not delaying unsupported requires, we want to record what
+      // modules have been initialized
+      if (!this.modules.delayUnsupportedRequires) {
+        if (
+          (this.requireStack.length === 0 || this.requireStack[this.requireStack.length - 1] !== moduleIdValue) &&
+          !this.modules.initializedModules.has(moduleIdValue) &&
+          this.modules.moduleIds.has(moduleIdValue)
+        ) {
+          this.requireStack.push(moduleIdValue);
+          try {
+            let value = performCall();
+            this.modules.initializedModules.set(moduleIdValue, value);
+            return value;
+          } catch (e) {
+            throw e;
+          } finally {
+            invariant(this.requireStack.pop() === moduleIdValue);
+          }
+        }
+        return undefined;
+      }
+
       this.log(`>require(${moduleIdValue})`);
       let isTopLevelRequire = this.requireStack.length === 0;
       if (this.evaluateForEffectsNesting > 0) {
@@ -139,6 +172,7 @@ class ModuleTracer extends Tracer {
                   nestedEffects[0] instanceof Value &&
                   this.modules.isModuleInitialized(nestedModuleId)
                 ) {
+                  this.nestedRequiredModulesAndValues.push({ id: nestedModuleId, value: nestedEffects[0] });
                   acceleratedModuleIds.push(nestedModuleId);
                 }
               }
@@ -195,6 +229,16 @@ class ModuleTracer extends Tracer {
               t.callExpression(t.identifier("require"), [t.valueToNode(moduleIdValue)])
             );
           } else {
+            invariant(result);
+            if (!(result instanceof Completion)) {
+              this.nestedRequiredModulesAndValues.push({ id: moduleIdValue, value: result });
+            }
+            if (isTopLevelRequire) {
+              for (let { id, value } of this.nestedRequiredModulesAndValues) {
+                this.modules.initializedModules.set(id, value);
+              }
+              this.nestedRequiredModulesAndValues = [];
+            }
             realm.applyEffects(effects, `initialization of module ${moduleIdValue}`);
           }
         } finally {
@@ -236,6 +280,7 @@ export class Modules {
     this.initializedModules = new Map();
     realm.tracers.push(new ModuleTracer(this, logModules));
     this.delayUnsupportedRequires = delayUnsupportedRequires;
+    this.disallowDelayingRequiresOverride = false;
   }
 
   realm: Realm;
@@ -247,6 +292,7 @@ export class Modules {
   initializedModules: Map<number | string, Value>;
   active: boolean;
   delayUnsupportedRequires: boolean;
+  disallowDelayingRequiresOverride: boolean;
 
   _getGlobalProperty(name: string) {
     if (this.active) return this.realm.intrinsics.undefined;
@@ -366,8 +412,8 @@ export class Modules {
     context.lexicalEnvironment = env;
     context.variableEnvironment = env;
     context.realm = realm;
-    let oldDelayUnsupportedRequires = this.delayUnsupportedRequires;
-    this.delayUnsupportedRequires = false;
+    let previousDisallowDelayingRequiresOverride = this.disallowDelayingRequiresOverride;
+    this.disallowDelayingRequiresOverride = true;
     realm.pushContext(context);
     let oldErrorHandler = realm.errorHandler;
     realm.errorHandler = () => "Fail";
@@ -391,7 +437,7 @@ export class Modules {
       else throw err;
     } finally {
       realm.popContext(context);
-      this.delayUnsupportedRequires = oldDelayUnsupportedRequires;
+      this.disallowDelayingRequiresOverride = previousDisallowDelayingRequiresOverride;
       realm.errorHandler = oldErrorHandler;
     }
   }
@@ -465,13 +511,6 @@ export class Modules {
       realm.popContext(context);
       realm.setReadOnly(oldReadOnly);
       this.delayUnsupportedRequires = oldDelayUnsupportedRequires;
-    }
-  }
-
-  resolveInitializedModules(): void {
-    for (let moduleId of this.moduleIds) {
-      let result = this.isModuleInitialized(moduleId);
-      if (result !== undefined) this.initializedModules.set(moduleId, result);
     }
   }
 }

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -108,9 +108,11 @@ class ModuleTracer extends Tracer {
           this.requireStack.push(moduleIdValue);
           try {
             let value = performCall();
-            this.modules.initializedModules.set(moduleIdValue, value);
-            if (this.modules.initializedModules.has(moduleIdValue))
+            if (this.modules.initializedModules.has(moduleIdValue)) {
               invariant(this.modules.initializedModules.get(moduleIdValue) === value);
+            } else {
+              this.modules.initializedModules.set(moduleIdValue, value);
+            }
             return value;
           } finally {
             invariant(this.requireStack.pop() === moduleIdValue);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -1448,9 +1448,6 @@ export class Serializer {
     }
     if (timingStats !== undefined) timingStats.globalCodeTime = Date.now() - timingStats.globalCodeTime;
     if (this.logger.hasErrors()) return undefined;
-    if (timingStats !== undefined) timingStats.initializeModulesTime = Date.now();
-    this.modules.resolveInitializedModules();
-    if (timingStats !== undefined) timingStats.initializeModulesTime = Date.now() - timingStats.initializeModulesTime;
     if (this.options.initializeMoreModules) {
       if (timingStats !== undefined) timingStats.initializeMoreModulesTime = Date.now();
       this.modules.initializeMoreModules();

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -84,13 +84,11 @@ export class TimingStatistics {
   constructor() {
     this.globalCodeTime = 0;
     this.initializeMoreModulesTime = 0;
-    this.initializeModulesTime = 0;
     this.deepTraversalTime = 0;
     this.referenceCountsTime = 0;
     this.serializePassTime = 0;
   }
   globalCodeTime: number;
-  initializeModulesTime: number;
   initializeMoreModulesTime: number;
   deepTraversalTime: number;
   referenceCountsTime: number;

--- a/test/serializer/optimizations/require_spec_accelerate_delay.js
+++ b/test/serializer/optimizations/require_spec_accelerate_delay.js
@@ -1,16 +1,15 @@
+// delay unsupported requires
+// initialize more modules
+
 var modules = Object.create(null);
 
-var require_count = 0;
-
+__d = define;
 function require(moduleId) {
-  // we should no longer optimize require calls because of this modification
-  require_count += 1;
   var moduleIdReallyIsNumber = moduleId;
   var module = modules[moduleIdReallyIsNumber];
   return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
 }
 
-__d = define;
 function define(factory, moduleId, dependencyMap) {
   if (moduleId in modules) {
     return;
@@ -96,33 +95,30 @@ function moduleThrewError(id) {
 // === End require code ===
 
 define(function(global, require, module, exports) {
-  module.exports = { foo: " hello " };
+  var nondet = global.__abstract ? __abstract("boolean", "true") : true;
+  if (nondet) {
+    require(1);
+  }
+  module.exports = 1;
 }, 0, null);
 
 define(function(global, require, module, exports) {
-  var x = require(0);
-  var y = require(2);
-  module.exports = {
-    bar: " goodbye",
-    foo2: x.foo,
-    baz: y.baz
-  };
+  module.exports = 2;
 }, 1, null);
 
+
 define(function(global, require, module, exports) {
-  module.exports = { baz: " foo " };
+  module.exports = require(3) + 3;
 }, 2, null);
 
-var x = require(0);
+define(function(global, require, module, exports) {
+  module.exports = require(4) + require(0) + 4;
+}, 3, null);
 
-function f() {
-  var res = x.foo === " hello " && modules[1].exports === undefined &&
-    require(1).bar === " goodbye" && require_count === 4;
-  return res;
-}
+define(function(global, require, module, exports) {
+  module.exports = 5;
+}, 4, null);
 
-inspect = function() {
-  // the require( 0) should be entirely eliminated from 1's factory function
-  // but the require(2) will remain
-  return f();
-}
+var x = require(2);
+
+inspect = function() { return x; }


### PR DESCRIPTION
Addresses #739, reduces prepacking time by 5% and removes a step from the serializer.

Resolving initialized modules is now done by the ModuleTracer at interpretation time by `detourCall` which now records what modules were successfully initialized.

Eliminated a test case that was unnecessarily strict. Prepack now changes behavior if the require function unconditionally has side effects.