### PR TITLE
Improve Test262 test runner

### DIFF
--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -564,9 +564,11 @@ function handleFinished(args: MasterProgramArgs, groups: GroupsMap, earlierNumSk
       if (errmsg) {
         console.log(errmsg);
       }
-    } else if (group_es5_failed + group_es6_failed > 0) {
+    }
+    if (group_es5_failed + group_es6_failed > 0) {
       failed_groups.push(msg);
     }
+
     numPassedES5 += group_es5_passed;
     numPassedES6 += group_es6_passed;
     numFailedES5 += group_es5_failed;
@@ -597,7 +599,7 @@ function handleFinished(args: MasterProgramArgs, groups: GroupsMap, earlierNumSk
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 22916 || numPassedES6 < 10336 || numTimeouts > 0)) {
+  if (!args.filterString && (numPassedES5 < 22916 || numPassedES6 < 10340 || numTimeouts > 0)) {
     console.log(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {


### PR DESCRIPTION
Two improvements:
1. The CI has 10340 ES6 tests passing so reflect the latest status in test runner.
2. Always show test failure groups summary even in success situation. This allows us to run the test locally and compare failure groups summary to the baseline summary in CI to find out which specific test group is failing. Saving much time in troubleshooting test failure!