### PR TITLE
Add source location information to completions

### DIFF
--- a/src/evaluators/BreakStatement.js
+++ b/src/evaluators/BreakStatement.js
@@ -21,5 +21,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): Value {
-  throw new BreakCompletion(realm.intrinsics.empty, ast.label && ast.label.name);
+  throw new BreakCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
 }

--- a/src/evaluators/ContinueStatement.js
+++ b/src/evaluators/ContinueStatement.js
@@ -21,5 +21,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): Value {
-  throw new ContinueCompletion(realm.intrinsics.empty, ast.label && ast.label.name);
+  throw new ContinueCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
 }

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -148,7 +148,7 @@ export function ForInOfHeadEvaluation(
     // a. If exprValue.[[Value]] is null or undefined, then
     if (exprValue instanceof NullValue || exprValue instanceof UndefinedValue) {
       // i. Return Completion{[[Type]]: break, [[Value]]: empty, [[Target]]: empty}.
-      throw new BreakCompletion(realm.intrinsics.empty, undefined);
+      throw new BreakCompletion(realm.intrinsics.empty, expr.loc, undefined);
     }
 
     // b. Let obj be ToObject(exprValue).

--- a/src/evaluators/ReturnStatement.js
+++ b/src/evaluators/ReturnStatement.js
@@ -28,5 +28,5 @@ export default function(
   } else {
     arg = realm.intrinsics.undefined;
   }
-  throw new ReturnCompletion(arg);
+  throw new ReturnCompletion(arg, ast.loc);
 }

--- a/src/evaluators/ThrowStatement.js
+++ b/src/evaluators/ThrowStatement.js
@@ -24,5 +24,5 @@ export default function(
 ): Value {
   let exprRef = env.evaluate(ast.argument, strictCode);
   let exprValue = GetValue(realm, exprRef);
-  throw new ThrowCompletion(exprValue);
+  throw new ThrowCompletion(exprValue, ast.loc);
 }

--- a/src/intrinsics/ecma262/FunctionPrototype.js
+++ b/src/intrinsics/ecma262/FunctionPrototype.js
@@ -29,7 +29,6 @@ import { Get } from "../../methods/get.js";
 import { IsCallable } from "../../methods/is.js";
 import { HasOwnProperty, HasSomeCompatibleType } from "../../methods/has.js";
 import { OrdinaryHasInstance } from "../../methods/abstract.js";
-import { ThrowCompletion } from "../../completions.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -151,7 +150,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     return F;
   });
 
-  // 19.2.3.6
+  // ECMA262 19.2.3.6
   obj.defineNativeMethod(
     realm.intrinsics.SymbolHasInstance,
     1,
@@ -165,6 +164,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     { writable: false, configurable: false }
   );
 
+  // ECMA262 19.2.3.5
   obj.defineNativeMethod("toString", 0, context => {
     context = context.throwIfNotConcrete();
     if (context instanceof NativeFunctionValue) {
@@ -172,8 +172,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else if (context instanceof FunctionValue) {
       return new StringValue(realm, "function () { TODO: provide function source code }");
     } else {
-      // Can I use realm.createErrorThrowCompletion here? what `type` error is this?
-      throw new ThrowCompletion(new StringValue(realm, "Function.prototype.toString is not generic"));
+      // 3. Throw a TypeError exception.
+      throw realm.createErrorThrowCompletion(
+        realm.intrinsics.TypeError,
+        new StringValue(realm, "Function.prototype.toString is not generic")
+      );
     }
   });
 }

--- a/src/intrinsics/ecma262/GeneratorPrototype.js
+++ b/src/intrinsics/ecma262/GeneratorPrototype.js
@@ -30,7 +30,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let g = context;
 
     // 2. Let C be Completion{[[Type]]: return, [[Value]]: value, [[Target]]: empty}.
-    let C = new ReturnCompletion(value);
+    let C = new ReturnCompletion(value, realm.currentLocation);
 
     // 3. Return ? GeneratorResumeAbrupt(g, C).
     return GeneratorResumeAbrupt(realm, g, C);
@@ -42,7 +42,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let g = context;
 
     // 2. Let C be Completion{[[Type]]: throw, [[Value]]: exception, [[Target]]: empty}.
-    let C = new ReturnCompletion(exception);
+    let C = new ReturnCompletion(exception, realm.currentLocation);
 
     // 3. Return ? GeneratorResumeAbrupt(g, C).
     return GeneratorResumeAbrupt(realm, g, C);

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -340,7 +340,7 @@ export function OrdinaryCallEvaluateBody(
       GeneratorStart(realm, G, code);
 
       // 4. Return Completion{[[Type]]: return, [[Value]]: G, [[Target]]: empty}.
-      return new ReturnCompletion(G);
+      return new ReturnCompletion(G, realm.currentLocation);
     } else {
       // 1. Perform ? FunctionDeclarationInstantiation(F, argumentsList).
       FunctionDeclarationInstantiation(realm, F, argumentsList);

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -35,7 +35,7 @@ import {
   Reference,
   LexicalEnvironment,
 } from "../environment.js";
-import { NormalCompletion, AbruptCompletion, ThrowCompletion } from "../completions.js";
+import { NormalCompletion, AbruptCompletion } from "../completions.js";
 import { FatalError } from "../errors.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
@@ -733,7 +733,8 @@ export function IteratorBindingInitialization(
       // 7. Return InitializeReferencedBinding(lhs, v).
       InitializeReferencedBinding(realm, lhs, v);
       continue;
-    } else if (param.type === "ObjectPattern" || param.type === "ArrayPattern") {
+    } else {
+      invariant(param.type === "ObjectPattern" || param.type === "ArrayPattern");
       // BindingElement : BindingPatternInitializer
 
       // Initialized later in the algorithm.
@@ -791,8 +792,6 @@ export function IteratorBindingInitialization(
       // 4. Return the result of performing BindingInitialization of BindingPattern with v and environment as the arguments.
       BindingInitialization(realm, param, v, strictCode, environment);
       continue;
-    } else {
-      throw new ThrowCompletion(new StringValue(realm, "unrecognized element"));
     }
   }
 
@@ -873,7 +872,8 @@ export function IteratorBindingInitialization(
       // h. Increment n by 1.
       n += 1;
     }
-  } else if (restEl && (restEl.argument.type === "ArrayPattern" || restEl.argument.type === "ObjectPattern")) {
+  } else if (restEl) {
+    invariant(restEl.argument.type === "ArrayPattern" || restEl.argument.type === "ObjectPattern");
     // 1. Let A be ArrayCreate(0).
     let A = ArrayCreate(realm, 0);
 
@@ -938,8 +938,6 @@ export function IteratorBindingInitialization(
       // h. Increment n by 1.
       n += 1;
     }
-  } else if (restEl) {
-    throw new ThrowCompletion(new StringValue(realm, "unrecognized rest argument"));
   }
 }
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -15,7 +15,6 @@ import type { Realm } from "../realm.js";
 import type { ECMAScriptFunctionValue } from "../values/index.js";
 import {
   Completion,
-  ThrowCompletion,
   ReturnCompletion,
   AbruptCompletion,
   JoinedAbruptCompletions,
@@ -1318,10 +1317,9 @@ export function EvalDeclarationInstantiation(
       for (let name of varNames) {
         // 1. If varEnvRec.HasLexicalDeclaration(name) is true, throw a SyntaxError exception.
         if (varEnvRec.HasLexicalDeclaration(name)) {
-          throw new ThrowCompletion(
-            Construct(realm, realm.intrinsics.SyntaxError, [
-              new StringValue(realm, name + " global object is restricted"),
-            ])
+          throw realm.createErrorThrowCompletion(
+            realm.intrinsics.SyntaxError,
+            new StringValue(realm, name + " global object is restricted")
           );
         }
         // 2. NOTE: eval will not create a global var declaration that would be shadowed by a global lexical declaration.

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -260,12 +260,12 @@ export function joinEffectsAndRemoveNestedReturnCompletions(
     if (e1[0] instanceof AbruptCompletion) {
       if (!(e2[0] instanceof ReturnCompletion)) {
         invariant(e2[0] instanceof Value); // otherwise c cannot possibly be normal
-        e2[0] = new ReturnCompletion(realm.intrinsics.undefined);
+        e2[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
       }
       return joinEffects(realm, c.joinCondition, e1, e2);
     } else if (e2[0] instanceof AbruptCompletion) {
       invariant(e1[0] instanceof Value); // otherwise c cannot possibly be normal
-      e1[0] = new ReturnCompletion(realm.intrinsics.undefined);
+      e1[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
       return joinEffects(realm, c.joinCondition, e1, e2);
     }
   }
@@ -336,22 +336,22 @@ function joinResults(
     throw new FatalError();
   }
   if (result1 instanceof BreakCompletion && result2 instanceof BreakCompletion && result1.target === result2.target) {
-    return new BreakCompletion(realm.intrinsics.empty, result1.target);
+    return new BreakCompletion(realm.intrinsics.empty, joinCondition.expressionLocation, result1.target);
   }
   if (
     result1 instanceof ContinueCompletion &&
     result2 instanceof ContinueCompletion &&
     result1.target === result2.target
   ) {
-    return new ContinueCompletion(realm.intrinsics.empty, result1.target);
+    return new ContinueCompletion(realm.intrinsics.empty, joinCondition.expressionLocation, result1.target);
   }
   if (result1 instanceof ReturnCompletion && result2 instanceof ReturnCompletion) {
     let val = joinValues(realm, result1.value, result2.value, getAbstractValue);
-    return new ReturnCompletion(val);
+    return new ReturnCompletion(val, joinCondition.expressionLocation);
   }
   if (result1 instanceof ThrowCompletion && result2 instanceof ThrowCompletion) {
     let val = joinValues(realm, result1.value, result2.value, getAbstractValue);
-    return new ThrowCompletion(val);
+    return new ThrowCompletion(val, result1.location);
   }
   if (result1 instanceof AbruptCompletion && result2 instanceof AbruptCompletion) {
     return new JoinedAbruptCompletions(realm, joinCondition, result1, e1, result2, e2);

--- a/src/partial-evaluators/BreakStatement.js
+++ b/src/partial-evaluators/BreakStatement.js
@@ -21,6 +21,6 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): [BreakCompletion, BabelNodeBreakStatement, Array<BabelNodeStatement>] {
-  let result = new BreakCompletion(realm.intrinsics.empty, ast.label && ast.label.name);
+  let result = new BreakCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
   return [result, ast, []];
 }

--- a/src/partial-evaluators/ContinueStatement.js
+++ b/src/partial-evaluators/ContinueStatement.js
@@ -21,6 +21,6 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): [ContinueCompletion, BabelNodeContinueStatement, Array<BabelNodeStatement>] {
-  let result = new ContinueCompletion(realm.intrinsics.empty, ast.label && ast.label.name);
+  let result = new ContinueCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
   return [result, ast, []];
 }

--- a/src/partial-evaluators/ReturnStatement.js
+++ b/src/partial-evaluators/ReturnStatement.js
@@ -27,6 +27,6 @@ export default function(
   } else {
     result = realm.intrinsics.undefined;
   }
-  if (!(result instanceof AbruptCompletion)) result = new ReturnCompletion(result);
+  if (!(result instanceof AbruptCompletion)) result = new ReturnCompletion(result, ast.loc);
   return [result, ast, []];
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -743,7 +743,7 @@ export class Realm {
     if (typeof message === "string") message = new StringValue(this, message);
     invariant(message instanceof StringValue);
     this.nextContextLocation = this.currentLocation;
-    return new ThrowCompletion(Construct(this, type, [message]));
+    return new ThrowCompletion(Construct(this, type, [message]), this.currentLocation);
   }
 
   appendGenerator(generator: Generator, leadingComment: string = ""): void {

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -10,12 +10,12 @@
 /* @flow */
 
 import type { BabelNodeCallExpression, BabelNodeSourceLocation } from "babel-types";
-import { ThrowCompletion } from "../completions.js";
+import { Completion, ThrowCompletion } from "../completions.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import invariant from "../invariant.js";
 import { type PropertyBindings, Realm } from "../realm.js";
 import type { PropertyBinding } from "../types.js";
-import { AbstractObjectValue, FunctionValue, ObjectValue, Value } from "../values/index.js";
+import { AbstractObjectValue, FunctionValue, ObjectValue } from "../values/index.js";
 import buildTemplate from "babel-template";
 import * as t from "babel-types";
 
@@ -63,10 +63,11 @@ export class Functions {
     let conflicts: Set<BabelNodeSourceLocation> = new Set();
     for (let [fname1, call1] of calls) {
       let e1 = this.realm.evaluateNodeForEffectsInGlobalEnv(call1);
-      if (!(e1[0] instanceof Value)) {
+      let c = e1[0];
+      if (c instanceof Completion) {
         let error = new CompilerDiagnostic(
           `Additional function ${fname1} may terminate abruptly`,
-          null,
+          c.location,
           "PP1002",
           "FatalError"
         );

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -77,8 +77,7 @@ export class Serializer {
       } finally {
         realm.popContext(context);
       }
-      // TODO: annotate AbruptCompletion instances with the locations of the statements that caused them.
-      let diagnostic = new CompilerDiagnostic("Global code may end abruptly", null, "PP0016", "FatalError");
+      let diagnostic = new CompilerDiagnostic("Global code may end abruptly", res.location, "PP0016", "FatalError");
       realm.handleError(diagnostic);
       throw new FatalError();
     }

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -60,7 +60,7 @@ export default function(
         loc: e.loc,
         stackDecorated: false,
       };
-      throw new ThrowCompletion(error);
+      throw new ThrowCompletion(error, undefined);
     } else {
       throw e;
     }

--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -101,7 +101,10 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
     for (let i = 0; i < this.length; i++) {
       argsList[i] = argsList[i] || this.$Realm.intrinsics.undefined;
     }
-    return new ReturnCompletion(this.callback(context, argsList, originalLength, newTarget));
+    return new ReturnCompletion(
+      this.callback(context, argsList, originalLength, newTarget),
+      this.$Realm.currentLocation
+    );
   }
 
   // for Proxy

--- a/test/error-handler/bad-functions.js
+++ b/test/error-handler/bad-functions.js
@@ -1,6 +1,6 @@
 // additional functions
 // recover-from-errors
-// expected errors: [{"location":null,"severity":"FatalError","errorCode":"PP1002","message":"Additional function global.additional1 may terminate abruptly"}]
+// expected errors: [{"location":{"start":{"line":8,"column":26},"end":{"line":8,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function global.additional1 may terminate abruptly"}]
 var wildcard = global.__abstract ? global.__abstract("number", 123, "123") : 123;
 global.a = "";
 

--- a/test/error-handler/bad-functions2.js
+++ b/test/error-handler/bad-functions2.js
@@ -1,6 +1,6 @@
 // additional functions
 // recover-from-errors
-// expected errors: [{"location":null,"severity":"FatalError","errorCode":"PP1002","message":"Additional function global['additional2'] may terminate abruptly"}]
+// expected errors: [{"location":{"start":{"line":13,"column":26},"end":{"line":13,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions2.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function global['additional2'] may terminate abruptly"}]
 
 var wildcard = global.__abstract ? global.__abstract("number", 123, "123") : 123;
 global.a = "";


### PR DESCRIPTION
Make it easier to report some errors with a relevant source location.

Also fixed up places where throw completions were not constructed via the factory in Realm.