### PR TITLE
Specify additional initialization functions to prepack

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -16,7 +16,6 @@ let Serializer = require("../lib/serializer/index.js").default;
 let construct_realm = require("../lib/construct_realm.js").default;
 let initializeGlobals = require("../lib/globals.js").default;
 let util = require("util");
-
 let chalk = require("chalk");
 let path = require("path");
 let fs = require("fs");
@@ -98,12 +97,18 @@ function runTest(name, code, options, args) {
     serialize: true,
     uniqueSuffix: "",
   });
+  if (code.includes("// additional functions")) options.additionalFunctions = ["additional1", "additional2"];
   if (code.includes("// throws introspection error")) {
     try {
       let realmOptions = { serialize: true, compatibility, uniqueSuffix: "" };
       let realm = construct_realm(realmOptions);
       initializeGlobals(realm);
-      let serializerOptions = { initializeMoreModules: speculate, delayUnsupportedRequires, internalDebug: true };
+      let serializerOptions = {
+        initializeMoreModules: speculate,
+        delayUnsupportedRequires,
+        internalDebug: true,
+        additionalFunctions: options.additionalFunctions,
+      };
       let serializer = new Serializer(realm, serializerOptions);
       let sources = [{ filePath: name, fileContents: code }];
       let serialized = serializer.init(sources, false);

--- a/src/options.js
+++ b/src/options.js
@@ -27,6 +27,7 @@ export type RealmOptions = {
 };
 
 export type SerializerOptions = {
+  additionalFunctions?: Array<string>,
   delayInitializations?: boolean,
   delayUnsupportedRequires?: boolean,
   initializeMoreModules?: boolean,
@@ -39,6 +40,7 @@ export type SerializerOptions = {
 };
 
 export type Options = {|
+  additionalFunctions?: Array<string>,
   compatibility?: Compatibility,
   debugNames?: boolean,
   delayInitializations?: boolean,
@@ -90,6 +92,7 @@ export function getRealmOptions({
 }
 
 export function getSerializerOptions({
+  additionalFunctions,
   delayInitializations = false,
   delayUnsupportedRequires = false,
   internalDebug = false,
@@ -100,7 +103,7 @@ export function getSerializerOptions({
   speculate = false,
   trace = false,
 }: Options): SerializerOptions {
-  return {
+  let result: SerializerOptions = {
     delayInitializations,
     delayUnsupportedRequires,
     initializeMoreModules: speculate,
@@ -111,4 +114,6 @@ export function getSerializerOptions({
     singlePass,
     trace,
   };
+  if (additionalFunctions) result.additionalFunctions = additionalFunctions;
+  return result;
 }

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { BabelNodeCallExpression, BabelNodeIdentifier } from "babel-types";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
+import invariant from "../invariant.js";
+import { intersectBindings } from "../methods/join.js";
+import { type PropertyBindings, Realm } from "../realm.js";
+import type { PropertyBinding } from "../types.js";
+import { EmptyValue, FunctionValue, Value } from "../values/index.js";
+import * as t from "babel-types";
+
+export class Functions {
+  constructor(realm: Realm, functions: ?Array<string>) {
+    this.realm = realm;
+    this.functions = functions;
+  }
+
+  realm: Realm;
+  functions: ?Array<string>;
+
+  checkThatFunctionsAreIndependent() {
+    let functions = this.functions;
+    invariant(functions, "This method should only be called if initialized with defined functions");
+
+    // lookup functions
+    let calls = [];
+    let glob = this.realm.$GlobalObject;
+    for (let fname of functions) {
+      let fun = glob.$Get(fname, glob);
+      if (!(fun instanceof FunctionValue)) {
+        let error = new CompilerDiagnostic(
+          `Additional function ${fname} not defined in the global object`,
+          null,
+          "PP1001",
+          "FatalError"
+        );
+        this.realm.handleError(error);
+        throw new FatalError();
+      }
+      let callee = t.identifier(fname);
+      let call = t.callExpression(callee, []);
+      calls.push(call);
+    }
+
+    // check that functions are independent
+    for (let call1 of calls) {
+      let e1 = this.realm.evaluateNodeForEffectsInGlobalEnv(call1);
+      if (!(e1[0] instanceof Value)) {
+        let fname = ((call1.callee: any): BabelNodeIdentifier).name;
+        let error = new CompilerDiagnostic(
+          `Additional function ${fname} may terminate abruptly`,
+          null,
+          "PP1002",
+          "FatalError"
+        );
+        this.realm.handleError(error);
+        throw new FatalError();
+      }
+      for (let call2 of calls) {
+        if (call1 === call2) continue;
+        let e2 = this.realm.evaluateNodeForEffectsInGlobalEnv(call2);
+        if (!(e2[0] instanceof Value)) continue; // will report error in outer loop
+        let e3 = intersectBindings(this.realm, e1, e2);
+        let hasWriteConflicts = false;
+        for (let pb of e3[3].values()) {
+          invariant(pb !== undefined); // guaranteed by intersectBindings
+          if (pb.value instanceof EmptyValue) {
+            hasWriteConflicts = true;
+            break;
+          }
+        }
+        if (hasWriteConflicts) this.reportWriteConflicts(e3[3], call1, call2);
+      }
+    }
+  }
+
+  reportWriteConflicts(pbs: PropertyBindings, call1: BabelNodeCallExpression, call2: BabelNodeCallExpression) {
+    let fname = "";
+    let oldReporter = this.realm.reportPropertyModification;
+    this.realm.reportPropertyModification = (pb: PropertyBinding) => {
+      if (pbs.has(pb)) {
+        let error = new CompilerDiagnostic(
+          `Property write conflicts with write in additional function ${fname}`,
+          this.realm.currentLocation,
+          "PP1003",
+          "FatalError"
+        );
+        this.realm.handleError(error);
+      }
+    };
+    try {
+      fname = ((call2.callee: any): BabelNodeIdentifier).name;
+      this.realm.evaluateNodeForEffectsInGlobalEnv(call1);
+      fname = ((call1.callee: any): BabelNodeIdentifier).name;
+      this.realm.evaluateNodeForEffectsInGlobalEnv(call2);
+    } finally {
+      this.realm.reportPropertyModification = oldReporter;
+    }
+    throw new FatalError();
+  }
+}

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -20,6 +20,7 @@ import traverseFast from "../utils/traverse-fast.js";
 import invariant from "../invariant.js";
 import type { SerializerOptions } from "../options.js";
 import { TimingStatistics, SerializerStatistics } from "./types.js";
+import { Functions } from "./functions.js";
 import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
 import { LoggingTracer } from "./LoggingTracer.js";
@@ -35,6 +36,7 @@ export class Serializer {
     realm.generator = new Generator(realm);
 
     this.realm = realm;
+    this.functions = new Functions(this.realm, serializerOptions.additionalFunctions);
     this.logger = new Logger(this.realm, !!serializerOptions.internalDebug);
     this.modules = new Modules(
       this.realm,
@@ -48,6 +50,7 @@ export class Serializer {
   }
 
   realm: Realm;
+  functions: Functions;
   logger: Logger;
   modules: Modules;
   options: SerializerOptions;
@@ -104,6 +107,9 @@ export class Serializer {
     if (timingStats !== undefined) timingStats.globalCodeTime = Date.now() - timingStats.globalCodeTime;
     if (this.logger.hasErrors()) return undefined;
     this.modules.resolveInitializedModules();
+    if (this.options.additionalFunctions) {
+      this.functions.checkThatFunctionsAreIndependent();
+    }
     if (this.options.initializeMoreModules) {
       if (timingStats !== undefined) timingStats.initializeMoreModulesTime = Date.now();
       this.modules.initializeMoreModules();

--- a/test/serializer/additional-functions/bad-functions.js
+++ b/test/serializer/additional-functions/bad-functions.js
@@ -1,0 +1,20 @@
+// additional functions
+// throws introspection error
+
+var wildcard = global.__abstract ? global.__abstract("number", 123, "123") : 123;
+global.a = "";
+
+function additional1() {
+  if (wildcard) throw new Exception();
+  global.a = "foo";
+}
+
+function additional2() {
+  global.a = "foo";
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.a;
+}

--- a/test/serializer/additional-functions/bad-functions2.js
+++ b/test/serializer/additional-functions/bad-functions2.js
@@ -1,0 +1,20 @@
+// additional functions
+// throws introspection error
+
+var wildcard = global.__abstract ? global.__abstract("number", 123, "123") : 123;
+global.a = "";
+
+function additional1() {
+  global.a = "foo";
+}
+
+function additional2() {
+  if (wildcard) throw new Exception();
+  global.a = "foo";
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.a;
+}

--- a/test/serializer/additional-functions/missing-functions.js
+++ b/test/serializer/additional-functions/missing-functions.js
@@ -1,0 +1,8 @@
+// additional functions
+// throws introspection error
+
+function additional1() {}
+
+inspect = function() {
+  return "foo";
+}

--- a/test/serializer/additional-functions/write-write-conflict.js
+++ b/test/serializer/additional-functions/write-write-conflict.js
@@ -1,0 +1,18 @@
+// additional functions
+// throws introspection error
+
+global.a = "";
+
+function additional1() {
+  global.a = "foo";
+}
+
+function additional2() {
+  global.a = "bar";
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.a;
+}

--- a/test/serializer/additional-functions/write-write-conflict2.js
+++ b/test/serializer/additional-functions/write-write-conflict2.js
@@ -1,0 +1,18 @@
+// additional functions
+// throws introspection error
+
+global.a = "";
+
+function additional1() {
+  delete global.a;
+}
+
+function additional2() {
+  global.a = "bar";
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.a;
+}

--- a/test/serializer/additional-functions/write-write-conflict3.js
+++ b/test/serializer/additional-functions/write-write-conflict3.js
@@ -1,0 +1,18 @@
+// additional functions
+// throws introspection error
+
+global.a = "";
+
+function additional1() {
+  global.a = "foo";
+}
+
+function additional2() {
+  delete global.a;
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.a;
+}

--- a/test/serializer/additional-functions/write-write-noconflict.js
+++ b/test/serializer/additional-functions/write-write-noconflict.js
@@ -1,0 +1,18 @@
+// additional functions
+
+global.a = "";
+global.b = "";
+
+function additional1() {
+  global.a = "foo";
+}
+
+function additional2() {
+  global.b = "bar";
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.a + global.b;
+}

--- a/test/serializer/additional-functions/write-write-noconflict2.js
+++ b/test/serializer/additional-functions/write-write-noconflict2.js
@@ -1,0 +1,17 @@
+// additional functions
+
+global.a = "";
+
+function additional1() {
+  global.a = "foo";
+}
+
+function additional2() {
+  global.a = "foo";
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.a + global.b;
+}


### PR DESCRIPTION
Provide a new option to specify a number of additional functions to prepack (in addition to the global code "function", that is). These functions need to exist in the global scope, have no parameters, be well behaved (never throw an exception) and should not depend on each other (the order in which they get called should not matter).

At the moment there are checks only for existence, good behavior and no write-write conflicts. Also, the functions are not actually prepacked yet.