### PR TITLE
Clean up options and fix test code

### DIFF
--- a/scripts/generate-sourcemaps-test.js
+++ b/scripts/generate-sourcemaps-test.js
@@ -53,7 +53,7 @@ function generateTest(name: string, test_path: string, code: string): boolean {
   try {
     let s = prepackFileSync(test_path, {
       internalDebug: true,
-      onError: errorHandler,
+      errorHandler: errorHandler,
       sourceMaps: true,
       serialize: true,
     });
@@ -69,7 +69,7 @@ function generateTest(name: string, test_path: string, code: string): boolean {
       compatibility: "node-source-maps",
       inputSourceMapFilename: name + ".new1.js.map",
       internalDebug: true,
-      onError: errorHandler,
+      errorHandler: errorHandler,
       sourceMaps: true,
       serialize: true,
     });

--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -70,7 +70,7 @@ function runTest(name: string, code: string): boolean {
       mathRandomSeed: "0",
       errorHandler: errorHandler.bind(null, recover ? "Recover" : "Fail", errors),
       serialize: true,
-      speculate: true,
+      initializeMoreModules: true,
     };
     if (additionalFunctions) (options: any).additionalFunctions = ["global.additional1", "global['additional2']"];
     prepackFileSync(name, options);

--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -68,7 +68,7 @@ function runTest(name: string, code: string): boolean {
     let options = {
       internalDebug: false,
       mathRandomSeed: "0",
-      onError: errorHandler.bind(null, recover ? "Recover" : "Fail", errors),
+      errorHandler: errorHandler.bind(null, recover ? "Recover" : "Fail", errors),
       serialize: true,
       speculate: true,
     };

--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -70,7 +70,7 @@ function runTest(name: string, code: string): boolean {
       mathRandomSeed: "0",
       errorHandler,
       serialize: true,
-      speculate: !modelCode,
+      initializeMoreModules: !modelCode,
       sourceMaps: !!sourceMap,
     };
     if (name.endsWith("/bundle.js~"))

--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -68,7 +68,7 @@ function runTest(name: string, code: string): boolean {
       compatibility: "jsc-600-1-4-17",
       delayUnsupportedRequires: true,
       mathRandomSeed: "0",
-      onError: errorHandler,
+      errorHandler,
       serialize: true,
       speculate: !modelCode,
       sourceMaps: !!sourceMap,

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -86,12 +86,12 @@ report(inspect());`,
 function runTest(name, code, options, args) {
   console.log(chalk.inverse(name) + " " + util.inspect(options));
   let compatibility = code.includes("// jsc") ? "jsc-600-1-4-17" : undefined;
-  let speculate = code.includes("// initialize more modules");
+  let initializeMoreModules = code.includes("// initialize more modules");
   let delayUnsupportedRequires = code.includes("// delay unsupported requires");
   let functionCloneCountMatch = code.match(/\/\/ serialized function clone count: (\d+)/);
   options = Object.assign({}, options, {
     compatibility,
-    speculate,
+    initializeMoreModules,
     delayUnsupportedRequires,
     errorHandler: diag => "Fail",
     internalDebug: true,
@@ -105,7 +105,7 @@ function runTest(name, code, options, args) {
       let realm = construct_realm(realmOptions);
       initializeGlobals(realm);
       let serializerOptions = {
-        initializeMoreModules: speculate,
+        initializeMoreModules,
         delayUnsupportedRequires,
         internalDebug: true,
         additionalFunctions: options.additionalFunctions,

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -93,7 +93,7 @@ function runTest(name, code, options, args) {
     compatibility,
     speculate,
     delayUnsupportedRequires,
-    onError: diag => "Fail",
+    errorHandler: diag => "Fail",
     internalDebug: true,
     serialize: true,
     uniqueSuffix: "",

--- a/src/environment.js
+++ b/src/environment.js
@@ -30,7 +30,8 @@ import {
   ThrowCompletion,
 } from "./completions.js";
 import { FatalError } from "./errors.js";
-import { defaultOptions, type Options } from "./options";
+import { defaultOptions } from "./options";
+import type { PartialEvaluatorOptions } from "./options";
 import { ExecutionContext } from "./realm.js";
 import { Value } from "./values/index.js";
 import {
@@ -1111,7 +1112,7 @@ export class LexicalEnvironment {
 
   executePartialEvaluator(
     sources: Array<SourceFile>,
-    options: Options = defaultOptions,
+    options: PartialEvaluatorOptions = defaultOptions,
     sourceType: SourceType = "script"
   ): AbruptCompletion | { code: string, map?: SourceMap } {
     let body: Array<BabelNodeStatement> = [];

--- a/src/options.js
+++ b/src/options.js
@@ -39,81 +39,8 @@ export type SerializerOptions = {
   trace?: boolean,
 };
 
-export type Options = {|
-  additionalFunctions?: Array<string>,
-  compatibility?: Compatibility,
-  debugNames?: boolean,
-  delayInitializations?: boolean,
-  delayUnsupportedRequires?: boolean,
-  inputSourceMapFilename?: string,
-  internalDebug?: boolean,
-  logStatistics?: boolean,
-  logModules?: boolean,
-  mathRandomSeed?: string,
-  onError?: ErrorHandler,
-  outputFilename?: string,
-  profile?: boolean,
-  residual?: boolean,
-  serialize?: boolean,
-  singlePass?: boolean,
+export type PartialEvaluatorOptions = {
   sourceMaps?: boolean,
-  speculate?: boolean,
-  statsFile?: string,
-  strictlyMonotonicDateNow?: boolean,
-  timeout?: number,
-  trace?: boolean,
-  uniqueSuffix?: string,
-|};
+};
 
 export const defaultOptions = {};
-
-export function getRealmOptions({
-  compatibility = "browser",
-  debugNames = false,
-  onError,
-  mathRandomSeed,
-  uniqueSuffix,
-  residual,
-  serialize = !residual,
-  strictlyMonotonicDateNow,
-  timeout,
-}: Options): RealmOptions {
-  return {
-    compatibility,
-    debugNames,
-    errorHandler: onError,
-    mathRandomSeed,
-    uniqueSuffix,
-    residual,
-    serialize,
-    strictlyMonotonicDateNow,
-    timeout,
-  };
-}
-
-export function getSerializerOptions({
-  additionalFunctions,
-  delayInitializations = false,
-  delayUnsupportedRequires = false,
-  internalDebug = false,
-  logStatistics = false,
-  logModules = false,
-  profile = false,
-  singlePass = false,
-  speculate = false,
-  trace = false,
-}: Options): SerializerOptions {
-  let result: SerializerOptions = {
-    delayInitializations,
-    delayUnsupportedRequires,
-    initializeMoreModules: speculate,
-    internalDebug,
-    logStatistics,
-    logModules,
-    profile,
-    singlePass,
-    trace,
-  };
-  if (additionalFunctions) result.additionalFunctions = additionalFunctions;
-  return result;
-}

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -61,7 +61,7 @@ function run(
   let outputSourceMap;
   let statsFileName;
   let flags = {
-    speculate: false,
+    initializeMoreModules: false,
     trace: false,
     debugNames: false,
     singlePass: false,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -132,7 +132,7 @@ function run(
       compatibility,
       mathRandomSeed,
       inputSourceMapFilename: inputSourceMap,
-      onError: errorHandler,
+      errorHandler: errorHandler,
       sourceMaps: !!outputSourceMap,
     },
     flags

--- a/src/prepack-node-environment.js
+++ b/src/prepack-node-environment.js
@@ -18,12 +18,12 @@ import { Completion } from "./completions.js";
 import { Value } from "./values";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
-import { getRealmOptions, getSerializerOptions } from "./options";
+import { getRealmOptions, getSerializerOptions } from "./prepack-options";
 import { FatalError } from "./errors.js";
 import initializeBootstrap from "./intrinsics/node/bootstrap.js";
 import initializeProcess from "./intrinsics/node/process.js";
 
-import type { Options } from "./options";
+import type { Options } from "./prepack-options";
 import { defaultOptions } from "./options";
 import type { SourceMap } from "./types.js";
 

--- a/src/prepack-node-environment.js
+++ b/src/prepack-node-environment.js
@@ -23,7 +23,7 @@ import { FatalError } from "./errors.js";
 import initializeBootstrap from "./intrinsics/node/bootstrap.js";
 import initializeProcess from "./intrinsics/node/process.js";
 
-import type { Options } from "./prepack-options";
+import type { PrepackOptions } from "./prepack-options";
 import { defaultOptions } from "./options";
 import type { SourceMap } from "./types.js";
 
@@ -31,7 +31,7 @@ declare var process: any;
 
 export function prepackNodeCLI(
   filename: string,
-  options: Options = defaultOptions,
+  options: PrepackOptions = defaultOptions,
   callback: (any, ?{ code: string, map?: SourceMap }) => void
 ) {
   let serialized;
@@ -44,7 +44,7 @@ export function prepackNodeCLI(
   callback(null, serialized);
 }
 
-export function prepackNodeCLISync(filename: string, options: Options = defaultOptions) {
+export function prepackNodeCLISync(filename: string, options: PrepackOptions = defaultOptions) {
   if (process.version !== "v7.9.0") {
     console.warn(
       `Prepack's node-cli mode currently only works on Node v7.9.0.\n` +

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -12,7 +12,8 @@
  */
 
 /* @flow */
-import { type Options, defaultOptions } from "./options";
+import { defaultOptions } from "./options";
+import { type Options } from "./prepack-options";
 import { prepackNodeCLI, prepackNodeCLISync } from "./prepack-node-environment.js";
 import { prepackString } from "./prepack-standalone.js";
 import { type SourceMap } from "./types.js";

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -13,7 +13,7 @@
 
 /* @flow */
 import { defaultOptions } from "./options";
-import { type Options } from "./prepack-options";
+import { type PrepackOptions } from "./prepack-options";
 import { prepackNodeCLI, prepackNodeCLISync } from "./prepack-node-environment.js";
 import { prepackString } from "./prepack-standalone.js";
 import { type SourceMap } from "./types.js";
@@ -24,7 +24,7 @@ export * from "./prepack-node-environment";
 export * from "./prepack-standalone";
 
 export function prepackStdin(
-  options: Options = defaultOptions,
+  options: PrepackOptions = defaultOptions,
   callback: (any, ?{ code: string, map?: SourceMap }) => void
 ) {
   let sourceMapFilename = options.inputSourceMapFilename || "";
@@ -51,7 +51,7 @@ export function prepackStdin(
 
 export function prepackFile(
   filename: string,
-  options: Options = defaultOptions,
+  options: PrepackOptions = defaultOptions,
   callback: (any, ?{ code: string, map?: SourceMap }) => void,
   fileErrorHandler?: (err: ?Error) => void
 ) {
@@ -82,7 +82,7 @@ export function prepackFile(
   });
 }
 
-export function prepackFileSync(filename: string, options: Options = defaultOptions) {
+export function prepackFileSync(filename: string, options: PrepackOptions = defaultOptions) {
   if (options.compatibility === "node-cli") {
     return prepackNodeCLISync(filename, options);
   }

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -10,12 +10,9 @@
 /* @flow */
 
 import type { ErrorHandler } from "./errors.js";
-import type { SerializerOptions, RealmOptions } from "./options";
+import type { SerializerOptions, RealmOptions, Compatibility } from "./options";
 
-export type Compatibility = "browser" | "jsc-600-1-4-17" | "node-source-maps" | "node-cli";
-export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "node-source-maps", "node-cli"];
-
-export type Options = {|
+export type PrepackOptions = {|
   additionalFunctions?: Array<string>,
   compatibility?: Compatibility,
   debugNames?: boolean,
@@ -33,7 +30,7 @@ export type Options = {|
   serialize?: boolean,
   singlePass?: boolean,
   sourceMaps?: boolean,
-  speculate?: boolean,
+  initializeMoreModules?: boolean,
   statsFile?: string,
   strictlyMonotonicDateNow?: boolean,
   timeout?: number,
@@ -51,11 +48,11 @@ export function getRealmOptions({
   serialize = !residual,
   strictlyMonotonicDateNow,
   timeout,
-}: Options): RealmOptions {
+}: PrepackOptions): RealmOptions {
   return {
     compatibility,
     debugNames,
-    errorHandler: errorHandler,
+    errorHandler,
     mathRandomSeed,
     uniqueSuffix,
     residual,
@@ -74,13 +71,13 @@ export function getSerializerOptions({
   logModules = false,
   profile = false,
   singlePass = false,
-  speculate = false,
+  initializeMoreModules = false,
   trace = false,
-}: Options): SerializerOptions {
+}: PrepackOptions): SerializerOptions {
   let result: SerializerOptions = {
     delayInitializations,
     delayUnsupportedRequires,
-    initializeMoreModules: speculate,
+    initializeMoreModules,
     internalDebug,
     logStatistics,
     logModules,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { ErrorHandler } from "./errors.js";
+import type { SerializerOptions, RealmOptions } from "./options";
+
+export type Compatibility = "browser" | "jsc-600-1-4-17" | "node-source-maps" | "node-cli";
+export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "node-source-maps", "node-cli"];
+
+export type Options = {|
+  additionalFunctions?: Array<string>,
+  compatibility?: Compatibility,
+  debugNames?: boolean,
+  delayInitializations?: boolean,
+  delayUnsupportedRequires?: boolean,
+  inputSourceMapFilename?: string,
+  internalDebug?: boolean,
+  logStatistics?: boolean,
+  logModules?: boolean,
+  mathRandomSeed?: string,
+  errorHandler?: ErrorHandler,
+  outputFilename?: string,
+  profile?: boolean,
+  residual?: boolean,
+  serialize?: boolean,
+  singlePass?: boolean,
+  sourceMaps?: boolean,
+  speculate?: boolean,
+  statsFile?: string,
+  strictlyMonotonicDateNow?: boolean,
+  timeout?: number,
+  trace?: boolean,
+  uniqueSuffix?: string,
+|};
+
+export function getRealmOptions({
+  compatibility = "browser",
+  debugNames = false,
+  errorHandler,
+  mathRandomSeed,
+  uniqueSuffix,
+  residual,
+  serialize = !residual,
+  strictlyMonotonicDateNow,
+  timeout,
+}: Options): RealmOptions {
+  return {
+    compatibility,
+    debugNames,
+    errorHandler: errorHandler,
+    mathRandomSeed,
+    uniqueSuffix,
+    residual,
+    serialize,
+    strictlyMonotonicDateNow,
+    timeout,
+  };
+}
+
+export function getSerializerOptions({
+  additionalFunctions,
+  delayInitializations = false,
+  delayUnsupportedRequires = false,
+  internalDebug = false,
+  logStatistics = false,
+  logModules = false,
+  profile = false,
+  singlePass = false,
+  speculate = false,
+  trace = false,
+}: Options): SerializerOptions {
+  let result: SerializerOptions = {
+    delayInitializations,
+    delayUnsupportedRequires,
+    initializeMoreModules: speculate,
+    internalDebug,
+    logStatistics,
+    logModules,
+    profile,
+    singlePass,
+    trace,
+  };
+  if (additionalFunctions) result.additionalFunctions = additionalFunctions;
+  return result;
+}

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -20,7 +20,7 @@ import { FatalError } from "./errors.js";
 import { SerializerStatistics, TimingStatistics } from "./serializer/types.js";
 import type { SourceFile } from "./types.js";
 import { AbruptCompletion } from "./completions.js";
-import type { Options } from "./prepack-options";
+import type { PrepackOptions } from "./prepack-options";
 import { defaultOptions } from "./options";
 import type { BabelNodeFile, BabelNodeProgram } from "babel-types";
 import invariant from "./invariant.js";
@@ -38,7 +38,7 @@ Object.setPrototypeOf(FatalError.prototype, InitializationError.prototype);
 
 export function prepackSources(
   sources: Array<SourceFile>,
-  options: Options = defaultOptions
+  options: PrepackOptions = defaultOptions
 ): { code: string, map?: SourceMap, statistics?: SerializerStatistics, timingStats?: TimingStatistics } {
   let realmOptions = getRealmOptions(options);
   realmOptions.errorHandler = options.errorHandler;
@@ -76,7 +76,7 @@ export function prepackString(
   filename: string,
   code: string,
   sourceMap: string,
-  options: Options = defaultOptions
+  options: PrepackOptions = defaultOptions
 ): { code: string, map?: SourceMap, statistics?: SerializerStatistics, timingStats?: TimingStatistics } {
   let sources = [{ filePath: filename, fileContents: code, sourceMapContents: sourceMap }];
   let realmOptions = getRealmOptions(options);
@@ -109,7 +109,7 @@ export function prepackString(
 }
 
 /* deprecated: please use prepackString instead. */
-export function prepack(code: string, options: Options = defaultOptions) {
+export function prepack(code: string, options: PrepackOptions = defaultOptions) {
   let filename = options.filename || "unknown";
   let sources = [{ filePath: filename, fileContents: code }];
 
@@ -127,7 +127,11 @@ export function prepack(code: string, options: Options = defaultOptions) {
 }
 
 /* deprecated: please use prepackString instead. */
-export function prepackFromAst(ast: BabelNodeFile | BabelNodeProgram, code: string, options: Options = defaultOptions) {
+export function prepackFromAst(
+  ast: BabelNodeFile | BabelNodeProgram,
+  code: string,
+  options: PrepackOptions = defaultOptions
+) {
   if (ast && ast.type === "Program") {
     ast = t.file(ast, [], []);
   }

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -15,12 +15,12 @@ import Serializer from "./serializer/index.js";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
 import * as t from "babel-types";
-import { getRealmOptions, getSerializerOptions } from "./options";
+import { getRealmOptions, getSerializerOptions } from "./prepack-options";
 import { FatalError } from "./errors.js";
 import { SerializerStatistics, TimingStatistics } from "./serializer/types.js";
 import type { SourceFile } from "./types.js";
 import { AbruptCompletion } from "./completions.js";
-import type { Options } from "./options";
+import type { Options } from "./prepack-options";
 import { defaultOptions } from "./options";
 import type { BabelNodeFile, BabelNodeProgram } from "babel-types";
 import invariant from "./invariant.js";
@@ -41,7 +41,7 @@ export function prepackSources(
   options: Options = defaultOptions
 ): { code: string, map?: SourceMap, statistics?: SerializerStatistics, timingStats?: TimingStatistics } {
   let realmOptions = getRealmOptions(options);
-  realmOptions.errorHandler = options.onError;
+  realmOptions.errorHandler = options.errorHandler;
   let realm = construct_realm(realmOptions);
   initializeGlobals(realm);
 
@@ -114,7 +114,7 @@ export function prepack(code: string, options: Options = defaultOptions) {
   let sources = [{ filePath: filename, fileContents: code }];
 
   let realmOptions = getRealmOptions(options);
-  realmOptions.errorHandler = options.onError;
+  realmOptions.errorHandler = options.errorHandler;
   let realm = construct_realm(realmOptions);
   initializeGlobals(realm);
 


### PR DESCRIPTION
- Clean up options and create new `prepack-options.js` file
- Add `PartialEvaluatorOptions` type which contains only `sourceMaps`
- Fix test code related to above change

https://github.com/facebook/prepack/issues/841