### PR TITLE
Fix a recent regression

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -259,7 +259,7 @@ function run(args) {
     //only run specific tests if desired
     if (!test.name.includes(args.filter)) continue;
 
-    total++;
+    total += 2;
     for (let delayInitializations of [false, true]) {
       let options = { delayInitializations: delayInitializations };
       if (runTest(test.name, test.file, options, args)) passed++;

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -259,8 +259,8 @@ function run(args) {
     //only run specific tests if desired
     if (!test.name.includes(args.filter)) continue;
 
-    total += 2;
     for (let delayInitializations of [false, true]) {
+      total++;
       let options = { delayInitializations: delayInitializations };
       if (runTest(test.name, test.file, options, args)) passed++;
       else failed++;

--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -144,7 +144,7 @@ function emitResidualLoopIfSafe(
       envRec.InitializeBinding(n, absStr);
     }
     let [compl, gen, bindings, properties, createdObj] = realm.evaluateNodeForEffects(body, strictCode, blockEnv);
-    if (compl instanceof Value && gen.body.length === 0 && bindings.size === 0 && properties.size === 1) {
+    if (compl instanceof Value && gen.empty() && bindings.size === 0 && properties.size === 1) {
       invariant(createdObj.size === 0); // or there will be more than one property
       let targetObject;
       let sourceObject;

--- a/src/realm.js
+++ b/src/realm.js
@@ -734,7 +734,7 @@ export class Realm {
         return n;
       };
       realmGeneratorBody.push({
-        declaresDerivedId: firstEntry.declaresDerivedId,
+        declared: firstEntry.declared,
         args: firstEntry.args,
         buildNode: buildNode,
       });

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { BoundFunctionValue, ProxyValue, AbstractValue, FunctionValue, Value, ObjectValue } from "../values/index.js";
-import type { BabelNodeStatement, BabelNodeIdentifier } from "babel-types";
+import type { BabelNodeStatement } from "babel-types";
 import { Generator } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import { BodyReference } from "./types.js";
@@ -22,26 +22,27 @@ import { ResidualFunctions } from "./ResidualFunctions.js";
 // once the dependency is available.
 export class Emitter {
   constructor(residualFunctions: ResidualFunctions) {
-    this._waitingForEmptyStack = [];
-    this._waitingForDeclaredDerivedIds = new Map();
+    this._waitingForValues = new Map();
     this._body = [];
-    this._declaredDerivedIds = new Set();
+    this._declaredValues = new Set();
     this._residualFunctions = residualFunctions;
-    this._stack = [];
+    this._activeStack = [];
+    this._activeValues = new Set();
   }
 
-  _stack: Array<string | Generator | Value>;
+  _activeStack: Array<string | Generator | Value>;
+  _activeValues: Set<Value>;
   _residualFunctions: ResidualFunctions;
-  _waitingForEmptyStack: Array<{ body: Array<BabelNodeStatement>, func: () => void }>;
-  _waitingForDeclaredDerivedIds: Map<
-    BabelNodeIdentifier,
+  _waitingForValues: Map<
+    Value,
     Array<{ body: Array<BabelNodeStatement>, dependencies: Array<Value>, func: () => void }>
   >;
-  _declaredDerivedIds: Set<BabelNodeIdentifier>;
+  _declaredValues: Set<Value>;
   _body: Array<BabelNodeStatement>;
 
   beginEmitting(dependency: string | Generator | Value, targetBody: Array<BabelNodeStatement>) {
-    this._stack.push(dependency);
+    this._activeStack.push(dependency);
+    if (dependency instanceof Value) this._activeValues.add(dependency);
     let oldBody = this._body;
     this._body = targetBody;
     return oldBody;
@@ -50,36 +51,47 @@ export class Emitter {
     this._body.push(statement);
   }
   endEmitting(dependency: string | Generator | Value, oldBody: Array<BabelNodeStatement>) {
-    let lastDependency = this._stack.pop();
+    let lastDependency = this._activeStack.pop();
     invariant(dependency === lastDependency);
-    let lastBody = this._body;
-    if (this._stack.length === 0) {
-      while (this._waitingForEmptyStack.length) {
-        invariant(this._stack.length === 0);
-        let delayed = this._waitingForEmptyStack.shift();
-        this._body = delayed.body;
-        delayed.func();
-      }
+    if (dependency instanceof Value) {
+      invariant(this._activeValues.has(dependency));
+      this._activeValues.delete(dependency);
+      this._process(dependency);
     }
+    let lastBody = this._body;
     this._body = oldBody;
     return lastBody;
+  }
+
+  _process(value: Value) {
+    let a = this._waitingForValues.get(value);
+    if (a !== undefined) {
+      let oldBody = this._body;
+      while (a.length > 0) {
+        let { body, dependencies, func } = a.shift();
+        this._body = body;
+        this.emitNowOrAfterWaitingForDependencies(dependencies, func);
+      }
+      this._body = oldBody;
+      this._waitingForValues.delete(value);
+    }
   }
 
   // Serialization of a statement related to a value MUST be delayed if
   // the creation of the value's identity requires the availability of either:
   // 1. a time-dependent value that is declared by some generator entry
   //    that has not yet been processed
-  //    (tracked by the `_declaredDerivedIds` set), or
+  //    (tracked by the `_declaredValues` set), or
   // 2. a value that is also currently being serialized
-  //    (tracked by the `_stack`).
-  getReasonToWaitForDependencies(dependencies: Value | Array<Value>): boolean | BabelNodeIdentifier {
+  //    (tracked by the `_activeStack`).
+  getReasonToWaitForDependencies(dependencies: Value | Array<Value>): void | Value {
     if (Array.isArray(dependencies)) {
       let values = ((dependencies: any): Array<Value>);
       for (let value of values) {
         let delayReason = this.getReasonToWaitForDependencies(value);
         if (delayReason) return delayReason;
       }
-      return false;
+      return undefined;
     }
 
     let val = ((dependencies: any): Value);
@@ -95,9 +107,9 @@ export class Emitter {
       }
     } else if (val instanceof FunctionValue) {
       this._residualFunctions.addFunctionUsage(val, this.getBodyReference());
-      return false;
+      return undefined;
     } else if (val instanceof AbstractValue) {
-      if (val.hasIdentifier() && !this._declaredDerivedIds.has(val.getIdentifier())) return val.getIdentifier();
+      if (val.hasIdentifier() && !this._declaredValues.has(val)) return val;
       for (let arg of val.args) {
         delayReason = this.getReasonToWaitForDependencies(arg);
         if (delayReason) return delayReason;
@@ -127,17 +139,14 @@ export class Emitter {
       }
     }
 
-    return this._stack.indexOf(val) >= 0;
+    if (this._activeValues.has(val)) return val;
+    return undefined;
   }
-  emitAfterWaiting(reason: boolean | BabelNodeIdentifier, dependencies: Array<Value>, func: () => void) {
-    invariant(reason);
-    if (reason === true) {
-      this._waitingForEmptyStack.push({ body: this._body, func });
-    } else {
-      let a = this._waitingForDeclaredDerivedIds.get(reason);
-      if (a === undefined) this._waitingForDeclaredDerivedIds.set(reason, (a = []));
-      a.push({ body: this._body, dependencies, func });
-    }
+  emitAfterWaiting(reason: Value, dependencies: Array<Value>, func: () => void) {
+    invariant(!this._declaredValues.has(reason) || this._activeValues.has(reason));
+    let a = this._waitingForValues.get(reason);
+    if (a === undefined) this._waitingForValues.set(reason, (a = []));
+    a.push({ body: this._body, dependencies, func });
   }
   emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void) {
     let delayReason = this.getReasonToWaitForDependencies(dependencies);
@@ -147,28 +156,18 @@ export class Emitter {
       func();
     }
   }
-  announceDeclaredDerivedId(id: BabelNodeIdentifier) {
-    this._declaredDerivedIds.add(id);
-    let a = this._waitingForDeclaredDerivedIds.get(id);
-    if (a !== undefined) {
-      let oldBody = this._body;
-      while (a.length > 0) {
-        invariant(this._stack.length === 0);
-        invariant(this._waitingForEmptyStack.length === 0);
-        let { body, dependencies, func } = a.shift();
-        this._body = body;
-        this.emitNowOrAfterWaitingForDependencies(dependencies, func);
-      }
-      this._body = oldBody;
-      this._waitingForDeclaredDerivedIds.delete(id);
-    }
+  declare(value: AbstractValue) {
+    invariant(!this._activeValues.has(value));
+    invariant(value.hasIdentifier());
+    this._declaredValues.add(value);
+    this._process(value);
   }
-  hasDeclaredDerivedIdBeenAnnounced(id: BabelNodeIdentifier) {
-    return this._declaredDerivedIds.has(id);
+  hasBeenDeclared(value: AbstractValue) {
+    return this._declaredValues.has(value);
   }
 
   assertIsDrained() {
-    invariant(this._waitingForDeclaredDerivedIds.size === 0);
+    invariant(this._waitingForValues.size === 0);
   }
 
   getBody(): Array<BabelNodeStatement> {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -591,7 +591,8 @@ export class ResidualHeapSerializer {
               invariant(elemVal instanceof Value);
               let mightHaveBeenDeleted = elemVal.mightHaveBeenDeleted();
               let delayReason =
-                this.emitter.getReasonToWaitForDependencies(elemVal) || mightHaveBeenDeleted ? val : undefined;
+                this.emitter.getReasonToWaitForDependencies(elemVal) ||
+                this.emitter.getReasonToWaitForActiveValue(val, mightHaveBeenDeleted);
               if (delayReason) {
                 this.emitter.emitAfterWaiting(delayReason, [elemVal, val], () => {
                   this._assignProperty(
@@ -646,9 +647,7 @@ export class ResidualHeapSerializer {
       let delayReason =
         this.emitter.getReasonToWaitForDependencies(key) ||
         this.emitter.getReasonToWaitForDependencies(value) ||
-        (mightHaveBeenDeleted || mapConstructorDoesntTakeArguments)
-          ? val
-          : undefined;
+        this.emitter.getReasonToWaitForActiveValue(val, mightHaveBeenDeleted || mapConstructorDoesntTakeArguments);
       if (delayReason) {
         this.emitter.emitAfterWaiting(delayReason, [key, value, val], () => {
           invariant(key !== undefined);
@@ -699,9 +698,7 @@ export class ResidualHeapSerializer {
       let mightHaveBeenDeleted = entry.mightHaveBeenDeleted();
       let delayReason =
         this.emitter.getReasonToWaitForDependencies(entry) ||
-        (mightHaveBeenDeleted || setConstructorDoesntTakeArguments)
-          ? val
-          : undefined;
+        this.emitter.getReasonToWaitForActiveValue(val, mightHaveBeenDeleted || setConstructorDoesntTakeArguments);
       if (delayReason) {
         this.emitter.emitAfterWaiting(delayReason, [entry, val], () => {
           invariant(entry !== undefined);
@@ -936,7 +933,8 @@ export class ResidualHeapSerializer {
             if (this.residualHeapInspector.canIgnoreProperty(val, key)) continue;
             let mightHaveBeenDeleted = propValue.mightHaveBeenDeleted();
             let delayReason =
-              this.emitter.getReasonToWaitForDependencies(propValue) || mightHaveBeenDeleted ? val : undefined;
+              this.emitter.getReasonToWaitForDependencies(propValue) ||
+              this.emitter.getReasonToWaitForActiveValue(val, mightHaveBeenDeleted);
             if (delayReason) {
               // self recursion
               this.emitter.emitAfterWaiting(delayReason, [propValue, val], () => {
@@ -1121,7 +1119,7 @@ export class ResidualHeapSerializer {
 
   serialize(): BabelNodeFile {
     this._emitGenerator(this.generator);
-    invariant(this.emitter._declaredValues.size <= this.preludeGenerator.derivedIds.size);
+    invariant(this.emitter._declaredAbstractValues.size <= this.preludeGenerator.derivedIds.size);
 
     Array.prototype.push.apply(this.prelude, this.preludeGenerator.prelude);
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -107,7 +107,7 @@ export default class AbstractValue extends Value {
 
   addSourceNamesTo(names: Array<string>) {
     let gen = this.$Realm.preludeGenerator;
-    function add_instrinsic(name: string) {
+    function add_intrinsic(name: string) {
       if (name.startsWith("_$")) {
         if (gen === undefined) return;
         add_args(gen.derivedIds.get(name));
@@ -119,7 +119,7 @@ export default class AbstractValue extends Value {
       if (args === undefined) return;
       for (let val of args) {
         if (val.intrinsicName) {
-          add_instrinsic(val.intrinsicName);
+          add_intrinsic(val.intrinsicName);
         } else if (val instanceof AbstractValue) {
           val.addSourceNamesTo(names);
         } else if (val instanceof StringValue) {
@@ -130,7 +130,7 @@ export default class AbstractValue extends Value {
       }
     }
     if (this.intrinsicName) {
-      add_instrinsic(this.intrinsicName);
+      add_intrinsic(this.intrinsicName);
     }
     add_args(this.args);
   }

--- a/test/serializer/abstract/RegressionTestForNestedGenerators.js
+++ b/test/serializer/abstract/RegressionTestForNestedGenerators.js
@@ -1,0 +1,10 @@
+(function() {
+    var x = global.__abstract ? __abstract("boolean", "(true)") : true;
+    if (x) {
+        var obj = {};
+        global.obj = obj;
+        obj.time = Date.now();
+    }
+    inspect = function() { return global.obj.time > 0; }
+})();
+        


### PR DESCRIPTION
In the refactoring #815, a subtle semantic change caused an invariant
around the `_waitingForEmptyStack` field of the Emitter to be broken.
While investigating the purpose of `_waitingForEmptyStack`, I concluded
that this entire concept was just there in order to work around
the design decision that delay-reasons and values-declared-by-generator-entries
were based on babel identifiers, and not the `Value`s themselves.

So I changed that design decision, made it all `Value` based.
Now we no longer need the dubious `true` delay reason, which used to
indiscriminately wait until *all* actively emitted values (those on the stack)
were available. Instead, as it's easy to name the `Value` that we actually
need to wait for, that's what we do now.

Overall, this will actually slightly change the generated code, hopefully for the better (in terms of local variable lifetimes), as we will now emit certain operations slightly more eagerly, closer to the declaration.

Without the need for the `true` delay reason, the `_waitingForEmptyStack`
concept is no longer needed.

While at it, I also did some trivial renamings, and speeding up serialization by
- avoiding potentially slow `this._stack.indexOf(val)` recursion checks, instead maintaining a set.
- prefer naming a compound value itself as the delay reason, and not one of its components

Adding regression test.