### PR TITLE
Fix moduletracer using global during interpretation

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -13,6 +13,7 @@ import type {
   BabelNode,
   BabelNodeComment,
   BabelNodeFile,
+  BabelNodeLVal,
   BabelNodePosition,
   BabelNodeStatement,
   BabelNodeSourceLocation,
@@ -53,6 +54,7 @@ import {
   HasProperty,
   Get,
   GetValue,
+  PutValue,
   DefinePropertyOrThrow,
   Set,
   IsExtensible,
@@ -1001,6 +1003,11 @@ export class LexicalEnvironment {
   environmentRecord: EnvironmentRecord;
   parent: null | LexicalEnvironment;
   realm: Realm;
+
+  assignToGlobal(globalAst: BabelNodeLVal, rvalue: Value) {
+    let globalValue = this.evaluate(globalAst, false);
+    PutValue(this.realm, globalValue, rvalue);
+  }
 
   partiallyEvaluateCompletionDeref(
     ast: BabelNode,

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -129,6 +129,14 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
+  // Maps from initialized moduleId to exports object
+  global.$DefineOwnProperty("__initializedModules", {
+    value: new ObjectValue(realm),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
   // Helper function used to instatiate a residual function
   function deriveNativeFunctionValue(unsafe: boolean): NativeFunctionValue {
     return new NativeFunctionValue(

--- a/src/realm.js
+++ b/src/realm.js
@@ -31,7 +31,13 @@ import type { Compatibility, RealmOptions } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
 import { Generator, PreludeGenerator } from "./utils/generator.js";
-import type { BabelNode, BabelNodeSourceLocation, BabelNodeStatement, BabelNodeExpression } from "babel-types";
+import type {
+  BabelNode,
+  BabelNodeSourceLocation,
+  BabelNodeLVal,
+  BabelNodeStatement,
+  BabelNodeExpression,
+} from "babel-types";
 import type { EnvironmentRecord } from "./environment.js";
 import * as t from "babel-types";
 import { ToString } from "./methods/to.js";
@@ -278,6 +284,14 @@ export class Realm {
       if (ctx.savedEffects !== undefined) this.addPriorEffects(ctx.savedEffects, savedEffects);
       ctx.savedEffects = savedEffects;
     }
+  }
+
+  assignToGlobal(name: BabelNodeLVal, value: Value) {
+    this.$GlobalEnv.assignToGlobal(name, value);
+  }
+
+  deleteGlobalBinding(name: string) {
+    this.$GlobalEnv.environmentRecord.DeleteBinding(name);
   }
 
   // Evaluate the given ast in a sandbox and return the evaluation results

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -15,7 +15,7 @@ import { Realm, ExecutionContext, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
 import { IsUnresolvableReference, ResolveBinding, Get } from "../methods/index.js";
 import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
-import { AbstractValue, Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
+import { Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import * as t from "babel-types";
 import type { BabelNodeIdentifier, BabelNodeLVal, BabelNodeCallExpression } from "babel-types";
@@ -294,18 +294,7 @@ export class Modules {
       invariant(property);
       let moduleValue = property.descriptor && property.descriptor.value;
       invariant(moduleValue);
-      if (moduleValue instanceof AbstractValue) {
-        if (moduleValue.values.isTop()) {
-          // Most likely something in the exports object came from the model,
-          // the exports object is abstract.
-          this.initializedModules.set(moduleId, moduleValue);
-        } else {
-          invariant(!moduleValue.mightNotBeObject() && moduleValue.values.getElements().size === 1);
-          this.initializedModules.set(moduleId, moduleValue.values.getElements().values().next().value);
-        }
-      } else {
-        this.initializedModules.set(moduleId, moduleValue);
-      }
+      this.initializedModules.set(moduleId, moduleValue);
     }
   }
 

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -15,7 +15,7 @@ import { Realm, ExecutionContext, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
 import { IsUnresolvableReference, ResolveBinding, Get } from "../methods/index.js";
 import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
-import { Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
+import { AbstractValue, Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import * as t from "babel-types";
 import type { BabelNodeIdentifier, BabelNodeLVal, BabelNodeCallExpression } from "babel-types";
@@ -31,7 +31,6 @@ class ModuleTracer extends Tracer {
     this.requireSequence = [];
     this.logModules = logModules;
     this.uninitializedModuleIdsRequiredInEvaluateForEffects = new Set();
-    this.nestedRequiredModulesAndValues = [];
   }
 
   modules: Modules;
@@ -41,7 +40,6 @@ class ModuleTracer extends Tracer {
   uninitializedModuleIdsRequiredInEvaluateForEffects: Set<number | string>;
   // We can't say that a module has been initialized if it was initialized in a
   // evaluate for effects context until we know the effects are applied.
-  nestedRequiredModulesAndValues: Array<{| id: number | string, value: Value |}>;
   logModules: boolean;
 
   log(message: string) {
@@ -100,11 +98,7 @@ class ModuleTracer extends Tracer {
           this.requireStack.push(moduleIdValue);
           try {
             let value = performCall();
-            if (this.modules.initializedModules.has(moduleIdValue)) {
-              invariant(this.modules.initializedModules.get(moduleIdValue) === value);
-            } /*else {
-              this.modules.initializedModules.set(moduleIdValue, value);
-            }*/
+            this.modules.recordModuleInitialized(moduleIdValue, value);
             return value;
           } finally {
             invariant(this.requireStack.pop() === moduleIdValue);
@@ -182,7 +176,6 @@ class ModuleTracer extends Tracer {
                   nestedEffects[0] instanceof Value &&
                   this.modules.isModuleInitialized(nestedModuleId)
                 ) {
-                  this.nestedRequiredModulesAndValues.push({ id: nestedModuleId, value: nestedEffects[0] });
                   acceleratedModuleIds.push(nestedModuleId);
                 }
               }
@@ -236,16 +229,10 @@ class ModuleTracer extends Tracer {
             );
           } else {
             invariant(result);
-            if (!(result instanceof Completion)) {
-              this.nestedRequiredModulesAndValues.push({ id: moduleIdValue, value: result });
-            }
-            if (isTopLevelRequire) {
-              /*for (let { id, value } of this.nestedRequiredModulesAndValues) {
-                this.modules.initializedModules.set(id, value);
-              }*/
-              this.nestedRequiredModulesAndValues = [];
-            }
             realm.applyEffects(effects, `initialization of module ${moduleIdValue}`);
+            if (!(result instanceof Completion)) {
+              this.modules.recordModuleInitialized(moduleIdValue, result);
+            }
           }
         } finally {
           realm.errorHandler = savedHandler;
@@ -300,13 +287,29 @@ export class Modules {
   disallowDelayingRequiresOverride: boolean;
 
   resolveInitializedModules(): void {
-    for (let moduleId of this.moduleIds) {
-      let result = this.isModuleInitialized(moduleId);
-      if (result !== undefined) this.initializedModules.set(moduleId, result);
+    let globalInitializedModulesMap = this._getGlobalProperty("__initializedModules");
+    invariant(globalInitializedModulesMap instanceof ObjectValue);
+    for (let moduleId of globalInitializedModulesMap.getOwnPropertyKeysArray()) {
+      let property = globalInitializedModulesMap.properties.get(moduleId);
+      invariant(property);
+      let moduleValue = property.descriptor && property.descriptor.value;
+      invariant(moduleValue);
+      if (moduleValue instanceof AbstractValue) {
+        if (moduleValue.values.isTop()) {
+          // Most likely something in the exports object came from the model,
+          // the exports object is abstract.
+          this.initializedModules.set(moduleId, moduleValue);
+        } else {
+          invariant(!moduleValue.mightNotBeObject() && moduleValue.values.getElements().size === 1);
+          this.initializedModules.set(moduleId, moduleValue.values.getElements().values().next().value);
+        }
+      } else {
+        this.initializedModules.set(moduleId, moduleValue);
+      }
     }
   }
 
-  _getGlobalProperty(name: string) {
+  _getGlobalProperty(name: string): Value {
     if (this.active) return this.realm.intrinsics.undefined;
     this.active = true;
     try {
@@ -383,6 +386,16 @@ export class Modules {
     };
   }
 
+  recordModuleInitialized(moduleId: number | string, value: Value) {
+    this.realm.assignToGlobal(
+      t.memberExpression(
+        t.memberExpression(t.identifier("global"), t.identifier("__initializedModules")),
+        t.identifier("" + moduleId)
+      ),
+      value
+    );
+  }
+
   tryInitializeModule(moduleId: number | string, message: string): void | Effects {
     let realm = this.realm;
     // setup execution environment
@@ -407,6 +420,7 @@ export class Modules {
         return undefined;
       }
 
+      if (result instanceof Value) this.recordModuleInitialized(moduleId, result);
       return effects;
     } catch (err) {
       if (err instanceof FatalError) return undefined;

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -72,7 +72,7 @@ export let ClosureRefReplacer = {
     state.requireStatistics.count++;
     if (state.modified[path.node.callee.name]) return;
 
-    let moduleId = path.node.arguments[0].value;
+    let moduleId = "" + path.node.arguments[0].value;
     let new_node = requireReturns.get(moduleId);
     if (new_node !== undefined) {
       markVisited(new_node, state.serializedBindings);

--- a/test/serializer/abstract/require_tracking2.js
+++ b/test/serializer/abstract/require_tracking2.js
@@ -1,0 +1,121 @@
+// delay unsupported requires
+
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+      try {
+
+   var _moduleObject = { exports: exports };
+
+   factory(global, require, _moduleObject, exports, dependencyMap);
+
+      module.factory = undefined;
+
+   return module.exports = _moduleObject.exports;
+ } catch (e) {
+   module.hasError = true;
+   module.isInitialized = false;
+   module.exports = undefined;
+   throw e;
+ }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+define(function(global, require, module, exports) {
+  let condition = global.__abstract ? __abstract("boolean", "true") : true;
+  let obj1 = global.__abstract ? __abstract("object", "({ foo: 5 })") : { foo: 5 };
+  let obj2 = global.__abstract ? __abstract("object", "({ foo: 8 })") : { foo: 8 };
+  module.exports = condition ? obj1 : obj2;
+}, 0, null);
+
+define(function(global, require, module, exports) {
+  //let condition = global.__abstract ? __abstract("boolean", "true") : true;
+  let topNum = global.__abstract ? __abstract("number", "5") : 5;
+  module.exports = topNum;
+}, 4, null);
+
+define(function(global, require, module, exports) {
+  var x = require(0);
+  module.exports = function() { return x; }
+}, 1, null);
+
+
+define(function(global, require, module, exports) {
+  module.exports = { foo: 5 };
+}, 2, null);
+
+var f = require(1);
+
+inspect = function() { return f().magic + require(1).foo; }


### PR DESCRIPTION
ModuleTracer now tracks initialized modules in a prepack-internal global which allows modules initialized in nested partial evaluation contexts (with effects that may or may not be applied) to be tracked properly.