### PR TITLE
Catch fatal errors in visitName.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "flow": "flow check",
     "test-residual": "babel-node scripts/test-residual.js",
     "test-residual-with-coverage": "./node_modules/.bin/istanbul cover ./lib/test-residual.js --dir coverage.residual && ./node_modules/.bin/remap-istanbul -i coverage.residual/coverage.json -o coverage-sourcemapped.residual -t html",
-    "test-serializer": "babel-node --stack_size=10000 scripts/test-runner.js",
+    "test-serializer": "babel-node --stack_trace_limit=200 --stack_size=10000 scripts/test-runner.js",
     "test-serializer-with-coverage": "./node_modules/.bin/istanbul cover ./lib/test-error-handler.js --dir coverage.error && ./node_modules/.bin/istanbul cover ./lib/test-runner.js && ./node_modules/.bin/remap-istanbul -i coverage.error/coverage.json -i coverage/coverage.json -o coverage-sourcemapped -t html",
     "test-sourcemaps": "babel-node scripts/generate-sourcemaps-test.js && bash < scripts/test-sourcemaps.sh",
     "test-test262": "babel-node scripts/test262-runner.js",

--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -28,7 +28,7 @@ export class Logger {
   internalDebug: boolean;
 
   // Wraps a query that might potentially execute user code.
-  tryQuery<T>(f: () => T, onCompletion: T | (Completion => T), logCompletion: boolean): T {
+  tryQuery<T>(f: () => T, defaultValue: T, logFailures: boolean): T {
     let context = new ExecutionContext();
     let realm = this.realm;
     let env = realm.$GlobalEnv;
@@ -37,6 +37,17 @@ export class Logger {
     context.realm = realm;
     realm.pushContext(context);
     // We use partial evaluation so that we can throw away any state mutations
+    let oldErrorHandler = realm.errorHandler;
+    let newErrorHandler;
+    realm.errorHandler = newErrorHandler = d => {
+      if (d.severity === "Information" || d.severity === "Warning") return "Recover";
+      if (logFailures) {
+        realm.errorHandler = oldErrorHandler;
+        realm.handleError(d);
+        realm.errorHandler = newErrorHandler;
+      }
+      return "Fail";
+    };
     try {
       let result;
       let effects = realm.evaluateForEffects(() => {
@@ -44,8 +55,10 @@ export class Logger {
           result = f();
         } catch (e) {
           if (e instanceof Completion) {
-            if (logCompletion) this.logCompletion(e);
-            result = onCompletion instanceof Function ? onCompletion(e) : onCompletion;
+            if (logFailures) this.logCompletion(e);
+            result = defaultValue;
+          } else if (e instanceof FatalError) {
+            result = defaultValue;
           } else {
             throw e;
           }
@@ -55,6 +68,7 @@ export class Logger {
       invariant(effects[0] === realm.intrinsics.undefined);
       return ((result: any): T);
     } finally {
+      realm.errorHandler = oldErrorHandler;
       realm.popContext(context);
     }
   }

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -15,10 +15,9 @@ import type { ECMAScriptSourceFunctionValue } from "../values/index.js";
 import type { BabelNodeExpression, BabelNodeStatement } from "babel-types";
 import { SameValue } from "../methods/abstract.js";
 import { Realm } from "../realm.js";
-import { Completion } from "../completions.js";
 import invariant from "../invariant.js";
 
-export type TryQuery<T> = (f: () => T, onCompletion: T | (Completion => T), logCompletion: boolean) => T;
+export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) => T;
 
 export type FunctionInstance = {
   serializedBindings: SerializedBindings,

--- a/test/serializer/basic/ClosureRefVisitor.js
+++ b/test/serializer/basic/ClosureRefVisitor.js
@@ -1,0 +1,10 @@
+// jsc
+(function() {
+  let o = {
+    encode:function encode(s){
+      return unescape(encodeURI(s));
+    }
+  };
+  inspect = function() { return o; }
+  if (global.__makePartial) { __makePartial(global); }
+})();


### PR DESCRIPTION
Introspection errors no longer show up as completions, so any time we evaluate a node that might cause an introspection error, we should expect to catch and handle a FatalError.

Also tweaked package.json to allow longer stack traces when running test-serializer and tweaked test-internal to output error messages that do not have associated source locations. (The latter should not happen in practice but could happen when things go wrong.)