### PR TITLE
Fixed bug in test-runner

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -217,10 +217,11 @@ function runTest(name, code, args) {
         oldCode = newCode;
         oldUniqueSuffix = newUniqueSuffix;
       }
-      if (i === max && anyDelayedValues) {
-        // TODO: Make delayed initializations logic more sophisticated in order to still reach a fixed point.
-        return true;
-      } else if (i === max) {
+      if (i === max) {
+        if (anyDelayedValues) {
+          // TODO: Make delayed initializations logic more sophisticated in order to still reach a fixed point.
+          return true;
+        }
         console.log(chalk.red(`Code generation did not reach fixed point after ${max} iterations!`));
       }
     } catch (err) {

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -217,7 +217,7 @@ function runTest(name, code, args) {
         oldCode = newCode;
         oldUniqueSuffix = newUniqueSuffix;
       }
-      if (anyDelayedValues) {
+      if (i === max && anyDelayedValues) {
         // TODO: Make delayed initializations logic more sophisticated in order to still reach a fixed point.
         return true;
       } else if (i === max) {


### PR DESCRIPTION
If a test case fails but there were delayedValues it was previously failing