### PR TITLE
Make delaying of initializations optional

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -27,6 +27,7 @@ export type RealmOptions = {
 };
 
 export type SerializerOptions = {
+  delayInitializations?: boolean,
   delayUnsupportedRequires?: boolean,
   initializeMoreModules?: boolean,
   internalDebug?: boolean,
@@ -40,6 +41,7 @@ export type SerializerOptions = {
 export type Options = {|
   compatibility?: Compatibility,
   debugNames?: boolean,
+  delayInitializations?: boolean,
   delayUnsupportedRequires?: boolean,
   inputSourceMapFilename?: string,
   internalDebug?: boolean,
@@ -88,6 +90,7 @@ export function getRealmOptions({
 }
 
 export function getSerializerOptions({
+  delayInitializations = false,
   delayUnsupportedRequires = false,
   internalDebug = false,
   logStatistics = false,
@@ -98,6 +101,7 @@ export function getSerializerOptions({
   trace = false,
 }: Options): SerializerOptions {
   return {
+    delayInitializations,
     delayUnsupportedRequires,
     initializeMoreModules: speculate,
     internalDebug,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -36,20 +36,20 @@ function run(
   fs
 ) {
   let HELP_STR = `
-    input    The name of the file to run Prepack over (for web please provide the single js bundle file)
-    --out    The name of the output file
-    --compatibility    The target environment for Prepack [${CompatibilityValues.map(v => `"${v}"`).join(", ")}]
-    --mathRandomSeed    If you want Prepack to evaluate Math.random() calls, please provide a seed.
-    --srcmapIn    The input sourcemap filename. If present, Prepack will output a sourcemap that maps from the original file (pre-input sourcemap) to Prepack's output
-    --srcmapOut    The output sourcemap filename.
-    --debugNames    Changes the output of Prepack so that for named functions and variables that get emitted into Prepack's output, the original name is appended as a suffix to Prepack's generated identifier.
-    --singlePass    Perform only one serialization pass. Disables some optimizations on Prepack's output. This will speed up Prepacking but result in code with less inlining.
-    --speculate    Enable speculative initialization of modules (for the module system Prepack has builtin knowledge about). Prepack will try to execute all factory functions it is able to.
-    --trace    Traces the order of module initialization.
-    --serialize    Serializes the partially evaluated global environment as a program that recreates it. (default = true)
-    --residual    Produces the residual program that results after constant folding.
-    --profile    Enables console logging of profile information of different phases of prepack.
-    --statsFile  The name of the output file where statistics will be written to.
+    input            The name of the file to run Prepack over (for web please provide the single js bundle file)
+    --out            The name of the output file
+    --compatibility  The target environment for Prepack [${CompatibilityValues.map(v => `"${v}"`).join(", ")}]
+    --mathRandomSeed If you want Prepack to evaluate Math.random() calls, please provide a seed.
+    --srcmapIn       The input sourcemap filename. If present, Prepack will output a sourcemap that maps from the original file (pre-input sourcemap) to Prepack's output
+    --srcmapOut      The output sourcemap filename.
+    --debugNames     Changes the output of Prepack so that for named functions and variables that get emitted into Prepack's output, the original name is appended as a suffix to Prepack's generated identifier.
+    --singlePass     Perform only one serialization pass. Disables some optimizations on Prepack's output. This will speed up Prepacking but result in code with less inlining.
+    --speculate      Enable speculative initialization of modules (for the module system Prepack has builtin knowledge about). Prepack will try to execute all factory functions it is able to.
+    --trace          Traces the order of module initialization.
+    --serialize      Serializes the partially evaluated global environment as a program that recreates it. (default = true)
+    --residual       Produces the residual program that results after constant folding.
+    --profile        Enables console logging of profile information of different phases of prepack.
+    --statsFile      The name of the output file where statistics will be written to.
   `;
   let args = Array.from(process.argv);
   args.splice(0, 2);
@@ -67,6 +67,7 @@ function run(
     singlePass: false,
     logStatistics: false,
     logModules: false,
+    delayInitializations: false,
     delayUnsupportedRequires: false,
     internalDebug: false,
     serialize: false,
@@ -107,7 +108,8 @@ function run(
           break;
         case "help":
           console.log(
-            "Usage: prepack.js [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --speculate ] [ --trace ] [ -- | input.js ] [ --singlePass ] [ --debugNames ]" +
+            "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] " +
+              Object.keys(flags).map(s => "[ --" + s + "]").join(" ") +
               "\n" +
               HELP_STR
           );

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -63,7 +63,8 @@ export class ResidualHeapSerializer {
     residualHeapInspector: ResidualHeapInspector,
     residualValues: Map<Value, Set<Scope>>,
     residualFunctionBindings: Map<FunctionValue, VisitedBindings>,
-    residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>
+    residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>,
+    delayInitializations: boolean
   ) {
     this.realm = realm;
     this.logger = logger;
@@ -113,6 +114,7 @@ export class ResidualHeapSerializer {
     this.residualValues = residualValues;
     this.residualFunctionBindings = residualFunctionBindings;
     this.residualFunctionInfos = residualFunctionInfos;
+    this.delayInitializations = delayInitializations;
   }
 
   emitter: Emitter;
@@ -143,6 +145,7 @@ export class ResidualHeapSerializer {
   residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>;
   serializedValues: Set<Value>;
   residualFunctions: ResidualFunctions;
+  delayInitializations: boolean;
 
   // Configures all mutable aspects of an object, in particular:
   // symbols, properties, prototype.
@@ -450,7 +453,7 @@ export class ResidualHeapSerializer {
       }
     }
 
-    if (generators.length === 0) {
+    if (this.delayInitializations && generators.length === 0) {
       let body = this.residualFunctions.residualFunctionInitializers.registerValueOnlyReferencedByResidualFunctions(
         functionValues,
         val

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -133,7 +133,8 @@ export class Serializer {
         residualHeapVisitor.inspector,
         residualHeapVisitor.values,
         residualHeapVisitor.functionBindings,
-        residualHeapVisitor.functionInfos
+        residualHeapVisitor.functionInfos,
+        !!this.options.delayInitializations
       ).serialize();
       if (this.logger.hasErrors()) return undefined;
       if (timingStats !== undefined) timingStats.referenceCountsTime = Date.now() - timingStats.referenceCountsTime;
@@ -151,7 +152,8 @@ export class Serializer {
       residualHeapVisitor.inspector,
       residualHeapVisitor.values,
       residualHeapVisitor.functionBindings,
-      residualHeapVisitor.functionInfos
+      residualHeapVisitor.functionInfos,
+      !!this.options.delayInitializations
     );
     let ast = residualHeapSerializer.serialize();
     let generated = generate(ast, { sourceMaps: sourceMaps }, (code: any));


### PR DESCRIPTION
That will allow to determine their perf implications.

Cleaned up --help text a bit.
Change serializer test runner to run each test twice, with delaying of initialization and without.
This also effectively re-enables fixed point check, as it is currently disabled whenever the
delaying of initializations kicks in. (See issue #835.)