### PR TITLE
Cleaning up detection of unbound identifiers in residual functions

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -132,11 +132,11 @@ export class ResidualFunctions {
     return scope;
   }
 
-  _referentialize(names: Names, instances: Array<FunctionInstance>): void {
+  _referentialize(unbound: Names, instances: Array<FunctionInstance>): void {
     for (let instance of instances) {
       let serializedBindings = instance.serializedBindings;
 
-      for (let name in names) {
+      for (let name in unbound) {
         let serializedBinding = serializedBindings[name];
         invariant(serializedBinding !== undefined);
         if (serializedBinding.modified) {
@@ -225,13 +225,13 @@ export class ResidualFunctions {
     for (let [funcBody, instances] of functionEntries) {
       let functionInfo = this.residualFunctionInfos.get(funcBody);
       invariant(functionInfo);
-      this._referentialize(functionInfo.names, instances);
+      this._referentialize(functionInfo.unbound, instances);
     }
 
     for (let [funcBody, instances] of functionEntries) {
       let functionInfo = this.residualFunctionInfos.get(funcBody);
       invariant(functionInfo);
-      let { names, modified, usesThis, usesArguments } = functionInfo;
+      let { unbound, modified, usesThis, usesArguments } = functionInfo;
       let params = instances[0].functionValue.$FormalParameters;
       invariant(params !== undefined);
 
@@ -331,7 +331,7 @@ export class ResidualFunctions {
           // filter included variables to only include those that are different
           let factoryNames: Array<string> = [];
           let sameSerializedBindings = Object.create(null);
-          for (let name in names) {
+          for (let name in unbound) {
             let isDifferent = false;
             let lastBinding;
 

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -28,7 +28,7 @@ export type FunctionInstance = {
 
 export type Names = { [key: string]: true };
 export type FunctionInfo = {
-  names: Names,
+  unbound: Names,
   modified: Names,
   usesArguments: boolean,
   usesThis: boolean,

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import { Realm } from "../realm.js";
-import { IsUnresolvableReference, ResolveBinding } from "../methods/index.js";
 import { FunctionValue } from "../values/index.js";
 import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeCallExpression } from "babel-types";
@@ -21,7 +20,6 @@ export type ClosureRefVisitorState = {
   tryQuery: TryQuery<*>,
   val: FunctionValue,
   functionInfo: FunctionInfo,
-  map: Names,
   realm: Realm,
 };
 
@@ -49,19 +47,23 @@ function shouldVisit(node, data) {
 //       they will be visited again and possibly transformed.
 //       If necessary we could implement this by following node.parentPath and checking
 //       if any parent nodes are marked visited, but that seem unnecessary right now.let closureRefReplacer = {
+function replaceName(path, serializedBinding, name, data) {
+  if (path.scope.hasBinding(name, /*noGlobals*/ true)) return;
+
+  if (serializedBinding && shouldVisit(path.node, data)) {
+    markVisited(serializedBinding.serializedValue, data);
+    path.replaceWith(serializedBinding.serializedValue);
+  }
+}
+
 export let ClosureRefReplacer = {
   ReferencedIdentifier(path: BabelTraversePath, state: ClosureRefReplacerState) {
     if (ignorePath(path)) return;
 
     let serializedBindings = state.serializedBindings;
-    let innerName = path.node.name;
-    if (path.scope.hasBinding(innerName, /*noGlobals*/ true)) return;
-
-    let serializedBinding = serializedBindings[innerName];
-    if (serializedBinding && shouldVisit(path.node, serializedBindings)) {
-      markVisited(serializedBinding.serializedValue, serializedBindings);
-      path.replaceWith(serializedBinding.serializedValue);
-    }
+    let name = path.node.name;
+    let serializedBinding = serializedBindings[name];
+    if (serializedBinding) replaceName(path, serializedBinding, name, serializedBindings);
   },
 
   CallExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
@@ -84,30 +86,22 @@ export let ClosureRefReplacer = {
   "AssignmentExpression|UpdateExpression"(path: BabelTraversePath, state: ClosureRefReplacerState) {
     let serializedBindings = state.serializedBindings;
     let ids = path.getBindingIdentifierPaths();
-
-    for (let innerName in ids) {
-      let nestedPath = ids[innerName];
-      if (path.scope.hasBinding(innerName, /*noGlobals*/ true)) return;
-
-      let serializedBinding = serializedBindings[innerName];
-      if (serializedBinding && shouldVisit(nestedPath.node, serializedBindings)) {
-        markVisited(serializedBinding.serializedValue, serializedBindings);
-        nestedPath.replaceWith(serializedBinding.serializedValue);
+    for (let name in ids) {
+      let serializedBinding = serializedBindings[name];
+      if (serializedBinding) {
+        let nestedPath = ids[name];
+        replaceName(nestedPath, serializedBinding, name, serializedBindings);
       }
     }
   },
 };
 
-function visitName(state, name, modified) {
-  let doesNotMatter = true;
-  let ref = state.tryQuery(
-    () => ResolveBinding(state.realm, name, doesNotMatter, state.val.$Environment),
-    undefined,
-    false
-  );
-  if (ref === undefined) return;
-  if (IsUnresolvableReference(state.realm, ref)) return;
-  state.map[name] = true;
+function visitName(path, state, name, modified) {
+  // Is the name bound to some local identifier? If so, we don't need to do anything
+  if (path.scope.hasBinding(name, /*noGlobals*/ true)) return;
+
+  // Otherwise, let's record that there's an unbound identifier
+  state.functionInfo.unbound[name] = true;
   if (modified) state.functionInfo.modified[name] = true;
 }
 
@@ -126,8 +120,7 @@ export let ClosureRefVisitor = {
       state.functionInfo.usesArguments = true;
       return;
     }
-    if (path.scope.hasBinding(innerName, /*noGlobals*/ true)) return;
-    visitName(state, innerName, false);
+    visitName(path, state, innerName, false);
   },
 
   ThisExpression(path: BabelTraversePath, state: ClosureRefVisitorState) {
@@ -136,8 +129,7 @@ export let ClosureRefVisitor = {
 
   "AssignmentExpression|UpdateExpression"(path: BabelTraversePath, state: ClosureRefVisitorState) {
     for (let name in path.getBindingIdentifiers()) {
-      if (path.scope.hasBinding(name, /*noGlobals*/ true)) continue;
-      visitName(state, name, true);
+      visitName(path, state, name, true);
     }
   },
 };


### PR DESCRIPTION
- Avoid calling ResolveBinding twice (or more) for no reason.
- Restructured visitor code a bit, factoring out redundancy.