### PR TITLE
Always throw FatalErrors or use invariants

### DIFF
--- a/scripts/test-residual.js
+++ b/scripts/test-residual.js
@@ -12,8 +12,8 @@
 let construct_realm = require("../lib/construct_realm.js").default;
 let initializeGlobals = require("../lib/globals.js").default;
 let AbruptCompletion = require("../lib/completions.js").AbruptCompletion;
-let IntrospectionThrowCompletion = require("../lib/completions.js").IntrospectionThrowCompletion;
 let ThrowCompletion = require("../lib/completions.js").ThrowCompletion;
+let FatalError = require("../lib/errors.js").FatalError;
 
 let chalk = require("chalk");
 let path = require("path");
@@ -88,9 +88,9 @@ function runTest(name, code) {
       let realm = construct_realm(realmOptions);
       initializeGlobals(realm);
       let result = realm.$GlobalEnv.executePartialEvaluator(sources);
-      if (result instanceof IntrospectionThrowCompletion) return true;
       if (result instanceof ThrowCompletion) throw result.value;
     } catch (err) {
+      if (err instanceof FatalError) return true;
       console.log(err);
     }
     return false;

--- a/src/completions.js
+++ b/src/completions.js
@@ -31,16 +31,10 @@ export class NormalCompletion extends Completion {}
 export class ThrowCompletion extends AbruptCompletion {
   constructor(value: Value, nativeStack?: ?string) {
     super(value);
-    invariant(
-      value.getType() !== value.$Realm.intrinsics.__IntrospectionError || this instanceof IntrospectionThrowCompletion
-    );
     this.nativeStack = nativeStack || new Error().stack;
   }
 
   nativeStack: string;
-}
-export class IntrospectionThrowCompletion extends ThrowCompletion {
-  reason: void | "readonly";
 }
 export class ContinueCompletion extends AbruptCompletion {}
 export class BreakCompletion extends AbruptCompletion {}

--- a/src/environment.js
+++ b/src/environment.js
@@ -365,7 +365,7 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
   // ECMA262 8.1.1.2.3
   CreateImmutableBinding(N: string, S: boolean): Value {
     // The concrete Environment Record method CreateImmutableBinding is never used within this specification in association with object Environment Records.
-    throw new Error("unreachable");
+    invariant(false);
   }
 
   // ECMA262 8.1.1.2.4
@@ -960,27 +960,27 @@ export class ModuleEnvironmentRecord extends DeclarativeEnvironmentRecord {
   BindThisValue(
     V: NullValue | ObjectValue | AbstractObjectValue | UndefinedValue
   ): NullValue | ObjectValue | AbstractObjectValue | UndefinedValue {
-    throw new Error("TODO: implement modules");
+    throw new FatalError("TODO: implement modules");
   }
 
   // ECMA262 8.1.1.3.2
   HasThisBinding(): boolean {
-    throw new Error("TODO: implement modules");
+    throw new FatalError("TODO: implement modules");
   }
 
   // ECMA262 8.1.1.3.3
   HasSuperBinding(): boolean {
-    throw new Error("TODO: implement modules");
+    throw new FatalError("TODO: implement modules");
   }
 
   // ECMA262 8.1.1.3.4
   GetThisBinding(): NullValue | ObjectValue | AbstractObjectValue | UndefinedValue {
-    throw new Error("TODO: implement modules");
+    throw new FatalError("TODO: implement modules");
   }
 
   // ECMA262 8.1.1.3.5
   GetSuperBase(): NullValue | ObjectValue | UndefinedValue {
-    throw new Error("TODO: implement modules");
+    throw new FatalError("TODO: implement modules");
   }
 }
 
@@ -1020,7 +1020,7 @@ export class LexicalEnvironment {
         // rethrowing Error should preserve stack trace
         throw err;
       // let's wrap into a proper Error to create stack trace
-      throw new Error(err);
+      throw new FatalError(err);
     }
   }
 
@@ -1043,7 +1043,7 @@ export class LexicalEnvironment {
         // rethrowing Error should preserve stack trace
         throw err;
       // let's wrap into a proper Error to create stack trace
-      throw new Error(err);
+      throw new FatalError(err);
     }
   }
 
@@ -1056,8 +1056,8 @@ export class LexicalEnvironment {
         // rethrowing Error should preserve stack trace
         throw err;
       // let's wrap into a proper Error to create stack trace
-      if (err instanceof Object) throw new Error(err.constructor.name + ": " + err);
-      throw new Error(err);
+      if (err instanceof Object) throw new FatalError(err.constructor.name + ": " + err);
+      throw new FatalError(err);
     }
   }
 

--- a/src/evaluators/AwaitExpression.js
+++ b/src/evaluators/AwaitExpression.js
@@ -11,6 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
+import { FatalError } from "../errors.js";
 import type { Value } from "../values/index.js";
 import type { BabelNodeAwaitExpression } from "babel-types";
 
@@ -20,5 +21,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): Value {
-  throw new Error("TODO: AwaitExpression");
+  throw new FatalError("TODO: AwaitExpression");
 }

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -15,6 +15,7 @@ import { AbruptCompletion, ThrowCompletion } from "../completions.js";
 import { UpdateEmpty } from "../methods/index.js";
 import { Value } from "../values/index.js";
 import type { BabelNodeTryStatement } from "babel-types";
+import invariant from "../invariant.js";
 
 export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value {
   let completions = [];
@@ -46,5 +47,5 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       return (UpdateEmpty(realm, completion, realm.intrinsics.undefined): any);
   }
 
-  throw new Error("shouldn't meet this condition");
+  invariant(false);
 }

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { AbruptCompletion, IntrospectionThrowCompletion, ThrowCompletion } from "../completions.js";
+import { AbruptCompletion, ThrowCompletion } from "../completions.js";
 import { UpdateEmpty } from "../methods/index.js";
 import { Value } from "../values/index.js";
 import type { BabelNodeTryStatement } from "babel-types";
@@ -20,9 +20,6 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
   let completions = [];
 
   let blockRes = env.evaluateCompletion(ast.block, strictCode);
-
-  // can't catch or run finally clauses on introspection errors
-  if (blockRes instanceof IntrospectionThrowCompletion) throw blockRes;
 
   if (blockRes instanceof ThrowCompletion && ast.handler) {
     completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -198,7 +198,8 @@ export default function(
       invariant(val instanceof AbstractValue);
       return computeAbstractly(realm, StringValue, "typeof", val);
     }
-  } else if (ast.operator === "delete") {
+  } else {
+    invariant(ast.operator === "delete");
     // ECMA262 12.5.3.2
 
     // 1. Let ref be the result of evaluating UnaryExpression.
@@ -253,6 +254,4 @@ export default function(
     invariant(typeof referencedName === "string");
     return new BooleanValue(realm, bindings.DeleteBinding(referencedName));
   }
-
-  throw new Error("unimplemented");
 }

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -11,6 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
+import { FatalError } from "../errors.js";
 import type { Value } from "../values/index.js";
 import { ObjectValue, StringValue } from "../values/index.js";
 import {
@@ -35,7 +36,7 @@ function letAndConst(
 ): Value {
   for (let declar of ast.declarations) {
     if (declar.id.type !== "Identifier") {
-      throw new Error("TODO: Patterns aren't supported yet");
+      throw new FatalError("TODO: Patterns aren't supported yet");
     }
 
     let Initializer = declar.init;

--- a/src/evaluators/YieldExpression.js
+++ b/src/evaluators/YieldExpression.js
@@ -11,6 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
+import { FatalError } from "../errors.js";
 import type { Value } from "../values/index.js";
 import type { BabelNodeYieldExpression } from "babel-types";
 
@@ -20,5 +21,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): Value {
-  throw new Error("TODO: YieldExpression");
+  throw new FatalError("TODO: YieldExpression");
 }

--- a/src/intrinsics/dom/global.js
+++ b/src/intrinsics/dom/global.js
@@ -14,6 +14,7 @@ import type { Realm } from "../../realm.js";
 import { FunctionValue, NativeFunctionValue } from "../../values/index.js";
 import initializeDocument from "./document.js";
 import initializeConsole from "../common/console.js";
+import { FatalError } from "../../errors.js";
 import invariant from "../../invariant.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 
@@ -53,7 +54,7 @@ export default function(realm: Realm): void {
       let callback = args[0].throwIfNotConcrete();
       if (!(callback instanceof FunctionValue))
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "callback arguments must be function");
-      if (!realm.useAbstractInterpretation) throw new Error("TODO: implement global.setTimeout");
+      if (!realm.useAbstractInterpretation) throw new FatalError("TODO: implement global.setTimeout");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
       return generator.emitCallAndCaptureResult(
@@ -70,7 +71,7 @@ export default function(realm: Realm): void {
 
   global.$DefineOwnProperty("clearTimeout", {
     value: new NativeFunctionValue(realm, "global.clearTimeout", "", 2, (context, args) => {
-      if (!realm.useAbstractInterpretation) throw new Error("TODO: implement global.clearTimeout");
+      if (!realm.useAbstractInterpretation) throw new FatalError("TODO: implement global.clearTimeout");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
       generator.emitCall(() => generator.preludeGenerator.memoizeReference("global.clearTimeout"), args);
@@ -83,7 +84,7 @@ export default function(realm: Realm): void {
 
   global.$DefineOwnProperty("setInterval", {
     value: new NativeFunctionValue(realm, "global.setInterval", "", 2, (context, args) => {
-      if (!realm.useAbstractInterpretation) throw new Error("TODO: implement global.setInterval");
+      if (!realm.useAbstractInterpretation) throw new FatalError("TODO: implement global.setInterval");
       let callback = args[0].throwIfNotConcrete();
       if (!(callback instanceof FunctionValue))
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "callback arguments must be function");
@@ -103,7 +104,7 @@ export default function(realm: Realm): void {
 
   global.$DefineOwnProperty("clearInterval", {
     value: new NativeFunctionValue(realm, "global.clearInterval", "", 2, (context, args) => {
-      if (!realm.useAbstractInterpretation) throw new Error("TODO: implement global.clearInterval");
+      if (!realm.useAbstractInterpretation) throw new FatalError("TODO: implement global.clearInterval");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
       generator.emitCall(() => generator.preludeGenerator.memoizeReference("global.clearInterval"), args);

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -12,7 +12,6 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { AbruptCompletion } from "../../completions.js";
-import { CompilerDiagnostic } from "../../errors.js";
 import {
   AbstractValue,
   BooleanValue,
@@ -34,7 +33,6 @@ import {
   IsConstructor,
   IsCallable,
   Set,
-  ToStringPartial,
 } from "../../methods/index.js";
 import { ToString, ToUint32, ToObject, ToLength } from "../../methods/to.js";
 import { GetIterator, IteratorClose, IteratorStep, IteratorValue } from "../../methods/iterator.js";
@@ -89,31 +87,8 @@ export default function(realm: Realm): NativeFunctionValue {
       } else {
         // 7. Else,
 
-        try {
-          len = len.throwIfNotConcreteNumber();
-        } catch (err) {
-          let value = err.value;
-          invariant(value instanceof ObjectValue);
-          value = ((value: any): ObjectValue);
-
-          realm.handleError(
-            new CompilerDiagnostic(
-              ToStringPartial(realm, Get(realm, value, "message")),
-              realm.currentLocation,
-              "PP0001",
-              "FatalError"
-            )
-          );
-
-          // Rethrow.
-          // TODO: In the future, we can try and recover from the error based on the
-          // return value of 'handleError' (will be looked into a part of the effort
-          // to try and improve error reporting)
-          throw err;
-        }
-
         // a. Let intLen be ToUint32(len).
-        intLen = ToUint32(realm, len);
+        intLen = ToUint32(realm, len.throwIfNotConcreteNumber());
 
         // b If intLen ≠ len, throw a RangeError exception.
         if (intLen !== len.value) {

--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -15,6 +15,7 @@ import { ToInteger, ToNumber, ToPrimitive } from "../../methods/to.js";
 import { OrdinaryCreateFromConstructor } from "../../methods/create.js";
 import { MakeTime, MakeDate, MakeDay, TimeClip, UTC, ToDateString, thisTimeValue } from "../../methods/date.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
+import { FatalError } from "../../errors.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import seedrandom from "seedrandom";
@@ -202,7 +203,8 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 20.3.3.2
   func.defineNativeMethod("parse", 1, (context, [string]) => {
     if (realm.useAbstractInterpretation) {
-      throw AbstractValue.createIntrospectionErrorThrowCompletion(string);
+      AbstractValue.reportIntrospectionError(string);
+      throw new FatalError();
     } else {
       const parsedDate = Date.parse(string.value);
       return new NumberValue(realm, parsedDate);

--- a/src/intrinsics/ecma262/DatePrototype.js
+++ b/src/intrinsics/ecma262/DatePrototype.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
+import { FatalError } from "../../errors.js";
 import { StringValue, ObjectValue, NumberValue } from "../../values/index.js";
 import {
   ToNumber,
@@ -677,7 +678,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
   // ECMA262 20.3.4.35
   obj.defineNativeMethod("toDateString", 0, context => {
-    throw new Error("TODO: implement Date.prototype.toDateString");
+    throw new FatalError("TODO: implement Date.prototype.toDateString");
   });
 
   // ECMA262 20.3.4.36
@@ -709,17 +710,17 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
   // ECMA262 20.3.4.38
   obj.defineNativeMethod("toLocaleDateString", 0, context => {
-    throw new Error("TODO: implement Date.prototype.toLocaleDateString");
+    throw new FatalError("TODO: implement Date.prototype.toLocaleDateString");
   });
 
   // ECMA262 20.3.4.39
   obj.defineNativeMethod("toLocaleString", 0, context => {
-    throw new Error("TODO: implement Date.prototype.toLocaleString");
+    throw new FatalError("TODO: implement Date.prototype.toLocaleString");
   });
 
   // ECMA262 20.3.4.40
   obj.defineNativeMethod("toLocaleTimeString", 0, context => {
-    throw new Error("TODO: implement Date.prototype.toLocaleTimeString");
+    throw new FatalError("TODO: implement Date.prototype.toLocaleTimeString");
   });
 
   // ECMA262 20.3.4.41
@@ -744,12 +745,12 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
   // ECMA262 20.3.4.42
   obj.defineNativeMethod("toTimeString", 0, context => {
-    throw new Error("TODO: implement Date.prototype.toTimeString");
+    throw new FatalError("TODO: implement Date.prototype.toTimeString");
   });
 
   // ECMA262 20.3.4.43
   obj.defineNativeMethod("toUTCString", 0, context => {
-    throw new Error("TODO: implement Date.prototype.toUTCString");
+    throw new FatalError("TODO: implement Date.prototype.toUTCString");
   });
 
   // ECMA262 20.3.4.44

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -41,6 +41,7 @@ import {
 } from "../../methods/index.js";
 import { InternalizeJSONProperty } from "../../methods/json.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
+import { FatalError } from "../../errors.js";
 import nativeToInterp from "../../utils/native-to-interp.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
@@ -313,7 +314,10 @@ function InternalGetTemplate(realm: Realm, val: AbstractObjectValue): ObjectValu
     invariant(binding.descriptor !== undefined);
     let value = binding.descriptor.value;
     ThrowIfMightHaveBeenDeleted(value);
-    if (value === undefined) throw AbstractValue.createIntrospectionErrorThrowCompletion(val, key); // cannot handle accessors
+    if (value === undefined) {
+      AbstractValue.reportIntrospectionError(val, key); // cannot handle accessors
+      throw new FatalError();
+    }
     CreateDataProperty(realm, template, key, InternalJSONClone(realm, value));
   }
   if (valTemplate.isPartial()) template.makePartial();

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import {
@@ -102,7 +103,10 @@ export default function(realm: Realm): NativeFunctionValue {
         // properties at runtime that will overwrite current properties in to.
         // For now, just throw if this happens.
         let to_keys = to.$OwnPropertyKeys();
-        if (to_keys.length !== 0) throw AbstractValue.createIntrospectionErrorThrowCompletion(nextSource);
+        if (to_keys.length !== 0) {
+          AbstractValue.reportIntrospectionError(nextSource);
+          throw new FatalError();
+        }
       }
 
       invariant(frm, "from required");

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { Realm } from "../../realm.js";
+import { FatalError } from "../../errors.js";
 import { AbstractValue, UndefinedValue, NumberValue, ObjectValue, StringValue, NullValue } from "../../values/index.js";
 import { IsCallable, IsRegExp } from "../../methods/is.js";
 import { GetMethod, GetSubstitution } from "../../methods/get.js";
@@ -809,7 +810,8 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
 
     if (realm.useAbstractInterpretation && (type === "LocaleUpper" || type === "LocaleLower")) {
       // The locale is environment-dependent
-      throw AbstractValue.createIntrospectionErrorThrowCompletion(O);
+      AbstractValue.reportIntrospectionError(O);
+      throw new FatalError();
     }
 
     // Omit the rest of the arguments. Just use the native impl.

--- a/src/intrinsics/node/bootstrap.js
+++ b/src/intrinsics/node/bootstrap.js
@@ -9,8 +9,8 @@
 
 /* @flow */
 
+import { FatalError } from "../../errors.js";
 import type { Realm } from "../../realm.js";
-
 import { FunctionValue } from "../../values/index.js";
 
 declare var process: any;
@@ -21,14 +21,14 @@ export default function(realm: Realm): FunctionValue {
   let bootstrapSource = nodeSourceCode["internal/bootstrap_node"];
   let bootstrapFilename = "bootstrap_node.js";
   if (!bootstrapSource) {
-    throw new Error("The node-cli mode is only compatible with Node 7.");
+    throw new FatalError("The node-cli mode is only compatible with Node 7.");
   }
 
   // We evaluate bootstrap script to get the bootstrap function.
   let bootstrapFn = realm.$GlobalEnv.execute(bootstrapSource, bootstrapFilename, "");
 
   if (!(bootstrapFn instanceof FunctionValue) || !bootstrapFn.$Call) {
-    throw new Error("The node bootstrap script should always yield a function.");
+    throw new FatalError("The node bootstrap script should always yield a function.");
   }
 
   return bootstrapFn;

--- a/src/intrinsics/node/buffer.js
+++ b/src/intrinsics/node/buffer.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import invariant from "../../invariant.js";
+import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NumberValue, NativeFunctionValue, ObjectValue, StringValue } from "../../values/index.js";
 import { Set, ToInteger } from "../../methods/index.js";
@@ -55,7 +56,7 @@ export default function(realm: Realm): ObjectValue {
 
       for (let name of simpleWrapperNames) {
         let wrapper = new NativeFunctionValue(realm, "Buffer.prototype." + name, name, 0, (context, args) => {
-          throw new Error("TODO: " + name);
+          throw new FatalError("TODO: " + name);
         });
         Set(realm, proto, name, wrapper, true);
       }
@@ -99,7 +100,7 @@ export default function(realm: Realm): ObjectValue {
     "createFromString",
     0,
     (context, args) => {
-      throw new Error("TODO");
+      throw new FatalError("TODO");
     }
   );
   Set(realm, obj, "createFromString", createFromString, true);
@@ -131,7 +132,7 @@ export default function(realm: Realm): ObjectValue {
 
   for (let name of simpleWrapperNames) {
     let wrapper = new NativeFunctionValue(realm, intrinsicName + "." + name, name, 0, (context, args) => {
-      throw new Error("TODO");
+      throw new FatalError("TODO");
     });
     Set(realm, obj, name, wrapper, true);
   }

--- a/src/intrinsics/node/process.js
+++ b/src/intrinsics/node/process.js
@@ -323,7 +323,7 @@ function reverseConfigJSON(config) {
 
 export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
   if (!realm.useAbstractInterpretation) {
-    throw new Error("Realm is not partial");
+    invariant(false, "Realm is not enabled for Abstract Interpretation");
   }
   // TODO: This causes a dependency on the native `process` which doesn't
   // exist in all environments such as the webpack version.

--- a/src/intrinsics/node/utils.js
+++ b/src/intrinsics/node/utils.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import invariant from "../../invariant.js";
+import { FatalError } from "../../errors.js";
 import type { Realm } from "../../realm.js";
 import { type Value, BooleanValue, ObjectValue, NumberValue, StringValue } from "../../values/index.js";
 import { DefinePropertyOrThrow } from "../../methods/index.js";
@@ -35,19 +36,19 @@ export function createDeepIntrinsic(realm: Realm, value: Value, intrinsicName: s
       return new StringValue(realm, value, intrinsicName);
     // $FlowFixMe flow doesn't understand symbols.
     case "symbol":
-      throw new Error("Symbol cannot be safely cloned.");
+      throw new FatalError("Symbol cannot be safely cloned.");
     case "function":
-      throw new Error("Functions could be supported but are not yet.");
+      throw new FatalError("Functions could be supported but are not yet.");
     case "object": {
       if (value === null) {
         return realm.intrinsics.null;
       }
       if (Array.isArray(value)) {
-        throw new Error("Arrays are not supported yet.");
+        throw new FatalError("Arrays are not supported yet.");
       }
       let prototype = Object.getPrototypeOf(value);
       if (prototype !== Object.prototype) {
-        throw new Error(
+        throw new FatalError(
           "Only simple objects are supported for now. Got: " +
             ((typeof prototype.constructor === "function" && prototype.constructor.name) ||
               Object.prototype.toString.call(prototype))
@@ -68,7 +69,7 @@ export function createDeepIntrinsic(realm: Realm, value: Value, intrinsicName: s
       return obj;
     }
     default:
-      throw new Error("Unknown type.");
+      invariant(false);
   }
 }
 
@@ -79,7 +80,7 @@ export function copyProperty(realm: Realm, originalObject: {}, realmObject: Obje
     return;
   }
   if (desc.get || desc.set) {
-    throw new Error("Getter/setters are not supported because functions are not supported yet.");
+    throw new FatalError("Getter/setters are not supported because functions are not supported yet.");
   }
   let newDesc = {
     value: value,

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
-import { CompilerDiagnostic } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import {
   BoundFunctionValue,
   EmptyValue,
@@ -78,8 +78,7 @@ export function RequireObjectCoercible(
     if (argLoc) {
       let error = new CompilerDiagnostic("member expression object is unknown", argLoc, "PP0012", "FatalError");
       realm.handleError(error);
-      // can't throw a FatalError here, yet, because there is some code that depends on seeing an
-      // introspection error in this situation. See tests/serializer/optimizations/require_unsupported.js
+      throw new FatalError();
     }
     arg.throwIfNotConcrete();
   }
@@ -499,7 +498,8 @@ export function Type(realm: Realm, val: Value): string {
     return "Object";
   } else {
     invariant(val instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(val);
+    AbstractValue.reportIntrospectionError(val);
+    throw new FatalError();
   }
 }
 

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -11,6 +11,7 @@
 
 import type { PropertyKeyValue } from "../types.js";
 import { LexicalEnvironment, Reference, EnvironmentRecord, GlobalEnvironmentRecord } from "../environment.js";
+import { FatalError } from "../errors.js";
 import { Realm, ExecutionContext } from "../realm.js";
 import Value from "../values/Value.js";
 import {
@@ -312,7 +313,7 @@ export function OrdinaryCallEvaluateBody(
       } else if (err instanceof Error) {
         throw err;
       } else {
-        throw new Error(err);
+        throw new FatalError(err);
       }
     }
   } else if (F.$FunctionKind === "generator") {

--- a/src/methods/date.js
+++ b/src/methods/date.js
@@ -42,7 +42,7 @@ export function DaysInYear(realm: Realm, y: number): 365 | 366 {
   if (y % 100 === 0 && y % 400 !== 0) return 365;
   if (y % 400 === 0) return 366;
 
-  throw new Error("Invalid condition");
+  invariant(false, "Invalid condition");
 }
 
 // ECMA262 20.3.1.3
@@ -75,7 +75,7 @@ export function InLeapYear(realm: Realm, t: number): number {
   let daysInYear = DaysInYear(realm, YearFromTime(realm, t));
   if (daysInYear === 365) return 0;
   if (daysInYear === 366) return 1;
-  throw new Error("invalid condition");
+  invariant(false, "invalid condition");
 }
 
 // ECMA262 20.3.1.4

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -36,6 +36,7 @@ import {
   LexicalEnvironment,
 } from "../environment.js";
 import { NormalCompletion, AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { FatalError } from "../errors.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   GetV,
@@ -86,8 +87,10 @@ export function HasPrimitiveBase(realm: Realm, V: Reference): boolean {
 // ECMA262 6.2.3
 // GetReferencedName(V). Returns the referenced name component of the reference V.
 export function GetReferencedName(realm: Realm, V: Reference): string | SymbolValue {
-  if (V.referencedName instanceof AbstractValue)
-    throw realm.createIntrospectionErrorThrowCompletion("abstract reference");
+  if (V.referencedName instanceof AbstractValue) {
+    AbstractValue.reportIntrospectionError(V.referencedName);
+    throw new FatalError();
+  }
   return V.referencedName;
 }
 

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -582,13 +582,12 @@ export function BindingInitialization(
 
     // 2. Return ? InitializeBoundName(name, value, environment).
     return InitializeBoundName(realm, name, value, environment);
-  } else if (node.type === "VariableDeclaration") {
+  } else {
+    invariant(node.type === "VariableDeclaration");
     // ECMA262 13.7.5.9
     for (let decl of ((node: any): BabelNodeVariableDeclaration).declarations) {
       BindingInitialization(realm, decl.id, value, strictCode, environment);
     }
-  } else {
-    throw new Error("Unknown node " + node.type);
   }
 }
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -20,7 +20,6 @@ import {
   JoinedAbruptCompletions,
   NormalCompletion,
   PossiblyNormalCompletion,
-  IntrospectionThrowCompletion,
 } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { ExecutionContext } from "../realm.js";
@@ -1146,10 +1145,6 @@ export function EvaluateStatements(
           let e = realm.getCapturedEffects();
           invariant(e !== undefined);
           realm.stopEffectCaptureAndUndoEffects();
-          if (res instanceof IntrospectionThrowCompletion) {
-            realm.applyEffects(e);
-            throw res;
-          }
           invariant(context.savedCompletion !== undefined);
           e[0] = res;
           let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, res, e);
@@ -1211,10 +1206,6 @@ export function PartiallyEvaluateStatements(
             let e = realm.getCapturedEffects();
             invariant(e !== undefined);
             realm.stopEffectCaptureAndUndoEffects();
-            if (res instanceof IntrospectionThrowCompletion) {
-              realm.applyEffects(e);
-              throw res;
-            }
             invariant(blockValue instanceof PossiblyNormalCompletion);
             e[0] = res;
             let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, blockValue, res, e);

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -26,6 +26,7 @@ import {
   AbstractObjectValue,
 } from "../values/index.js";
 import { Reference } from "../environment.js";
+import { FatalError } from "../errors.js";
 import { ArrayCreate } from "./create.js";
 import { SetIntegrityLevel } from "./integrity.js";
 import { ToString } from "./to.js";
@@ -143,7 +144,8 @@ export function OrdinaryGet(
   if (IsDataDescriptor(realm, desc)) return descValue;
   if (dataOnly) {
     invariant(descValue instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(descValue);
+    AbstractValue.reportIntrospectionError(descValue);
+    throw new FatalError();
   }
 
   // 5. Assert: IsAccessorDescriptor(desc) is true.

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
 import { ThrowIfMightHaveBeenDeleted, IsPropertyKey } from "./index.js";
@@ -124,7 +125,8 @@ export function HasCompatibleType(value: Value, type: typeof Value): boolean {
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(value);
+    AbstractValue.reportIntrospectionError(value);
+    throw new FatalError();
   }
   return Value.isTypeCompatibleWith(valueType, type);
 }
@@ -133,7 +135,8 @@ export function HasSomeCompatibleType(value: Value, ...manyTypes: Array<typeof V
   let valueType = value.getType();
   if (valueType === Value) {
     invariant(value instanceof AbstractValue);
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(value);
+    AbstractValue.reportIntrospectionError(value);
+    throw new FatalError();
   }
   return manyTypes.some(Value.isTypeCompatibleWith.bind(null, valueType));
 }

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { FatalError } from "../errors.js";
 import type { PropertyKeyValue } from "../types.js";
 import type { Realm } from "../realm.js";
 import type { Descriptor } from "../types.js";
@@ -152,7 +153,10 @@ export function IsPropertyKey(realm: Realm, arg: string | Value): boolean {
   // 2. If Type(argument) is Symbol, return true.
   if (arg instanceof SymbolValue) return true;
 
-  if (arg instanceof AbstractValue) throw AbstractValue.createIntrospectionErrorThrowCompletion(arg);
+  if (arg instanceof AbstractValue) {
+    AbstractValue.reportIntrospectionError(arg);
+    throw new FatalError();
+  }
 
   // 3. Return false.
   return false;

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -549,7 +549,7 @@ export function joinDescriptors(
   getAbstractValue: (void | Value, void | Value) => AbstractValue
 ): void | Descriptor {
   function clone_with_abstract_value(d: Descriptor) {
-    if (!IsDataDescriptor(realm, d)) throw new Error("TODO: join computed properties");
+    if (!IsDataDescriptor(realm, d)) throw new FatalError("TODO: join computed properties");
     let dc = cloneDescriptor(d);
     invariant(dc !== undefined);
     dc.value = getAbstractValue(d.value, realm.intrinsics.empty);

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -11,6 +11,7 @@
 
 import type { BabelNodeBlockStatement } from "babel-types";
 import type { Binding } from "../environment.js";
+import { FatalError } from "../errors.js";
 import type { Bindings, Effects, EvaluationResult, PropertyBindings, CreatedObjects, Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding } from "../types.js";
 
@@ -23,7 +24,6 @@ import {
   JoinedAbruptCompletions,
   NormalCompletion,
   ReturnCompletion,
-  IntrospectionThrowCompletion,
   ThrowCompletion,
 } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -45,10 +45,6 @@ export function stopEffectCaptureAndJoinCompletions(
   let e = realm.getCapturedEffects();
   invariant(e !== undefined);
   realm.stopEffectCaptureAndUndoEffects();
-  if (c2 instanceof IntrospectionThrowCompletion) {
-    realm.applyEffects(e);
-    throw c2;
-  }
   e[0] = c2;
   let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, c1, c2, e);
   realm.applyEffects(joined_effects);
@@ -298,8 +294,6 @@ export function joinEffects(realm: Realm, joinCondition: AbstractValue, e1: Effe
   let [result1, gen1, bindings1, properties1, createdObj1] = e1;
   let [result2, gen2, bindings2, properties2, createdObj2] = e2;
 
-  if (result1 instanceof IntrospectionThrowCompletion) return e1;
-  if (result2 instanceof IntrospectionThrowCompletion) return e2;
   let result = joinResults(realm, joinCondition, result1, result2, e1, e2);
   if (result1 instanceof AbruptCompletion) {
     if (!(result2 instanceof AbruptCompletion)) {
@@ -338,7 +332,8 @@ function joinResults(
     return joinValuesAsConditional(realm, joinCondition, v1, v2);
   }
   if (result1 instanceof Reference || result2 instanceof Reference) {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(joinCondition);
+    AbstractValue.reportIntrospectionError(joinCondition);
+    throw new FatalError();
   }
   if (result1 instanceof BreakCompletion && result2 instanceof BreakCompletion && result1.target === result2.target) {
     return new BreakCompletion(realm.intrinsics.empty, result1.target);

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -15,6 +15,7 @@ import { GetMethod, Get } from "./get.js";
 import { StringCreate } from "./create.js";
 import { HasProperty } from "./has.js";
 import { Call } from "./call.js";
+import { FatalError } from "../errors.js";
 import { IsCallable } from "./is.js";
 import { SameValue, SameValueZero } from "./abstract.js";
 import {
@@ -456,7 +457,8 @@ export function ToNumber(realm: Realm, val: numberOrValue): number {
   if (typeof val === "number") {
     return val;
   } else if (val instanceof AbstractValue) {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(val);
+    AbstractValue.reportIntrospectionError(val);
+    throw new FatalError();
   } else if (val instanceof UndefinedValue) {
     return NaN;
   } else if (val instanceof NullValue) {

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -11,6 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { TypedArrayKind } from "../types.js";
+import { FatalError } from "../errors.js";
 import {
   AbstractValue,
   IntegerIndexedExotic,
@@ -339,7 +340,8 @@ export function TypedArrayCreate(realm: Realm, constructor: ObjectValue, argumen
   if (argumentList.length === 1 && argumentList[0].mightBeNumber()) {
     if (argumentList[0].mightNotBeNumber()) {
       invariant(argumentList[0] instanceof AbstractValue);
-      throw AbstractValue.createIntrospectionErrorThrowCompletion(argumentList[0]);
+      AbstractValue.reportIntrospectionError(argumentList[0]);
+      throw new FatalError();
     }
     // a. If newTypedArray.[[ArrayLength]] < argumentList[0], throw a TypeError exception.
     invariant(typeof newTypedArray.$ArrayLength === "number");

--- a/src/partial-evaluators/ArrayExpression.js
+++ b/src/partial-evaluators/ArrayExpression.js
@@ -15,6 +15,7 @@ import type { Realm } from "../realm.js";
 
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
+import { FatalError } from "../errors.js";
 import {
   ArrayCreate,
   CreateDataProperty,
@@ -61,7 +62,8 @@ export default function(
       return [elemValue, ast, io]; //todo: log an error message
     } else if (elemValue instanceof PossiblyNormalCompletion) {
       // TODO: there was a conditional abrupt completion while evaluating elem, so join states somehow
-      return [AbstractValue.createIntrospectionErrorThrowCompletion(elemValue.value), ast, io];
+      AbstractValue.reportIntrospectionError(elemValue.value);
+      throw new FatalError();
     }
     invariant(elemValue instanceof Value);
     partial_elements[nextIndex] = (elemAst: any);
@@ -119,7 +121,8 @@ export default function(
         // expressions will be evaluated at runtime. As a consequence their effects
         // have be provisional.
         // TODO: join states somehow
-        return [AbstractValue.createIntrospectionErrorThrowCompletion(spreadObj), ast, io];
+        AbstractValue.reportIntrospectionError(spreadObj);
+        throw new FatalError();
       }
     } else if (array.isPartial()) {
       // Dealing with an array element that follows on a spread object that

--- a/src/partial-evaluators/AssignmentExpression.js
+++ b/src/partial-evaluators/AssignmentExpression.js
@@ -22,6 +22,7 @@ import { computeBinary } from "../evaluators/BinaryExpression.js";
 import { createAbstractValueForBinary } from "../partial-evaluators/BinaryExpression.js";
 import { AbruptCompletion, Completion } from "../completions.js";
 import { Reference } from "../environment.js";
+import { FatalError } from "../errors.js";
 import { BooleanValue, ConcreteValue, NullValue, ObjectValue, UndefinedValue, Value } from "../values/index.js";
 import {
   GetValue,
@@ -97,7 +98,7 @@ export default function(
       rval = composeNormalCompletions(leftCompletion, rightCompletion, rval, realm);
       return [rval, resultAst, io];
     }
-    throw new Error("Patterns aren't supported yet");
+    throw new FatalError("Patterns aren't supported yet");
     // 2. Let assignmentPattern be the parse of the source text corresponding to LeftHandSideExpression using AssignmentPattern[?Yield] as the goal symbol.
     // 3. Let rref be the result of evaluating AssignmentExpression.
     // 4. Let rval be ? GetValue(rref).

--- a/src/partial-evaluators/BinaryExpression.js
+++ b/src/partial-evaluators/BinaryExpression.js
@@ -22,6 +22,7 @@ import type { Realm } from "../realm.js";
 import { computeBinary, getPureBinaryOperationResultType } from "../evaluators/BinaryExpression.js";
 import { AbruptCompletion, Completion, NormalCompletion } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
+import { FatalError } from "../errors.js";
 import { composeNormalCompletions, unbundleNormalCompletion } from "../methods/index.js";
 import { AbstractValue, BooleanValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
 
@@ -112,7 +113,8 @@ export function createAbstractValueForBinary(
       // We choose to do the latter.
       // TODO: report the error and carry on assuming no side effects.
       let val = lval instanceof AbstractValue ? lval : rval;
-      return [AbstractValue.createIntrospectionErrorThrowCompletion((val: any)), ast, io];
+      AbstractValue.reportIntrospectionError((val: any));
+      throw new FatalError();
     }
     resultValue = realm.createAbstract(
       new TypesDomain(resultType),

--- a/src/partial-evaluators/ClassExpression.js
+++ b/src/partial-evaluators/ClassExpression.js
@@ -11,6 +11,7 @@
 
 import type { BabelNodeClassExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
+import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 
 import { AbruptCompletion } from "../completions.js";
@@ -22,5 +23,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): [AbruptCompletion | Value, BabelNodeClassExpression, Array<BabelNodeStatement>] {
-  throw new Error("TODO: ClassExpression");
+  throw new FatalError("TODO: ClassExpression");
 }

--- a/src/partial-evaluators/YieldExpression.js
+++ b/src/partial-evaluators/YieldExpression.js
@@ -11,6 +11,7 @@
 
 import type { BabelNodeYieldExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
+import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { Value } from "../values/index.js";
 
@@ -20,5 +21,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): [Value, BabelNodeYieldExpression, Array<BabelNodeStatement>] {
-  throw new Error("TODO: YieldExpression");
+  throw new FatalError("TODO: YieldExpression");
 }

--- a/src/prepack-node-environment.js
+++ b/src/prepack-node-environment.js
@@ -76,7 +76,7 @@ export function prepackNodeCLISync(filename: string, options: Options = defaultO
     } else if (err instanceof Error) {
       throw err;
     } else {
-      throw new Error(err);
+      throw new FatalError(err);
     }
   } finally {
     realm.popContext(context);

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -130,9 +130,8 @@ export function prepack(code: string, options: Options = defaultOptions) {
 export function prepackFromAst(ast: BabelNodeFile | BabelNodeProgram, code: string, options: Options = defaultOptions) {
   if (ast && ast.type === "Program") {
     ast = t.file(ast, [], []);
-  } else if (!ast || ast.type !== "File") {
-    throw new Error("Not a valid ast?");
   }
+  invariant(ast && ast.type === "File");
   let filename = options.filename || (ast.loc && ast.loc.source) || "unknown";
   let sources = [{ filePath: filename, fileContents: code }];
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -252,7 +252,7 @@ export class Realm {
       this.timeoutCounter = this.timeoutCounterThreshold;
       let total = Date.now() - this.start;
       if (total > timeout) {
-        throw new Error("Timed out");
+        throw new FatalError("Timed out");
       }
     }
   }

--- a/src/repl-cli.js
+++ b/src/repl-cli.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { Realm, ExecutionContext } from "./realm.js";
+import { FatalError } from "./errors.js";
 import { Get } from "./methods/index.js";
 import { ToStringPartial, InstanceofOperator } from "./methods/index.js";
 import { AbruptCompletion, ThrowCompletion } from "./completions.js";
@@ -32,10 +33,10 @@ function serialize(realm: Realm, res: Value | AbruptCompletion): any {
     try {
       let value = res.value;
       if (value instanceof ObjectValue && InstanceofOperator(realm, value, realm.intrinsics.Error)) {
-        err = new Error(ToStringPartial(realm, Get(realm, value, "message")));
+        err = new FatalError(ToStringPartial(realm, Get(realm, value, "message")));
         err.stack = ToStringPartial(realm, Get(realm, value, "stack"));
       } else {
-        err = new Error(ToStringPartial(realm, value));
+        err = new FatalError(ToStringPartial(realm, value));
       }
     } finally {
       realm.popContext(context);

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { DeclarativeEnvironmentRecord } from "../environment.js";
+import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import { FunctionValue } from "../values/index.js";
 import * as t from "babel-types";
@@ -410,7 +411,7 @@ export class ResidualFunctions {
               for (let flatArg of flatArgs) callArgs.push(flatArg);
               for (let param of params) {
                 if (param.type !== "Identifier") {
-                  throw new Error("TODO: do not know how to deal with non-Identifier parameters");
+                  throw new FatalError("TODO: do not know how to deal with non-Identifier parameters");
                 }
                 callArgs.push(((param: any): BabelNodeIdentifier));
               }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { Realm } from "../realm.js";
+import { FatalError } from "../errors.js";
 import type { Descriptor, PropertyBinding } from "../types.js";
 import { ToLength, IsArray, Get } from "../methods/index.js";
 import {
@@ -928,7 +929,7 @@ export class ResidualHeapSerializer {
     }
 
     if (val instanceof NativeFunctionValue) {
-      throw new Error("TODO: do not know how to serialize non-intrinsic native function value");
+      throw new FatalError("TODO: do not know how to serialize non-intrinsic native function value");
     }
 
     let residualBindings = this.residualFunctionBindings.get(val);

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../environment.js";
+import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import type { Descriptor } from "../types.js";
 import { IsUnresolvableReference, ResolveBinding, IsArray, Get } from "../methods/index.js";
@@ -315,7 +316,7 @@ export class ResidualHeapVisitor {
           let referencedBase = reference.base;
           let referencedName: string = (reference.referencedName: any);
           if (typeof referencedName !== "string") {
-            throw new Error("TODO: do not know how to visit reference with symbol");
+            throw new FatalError("TODO: do not know how to visit reference with symbol");
           }
           if (reference.base instanceof GlobalEnvironmentRecord) {
             visitedBinding = this.visitGlobalBinding(referencedName);

--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { Realm, ExecutionContext } from "../realm.js";
+import { FatalError } from "../errors.js";
 import { ToStringPartial, Get, InstanceofOperator } from "../methods/index.js";
 import { Completion, ThrowCompletion } from "../completions.js";
 import { ObjectValue, StringValue, Value } from "../values/index.js";
@@ -71,7 +72,7 @@ export class Logger {
     ) {
       let object = ((value: any): ObjectValue);
       try {
-        let err = new Error(
+        let err = new FatalError(
           this.tryQuery(() => ToStringPartial(realm, Get(realm, object, "message")), "(unknown message)", false)
         );
         err.stack = this.tryQuery(() => ToStringPartial(realm, Get(realm, object, "stack")), "(unknown stack)", false);

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -13,14 +13,8 @@ import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../enviro
 import { FatalError } from "../errors.js";
 import { Realm, ExecutionContext, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
-import { IsUnresolvableReference, ResolveBinding, ToStringPartial, Get } from "../methods/index.js";
-import {
-  AbruptCompletion,
-  Completion,
-  IntrospectionThrowCompletion,
-  PossiblyNormalCompletion,
-  ThrowCompletion,
-} from "../completions.js";
+import { IsUnresolvableReference, ResolveBinding, Get } from "../methods/index.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
 import { Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import * as t from "babel-types";
@@ -97,8 +91,6 @@ class ModuleTracer extends Tracer {
         return undefined;
       } else {
         let result;
-        let oldErrorHandler = realm.errorHandler;
-        realm.errorHandler = () => "Fail";
         try {
           this.requireStack.push(moduleIdValue);
           let requireSequenceStart = this.requireSequence.length;
@@ -152,20 +144,16 @@ class ModuleTracer extends Tracer {
             }
           } while (acceleratedModuleIds.length > 0);
 
-          if (effects === undefined) {
-            // TODO: We got here due to a fatal error. Report the message somehow.
-            console.log(`delaying require(${moduleIdValue})`);
-          } else {
-            [result] = effects;
+          if (effects !== undefined) {
+            result = effects[0];
             invariant(result instanceof Value || result instanceof Completion);
-            if (result instanceof IntrospectionThrowCompletion || result instanceof PossiblyNormalCompletion) {
-              let [message, stack] = this.modules.getMessageAndStack(effects);
-              console.log(`delaying require(${moduleIdValue}): ${message} ${stack}`);
+            if (result instanceof PossiblyNormalCompletion) {
               effects = undefined;
             }
           }
 
           if (effects === undefined) {
+            console.log(`delaying require(${moduleIdValue})`);
             // So we are about to emit a delayed require(...) call.
             // However, before we do that, let's try to require all modules that we
             // know this delayed require call will require.
@@ -201,10 +189,8 @@ class ModuleTracer extends Tracer {
           let popped = this.requireStack.pop();
           invariant(popped === moduleIdValue);
           let message = "";
-          invariant(!(result instanceof IntrospectionThrowCompletion));
           if (result instanceof ThrowCompletion) message = " threw an error";
           this.log(`<require(${moduleIdValue})${message}`);
-          realm.errorHandler = oldErrorHandler;
         }
         if (result instanceof Completion) throw result;
         return result;
@@ -325,39 +311,6 @@ export class Modules {
     };
   }
 
-  getMessageAndStack([result, generator, bindings, properties, createdObjects]: Effects): [string, string] {
-    let realm = this.realm;
-    if (!(result instanceof Completion) || !(result.value instanceof ObjectValue))
-      return ["(no message)", "(no stack)"];
-
-    // Temporarily apply state changes in order to retrieve message
-    realm.restoreBindings(bindings);
-    realm.restoreProperties(properties);
-
-    let value = result.value;
-    let message: string = this.logger.tryQuery(
-      () => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "message")),
-      "(cannot get message)",
-      false
-    );
-    let stack: string = this.logger.tryQuery(
-      () => ToStringPartial(realm, Get(realm, ((value: any): ObjectValue), "stack")),
-      "",
-      false
-    );
-
-    // Undo state changes
-    realm.restoreBindings(bindings);
-    realm.restoreProperties(properties);
-
-    if (result instanceof IntrospectionThrowCompletion && result.reason !== undefined)
-      message = `[${result.reason}] ${message}`;
-
-    let i = stack.indexOf("\n");
-    if (i >= 0) stack = stack.slice(i);
-    return [message, stack];
-  }
-
   tryInitializeModule(moduleId: number | string, message: string): void | Effects {
     let realm = this.realm;
     // setup execution environment
@@ -370,15 +323,12 @@ export class Modules {
     this.delayUnsupportedRequires = false;
     realm.pushContext(context);
     let oldErrorHandler = realm.errorHandler;
-    realm.errorHandler = () => "Fail";
     try {
       let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
 
       let effects = realm.evaluateNodeForEffects(node, true, env);
-      let result = effects[0];
-      if (result instanceof IntrospectionThrowCompletion) return effects;
-
       realm.applyEffects(effects, message);
+      let result = effects[0];
       if (result instanceof Completion) {
         console.log(`=== UNEXPECTED ERROR during ${message} ===`);
         this.logger.logCompletion(result);
@@ -399,35 +349,16 @@ export class Modules {
   initializeMoreModules() {
     // partially evaluate all factory methods by calling require
     let count = 0;
-    let introspectionErrors = Object.create(null);
     for (let moduleId of this.moduleIds) {
       if (this.initializedModules.has(moduleId)) continue;
-
       let effects = this.tryInitializeModule(moduleId, `Speculative initialization of module ${moduleId}`);
-
       if (effects === undefined) continue;
       let result = effects[0];
-      if (result instanceof IntrospectionThrowCompletion) {
-        invariant(result instanceof IntrospectionThrowCompletion);
-        let [message, stack] = this.getMessageAndStack(effects);
-        let stacks = (introspectionErrors[message] = introspectionErrors[message] || []);
-        stacks.push(stack);
-        continue;
-      }
-
       invariant(result instanceof Value);
       count++;
       this.initializedModules.set(moduleId, result);
     }
-    // TODO: How do FatalError / Realm.handleError participate in these statistics?
     if (count > 0) console.log(`=== speculatively initialized ${count} additional modules`);
-    let a = [];
-    for (let key in introspectionErrors) a.push([introspectionErrors[key], key]);
-    a.sort((x, y) => y[0].length - x[0].length);
-    if (a.length) {
-      console.log(`=== speculative module initialization failures ordered by frequency`);
-      for (let [stacks, n] of a) console.log(`${stacks.length}x ${n} ${stacks.join("\nas well as")}]`);
-    }
   }
 
   isModuleInitialized(moduleId: number | string): void | Value {
@@ -461,6 +392,9 @@ export class Modules {
       if (escapes) return undefined;
 
       return compl;
+    } catch (err) {
+      if (err instanceof FatalError) return undefined;
+      throw err;
     } finally {
       realm.popContext(context);
       realm.setReadOnly(oldReadOnly);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -10,13 +10,12 @@
 /* @flow */
 
 import { Realm, ExecutionContext } from "../realm.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { SourceFile } from "../types.js";
-import { Completion } from "../completions.js";
-import { Value } from "../values/index.js";
+import { AbruptCompletion } from "../completions.js";
 import { Generator } from "../utils/generator.js";
 import generate from "babel-generator";
 import type SourceMap from "babel-generator";
-// import { transform } from "babel-core";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";
 import type { SerializerOptions } from "../options.js";
@@ -52,7 +51,7 @@ export class Serializer {
   modules: Modules;
   options: SerializerOptions;
 
-  _execute(filename: string, code: string, map: string, onError: void | ((Realm, Value) => void)) {
+  _execute(filename: string, code: string, map: string) {
     let realm = this.realm;
     let res = realm.$GlobalEnv.execute(code, filename, map, "script", ast => {
       let realmPreludeGenerator = realm.preludeGenerator;
@@ -60,24 +59,24 @@ export class Serializer {
       traverse(ast, IdentifierCollector, null, realmPreludeGenerator.nameGenerator.forbiddenNames);
     });
 
-    if (res instanceof Completion) {
+    if (res instanceof AbruptCompletion) {
       let context = new ExecutionContext();
       realm.pushContext(context);
       try {
-        if (onError) {
-          onError(realm, res.value);
-        }
         this.logger.logCompletion(res);
       } finally {
         realm.popContext(context);
       }
+      // TODO: annotate AbruptCompletion instances with the locations of the statements that caused them.
+      let diagnostic = new CompilerDiagnostic("Global code may end abruptly", null, "PP0016", "FatalError");
+      realm.handleError(diagnostic);
+      throw new FatalError();
     }
   }
 
   init(
     sources: Array<SourceFile>,
-    sourceMaps?: boolean = false,
-    onError?: (Realm, Value) => void
+    sourceMaps?: boolean = false
   ): void | {
     code: string,
     map: void | SourceMap,
@@ -92,7 +91,7 @@ export class Serializer {
     }
     let code = {};
     for (let source of sources) {
-      this._execute(source.filePath, source.fileContents, source.sourceMapContents || "", onError);
+      this._execute(source.filePath, source.fileContents, source.sourceMapContents || "");
       code[source.filePath] = source.fileContents;
     }
     if (timingStats !== undefined) timingStats.globalCodeTime = Date.now() - timingStats.globalCodeTime;

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -12,6 +12,7 @@
 import buildTemplate from "babel-template";
 import type { BabelNodeExpression } from "babel-types";
 import type { PreludeGenerator } from "./generator.js";
+import invariant from "../invariant.js";
 
 export default function buildExpressionTemplate(code: string): (void | PreludeGenerator) => any => BabelNodeExpression {
   let template;
@@ -25,7 +26,7 @@ export default function buildExpressionTemplate(code: string): (void | PreludeGe
         obj
       );
     let result = template(obj).expression;
-    if (result === undefined) throw new Error("Code does not represent an expression: " + code);
+    invariant(result !== undefined, "Code does not represent an expression: " + code);
     return result;
   };
 }

--- a/src/utils/native-to-interp.js
+++ b/src/utils/native-to-interp.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
+import { FatalError } from "../errors.js";
 import { Value, StringValue, NumberValue, ObjectValue } from "../values/index.js";
 import { CreateArrayFromList } from "../methods/index.js";
 
@@ -42,6 +43,6 @@ export default function convert(realm: Realm, val: any): Value {
 
     return obj;
   } else {
-    throw new Error("dunno how to convert this");
+    throw new FatalError("TODO: need to convert value of type " + typeof val);
   }
 }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -10,10 +10,10 @@
 /* @flow */
 
 import type { BabelNodeExpression, BabelNodeIdentifier, BabelNodeSourceLocation } from "babel-types";
+import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
 
-import { IntrospectionThrowCompletion } from "../completions.js";
 import {
   AbstractObjectValue,
   BooleanValue,
@@ -233,26 +233,27 @@ export default class AbstractValue extends Value {
   }
 
   throwIfNotConcrete(): ConcreteValue {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
   throwIfNotConcreteNumber(): NumberValue {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
   throwIfNotConcreteObject(): ObjectValue {
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
   throwIfNotObject(): AbstractObjectValue {
     invariant(!(this instanceof AbstractObjectValue));
-    throw AbstractValue.createIntrospectionErrorThrowCompletion(this);
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
   }
 
-  static createIntrospectionErrorThrowCompletion(
-    val: Value,
-    propertyName: void | PropertyKeyValue
-  ): IntrospectionThrowCompletion {
+  static reportIntrospectionError(val: Value, propertyName: void | PropertyKeyValue) {
     let realm = val.$Realm;
 
     let identity;
@@ -278,6 +279,6 @@ export default class AbstractValue extends Value {
 
     let message = `This operation is not yet supported on ${identity} ${location}`;
 
-    return realm.createIntrospectionErrorThrowCompletion(message);
+    return realm.reportIntrospectionError(message);
   }
 }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -81,35 +81,35 @@ export default class Value {
   }
 
   mightBeFalse(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightNotBeFalse(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightBeNull(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightBeNumber(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightNotBeNumber(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightNotBeObject(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightBeObject(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightNotBeString(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightBeTrue(): boolean {
@@ -121,49 +121,47 @@ export default class Value {
   }
 
   mightBeUndefined(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   mightHaveBeenDeleted(): boolean {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   promoteEmptyToUndefined(): Value {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   throwIfNotConcrete(): ConcreteValue {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   throwIfNotConcreteNumber(): NumberValue {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   throwIfNotConcreteObject(): ObjectValue {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   throwIfNotObject(): ObjectValue | AbstractObjectValue {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 
   serialize(stack: Map<Value, any> = new Map()): any {
     if (stack.has(this)) {
       return stack.get(this);
-    } else if (this._serialize) {
+    } else {
       let set = val => {
         stack.set(this, val);
         return val;
       };
 
       return set(this._serialize(set, stack));
-    } else {
-      throw new Error("can't serialize this type");
     }
   }
 
   _serialize(set: Function, stack: Map<Value, any>): any {
-    throw new Error("abstract method; please override");
+    invariant(false, "abstract method; please override");
   }
 }


### PR DESCRIPTION
This cleans up the current uses of "throw Error('some string');" turning some into invariants (when the throw could only happen if there is a programming bug) and others into "throw new FatalError" (when the throw could happen because an input program contains something that is not yet supported).

In the fullness of time the second category of errors need to be paired up with handleError calls and some of them will go away as more features are implemented.