### PR TITLE
Add JSXElement extension to IsFunctionDefinition

### DIFF
--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -281,6 +281,9 @@ export function IsFunctionDefinition(realm: Realm, node: BabelNodeExpression): b
     // 14.5.8 Static Semantics: IsFunctionDefinition
     case "ClassExpression":
       return true;
+    // JSX Extensions: http://facebook.github.io/jsx/
+    case "JSXElement":
+      return false;
     default:
       throw Error("Unexpected AST form : " + node.type);
   }


### PR DESCRIPTION
I don't want to add the full implementation upstream right now since it varies by framework and changes with the framework life-cycle. However, since this is a non-forkable point I'll need to add this extension upstream. I need this upstream since otherwise I'll need to fork and use my fork as the npm dependency for experiments.

I don't really have a good idea how to add a test to this since we don't have a test harness for the interpreter alone and I can't run the same code in Node so the serializer tests won't work. If you break it, it's no big deal. It's just an experiment.
