### PR TITLE
Do some CSE in the serializer

### DIFF
--- a/src/methods/hash.js
+++ b/src/methods/hash.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { BabelBinaryOperator, BabelUnaryOperator } from "babel-types";
+import invariant from "../invariant.js";
+
+interface Hashable { getHash(): number, mightBeString(): boolean, mightBeObject(): boolean }
+
+export function hashBinary<T: Hashable>(op: BabelBinaryOperator, x: T, y: T): [number, Array<T>] {
+  let xHash = x.getHash();
+  let yHash = y.getHash();
+  if (yHash < xHash) {
+    // Check if the operation is commutative so that we can normalize the arguments on hash value order.
+    let commutative;
+    switch (op) {
+      case "*":
+      case "==":
+      case "!=":
+      case "===":
+      case "!==":
+        // If both operands might be objects, the operation does not commute because of the possibility
+        // that arbitrary code can run on both operands while converting them, in which case the order of the
+        // operands must be maintained to make sure any side-effects happen in the right order.
+        commutative = !(x.mightBeObject() && y.mightBeObject());
+        break;
+      case "+":
+        // As above, but in addition, if one of the operands might be a string the operation does not commute
+        commutative = !(x.mightBeObject() && y.mightBeObject()) && !(x.mightBeString() || y.mightBeString());
+        break;
+      default:
+        // The operation itself is not commutative
+        commutative = false;
+        break;
+    }
+    if (commutative) {
+      [x, y] = [y, x];
+      [xHash, yHash] = [yHash, xHash];
+    }
+  }
+  let hash = (((hashString(op) * 13) ^ xHash) * 13) ^ yHash;
+  return [hash, [x, y]];
+}
+
+export function hashCall<T: Hashable>(calleeName: string, ...args: Array<T>): [number, Array<T>] {
+  let hash = hashString(calleeName);
+  for (let a of args) hash = (hash * 13) ^ a.getHash();
+  return [hash, args];
+}
+
+export function hashTernary<T: Hashable>(x: T, y: T, z: T): [number, Array<T>] {
+  let hash = (((x.getHash() * 13) ^ y.getHash()) * 13) ^ z.getHash();
+  return [hash, [x, y, z]];
+}
+
+export function hashString(value: string): number {
+  let hash = 5381;
+  for (let i = value.length - 1; i >= 0; i--) {
+    hash = (hash * 33) ^ value.charCodeAt(i);
+  }
+  return hash;
+}
+
+export function hashUnary(op: BabelUnaryOperator, x: Hashable): number {
+  return (hashString(op) * 13) ^ x.getHash();
+}
+
+interface Equatable { equals(x: any): boolean }
+
+export class HashSet<T: Equatable & Hashable> {
+  constructor(expectedEntries?: number = 32 * 1024) {
+    let initialSize = 16;
+    expectedEntries *= 2;
+    while (initialSize < expectedEntries) initialSize *= 2;
+    this._entries = new Array(initialSize);
+    this._count = 0;
+  }
+
+  _count: number;
+  _entries: Array<void | T>;
+
+  add(e: T): T {
+    let entries = this._entries;
+    let n = entries.length;
+    let key = e.getHash();
+    let i = key & (n - 1);
+    while (true) {
+      let entry = entries[i];
+      if (entry === undefined) {
+        entries[i] = e;
+        if (++this._count > n / 2) this.expand();
+        return e;
+      } else if (e.equals(entry)) {
+        return entry;
+      }
+      if (++i >= n) i = 0;
+    }
+    invariant(false); // otherwise Flow thinks this method can return undefined
+  }
+
+  expand() {
+    let oldEntries = this._entries;
+    let n = oldEntries.length;
+    let m = n * 2;
+    if (m <= 0) return;
+    let entries = new Array(m);
+    for (let i = 0; i < n; i++) {
+      let oldEntry = oldEntries[i];
+      if (oldEntry === undefined) continue;
+      let key = oldEntry.getHash();
+      let j = key & (m - 1);
+      while (true) {
+        let entry = entries[j];
+        if (entry === undefined) {
+          entries[j] = oldEntry;
+          break;
+        }
+        if (++j >= m) j = 0;
+      }
+    }
+    this._entries = entries;
+  }
+}

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -20,6 +20,7 @@ export * from "./environment.js";
 export * from "./function.js";
 export * from "./get.js";
 export * from "./has.js";
+export * from "./hash.js";
 export * from "./integrity.js";
 export * from "./is.js";
 export * from "./iterator.js";

--- a/src/realm.js
+++ b/src/realm.js
@@ -219,6 +219,8 @@ export class Realm {
   MOBILE_JSC_VERSION = "jsc-600-1-4-17";
 
   errorHandler: ?ErrorHandler;
+  objectCount = 0;
+  symbolCount = 867501803871088;
 
   globalSymbolRegistry: Array<{ $Key: string, $Symbol: SymbolValue }>;
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -13,7 +13,7 @@ import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../enviro
 import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import type { Descriptor } from "../types.js";
-import { IsUnresolvableReference, ToLength, ResolveBinding, IsArray, Get } from "../methods/index.js";
+import { IsUnresolvableReference, ToLength, ResolveBinding, HashSet, IsArray, Get } from "../methods/index.js";
 import {
   BoundFunctionValue,
   ProxyValue,
@@ -66,6 +66,7 @@ export class ResidualHeapVisitor {
     this.inspector = new ResidualHeapInspector(realm, logger);
     this.referencedDeclaredValues = new Set();
     this.delayedVisitGeneratorEntries = [];
+    this.equivalenceSet = new HashSet();
   }
 
   realm: Realm;
@@ -82,6 +83,7 @@ export class ResidualHeapVisitor {
   inspector: ResidualHeapInspector;
   referencedDeclaredValues: Set<AbstractValue>;
   delayedVisitGeneratorEntries: Array<{| generator: Generator, entry: GeneratorEntry |}>;
+  equivalenceSet: HashSet<AbstractValue>;
 
   _withScope(scope: Scope, f: () => void) {
     let oldScope = this.scope;
@@ -162,7 +164,7 @@ export class ResidualHeapVisitor {
       this.visitValue(V);
     } else {
       // conditional assignment
-      this.visitValue(cond);
+      absVal.args[0] = this.visitEquivalentValue(cond);
       let consequent = absVal.args[1];
       invariant(consequent instanceof AbstractValue);
       let alternate = absVal.args[2];
@@ -173,7 +175,7 @@ export class ResidualHeapVisitor {
   }
 
   visitDescriptor(desc: Descriptor): void {
-    if (desc.value !== undefined) this.visitValue(desc.value);
+    if (desc.value !== undefined) desc.value = this.visitEquivalentValue(desc.value);
     if (desc.get !== undefined) this.visitValue(desc.get);
     if (desc.set !== undefined) this.visitValue(desc.set);
   }
@@ -194,7 +196,7 @@ export class ResidualHeapVisitor {
       visitedBindings[n] = visitedBinding;
     }
     invariant(visitedBinding.value !== undefined);
-    this.visitValue(visitedBinding.value);
+    visitedBinding.value = this.visitEquivalentValue(visitedBinding.value);
     return visitedBinding;
   }
 
@@ -412,7 +414,9 @@ export class ResidualHeapVisitor {
   visitAbstractValue(val: AbstractValue): void {
     if (val.kind === "sentinel member expression")
       this.logger.logError(val, "expressions of type o[p] are not yet supported for partially known o and unknown p");
-    for (let abstractArg of val.args) this.visitValue(abstractArg);
+    for (let i = 0, n = val.args.length; i < n; i++) {
+      val.args[i] = this.visitEquivalentValue(val.args[i]);
+    }
   }
 
   _mark(val: Value): boolean {
@@ -421,6 +425,16 @@ export class ResidualHeapVisitor {
     if (scopes.has(this.scope)) return false;
     scopes.add(this.scope);
     return true;
+  }
+
+  visitEquivalentValue<T: Value>(val: T): T {
+    if (val instanceof AbstractValue) {
+      let equivalentValue = this.equivalenceSet.add(val);
+      if (this._mark(equivalentValue)) this.visitAbstractValue(equivalentValue);
+      return (equivalentValue: any);
+    }
+    this.visitValue(val);
+    return val;
   }
 
   visitValue(val: Value): void {
@@ -472,13 +486,15 @@ export class ResidualHeapVisitor {
       binding = ({ value, modified: true }: VisitedBinding);
       this.globalBindings.set(key, binding);
     }
-    if (binding.value) this.visitValue(binding.value);
+    if (binding.value) binding.value = this.visitEquivalentValue(binding.value);
     return binding;
   }
 
   createGeneratorVisitCallbacks(generator: Generator): VisitEntryCallbacks {
     return {
-      visitValue: this.visitValue.bind(this),
+      visitValues: (values: Array<Value>) => {
+        for (let i = 0, n = values.length; i < n; i++) values[i] = this.visitEquivalentValue(values[i]);
+      },
       visitGenerator: this.visitGenerator.bind(this),
       canSkip: (value: AbstractValue): boolean => {
         return !this.referencedDeclaredValues.has(value) && !this.values.has(value);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -58,7 +58,7 @@ export type GeneratorEntry = {
 };
 
 export type VisitEntryCallbacks = {|
-  visitValue: Value => void,
+  visitValues: (Array<Value>) => void,
   visitGenerator: Generator => void,
   canSkip: AbstractValue => boolean,
   recordDeclaration: AbstractValue => void,
@@ -254,7 +254,7 @@ export class Generator {
     let options = {};
     if (optionalArgs && optionalArgs.kind) options.kind = optionalArgs.kind;
     let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;
-    let res = new Constructor(this.realm, types, values, [], id, options);
+    let res = new Constructor(this.realm, types, values, 0, [], id, options);
     this.body.push({
       isPure: optionalArgs ? optionalArgs.isPure : undefined,
       declared: res,
@@ -325,7 +325,7 @@ export class Generator {
       callbacks.recordDelayedEntry(entry);
     } else {
       if (entry.declared) callbacks.recordDeclaration(entry.declared);
-      for (let boundArg of entry.args) callbacks.visitValue(boundArg);
+      callbacks.visitValues(entry.args);
       if (entry.dependencies) for (let dependency of entry.dependencies) callbacks.visitGenerator(dependency);
     }
   }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -24,11 +24,12 @@ export default class AbstractObjectValue extends AbstractValue {
     realm: Realm,
     types: TypesDomain,
     values: ValuesDomain,
+    hashValue: number,
     args: Array<Value>,
     buildNode?: AbstractValueBuildNodeFunction | BabelNodeExpression,
-    optionalArgs?: {| kind?: string, intrinsicName?: string, isPure?: boolean |}
+    optionalArgs?: {| kind?: string, intrinsicName?: string |}
   ) {
-    super(realm, types, values, args, buildNode, optionalArgs);
+    super(realm, types, values, hashValue, args, buildNode, optionalArgs);
   }
 
   getTemplate(): ObjectValue {

--- a/src/values/BooleanValue.js
+++ b/src/values/BooleanValue.js
@@ -23,6 +23,10 @@ export default class BooleanValue extends PrimitiveValue {
 
   value: boolean;
 
+  getHash(): number {
+    return this.value ? 12484058682847432 : 3777063795205331;
+  }
+
   mightBeFalse(): boolean {
     return !this.value;
   }

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -53,6 +53,10 @@ export default class ConcreteValue extends Value {
     return this instanceof ObjectValue;
   }
 
+  mightBeString(): boolean {
+    return this instanceof StringValue;
+  }
+
   mightNotBeString(): boolean {
     return !(this instanceof StringValue);
   }

--- a/src/values/EmptyValue.js
+++ b/src/values/EmptyValue.js
@@ -11,4 +11,8 @@
 
 import { UndefinedValue } from "./index.js";
 
-export default class EmptyValue extends UndefinedValue {}
+export default class EmptyValue extends UndefinedValue {
+  getHash(): number {
+    return 4523845144584502;
+  }
+}

--- a/src/values/NullValue.js
+++ b/src/values/NullValue.js
@@ -16,6 +16,10 @@ export default class NullValue extends PrimitiveValue {
     return null;
   }
 
+  getHash(): number {
+    return 5613143836447527;
+  }
+
   mightBeFalse(): boolean {
     return true;
   }

--- a/src/values/NumberValue.js
+++ b/src/values/NumberValue.js
@@ -21,6 +21,12 @@ export default class NumberValue extends PrimitiveValue {
 
   value: number;
 
+  getHash(): number {
+    let num = Math.abs(this.value);
+    if (num < 100) num *= 10000000;
+    return num | 0; // make a 32-bit integer out of this and get rid of NaN
+  }
+
   mightBeFalse(): boolean {
     return this.value === 0 || isNaN(this.value);
   }

--- a/src/values/StringValue.js
+++ b/src/values/StringValue.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { hashString } from "../methods/index.js";
 import { PrimitiveValue } from "../values/index.js";
 import type { Realm } from "../realm.js";
 
@@ -19,6 +20,10 @@ export default class StringValue extends PrimitiveValue {
   }
 
   value: string;
+
+  getHash(): number {
+    return hashString(this.value);
+  }
 
   mightBeFalse(): boolean {
     return this.value.length === 0;

--- a/src/values/SymbolValue.js
+++ b/src/values/SymbolValue.js
@@ -20,6 +20,15 @@ export default class SymbolValue extends PrimitiveValue {
 
   $Description: void | Value;
 
+  hashValue: void | number;
+
+  getHash(): number {
+    if (!this.hashValue) {
+      this.hashValue = this.$Description ? this.$Description.getHash() : ++this.$Realm.symbolCount;
+    }
+    return this.hashValue;
+  }
+
   mightBeFalse(): boolean {
     return false;
   }

--- a/src/values/UndefinedValue.js
+++ b/src/values/UndefinedValue.js
@@ -16,6 +16,10 @@ export default class UndefinedValue extends PrimitiveValue {
     return undefined;
   }
 
+  getHash(): number {
+    return 792057514635681;
+  }
+
   mightBeFalse(): boolean {
     return true;
   }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -37,6 +37,10 @@ export default class Value {
   // Name from original source if existant
   __originalName: void | string;
 
+  getHash(): number {
+    invariant(false, "abstract method; please override");
+  }
+
   getType(): typeof Value {
     return this.constructor;
   }
@@ -113,6 +117,10 @@ export default class Value {
   }
 
   mightBeObject(): boolean {
+    invariant(false, "abstract method; please override");
+  }
+
+  mightBeString(): boolean {
     invariant(false, "abstract method; please override");
   }
 

--- a/test/serializer/optimizations/CommonSubExpr.js
+++ b/test/serializer/optimizations/CommonSubExpr.js
@@ -1,0 +1,5 @@
+let x = global.__abstract ? __abstract("number", "10") : 10;
+global.a = x + 1;
+global.b = x + 1;
+
+inspect = function() { return a + b; }

--- a/test/serializer/optimizations/CommonSubExpr2.js
+++ b/test/serializer/optimizations/CommonSubExpr2.js
@@ -1,0 +1,26 @@
+var x = global.__abstract ? __abstract('number', '1') : 1;
+var y = global.__abstract ? __abstract('number', '2') : 2;
+
+var useFoo = true;
+
+function foo(v) {
+  if (v > 2) {
+    return 'hello';
+  } else {
+    return 'world';
+  }
+}
+
+let a;
+if (x > 100) {
+  if (useFoo) {
+    a = foo(y);
+  } else {
+    a = x;
+  }
+} else {
+  a = foo(y);
+}
+result = a;
+
+inspect = function() { return result; }

--- a/test/serializer/optimizations/CommonSubExpr3.js
+++ b/test/serializer/optimizations/CommonSubExpr3.js
@@ -1,0 +1,25 @@
+var x = global.__abstract ? __abstract('number', '1') : 1;
+var y = global.__abstract ? __abstract('number', '2') : 2;
+
+var useFoo = true;
+
+function foo(v) {
+  if (v > 2) {
+    return 'hello';
+  } else {
+    return 'world';
+  }
+}
+
+var a;
+if (x > 100) {
+  if (useFoo) {
+    a = foo(y);
+  } else {
+    a = x;
+  }
+} else {
+  a = foo(y);
+}
+
+inspect = function() { return a; }


### PR DESCRIPTION
Added Value.getHash() and AbstractValue.equals so that we can quickly find abstract values that are structurally equivalent and thus coalesce them into a single expressions. (This is safe because abstract values must correspond to expressions that depend only on the final state and have no side effects.)

Added logic to the serializer code to find and substitute equivalent expressions.

Issues #825 and #597.