### PR TITLE
Throw FatalError after reporting generic introspection error

### DIFF
--- a/scripts/test-residual.js
+++ b/scripts/test-residual.js
@@ -12,8 +12,8 @@
 let construct_realm = require("../lib/construct_realm.js").default;
 let initializeGlobals = require("../lib/globals.js").default;
 let AbruptCompletion = require("../lib/completions.js").AbruptCompletion;
-let IntrospectionThrowCompletion = require("../lib/completions.js").IntrospectionThrowCompletion;
 let ThrowCompletion = require("../lib/completions.js").ThrowCompletion;
+let FatalError = require("../lib/errors.js").FatalError;
 
 let chalk = require("chalk");
 let path = require("path");
@@ -88,9 +88,9 @@ function runTest(name, code) {
       let realm = construct_realm(realmOptions);
       initializeGlobals(realm);
       let result = realm.$GlobalEnv.executePartialEvaluator(sources);
-      if (result instanceof IntrospectionThrowCompletion) return true;
       if (result instanceof ThrowCompletion) throw result.value;
     } catch (err) {
+      if (err instanceof FatalError) return true;
       console.log(err);
     }
     return false;

--- a/src/completions.js
+++ b/src/completions.js
@@ -31,16 +31,10 @@ export class NormalCompletion extends Completion {}
 export class ThrowCompletion extends AbruptCompletion {
   constructor(value: Value, nativeStack?: ?string) {
     super(value);
-    invariant(
-      value.getType() !== value.$Realm.intrinsics.__IntrospectionError || this instanceof IntrospectionThrowCompletion
-    );
     this.nativeStack = nativeStack || new Error().stack;
   }
 
   nativeStack: string;
-}
-export class IntrospectionThrowCompletion extends ThrowCompletion {
-  reason: void | "readonly";
 }
 export class ContinueCompletion extends AbruptCompletion {}
 export class BreakCompletion extends AbruptCompletion {}

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { AbruptCompletion, IntrospectionThrowCompletion, ThrowCompletion } from "../completions.js";
+import { AbruptCompletion, ThrowCompletion } from "../completions.js";
 import { UpdateEmpty } from "../methods/index.js";
 import { Value } from "../values/index.js";
 import type { BabelNodeTryStatement } from "babel-types";
@@ -20,9 +20,6 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
   let completions = [];
 
   let blockRes = env.evaluateCompletion(ast.block, strictCode);
-
-  // can't catch or run finally clauses on introspection errors
-  if (blockRes instanceof IntrospectionThrowCompletion) throw blockRes;
 
   if (blockRes instanceof ThrowCompletion && ast.handler) {
     completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -12,7 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { AbruptCompletion } from "../../completions.js";
-import { CompilerDiagnostic } from "../../errors.js";
 import {
   AbstractValue,
   BooleanValue,
@@ -34,7 +33,6 @@ import {
   IsConstructor,
   IsCallable,
   Set,
-  ToStringPartial,
 } from "../../methods/index.js";
 import { ToString, ToUint32, ToObject, ToLength } from "../../methods/to.js";
 import { GetIterator, IteratorClose, IteratorStep, IteratorValue } from "../../methods/iterator.js";
@@ -89,31 +87,8 @@ export default function(realm: Realm): NativeFunctionValue {
       } else {
         // 7. Else,
 
-        try {
-          len = len.throwIfNotConcreteNumber();
-        } catch (err) {
-          let value = err.value;
-          invariant(value instanceof ObjectValue);
-          value = ((value: any): ObjectValue);
-
-          realm.handleError(
-            new CompilerDiagnostic(
-              ToStringPartial(realm, Get(realm, value, "message")),
-              realm.currentLocation,
-              "PP0001",
-              "FatalError"
-            )
-          );
-
-          // Rethrow.
-          // TODO: In the future, we can try and recover from the error based on the
-          // return value of 'handleError' (will be looked into a part of the effort
-          // to try and improve error reporting)
-          throw err;
-        }
-
         // a. Let intLen be ToUint32(len).
-        intLen = ToUint32(realm, len);
+        intLen = ToUint32(realm, len.throwIfNotConcreteNumber());
 
         // b If intLen ≠ len, throw a RangeError exception.
         if (intLen !== len.value) {

--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -15,6 +15,7 @@ import { ToInteger, ToNumber, ToPrimitive } from "../../methods/to.js";
 import { OrdinaryCreateFromConstructor } from "../../methods/create.js";
 import { MakeTime, MakeDate, MakeDay, TimeClip, UTC, ToDateString, thisTimeValue } from "../../methods/date.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
+import { FatalError } from "../../errors.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import seedrandom from "seedrandom";
@@ -202,7 +203,8 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 20.3.3.2
   func.defineNativeMethod("parse", 1, (context, [string]) => {
     if (realm.useAbstractInterpretation) {
-      throw AbstractValue.createIntrospectionErrorThrowCompletion(string);
+      AbstractValue.reportIntrospectionError(string);
+      throw new FatalError();
     } else {
       const parsedDate = Date.parse(string.value);
       return new NumberValue(realm, parsedDate);

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -41,6 +41,7 @@ import {
 } from "../../methods/index.js";
 import { InternalizeJSONProperty } from "../../methods/json.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
+import { FatalError } from "../../errors.js";
 import nativeToInterp from "../../utils/native-to-interp.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
@@ -313,7 +314,10 @@ function InternalGetTemplate(realm: Realm, val: AbstractObjectValue): ObjectValu
     invariant(binding.descriptor !== undefined);
     let value = binding.descriptor.value;
     ThrowIfMightHaveBeenDeleted(value);
-    if (value === undefined) throw AbstractValue.createIntrospectionErrorThrowCompletion(val, key); // cannot handle accessors
+    if (value === undefined) {
+      AbstractValue.reportIntrospectionError(val, key); // cannot handle accessors
+      throw new FatalError();
+    }
     CreateDataProperty(realm, template, key, InternalJSONClone(realm, value));
   }
   if (valTemplate.isPartial()) template.makePartial();

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import {
@@ -102,7 +103,10 @@ export default function(realm: Realm): NativeFunctionValue {
         // properties at runtime that will overwrite current properties in to.
         // For now, just throw if this happens.
         let to_keys = to.$OwnPropertyKeys();
-        if (to_keys.length !== 0) throw AbstractValue.createIntrospectionErrorThrowCompletion(nextSource);
+        if (to_keys.length !== 0) {
+          AbstractValue.reportIntrospectionError(nextSource);
+          throw new FatalError();
+        }
       }
 
       invariant(frm, "from required");

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { Realm } from "../../realm.js";
+import { FatalError } from "../../errors.js";
 import { AbstractValue, UndefinedValue, NumberValue, ObjectValue, StringValue, NullValue } from "../../values/index.js";
 import { IsCallable, IsRegExp } from "../../methods/is.js";
 import { GetMethod, GetSubstitution } from "../../methods/get.js";
@@ -809,7 +810,8 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
 
     if (realm.useAbstractInterpretation && (type === "LocaleUpper" || type === "LocaleLower")) {
       // The locale is environment-dependent
-      throw AbstractValue.createIntrospectionErrorThrowCompletion(O);
+      AbstractValue.reportIntrospectionError(O);
+      throw new FatalError();
     }
 
     // Omit the rest of the arguments. Just use the native impl.

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
-import { CompilerDiagnostic } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import {
   BoundFunctionValue,
   EmptyValue,
@@ -78,8 +78,7 @@ export function RequireObjectCoercible(
     if (argLoc) {
       let error = new CompilerDiagnostic("member expression object is unknown", argLoc, "PP0012", "FatalError");
       realm.handleError(error);
-      // can't throw a FatalError here, yet, because there is some code that depends on seeing an
-      // introspection error in this situation. See tests/serializer/optimizations/require_unsupported.js
+      throw new FatalError();
     }
     arg.throwIfNotConcrete();
   }
@@ -499,7 +498,8 @@ export function Type(realm: Realm, val: Value): string {
     return "Object";
   } else {
     invariant(val instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(val);
+    AbstractValue.reportIntrospectionError(val);
+    throw new FatalError();
   }
 }
 

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -36,6 +36,7 @@ import {
   LexicalEnvironment,
 } from "../environment.js";
 import { NormalCompletion, AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { FatalError } from "../errors.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   GetV,
@@ -86,8 +87,10 @@ export function HasPrimitiveBase(realm: Realm, V: Reference): boolean {
 // ECMA262 6.2.3
 // GetReferencedName(V). Returns the referenced name component of the reference V.
 export function GetReferencedName(realm: Realm, V: Reference): string | SymbolValue {
-  if (V.referencedName instanceof AbstractValue)
-    throw realm.createIntrospectionErrorThrowCompletion("abstract reference");
+  if (V.referencedName instanceof AbstractValue) {
+    AbstractValue.reportIntrospectionError(V.referencedName);
+    throw new FatalError();
+  }
   return V.referencedName;
 }
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -20,7 +20,6 @@ import {
   JoinedAbruptCompletions,
   NormalCompletion,
   PossiblyNormalCompletion,
-  IntrospectionThrowCompletion,
 } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { ExecutionContext } from "../realm.js";
@@ -1146,10 +1145,6 @@ export function EvaluateStatements(
           let e = realm.getCapturedEffects();
           invariant(e !== undefined);
           realm.stopEffectCaptureAndUndoEffects();
-          if (res instanceof IntrospectionThrowCompletion) {
-            realm.applyEffects(e);
-            throw res;
-          }
           invariant(context.savedCompletion !== undefined);
           e[0] = res;
           let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, res, e);
@@ -1211,10 +1206,6 @@ export function PartiallyEvaluateStatements(
             let e = realm.getCapturedEffects();
             invariant(e !== undefined);
             realm.stopEffectCaptureAndUndoEffects();
-            if (res instanceof IntrospectionThrowCompletion) {
-              realm.applyEffects(e);
-              throw res;
-            }
             invariant(blockValue instanceof PossiblyNormalCompletion);
             e[0] = res;
             let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, blockValue, res, e);

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -26,6 +26,7 @@ import {
   AbstractObjectValue,
 } from "../values/index.js";
 import { Reference } from "../environment.js";
+import { FatalError } from "../errors.js";
 import { ArrayCreate } from "./create.js";
 import { SetIntegrityLevel } from "./integrity.js";
 import { ToString } from "./to.js";
@@ -143,7 +144,8 @@ export function OrdinaryGet(
   if (IsDataDescriptor(realm, desc)) return descValue;
   if (dataOnly) {
     invariant(descValue instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(descValue);
+    AbstractValue.reportIntrospectionError(descValue);
+    throw new FatalError();
   }
 
   // 5. Assert: IsAccessorDescriptor(desc) is true.

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
 import { ThrowIfMightHaveBeenDeleted, IsPropertyKey } from "./index.js";
@@ -124,7 +125,8 @@ export function HasCompatibleType(value: Value, type: typeof Value): boolean {
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(value);
+    AbstractValue.reportIntrospectionError(value);
+    throw new FatalError();
   }
   return Value.isTypeCompatibleWith(valueType, type);
 }
@@ -133,7 +135,8 @@ export function HasSomeCompatibleType(value: Value, ...manyTypes: Array<typeof V
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(value);
+    AbstractValue.reportIntrospectionError(value);
+    throw new FatalError();
   }
   return manyTypes.some(Value.isTypeCompatibleWith.bind(null, valueType));
 }

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { FatalError } from "../errors.js";
 import type { PropertyKeyValue } from "../types.js";
 import type { Realm } from "../realm.js";
 import type { Descriptor } from "../types.js";
@@ -152,7 +153,10 @@ export function IsPropertyKey(realm: Realm, arg: string | Value): boolean {
   // 2. If Type(argument) is Symbol, return true.
   if (arg instanceof SymbolValue) return true;
 
-  if (arg instanceof AbstractValue) throw AbstractValue.createIntrospectionErrorThrowCompletion(arg);
+  if (arg instanceof AbstractValue) {
+    AbstractValue.reportIntrospectionError(arg);
+    throw new FatalError();
+  }
 
   // 3. Return false.
   return false;

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -11,6 +11,7 @@
 
 import type { BabelNodeBlockStatement } from "babel-types";
 import type { Binding } from "../environment.js";
+import { FatalError } from "../errors.js";
 import type { Bindings, Effects, EvaluationResult, PropertyBindings, CreatedObjects, Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding } from "../types.js";
 
@@ -23,7 +24,6 @@ import {
   JoinedAbruptCompletions,
   NormalCompletion,
   ReturnCompletion,
-  IntrospectionThrowCompletion,
   ThrowCompletion,
 } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -45,10 +45,6 @@ export function stopEffectCaptureAndJoinCompletions(
   let e = realm.getCapturedEffects();
   invariant(e !== undefined);
   realm.stopEffectCaptureAndUndoEffects();
-  if (c2 instanceof IntrospectionThrowCompletion) {
-    realm.applyEffects(e);
-    throw c2;
-  }
   e[0] = c2;
   let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, c1, c2, e);
   realm.applyEffects(joined_effects);
@@ -298,8 +294,6 @@ export function joinEffects(realm: Realm, joinCondition: AbstractValue, e1: Effe
   let [result1, gen1, bindings1, properties1, createdObj1] = e1;
   let [result2, gen2, bindings2, properties2, createdObj2] = e2;
 
-  if (result1 instanceof IntrospectionThrowCompletion) return e1;
-  if (result2 instanceof IntrospectionThrowCompletion) return e2;
   let result = joinResults(realm, joinCondition, result1, result2, e1, e2);
   if (result1 instanceof AbruptCompletion) {
     if (!(result2 instanceof AbruptCompletion)) {
@@ -338,7 +332,8 @@ function joinResults(
     return joinValuesAsConditional(realm, joinCondition, v1, v2);
   }
   if (result1 instanceof Reference || result2 instanceof Reference) {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(joinCondition);
+    AbstractValue.reportIntrospectionError(joinCondition);
+    throw new FatalError();
   }
   if (result1 instanceof BreakCompletion && result2 instanceof BreakCompletion && result1.target === result2.target) {
     return new BreakCompletion(realm.intrinsics.empty, result1.target);

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -15,6 +15,7 @@ import { GetMethod, Get } from "./get.js";
 import { StringCreate } from "./create.js";
 import { HasProperty } from "./has.js";
 import { Call } from "./call.js";
+import { FatalError } from "../errors.js";
 import { IsCallable } from "./is.js";
 import { SameValue, SameValueZero } from "./abstract.js";
 import {
@@ -456,7 +457,8 @@ export function ToNumber(realm: Realm, val: numberOrValue): number {
   if (typeof val === "number") {
     return val;
   } else if (val instanceof AbstractValue) {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(val);
+    AbstractValue.reportIntrospectionError(val);
+    throw new FatalError();
   } else if (val instanceof UndefinedValue) {
     return NaN;
   } else if (val instanceof NullValue) {

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -11,6 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { TypedArrayKind } from "../types.js";
+import { FatalError } from "../errors.js";
 import {
   AbstractValue,
   IntegerIndexedExotic,
@@ -339,7 +340,8 @@ export function TypedArrayCreate(realm: Realm, constructor: ObjectValue, argumen
   if (argumentList.length === 1 && argumentList[0].mightBeNumber()) {
     if (argumentList[0].mightNotBeNumber()) {
       invariant(argumentList[0] instanceof AbstractValue);
-      throw AbstractValue.createIntrospectionErrorThrowCompletion(argumentList[0]);
+      AbstractValue.reportIntrospectionError(argumentList[0]);
+      throw new FatalError();
     }
     // a. If newTypedArray.[[ArrayLength]] < argumentList[0], throw a TypeError exception.
     invariant(typeof newTypedArray.$ArrayLength === "number");

--- a/src/partial-evaluators/ArrayExpression.js
+++ b/src/partial-evaluators/ArrayExpression.js
@@ -15,6 +15,7 @@ import type { Realm } from "../realm.js";
 
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
+import { FatalError } from "../errors.js";
 import {
   ArrayCreate,
   CreateDataProperty,
@@ -61,7 +62,8 @@ export default function(
       return [elemValue, ast, io]; //todo: log an error message
     } else if (elemValue instanceof PossiblyNormalCompletion) {
       // TODO: there was a conditional abrupt completion while evaluating elem, so join states somehow
-      return [AbstractValue.createIntrospectionErrorThrowCompletion(elemValue.value), ast, io];
+      AbstractValue.reportIntrospectionError(elemValue.value);
+      throw new FatalError();
     }
     invariant(elemValue instanceof Value);
     partial_elements[nextIndex] = (elemAst: any);
@@ -119,7 +121,8 @@ export default function(
         // expressions will be evaluated at runtime. As a consequence their effects
         // have be provisional.
         // TODO: join states somehow
-        return [AbstractValue.createIntrospectionErrorThrowCompletion(spreadObj), ast, io];
+        AbstractValue.reportIntrospectionError(spreadObj);
+        throw new FatalError();
       }
     } else if (array.isPartial()) {
       // Dealing with an array element that follows on a spread object that

--- a/src/partial-evaluators/BinaryExpression.js
+++ b/src/partial-evaluators/BinaryExpression.js
@@ -22,6 +22,7 @@ import type { Realm } from "../realm.js";
 import { computeBinary, getPureBinaryOperationResultType } from "../evaluators/BinaryExpression.js";
 import { AbruptCompletion, Completion, NormalCompletion } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
+import { FatalError } from "../errors.js";
 import { composeNormalCompletions, unbundleNormalCompletion } from "../methods/index.js";
 import { AbstractValue, BooleanValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
 
@@ -112,7 +113,8 @@ export function createAbstractValueForBinary(
       // We choose to do the latter.
       // TODO: report the error and carry on assuming no side effects.
       let val = lval instanceof AbstractValue ? lval : rval;
-      return [AbstractValue.createIntrospectionErrorThrowCompletion((val: any)), ast, io];
+      AbstractValue.reportIntrospectionError((val: any));
+      throw new FatalError();
     }
     resultValue = realm.createAbstract(
       new TypesDomain(resultType),

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -13,14 +13,8 @@ import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../enviro
 import { FatalError } from "../errors.js";
 import { Realm, ExecutionContext, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
-import { IsUnresolvableReference, ResolveBinding, ToStringPartial, Get } from "../methods/index.js";
-import {
-  AbruptCompletion,
-  Completion,
-  IntrospectionThrowCompletion,
-  PossiblyNormalCompletion,
-  ThrowCompletion,
-} from "../completions.js";
+import { IsUnresolvableReference, ResolveBinding, Get } from "../methods/index.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
 import { Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import * as t from "babel-types";
@@ -97,8 +91,6 @@ class ModuleTracer extends Tracer {
         return undefined;
       } else {
         let result;
-        let oldErrorHandler = realm.errorHandler;
-        realm.errorHandler = () => "Fail";
         try {
           this.requireStack.push(moduleIdValue);
           let requireSequenceStart = this.requireSequence.length;
@@ -152,20 +144,16 @@ class ModuleTracer extends Tracer {
             }
           } while (acceleratedModuleIds.length > 0);
 
-          if (effects === undefined) {
-            // TODO: We got here due to a fatal error. Report the message somehow.
-            console.log(`delaying require(${moduleIdValue})`);
-          } else {
-            [result] = effects;
+          if (effects !== undefined) {
+            result = effects[0];
             invariant(result instanceof Value || result instanceof Completion);
-            if (result instanceof IntrospectionThrowCompletion || result instanceof PossiblyNormalCompletion) {
-              let [message, stack] = this.modules.getMessageAndStack(effects);
-              console.log(`delaying require(${moduleIdValue}): ${message} ${stack}`);
+            if (result instanceof PossiblyNormalCompletion) {
               effects = undefined;
             }
           }
 
           if (effects === undefined) {
+            console.log(`delaying require(${moduleIdValue})`);
             // So we are about to emit a delayed require(...) call.
             // However, before we do that, let's try to require all modules that we
             // know this delayed require call will require.
@@ -201,10 +189,8 @@ class ModuleTracer extends Tracer {
           let popped = this.requireStack.pop();
           invariant(popped === moduleIdValue);
           let message = "";
-          invariant(!(result instanceof IntrospectionThrowCompletion));
           if (result instanceof ThrowCompletion) message = " threw an error";
           this.log(`<require(${moduleIdValue})${message}`);
-          realm.errorHandler = oldErrorHandler;
         }
         if (result instanceof Completion) throw result;
         return result;
@@ -325,39 +311,6 @@ export class Modules {
     };
   }
 
-  getMessageAndStack([result, generator, bindings, properties, createdObjects]: Effects): [string, string] {
-    let realm = this.realm;
-    if (!(result instanceof Completion) || !(result.value instanceof ObjectValue))
-      return ["(no message)", "(no stack)"];
-
-    // Temporarily apply state changes in order to retrieve message
-    realm.restoreBindings(bindings);
-    realm.restoreProperties(properties);
-
-    let value = result.value;
-    let message: string = this.logger.tryQuery(
-      () => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "message")),
-      "(cannot get message)",
-      false
-    );
-    let stack: string = this.logger.tryQuery(
-      () => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "stack")),
-      "",
-      false
-    );
-
-    // Undo state changes
-    realm.restoreBindings(bindings);
-    realm.restoreProperties(properties);
-
-    if (result instanceof IntrospectionThrowCompletion && result.reason !== undefined)
-      message = `[${result.reason}] ${message}`;
-
-    let i = stack.indexOf("\n");
-    if (i >= 0) stack = stack.slice(i);
-    return [message, stack];
-  }
-
   tryInitializeModule(moduleId: number | string, message: string): void | Effects {
     let realm = this.realm;
     // setup execution environment
@@ -370,15 +323,12 @@ export class Modules {
     this.delayUnsupportedRequires = false;
     realm.pushContext(context);
     let oldErrorHandler = realm.errorHandler;
-    realm.errorHandler = () => "Fail";
     try {
       let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
 
       let effects = realm.evaluateNodeForEffects(node, true, env);
-      let result = effects[0];
-      if (result instanceof IntrospectionThrowCompletion) return effects;
-
       realm.applyEffects(effects, message);
+      let result = effects[0];
       if (result instanceof Completion) {
         console.log(`=== UNEXPECTED ERROR during ${message} ===`);
         this.logger.logCompletion(result);
@@ -399,35 +349,16 @@ export class Modules {
   initializeMoreModules() {
     // partially evaluate all factory methods by calling require
     let count = 0;
-    let introspectionErrors = Object.create(null);
     for (let moduleId of this.moduleIds) {
       if (this.initializedModules.has(moduleId)) continue;
-
       let effects = this.tryInitializeModule(moduleId, `Speculative initialization of module ${moduleId}`);
-
       if (effects === undefined) continue;
       let result = effects[0];
-      if (result instanceof IntrospectionThrowCompletion) {
-        invariant(result instanceof IntrospectionThrowCompletion);
-        let [message, stack] = this.getMessageAndStack(effects);
-        let stacks = (introspectionErrors[message] = introspectionErrors[message] || []);
-        stacks.push(stack);
-        continue;
-      }
-
       invariant(result instanceof Value);
       count++;
       this.initializedModules.set(moduleId, result);
     }
-    // TODO: How do FatalError / Realm.handleError participate in these statistics?
     if (count > 0) console.log(`=== speculatively initialized ${count} additional modules`);
-    let a = [];
-    for (let key in introspectionErrors) a.push([introspectionErrors[key], key]);
-    a.sort((x, y) => y[0].length - x[0].length);
-    if (a.length) {
-      console.log(`=== speculative module initialization failures ordered by frequency`);
-      for (let [stacks, n] of a) console.log(`${stacks.length}x ${n} ${stacks.join("\nas well as")}]`);
-    }
   }
 
   isModuleInitialized(moduleId: number | string): void | Value {
@@ -461,6 +392,9 @@ export class Modules {
       if (escapes) return undefined;
 
       return compl;
+    } catch (err) {
+      if (err instanceof FatalError) return undefined;
+      throw err;
     } finally {
       realm.popContext(context);
       realm.setReadOnly(oldReadOnly);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -10,13 +10,12 @@
 /* @flow */
 
 import { Realm, ExecutionContext } from "../realm.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { SourceFile } from "../types.js";
-import { Completion } from "../completions.js";
-import { Value } from "../values/index.js";
+import { AbruptCompletion } from "../completions.js";
 import { Generator } from "../utils/generator.js";
 import generate from "babel-generator";
 import type SourceMap from "babel-generator";
-// import { transform } from "babel-core";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";
 import type { SerializerOptions } from "../options.js";
@@ -52,7 +51,7 @@ export class Serializer {
   modules: Modules;
   options: SerializerOptions;
 
-  _execute(filename: string, code: string, map: string, onError: void | ((Realm, Value) => void)) {
+  _execute(filename: string, code: string, map: string) {
     let realm = this.realm;
     let res = realm.$GlobalEnv.execute(code, filename, map, "script", ast => {
       let realmPreludeGenerator = realm.preludeGenerator;
@@ -60,24 +59,24 @@ export class Serializer {
       traverse(ast, IdentifierCollector, null, realmPreludeGenerator.nameGenerator.forbiddenNames);
     });
 
-    if (res instanceof Completion) {
+    if (res instanceof AbruptCompletion) {
       let context = new ExecutionContext();
       realm.pushContext(context);
       try {
-        if (onError) {
-          onError(realm, res.value);
-        }
         this.logger.logCompletion(res);
       } finally {
         realm.popContext(context);
       }
+      // TODO: annotate AbruptCompletion instances with the locations of the statements that caused them.
+      let diagnostic = new CompilerDiagnostic("Global code may end abruptly", null, "PP0016", "FatalError");
+      realm.handleError(diagnostic);
+      throw new FatalError();
     }
   }
 
   init(
     sources: Array<SourceFile>,
-    sourceMaps?: boolean = false,
-    onError?: (Realm, Value) => void
+    sourceMaps?: boolean = false
   ): void | {
     code: string,
     map: void | SourceMap,
@@ -92,7 +91,7 @@ export class Serializer {
     }
     let code = {};
     for (let source of sources) {
-      this._execute(source.filePath, source.fileContents, source.sourceMapContents || "", onError);
+      this._execute(source.filePath, source.fileContents, source.sourceMapContents || "");
       code[source.filePath] = source.fileContents;
     }
     if (timingStats !== undefined) timingStats.globalCodeTime = Date.now() - timingStats.globalCodeTime;

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -10,10 +10,10 @@
 /* @flow */
 
 import type { BabelNodeExpression, BabelNodeIdentifier, BabelNodeSourceLocation } from "babel-types";
+import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
 
-import { IntrospectionThrowCompletion } from "../completions.js";
 import {
   AbstractObjectValue,
   BooleanValue,
@@ -233,26 +233,27 @@ export default class AbstractValue extends Value {
   }
 
   throwIfNotConcrete(): ConcreteValue {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
   throwIfNotConcreteNumber(): NumberValue {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
   throwIfNotConcreteObject(): ObjectValue {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
   throwIfNotObject(): AbstractObjectValue {
     invariant(!(this instanceof AbstractObjectValue));
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
-  static createIntrospectionErrorThrowCompletion(
-    val: Value,
-    propertyName: void | PropertyKeyValue
-  ): IntrospectionThrowCompletion {
+  static reportIntrospectionError(val: Value, propertyName: void | PropertyKeyValue) {
     let realm = val.$Realm;
 
     let identity;
@@ -278,6 +279,6 @@ export default class AbstractValue extends Value {
 
     let message = `This operation is not yet supported on ${identity} ${location}`;
 
-    return realm.createIntrospectionErrorThrowCompletion(message);
+    return realm.reportIntrospectionError(message);
   }
 }


### PR DESCRIPTION
Instead of throwing peculiarly behaving introspection error completions, we now report all errors via the error handler, using CompilerDiagnostic objects that are just normal host objects. Following a report, we always throw a FatalError.

Eventually all of the places where generic introspection errors are thrown will be replaced by specific errors and may have site specific error recovery logic.