### PR TITLE
Rename CompilerDiagnostics to CompilerDiagnostic

### DIFF
--- a/scripts/generate-sourcemaps-test.js
+++ b/scripts/generate-sourcemaps-test.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { CompilerDiagnostics, ErrorHandlerResult } from "../lib/errors.js";
+import type { CompilerDiagnostic, ErrorHandlerResult } from "../lib/errors.js";
 import { prepackFileSync } from "../lib/prepack-node.js";
 import invariant from "../lib/invariant.js";
 
@@ -40,7 +40,7 @@ function search(dir, relative) {
 
 let tests = search(`${__dirname}/../test/source-maps`, "test/source-maps");
 
-function errorHandler(diagnostic: CompilerDiagnostics): ErrorHandlerResult {
+function errorHandler(diagnostic: CompilerDiagnostic): ErrorHandlerResult {
   let loc = diagnostic.location;
   if (loc) console.log(`${loc.start.line}:${loc.start.column + 1} ${diagnostic.errorCode} ${diagnostic.message}`);
   else console.log(`unknown location: ${diagnostic.errorCode} ${diagnostic.message}`);

--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { CompilerDiagnostics, ErrorHandlerResult } from "../lib/errors.js";
+import type { CompilerDiagnostic, ErrorHandlerResult } from "../lib/errors.js";
 import { prepackFileSync } from "../lib/prepack-node.js";
 import invariant from "../lib/invariant.js";
 
@@ -43,8 +43,8 @@ let tests = search(`${__dirname}/../test/error-handler`, "test/error-handler");
 
 function errorHandler(
   retval: ErrorHandlerResult,
-  errors: Array<CompilerDiagnostics>,
-  error: CompilerDiagnostics
+  errors: Array<CompilerDiagnostic>,
+  error: CompilerDiagnostic
 ): ErrorHandlerResult {
   errors.push(error);
   return retval;

--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { CompilerDiagnostics, ErrorHandlerResult } from "../lib/errors.js";
+import type { CompilerDiagnostic, ErrorHandlerResult } from "../lib/errors.js";
 import type { BabelNodeSourceLocation } from "babel-types";
 import { prepackSources } from "../lib/prepack-standalone.js";
 
@@ -41,8 +41,8 @@ function search(dir, relative) {
 
 let tests = search(`${__dirname}/../facebook/test`, "facebook/test");
 
-let errors: Map<BabelNodeSourceLocation, CompilerDiagnostics> = new Map();
-function errorHandler(diagnostic: CompilerDiagnostics): ErrorHandlerResult {
+let errors: Map<BabelNodeSourceLocation, CompilerDiagnostic> = new Map();
+function errorHandler(diagnostic: CompilerDiagnostic): ErrorHandlerResult {
   if (diagnostic.location) errors.set(diagnostic.location, diagnostic);
   return "Fail";
 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -17,7 +17,7 @@ export type ErrorCode = "PP0001";
 
 // This is the error format used to report errors to the caller-supplied
 // error-handler
-export class CompilerDiagnostics extends Error {
+export class CompilerDiagnostic extends Error {
   constructor(message: string, location: ?BabelNodeSourceLocation, errorCode: string, severity: Severity) {
     super(message);
 
@@ -42,4 +42,4 @@ export function FatalError(message?: string) {
 Object.setPrototypeOf(FatalError, Error);
 Object.setPrototypeOf(FatalError.prototype, Error.prototype);
 
-export type ErrorHandler = (error: CompilerDiagnostics) => ErrorHandlerResult;
+export type ErrorHandler = (error: CompilerDiagnostic) => ErrorHandlerResult;

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import {
   Value,
   AbstractValue,
@@ -75,7 +75,7 @@ export function getPureBinaryOperationResultType(
     let rightPure = purityTest(realm, rval);
     if (leftPure && rightPure) return typeIfPure;
     let loc = !leftPure ? lloc : rloc;
-    let error = new CompilerDiagnostics(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
+    let error = new CompilerDiagnostic(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
     if (realm.handleError(error) === "Recover") {
       // Assume that an unknown value is actually a primitive or otherwise a well behaved object.
       return typeIfPure;
@@ -87,7 +87,7 @@ export function getPureBinaryOperationResultType(
     let rtype = GetToPrimitivePureResultType(realm, rval);
     if (ltype === undefined || rtype === undefined) {
       let loc = ltype === undefined ? lloc : rloc;
-      let error = new CompilerDiagnostics(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
+      let error = new CompilerDiagnostic(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
       if (realm.handleError(error) === "Recover") {
         // Assume that the unknown value is actually a primitive or otherwise a well behaved object.
         ltype = lval.getType();
@@ -120,7 +120,7 @@ export function getPureBinaryOperationResultType(
     return reportErrorIfNotPure(IsToNumberPure, NumberValue);
   } else if (op === "in" || op === "instanceof") {
     if (rval.mightNotBeObject()) {
-      let error = new CompilerDiagnostics(
+      let error = new CompilerDiagnostic(
         `might not be an object, hence the ${op} operator might throw a TypeError`,
         rloc,
         "PP0003",
@@ -136,7 +136,7 @@ export function getPureBinaryOperationResultType(
       // Simple object won't throw here, aren't proxy objects or typed arrays and do not have @@hasInstance properties.
       if (rval.isSimple()) return BooleanValue;
     }
-    let error = new CompilerDiagnostics(
+    let error = new CompilerDiagnostic(
       `might be an object that behaves badly for the ${op} operator`,
       rloc,
       "PP0004",

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion, Completion, NormalCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
@@ -122,7 +122,7 @@ function EvaluateCall(
   if (func instanceof AbstractValue) {
     if (func.getType() !== FunctionValue) {
       let loc = ast.callee.type === "MemberExpression" ? ast.callee.property.loc : ast.callee.loc;
-      let error = new CompilerDiagnostics("might not be a function", loc, "PP0005", "RecoverableError");
+      let error = new CompilerDiagnostic("might not be a function", loc, "PP0005", "RecoverableError");
       if (realm.handleError(error) === "Fail") throw new FatalError();
     } else if (func.kind === "conditional") {
       return callBothFunctionsAndJoinTheirEffects(func.args, ast, strictCode, env, realm);
@@ -150,7 +150,7 @@ function EvaluateCall(
       // vi. Return ? PerformEval(evalText, evalRealm, strictCaller, true).
       if (evalText instanceof AbstractValue) {
         let loc = ast.arguments[0].loc;
-        let error = new CompilerDiagnostics("eval argument must be a known value", loc, "PP0006", "RecoverableError");
+        let error = new CompilerDiagnostic("eval argument must be a known value", loc, "PP0006", "RecoverableError");
         if (realm.handleError(error) === "Fail") throw new FatalError();
         // Assume that it is a safe eval with no visible heap changes or abrupt control flow.
         return generateRuntimeCall();

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, Value } from "../values/index.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { NullValue, EmptyValue, ObjectValue } from "../values/index.js";
 import type {
   BabelNodeClassDeclaration,
@@ -49,7 +49,7 @@ function EvaluateClassHeritage(
   let ref = realm.getRunningContext().lexicalEnvironment.evaluate(ClassHeritage, strictCode);
   let val = GetValue(realm, ref);
   if (val instanceof AbstractValue) {
-    let error = new CompilerDiagnostics("unknown super class", ClassHeritage.loc, "PP0009", "RecoverableError");
+    let error = new CompilerDiagnostic("unknown super class", ClassHeritage.loc, "PP0009", "RecoverableError");
     if (realm.handleError(error) === "Fail") throw new FatalError();
   }
   if (!(val instanceof ObjectValue)) {
@@ -131,7 +131,7 @@ export function ClassDefinitionEvaluation(
       // iv. If Type(protoParent) is neither Object nor Null, throw a TypeError exception.
       if (!(protoParent instanceof ObjectValue || protoParent instanceof NullValue)) {
         if (protoParent instanceof AbstractValue) {
-          let error = new CompilerDiagnostics(
+          let error = new CompilerDiagnostic(
             "unknown super class prototype",
             ClassHeritage.loc,
             "PP0010",

--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -14,7 +14,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { BreakCompletion } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { DeclarativeEnvironmentRecord } from "../environment.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { ForInOfHeadEvaluation, ForInOfBodyEvaluation } from "./ForOfStatement.js";
 import { BoundNames, EnumerableOwnProperties, NewDeclarativeEnvironment, UpdateEmpty } from "../methods/index.js";
 import {
@@ -38,7 +38,7 @@ import * as t from "babel-types";
 
 // helper func to report error
 function reportError(realm: Realm, loc: ?BabelNodeSourceLocation) {
-  let error = new CompilerDiagnostics(
+  let error = new CompilerDiagnostic(
     "for in loops over unknown objects are not yet supported",
     loc,
     "PP0013",

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { DeclarativeEnvironmentRecord } from "../environment.js";
 import { Reference } from "../environment.js";
 import { BreakCompletion, AbruptCompletion, ContinueCompletion } from "../completions.js";
@@ -166,7 +166,7 @@ export function ForInOfHeadEvaluation(
     invariant(iterationKind === "iterate", "expected iterationKind to be iterate");
 
     if (exprValue instanceof AbstractValue) {
-      let error = new CompilerDiagnostics(
+      let error = new CompilerDiagnostic(
         "for of loops over unknown collections are not yet supported",
         expr.loc,
         "PP0014",

--- a/src/evaluators/ObjectExpression.js
+++ b/src/evaluators/ObjectExpression.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbstractValue, ConcreteValue, ObjectValue, StringValue } from "../values/index.js";
 import {
   ObjectCreate,
@@ -42,7 +42,7 @@ export function EvalPropertyName(
 ): PropertyKeyValue {
   let result = EvalPropertyNamePartial(prop, env, realm, strictCode);
   if (result instanceof AbstractValue) {
-    let error = new CompilerDiagnostics("unknown computed property name", prop.loc, "PP0014", "FatalError");
+    let error = new CompilerDiagnostic("unknown computed property name", prop.loc, "PP0014", "FatalError");
     realm.handleError(error);
     throw new FatalError();
   }
@@ -113,7 +113,7 @@ export default function(
       // 7. Return CreateDataPropertyOrThrow(object, propKey, propValue).
       if (propKey instanceof AbstractValue) {
         if (propKey.mightNotBeString()) {
-          let error = new CompilerDiagnostics("property key value is unknown", prop.loc, "PP0011", "FatalError");
+          let error = new CompilerDiagnostic("property key value is unknown", prop.loc, "PP0011", "FatalError");
           if (realm.handleError(error) === "Fail") throw new FatalError();
           continue; // recover by ignoring the property, which is only ever safe to do if the property is dead,
           // which is assuming a bit much, hence the designation as a FatalError.

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import {
   AbstractObjectValue,
   Value,
@@ -63,7 +63,7 @@ export default function(
   realm: Realm
 ): Value {
   function reportError() {
-    let error = new CompilerDiagnostics(
+    let error = new CompilerDiagnostic(
       "might be a symbol or an object with an unknown valueOf or toString or Symbol.toPrimitive method",
       ast.argument.loc,
       "PP0008",

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { Add, GetValue, ToNumber, PutValue, IsToNumberPure } from "../methods/index.js";
 import { AbstractValue, NumberValue } from "../values/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -35,7 +35,7 @@ export default function(
   let oldExpr = GetValue(realm, expr);
   if (oldExpr instanceof AbstractValue) {
     if (!IsToNumberPure(realm, oldExpr)) {
-      let error = new CompilerDiagnostics(
+      let error = new CompilerDiagnostic(
         "might be a symbol or an object with an unknown valueOf or toString or Symbol.toPrimitive method",
         ast.argument.loc,
         "PP0008",

--- a/src/evaluators/WithStatement.js
+++ b/src/evaluators/WithStatement.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import { LexicalEnvironment, ObjectEnvironmentRecord } from "../environment.js";
-import { CompilerDiagnostics, FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion } from "../completions.js";
 import { AbstractValue, Value } from "../values/index.js";
 import { ToObjectPartial, GetValue, NewObjectEnvironment, UpdateEmpty } from "../methods/index.js";
@@ -32,7 +32,7 @@ export default function(
   val = GetValue(realm, val);
   if (val instanceof AbstractValue) {
     let loc = ast.object.loc;
-    let error = new CompilerDiagnostics("with object must be a known value", loc, "PP0007", "RecoverableError");
+    let error = new CompilerDiagnostic("with object must be a known value", loc, "PP0007", "RecoverableError");
     if (realm.handleError(error) === "Fail") throw new FatalError();
   }
   let obj = ToObjectPartial(realm, val);

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { AbruptCompletion } from "../../completions.js";
-import { CompilerDiagnostics } from "../../errors.js";
+import { CompilerDiagnostic } from "../../errors.js";
 import {
   AbstractValue,
   BooleanValue,
@@ -97,7 +97,7 @@ export default function(realm: Realm): NativeFunctionValue {
           value = ((value: any): ObjectValue);
 
           realm.handleError(
-            new CompilerDiagnostics(
+            new CompilerDiagnostic(
               ToStringPartial(realm, Get(realm, value, "message")),
               realm.currentLocation,
               "PP0001",

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
-import { CompilerDiagnostics } from "../errors.js";
+import { CompilerDiagnostic } from "../errors.js";
 import {
   BoundFunctionValue,
   EmptyValue,
@@ -76,7 +76,7 @@ export function RequireObjectCoercible(
 ): AbstractValue | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue {
   if (arg instanceof AbstractValue && (arg.mightBeNull() || arg.mightBeUndefined())) {
     if (argLoc) {
-      let error = new CompilerDiagnostics("member expression object is unknown", argLoc, "PP0012", "FatalError");
+      let error = new CompilerDiagnostic("member expression object is unknown", argLoc, "PP0012", "FatalError");
       realm.handleError(error);
       // can't throw a FatalError here, yet, because there is some code that depends on seeing an
       // introspection error in this situation. See tests/serializer/optimizations/require_unsupported.js

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -11,7 +11,7 @@
 
 /* eslint-disable no-shadow */
 
-import { CompilerDiagnostics, type ErrorHandlerResult, FatalError } from "./errors.js";
+import { CompilerDiagnostic, type ErrorHandlerResult, FatalError } from "./errors.js";
 import { type Compatibility, CompatibilityValues } from "./options.js";
 import { prepackStdin, prepackFileSync } from "./prepack-node.js";
 import type { BabelNodeSourceLocation } from "babel-types";
@@ -136,8 +136,8 @@ function run(
     flags
   );
 
-  let errors: Map<BabelNodeSourceLocation, CompilerDiagnostics> = new Map();
-  function errorHandler(diagnostic: CompilerDiagnostics): ErrorHandlerResult {
+  let errors: Map<BabelNodeSourceLocation, CompilerDiagnostic> = new Map();
+  function errorHandler(diagnostic: CompilerDiagnostic): ErrorHandlerResult {
     if (diagnostic.location) errors.set(diagnostic.location, diagnostic);
     return "Recover";
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { Intrinsics, PropertyBinding, Descriptor } from "./types.js";
-import { CompilerDiagnostics, type ErrorHandlerResult, type ErrorHandler } from "./errors.js";
+import { CompilerDiagnostic, type ErrorHandlerResult, type ErrorHandler } from "./errors.js";
 import type { NativeFunctionValue, FunctionValue } from "./values/index.js";
 import {
   Value,
@@ -729,7 +729,7 @@ export class Realm {
   // Pass the error to the realm's error-handler
   // Return value indicates whether the caller should try to recover from the
   // error or not ('true' means recover if possible).
-  handleError(diagnostic: CompilerDiagnostics): ErrorHandlerResult {
+  handleError(diagnostic: CompilerDiagnostic): ErrorHandlerResult {
     // Default behaviour is to bail on the first error
     let errorHandler = this.errorHandler;
     if (!errorHandler) {


### PR DESCRIPTION
An instance of this class is a single diagnostic message, so the plural just seems wrong.