### PR TITLE
Clean up when and where statements are emitted.

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -17,64 +17,119 @@ import { BodyReference } from "./types.js";
 import { ResidualFunctions } from "./ResidualFunctions.js";
 
 // The emitter keeps track of a stack of what's currently being emitted.
-// If an emission task depends on the result of another emission task which
-// is still currently being emitted, then the emission task must be performed later,
-// once the dependency is available.
+// There are two kinds of interesting dependencies the emitter is dealing with:
+// 1. Value dependencies:
+//    If an emission task depends on the result of another emission task which
+//    is still currently being emitted, then the emission task must be performed later,
+//    once the dependency is available.
+//    To this end, the emitter maintains the `_activeValues` and `_waitingForValues` datastructures.
+// 2. Generator dependencies:
+//    For each generator, there's a corresponding "body", i.e. a stream of babel statements
+//    that the emitter is appending to.
+//    There's always a "current" body that is currently being emitted to.
+//    There's also a distinguished `mainBody` to which all statements get directly or indirectly appended.
+//    If there are multiple generators/bodies involved, then they form a stack.
+//    Nested bodies are usually composed into an instruction emitted to the outer body.
+//    For example, two nested generators may yield the then and else-branch of an `if` statement.
+//    When an emission is supposed to target a body that is the current body, i.e. when it sits
+//    lower on the stack, then the emission task gets delayed until the next emission task on
+//    the lower body entry is finished.
+//    To this end, the emitter maintains the `_activeBodies` and `_waitingForBodies` datastructures.
 export class Emitter {
   constructor(residualFunctions: ResidualFunctions) {
+    let mainBody = [];
     this._waitingForValues = new Map();
-    this._body = [];
+    this._waitingForBodies = new Map();
+    this._body = mainBody;
     this._declaredAbstractValues = new Set();
     this._residualFunctions = residualFunctions;
     this._activeStack = [];
     this._activeValues = new Set();
+    this._activeBodies = new Set([mainBody]);
+    this._finalized = false;
   }
 
+  _finalized: boolean;
   _activeStack: Array<string | Generator | Value>;
   _activeValues: Set<Value>;
+  _activeBodies: Set<Array<BabelNodeStatement>>;
   _residualFunctions: ResidualFunctions;
   _waitingForValues: Map<
     Value,
     Array<{ body: Array<BabelNodeStatement>, dependencies: Array<Value>, func: () => void }>
   >;
+  _waitingForBodies: Map<Array<BabelNodeStatement>, Array<{ dependencies: Array<Value>, func: () => void }>>;
   _declaredAbstractValues: Set<AbstractValue>;
   _body: Array<BabelNodeStatement>;
 
   beginEmitting(dependency: string | Generator | Value, targetBody: Array<BabelNodeStatement>) {
+    invariant(!this._finalized);
     this._activeStack.push(dependency);
     if (dependency instanceof Value) this._activeValues.add(dependency);
+    else if (dependency instanceof Generator) this._activeBodies.add(targetBody);
     let oldBody = this._body;
     this._body = targetBody;
     return oldBody;
   }
   emit(statement: BabelNodeStatement) {
+    invariant(!this._finalized);
     this._body.push(statement);
+    this._processCurrentBody();
   }
   endEmitting(dependency: string | Generator | Value, oldBody: Array<BabelNodeStatement>) {
+    invariant(!this._finalized);
     let lastDependency = this._activeStack.pop();
     invariant(dependency === lastDependency);
     if (dependency instanceof Value) {
       invariant(this._activeValues.has(dependency));
       this._activeValues.delete(dependency);
-      this._process(dependency);
+      this._processValue(dependency);
+    } else if (dependency instanceof Generator) {
+      invariant(this._activeBodies.has(this._body));
+      this._activeBodies.delete(this._body);
     }
     let lastBody = this._body;
     this._body = oldBody;
     return lastBody;
   }
-
-  _process(value: Value) {
+  finalize() {
+    invariant(!this._finalized);
+    invariant(this._activeBodies.size === 1);
+    invariant(this._activeBodies.has(this._body));
+    this._activeBodies.delete(this._body);
+    this._processCurrentBody();
+    this._finalized = true;
+    invariant(this._waitingForBodies.size === 0);
+    invariant(this._waitingForValues.size === 0);
+    invariant(this._activeStack.length === 0);
+    invariant(this._activeValues.size === 0);
+    invariant(this._activeBodies.size === 0);
+  }
+  _processCurrentBody() {
+    let a = this._waitingForBodies.get(this._body);
+    if (a === undefined) return;
+    while (a.length > 0) {
+      let { dependencies, func } = a.shift();
+      this.emitNowOrAfterWaitingForDependencies(dependencies, func);
+    }
+    this._waitingForBodies.delete(this._body);
+  }
+  _processValue(value: Value) {
     let a = this._waitingForValues.get(value);
-    if (a !== undefined) {
-      let oldBody = this._body;
-      while (a.length > 0) {
-        let { body, dependencies, func } = a.shift();
-        this._body = body;
+    if (a === undefined) return;
+    let oldBody = this._body;
+    while (a.length > 0) {
+      let { body, dependencies, func } = a.shift();
+      if (body !== oldBody) {
+        invariant(this._activeBodies.has(body));
+        let b = this._waitingForBodies.get(body);
+        if (b === undefined) this._waitingForBodies.set(body, (b = []));
+        b.push({ dependencies, func });
+      } else {
         this.emitNowOrAfterWaitingForDependencies(dependencies, func);
       }
-      this._body = oldBody;
-      this._waitingForValues.delete(value);
     }
+    this._waitingForValues.delete(value);
   }
 
   // Serialization of a statement related to a value MUST be delayed if
@@ -85,6 +140,7 @@ export class Emitter {
   // 2. a value that is also currently being serialized
   //    (tracked by the `_activeStack`).
   getReasonToWaitForDependencies(dependencies: Value | Array<Value>): void | Value {
+    invariant(!this._finalized);
     if (Array.isArray(dependencies)) {
       let values = ((dependencies: any): Array<Value>);
       for (let value of values) {
@@ -145,11 +201,12 @@ export class Emitter {
   }
   // Wait for a known-to-be active value if a condition is met.
   getReasonToWaitForActiveValue(value: Value, condition: boolean): void | Value {
+    invariant(!this._finalized);
     invariant(this._activeValues.has(value));
     return condition ? value : undefined;
   }
-
   emitAfterWaiting(reason: Value, dependencies: Array<Value>, func: () => void) {
+    invariant(!this._finalized);
     invariant(
       !(reason instanceof AbstractValue && this._declaredAbstractValues.has(reason)) || this._activeValues.has(reason)
     );
@@ -158,6 +215,7 @@ export class Emitter {
     a.push({ body: this._body, dependencies, func });
   }
   emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void) {
+    invariant(!this._finalized);
     let delayReason = this.getReasonToWaitForDependencies(dependencies);
     if (delayReason) {
       this.emitAfterWaiting(delayReason, dependencies, func);
@@ -166,23 +224,21 @@ export class Emitter {
     }
   }
   declare(value: AbstractValue) {
+    invariant(!this._finalized);
     invariant(!this._activeValues.has(value));
     invariant(value.hasIdentifier());
     this._declaredAbstractValues.add(value);
-    this._process(value);
+    this._processValue(value);
   }
   hasBeenDeclared(value: AbstractValue) {
+    invariant(!this._finalized);
     return this._declaredAbstractValues.has(value);
   }
-
-  assertIsDrained() {
-    invariant(this._waitingForValues.size === 0);
-  }
-
   getBody(): Array<BabelNodeStatement> {
     return this._body;
   }
   getBodyReference() {
+    invariant(!this._finalized);
     return new BodyReference(this._body, this._body.length);
   }
 }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1111,11 +1111,6 @@ export class ResidualHeapSerializer {
     return context;
   }
 
-  _emitGenerator(generator: Generator) {
-    generator.serialize(this._getContext());
-    this.emitter.assertIsDrained();
-  }
-
   _shouldBeWrapped(body: Array<any>) {
     for (let i = 0; i < body.length; i++) {
       let item = body[i];
@@ -1144,7 +1139,7 @@ export class ResidualHeapSerializer {
   }
 
   serialize(): BabelNodeFile {
-    this._emitGenerator(this.generator);
+    this.generator.serialize(this._getContext());
     invariant(this.emitter._declaredAbstractValues.size <= this.preludeGenerator.derivedIds.size);
 
     Array.prototype.push.apply(this.prelude, this.preludeGenerator.prelude);
@@ -1154,6 +1149,8 @@ export class ResidualHeapSerializer {
     // TODO #21: add event listeners
     for (let [moduleId, moduleValue] of this.modules.initializedModules)
       this.requireReturns.set(moduleId, this.serializeValue(moduleValue));
+
+    this.emitter.finalize();
 
     let {
       hoistedBody,

--- a/test/serializer/abstract/GeneratorScoping1.js
+++ b/test/serializer/abstract/GeneratorScoping1.js
@@ -1,0 +1,11 @@
+(function() {
+    let a = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let obj = {};
+    global.early = obj; // assignments to intrinsics are emitted in chronological order via the generator
+    if (a) {
+        obj.f = Date.now(); // calls to Date.now() are also emitted along the same timeline, so this comes later
+    } else {
+        obj.f = -1;
+    }
+    inspect = function() { return a ? obj.f > 0 : obj.f < 0; }
+})();


### PR DESCRIPTION
This addresses #500.
Added long comments at the top of Emitter.js that describes what now happens.
Added a bunch of invariants that check consistency.
Added regression test that used to fail (and motivated filing #500).