### PR TITLE
Distinguish two kinds of intrinsic values

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -516,7 +516,7 @@ export default function(realm: Realm): ObjectValue {
         let iName = result.intrinsicName;
         invariant(iName);
         invariant(realm.generator);
-        realm.rebuildNestedProperties(realm.generator, result, iName);
+        realm.rebuildNestedProperties(result, iName);
       }
       return result;
     }
@@ -570,7 +570,7 @@ export default function(realm: Realm): ObjectValue {
       if (template) {
         invariant(unfiltered.intrinsicName);
         invariant(realm.generator);
-        realm.rebuildNestedProperties(realm.generator, unfiltered, unfiltered.intrinsicName);
+        realm.rebuildNestedProperties(unfiltered, unfiltered.intrinsicName);
       }
     } else {
       // 1. Let JText be ? ToString(text).

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -515,7 +515,8 @@ export default function(realm: Realm): ObjectValue {
       if (clonedValue instanceof ObjectValue) {
         let iName = result.intrinsicName;
         invariant(iName);
-        realm.rebuildNestedProperties(result, iName);
+        invariant(realm.generator);
+        realm.rebuildNestedProperties(realm.generator, result, iName);
       }
       return result;
     }
@@ -568,7 +569,8 @@ export default function(realm: Realm): ObjectValue {
       unfiltered = realm.deriveAbstract(types, values, [text], buildNode, { kind: "JSON.parse(...)" });
       if (template) {
         invariant(unfiltered.intrinsicName);
-        realm.rebuildNestedProperties(unfiltered, unfiltered.intrinsicName);
+        invariant(realm.generator);
+        realm.rebuildNestedProperties(realm.generator, unfiltered, unfiltered.intrinsicName);
       }
     } else {
       // 1. Let JText be ? ToString(text).

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -120,7 +120,7 @@ export default function(realm: Realm): void {
           // why exclude functions?
           template.makePartial();
           invariant(realm.generator);
-          if (nameString) realm.rebuildNestedProperties(realm.generator, result, nameString);
+          if (nameString) realm.rebuildNestedProperties(result, nameString);
         }
         return result;
       }
@@ -170,7 +170,7 @@ export default function(realm: Realm): void {
           );
           template.makePartial();
           invariant(realm.generator);
-          realm.rebuildNestedProperties(realm.generator, result, ((result._buildNode: any): BabelNodeIdentifier).name);
+          realm.rebuildNestedProperties(result, ((result._buildNode: any): BabelNodeIdentifier).name);
         }
         return result;
       }
@@ -277,7 +277,7 @@ export default function(realm: Realm): void {
           // casting to due to Flow workaround above
           (object: any).$Set(key, value, object);
           realm.generator = generator;
-          if (object.intrinsicName) realm.rebuildObjectProperty(generator, object, key, value, object.intrinsicName);
+          if (object.intrinsicName) realm.rebuildObjectProperty(object, key, value, object.intrinsicName);
           return context.$Realm.intrinsics.undefined;
         }
 

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -119,7 +119,8 @@ export default function(realm: Realm): void {
         if (template && !(template instanceof FunctionValue)) {
           // why exclude functions?
           template.makePartial();
-          if (nameString) realm.rebuildNestedProperties(result, nameString);
+          invariant(realm.generator);
+          if (nameString) realm.rebuildNestedProperties(realm.generator, result, nameString);
         }
         return result;
       }
@@ -168,7 +169,8 @@ export default function(realm: Realm): void {
             "the nested properties should only be rebuilt for an abstract value"
           );
           template.makePartial();
-          realm.rebuildNestedProperties(result, ((result.buildNode: any): BabelNodeIdentifier).name);
+          invariant(realm.generator);
+          realm.rebuildNestedProperties(realm.generator, result, ((result._buildNode: any): BabelNodeIdentifier).name);
         }
         return result;
       }
@@ -264,18 +266,18 @@ export default function(realm: Realm): void {
         // casting to any to avoid Flow bug "*** Recursion limit exceeded ***"
         if ((object: any) instanceof AbstractObjectValue || (object: any) instanceof ObjectValue) {
           let generator = realm.generator;
-          if (generator)
-            generator.emitInvariant(
-              [object, value, object],
-              ([objectNode, valueNode]) =>
-                t.binaryExpression("!==", t.memberExpression(objectNode, t.identifier(key)), valueNode),
-              objnode => t.memberExpression(objnode, t.identifier(key))
-            );
+          invariant(generator);
+          generator.emitInvariant(
+            [object, value, object],
+            ([objectNode, valueNode]) =>
+              t.binaryExpression("!==", t.memberExpression(objectNode, t.identifier(key)), valueNode),
+            objnode => t.memberExpression(objnode, t.identifier(key))
+          );
           realm.generator = undefined; // don't emit code during the following $Set call
           // casting to due to Flow workaround above
           (object: any).$Set(key, value, object);
           realm.generator = generator;
-          if (object.intrinsicName) realm.rebuildObjectProperty(object, key, value, object.intrinsicName);
+          if (object.intrinsicName) realm.rebuildObjectProperty(generator, object, key, value, object.intrinsicName);
           return context.$Realm.intrinsics.undefined;
         }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -671,6 +671,7 @@ export class Realm {
     let template = abstractValue.getTemplate();
     invariant(!template.intrinsicName || template.intrinsicName === path);
     template.intrinsicName = path;
+    invariant(template.generator === undefined || template.generator === generator);
     template.generator = generator;
     for (let [key, binding] of template.properties) {
       if (binding === undefined || binding.descriptor === undefined) continue; // deleted

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -565,16 +565,10 @@ export class ResidualHeapSerializer {
     let declar = t.variableDeclaration("var", [
       t.variableDeclarator(intrinsicId, this.preludeGenerator.convertStringToMember(intrinsicName)),
     ]);
-    if (val instanceof ObjectValue && val.generator !== undefined) {
-      let activeBody = this.activeGeneratorBodies.get(val.generator);
-      invariant(
-        // Case 1: The generator is the top-level realm generator.
-        val.generator === this.generator ||
-          // Case 2a: The generator is a nested generator.
-          activeBody === this.emitter.getBody() ||
-          // Case 2b: An error was logged by `_getTarget`, and we don't actually have a proper generator
-          activeBody === undefined
-      );
+    if (val instanceof ObjectValue && val.intrinsicNameGenerated) {
+      // TODO #882: The value came into existance as a template for an abstract object.
+      // Unfortunately, we are not properly tracking which generate it's associated with.
+      // Until this gets fixed, let's stick to the historical behavior: Emit to the current emitter body.
       this.emitter.emit(declar);
     } else {
       invariant(this.emitter.getBody() === this.mainBody);

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -428,11 +428,9 @@ export class ResidualHeapVisitor {
     if (val instanceof AbstractValue) {
       if (this._mark(val)) this.visitAbstractValue(val);
     } else if (val.isIntrinsic()) {
-      // Some object values marked as "intrinsic" conceptually only came into life at a particular
-      // point in time by being an template for an abstract value that was derived via a generator.
-      // However, all other intrinsics conceptually exist ahead of time,
-      // and we can think of them as coming from the global code.
-      this._withScope((val instanceof ObjectValue && val.generator) || this.realmGenerator, () => {
+      // All intrinsic values exist from the beginning of time...
+      // ...except for a few that come into existance as templates for abstract objects (TODO #882).
+      this._withScope(this.realmGenerator, () => {
         this._mark(val);
       });
     } else if (val instanceof EmptyValue) {

--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -123,6 +123,8 @@ export class Logger {
       let locString = `${loc.start.line}:${loc.start.column + 1}`;
       if (loc.source) locString = `${loc.source}:${locString}`;
       message = `${message}\nat: ${locString}`;
+    } else if (value.intrinsicName) {
+      message = `${message}\nintrinsic name: ${value.intrinsicName}`;
     }
 
     console.error(message);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -276,8 +276,8 @@ export class Generator {
         ]),
     });
     let type = types.getType();
-    if (optionalArgs && optionalArgs.skipInvariant) return res;
     res.intrinsicName = id.name;
+    if (optionalArgs && optionalArgs.skipInvariant) return res;
     let typeofString;
     if (type instanceof FunctionValue) typeofString = "function";
     else if (type === UndefinedValue) invariant(false);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -68,12 +68,6 @@ export default class AbstractValue extends Value {
     return this.types.getType();
   }
 
-  getGenerator() {
-    let realmGenerator = this.$Realm.generator;
-    invariant(realmGenerator);
-    return realmGenerator;
-  }
-
   kind: ?string;
   types: TypesDomain;
   values: ValuesDomain;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -52,6 +52,7 @@ import {
   ThrowIfMightHaveBeenDeleted,
 } from "../methods/index.js";
 import * as t from "babel-types";
+import type { Generator } from "../utils/generator.js";
 import invariant from "../invariant.js";
 
 export default class ObjectValue extends ConcreteValue {
@@ -220,6 +221,11 @@ export default class ObjectValue extends ConcreteValue {
   properties: Map<string, PropertyBinding>;
   symbols: Map<SymbolValue, PropertyBinding>;
   unknownProperty: void | PropertyBinding;
+
+  // An object value with an intrinsic name can either exist from the beginning of time,
+  // or it can be associated with a particular point in time by being used as a template
+  // when deriving an abstract value via a generator.
+  generator: void | Generator;
 
   mightBeFalse(): boolean {
     return false;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -52,7 +52,6 @@ import {
   ThrowIfMightHaveBeenDeleted,
 } from "../methods/index.js";
 import * as t from "babel-types";
-import type { Generator } from "../utils/generator.js";
 import invariant from "../invariant.js";
 
 export default class ObjectValue extends ConcreteValue {
@@ -225,7 +224,7 @@ export default class ObjectValue extends ConcreteValue {
   // An object value with an intrinsic name can either exist from the beginning of time,
   // or it can be associated with a particular point in time by being used as a template
   // when deriving an abstract value via a generator.
-  generator: void | Generator;
+  intrinsicNameGenerated: void | true;
 
   mightBeFalse(): boolean {
     return false;

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -24,7 +24,6 @@ import {
   AbstractObjectValue,
   FunctionValue,
 } from "./index.js";
-
 import invariant from "../invariant.js";
 
 export default class Value {
@@ -71,7 +70,8 @@ export default class Value {
     return type.prototype instanceof Constructor || type.prototype === Constructor.prototype;
   }
 
-  intrinsicName: ?string;
+  intrinsicName: void | string;
+
   // The source location of the expression that first produced this value.
   expressionLocation: ?BabelNodeSourceLocation;
   $Realm: Realm;

--- a/test/serializer/basic/IntrinsicSerialization.js
+++ b/test/serializer/basic/IntrinsicSerialization.js
@@ -1,0 +1,6 @@
+(function() {
+    let old = Array.prototype.forEach;
+    Array.prototype.forEach = function() {};
+    Array.prototype.forEach = old;
+    inspect = function() { return Array.prototype.forEach.name; }
+})();


### PR DESCRIPTION
- Those which conceptually exist ahead of time. For those, we need to capture the value in the prelude. And...
- Those object values which are used as a template when creating an `__abstract` values. The template object becomes tied to the point in time of when then __abstract value was created.

Adding regression test.

This fixes #439.