### PR TITLE
Add option to not emit invariants for model functions

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -254,7 +254,7 @@ export default function(realm: Realm): void {
       "global.__assumeDataProperty",
       "__assumeDataProperty",
       3,
-      (context, [object, propertyName, value]) => {
+      (context, [object, propertyName, value, skipInvariant]) => {
         if (!realm.useAbstractInterpretation) {
           throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
         }
@@ -264,7 +264,7 @@ export default function(realm: Realm): void {
         // casting to any to avoid Flow bug "*** Recursion limit exceeded ***"
         if ((object: any) instanceof AbstractObjectValue || (object: any) instanceof ObjectValue) {
           let generator = realm.generator;
-          if (generator)
+          if (!skipInvariant && generator)
             generator.emitInvariant(
               [object, value, object],
               ([objectNode, valueNode]) =>

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -267,24 +267,29 @@ export default function(realm: Realm): void {
           if (generator) {
             let condition = ([objectNode, valueNode]) =>
               t.binaryExpression("!==", t.memberExpression(objectNode, t.identifier(key)), valueNode);
-            if (invariantOptions && invariantOptions instanceof StringValue) {
-              switch (invariantOptions.value) {
-                case "DEFINED":
+            if (invariantOptions) {
+              let invariantOptionString = ToStringPartial(realm, invariantOptions);
+              switch (invariantOptionString) {
+                case "VALUE_DEFINED_INVARIANT":
                   condition = ([objectNode, valueNode]) =>
-                    t.unaryExpression("!", t.memberExpression(objectNode, t.identifier(key)));
+                    t.binaryExpression(
+                      "===",
+                      t.memberExpression(objectNode, t.identifier(key)),
+                      t.valueToNode(undefined)
+                    );
                   break;
-                case "SKIP":
+                case "SKIP_INVARIANT":
                   condition = null;
                   break;
-                case "FULL":
+                case "FULL_INVARIANT":
                   break;
                 default:
-                  invariant(false, "Invalid invariantOption " + invariantOptions.value);
+                  invariant(false, "Invalid invariantOption " + invariantOptionString);
               }
             }
             if (condition)
-              generator.emitInvariant([object, value, object], condition,
-                objnode => t.memberExpression(objnode, t.identifier(key))
+              generator.emitInvariant([object, value, object], condition, objnode =>
+                t.memberExpression(objnode, t.identifier(key))
               );
           }
           realm.generator = undefined; // don't emit code during the following $Set call

--- a/test/serializer/abstract/ModelFunction.js
+++ b/test/serializer/abstract/ModelFunction.js
@@ -1,0 +1,16 @@
+var result = [];
+global.log = function (arg) { result.push(arg); };
+if (global.__assumeDataProperty) {
+  __assumeDataProperty(global, "fun", 
+    function (arg1) {
+      __residual("void", function(arg1, global) {
+        global.log(arg1);
+      }, arg1, global);
+    }, true);
+} else {
+  global.fun = global.log;
+}
+
+global.fun("literal");
+
+inspect = function() { return "" + result; };

--- a/test/serializer/abstract/ModelFunction.js
+++ b/test/serializer/abstract/ModelFunction.js
@@ -1,16 +1,15 @@
+// add at runtime: global.fun = console.log;
 var result = [];
 global.log = function (arg) { result.push(arg); };
 if (global.__assumeDataProperty) {
   __assumeDataProperty(global, "fun", 
     function (arg1) {
-      __residual("void", function(arg1, global) {
-        global.log(arg1);
-      }, arg1, global);
-    }, true);
-} else {
-  global.fun = global.log;
+      __residual("void", function(arg1, console) {
+        console.log(arg1);
+      }, arg1, console);
+    }, "DEFINED");
 }
 
 global.fun("literal");
 
-inspect = function() { return "" + result; };
+inspect = function() { return undefined; };

--- a/test/serializer/abstract/ModelFunction.js
+++ b/test/serializer/abstract/ModelFunction.js
@@ -7,7 +7,7 @@ if (global.__assumeDataProperty) {
       __residual("void", function(arg1, console) {
         console.log(arg1);
       }, arg1, console);
-    }, "DEFINED");
+    }, "VALUE_DEFINED_INVARIANT");
 }
 
 global.fun("literal");


### PR DESCRIPTION
FunctionValues should not be compared with `===` from the model. Add an option to disable this invariant.