### PR TITLE
Fixes for prepacking new internal test

### DIFF
--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -63,7 +63,7 @@ function runTest(name: string, code: string): boolean {
     if (modelCode) sources.push({ filePath: modelName, fileContents: modelCode });
     sources.push({ filePath: name, fileContents: sourceCode, sourceMapContents: sourceMap });
 
-    let serialized = prepackSources(sources, {
+    let options = {
       internalDebug: true,
       compatibility: "jsc-600-1-4-17",
       delayUnsupportedRequires: true,
@@ -72,7 +72,13 @@ function runTest(name: string, code: string): boolean {
       serialize: true,
       speculate: !modelCode,
       sourceMaps: !!sourceMap,
-    });
+    };
+    if (name.endsWith("/bundle.js~"))
+      (options: any).additionalFunctions = [
+        "global.WildeBundle.prepareComponentScript",
+        "global.WildeBundle.prepareReact",
+      ];
+    let serialized = prepackSources(sources, options);
     let new_map = serialized.map; // force source maps to get computed
     if (!new_map) console.log(chalk.red("No source map"));
     if (!serialized) {

--- a/src/errors.js
+++ b/src/errors.js
@@ -26,6 +26,7 @@ export class CompilerDiagnostic extends Error {
     this.errorCode = errorCode;
   }
 
+  callStack: void | string;
   location: ?BabelNodeSourceLocation;
   severity: Severity;
   errorCode: string;

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -546,8 +546,13 @@ export default function(realm: Realm): ObjectValue {
     let unfiltered;
     if (text instanceof AbstractValue && text.kind === "JSON.stringify(...)") {
       // Enable cloning via JSON.parse(JSON.stringify(...)).
-      let value = text.args[0];
-      let clonedValue = text.args[1];
+      let gen = realm.preludeGenerator;
+      invariant(gen); // text is abstract, so we are doing abstract interpretation
+      let args = gen.derivedIds.get(text.intrinsicName);
+      invariant(args); // since text.kind === "JSON.stringify(...)" we know this must be true
+      let value = args[0];
+      invariant(value instanceof AbstractValue); // put there by stringify above
+      let clonedValue = args[1];
       let type = value.getType();
       let template;
       if (clonedValue instanceof AbstractObjectValue) {

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -41,7 +41,7 @@ function downgradeErrorsToWarnings(realm: Realm, f: () => any) {
   }
 }
 
-class ModuleTracer extends Tracer {
+export class ModuleTracer extends Tracer {
   constructor(modules: Modules, logModules: boolean) {
     super();
     this.modules = modules;
@@ -279,7 +279,7 @@ export class Modules {
     this.factoryFunctions = new Set();
     this.moduleIds = new Set();
     this.initializedModules = new Map();
-    realm.tracers.push(new ModuleTracer(this, logModules));
+    realm.tracers.push((this.moduleTracer = new ModuleTracer(this, logModules)));
     this.delayUnsupportedRequires = delayUnsupportedRequires;
     this.disallowDelayingRequiresOverride = false;
   }
@@ -294,6 +294,7 @@ export class Modules {
   active: boolean;
   delayUnsupportedRequires: boolean;
   disallowDelayingRequiresOverride: boolean;
+  moduleTracer: ModuleTracer;
 
   resolveInitializedModules(): void {
     let globalInitializedModulesMap = this._getGlobalProperty("__initializedModules");

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -36,7 +36,6 @@ export class Serializer {
     realm.generator = new Generator(realm);
 
     this.realm = realm;
-    this.functions = new Functions(this.realm, serializerOptions.additionalFunctions);
     this.logger = new Logger(this.realm, !!serializerOptions.internalDebug);
     this.modules = new Modules(
       this.realm,
@@ -44,6 +43,7 @@ export class Serializer {
       !!serializerOptions.logModules,
       !!serializerOptions.delayUnsupportedRequires
     );
+    this.functions = new Functions(this.realm, serializerOptions.additionalFunctions, this.modules.moduleTracer);
     if (serializerOptions.trace) this.realm.tracers.push(new LoggingTracer(this.realm));
 
     this.options = serializerOptions;

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -103,7 +103,7 @@ function visitName(state, name, modified) {
   let ref = state.tryQuery(
     () => ResolveBinding(state.realm, name, doesNotMatter, state.val.$Environment),
     undefined,
-    true
+    false
   );
   if (ref === undefined) return;
   if (IsUnresolvableReference(state.realm, ref)) return;

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { FatalError } from "../errors.js";
+import { Realm } from "../realm.js";
+
+export function ignoreErrorsIn<T>(realm: Realm, f: () => T): void | T {
+  let savedHandler = realm.errorHandler;
+  realm.errorHandler = d => "Recover";
+  try {
+    return f();
+  } catch (err) {
+    if (err instanceof FatalError) return undefined;
+    throw err;
+  } finally {
+    realm.errorHandler = savedHandler;
+  }
+}

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -260,7 +260,7 @@ export class Generator {
     invariant(buildNode_ instanceof Function || args.length === 0);
     let id = t.identifier(this.preludeGenerator.nameGenerator.generate("derived"));
     this.preludeGenerator.derivedIds.set(id.name, args);
-    let res = this.realm.createAbstract(types, values, args, id, optionalArgs ? optionalArgs.kind : undefined);
+    let res = this.realm.createAbstract(types, values, [], id, optionalArgs ? optionalArgs.kind : undefined);
     this.body.push({
       isPure: optionalArgs ? optionalArgs.isPure : undefined,
       declared: res,

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -45,6 +45,7 @@ export default class AbstractValue extends Value {
   ) {
     invariant(realm.useAbstractInterpretation);
     super(realm, optionalArgs ? optionalArgs.intrinsicName : undefined);
+    invariant(buildNode instanceof Function || args.length === 0);
     invariant(!Value.isTypeCompatibleWith(types.getType(), ObjectValue) || this instanceof AbstractObjectValue);
     invariant(types.getType() !== NullValue && types.getType() !== UndefinedValue);
     this.types = types;


### PR DESCRIPTION
Added more invariants calls to better enforce the global invariant requiring abstract values with non functional builders to have no arguments.

Also added a way to suppress extraneous errors that may arise while traversing additional function bodies to find read/write conflicts. Fixed the initial traversals to report errors and now pass in parameter needed to allow delayed requires inside these functions.

Fixed a bug in generator where it created an abstract value with a non functional builder and some arguments. Then fixed a bug in JSON.parse where it special cased abstract values produced the wrong way.

Added some logic to test-internal to invoke prepack with specified additional functions if the test case has a particular name. This test has to be run manually since it takes a rather long time to complete.

Added logic to populate CompilerDiagnostic objects with a callStack property so that it is easier to find the ultimate source of a prepack error.
