### PR TITLE
Report conflicts involving reflection

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -172,6 +172,7 @@ export class Realm {
   modifiedBindings: void | Bindings;
   modifiedProperties: void | PropertyBindings;
   createdObjects: void | CreatedObjects;
+  reportObjectGetOwnProperties: void | (ObjectValue => void);
   reportPropertyAccess: void | (PropertyBinding => void);
 
   currentLocation: ?BabelNodeSourceLocation;
@@ -541,6 +542,12 @@ export class Realm {
     if (this.modifiedBindings !== undefined && !this.modifiedBindings.has(binding))
       this.modifiedBindings.set(binding, binding.value);
     return binding;
+  }
+
+  callReportObjectGetOwnProperties(ob: ObjectValue): void {
+    if (this.reportObjectGetOwnProperties !== undefined) {
+      this.reportObjectGetOwnProperties(ob);
+    }
   }
 
   callReportPropertyAccess(binding: PropertyBinding): void {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -360,10 +360,9 @@ export default class ObjectValue extends ConcreteValue {
       throw new FatalError();
     }
 
-    let o = this;
-    let keyArray = Array.from(o.properties.keys());
-    keyArray = keyArray.filter(function(x) {
-      let pb = o.properties.get(x);
+    let keyArray = Array.from(this.properties.keys());
+    keyArray = keyArray.filter(x => {
+      let pb = this.properties.get(x);
       if (!pb || pb.descriptor === undefined) return false;
       let pv = pb.descriptor.value;
       if (pv === undefined) return true;
@@ -375,6 +374,7 @@ export default class ObjectValue extends ConcreteValue {
       AbstractValue.reportIntrospectionError(pv);
       throw new FatalError();
     });
+    this.$Realm.callReportObjectGetOwnProperties(this);
     return keyArray;
   }
 

--- a/test/error-handler/write-forin-conflict.js
+++ b/test/error-handler/write-forin-conflict.js
@@ -1,0 +1,19 @@
+// additional functions
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":10,"column":16},"end":{"line":10,"column":22},"identifierName":"global","source":"test/error-handler/write-forin-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
+
+function additional1() {
+  global.a = { f: "foo" };
+}
+
+function additional2() {
+  for (let p in global.a) {
+
+  }
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.b;
+}

--- a/test/error-handler/write-reflect-conflict.js
+++ b/test/error-handler/write-reflect-conflict.js
@@ -1,0 +1,19 @@
+// additional functions
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":12,"column":29},"end":{"line":12,"column":30},"identifierName":"a","source":"test/error-handler/write-reflect-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
+
+a = {};
+
+function additional1() {
+  global.a = { f: "foo" };
+}
+
+function additional2() {
+  global.b = Reflect.ownKeys(a);
+}
+
+inspect = function() {
+  additional2();
+  additional1();
+  return global.b;
+}


### PR DESCRIPTION
If one additional function writes a property to an object and the other reflects on the same object, we should report a potential conflict.

This concludes adding checks for known sources of interference.

#799