### PR TITLE
Find common ancestors for multiple generators/functions

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -53,7 +53,7 @@ import { factorifyObjects } from "./factorify.js";
 import { voidExpression, emptyExpression, constructorExpression, protoExpression } from "../utils/internalizer.js";
 import { Emitter } from "./Emitter.js";
 import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js";
-import { getSuggestedArrayLiteralLength } from "./utils.js";
+import { commonAncestorOf, getSuggestedArrayLiteralLength } from "./utils.js";
 
 export class ResidualHeapSerializer {
   constructor(
@@ -479,29 +479,13 @@ export class ResidualHeapSerializer {
       }
     }
 
-    if (generators.length === 1 && functionValues.length === 0) {
-      // This value is only referenced from a single generator, and it's not the realm generator.
-      invariant(generators[0] !== this.generator);
-      // We can emit the initialization of this value into the body associated with that generator.
-      let body = this.activeGeneratorBodies.get(generators[0]);
-      if (body === undefined) {
-        // TODO: The generator is no longer active! We missed the right time to emit this value.
-        this.logger.logError(val, "Value is referenced in an unsupported scope.");
-        return { body: this.mainBody };
-      } else {
-        invariant(body === this.emitter.getBody());
-        return { body };
-      }
-    }
-
-    // TODO #482: If there's more than...
-    // - one generator, or
-    // - one (non-main) generator and some functions
-    // involved, then we need to work a bit harder to figure out where the emit this value.
-    // In the presence of functions, we need to figure out in which generator a function is first exposed.
-    // Then we could walk up the generator chain to find the first common ancestor of all involved generators.
-    this.logger.logError(val, "Value is referenced in an unsupported combination of scopes.");
-    return { body: this.mainBody };
+    // This value is referenced from more than one generator or function.
+    // We can emit the initialization of this value into the body associated with their common ancestor.
+    let commonAncestor = Array.from(scopes).reduce((x, y) => commonAncestorOf(x, y), generators[0]);
+    invariant(commonAncestor instanceof Generator); // every scope is either the root, or a descendant
+    let body = commonAncestor === this.generator ? this.mainBody : this.activeGeneratorBodies.get(commonAncestor);
+    invariant(body !== undefined);
+    return { body: body };
   }
 
   serializeValue(val: Value, referenceOnly?: boolean, bindingType?: BabelVariableKind): BabelNodeExpression {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -70,6 +70,7 @@ export class Generator {
     let realmPreludeGenerator = realm.preludeGenerator;
     invariant(realmPreludeGenerator);
     this.preludeGenerator = realmPreludeGenerator;
+    this.parent = realm.generator;
     this.realm = realm;
     this.body = [];
   }
@@ -77,6 +78,7 @@ export class Generator {
   realm: Realm;
   body: Array<GeneratorEntry>;
   preludeGenerator: PreludeGenerator;
+  parent: void | Generator;
 
   clone(): Generator {
     let result = new Generator(this.realm);
@@ -98,6 +100,10 @@ export class Generator {
     }
 
     return t.stringLiteral(key);
+  }
+
+  getParent(): void | Generator {
+    return this.parent;
   }
 
   empty() {

--- a/src/values/FunctionValue.js
+++ b/src/values/FunctionValue.js
@@ -13,14 +13,17 @@ import type { ObjectKind } from "../types.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 import { ObjectValue, NumberValue } from "./index.js";
+import { Generator } from "../utils/generator.js";
 import invariant from "../invariant.js";
 
 /* Abstract base class for all function objects */
 export default class FunctionValue extends ObjectValue {
   constructor(realm: Realm, intrinsicName?: string) {
     super(realm, realm.intrinsics.FunctionPrototype, intrinsicName);
+    this.parent = realm.generator;
   }
 
+  parent: void | Generator;
   $Environment: LexicalEnvironment;
   $ScriptOrModule: any;
 
@@ -44,6 +47,10 @@ export default class FunctionValue extends ObjectValue {
     let value = desc.value;
     if (!(value instanceof NumberValue)) return undefined;
     return value.value;
+  }
+
+  getParent(): void | Generator {
+    return this.parent;
   }
 
   hasDefaultLength(): boolean {

--- a/test/serializer/abstract/GeneratorScoping3.js
+++ b/test/serializer/abstract/GeneratorScoping3.js
@@ -5,7 +5,7 @@
     if (a) {
         z = y;
     } else {
-        z = y;
+        z = function() { return y; }
     }
-    inspect = function() { return z.toString(); }
+    inspect = function() { return (z instanceof Function ? z() : z).toString(); }
 })();

--- a/test/serializer/abstract/GeneratorScoping4.js
+++ b/test/serializer/abstract/GeneratorScoping4.js
@@ -1,0 +1,13 @@
+(function() {
+    let x = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let y = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let obj = { p: 42 };
+    if (y) {
+        if (x) {
+            f = function() { return obj; }
+        } else {
+            g = function() { return obj; }
+        }
+    }
+    inspect = function() { return (f || g)().p };
+})();

--- a/test/serializer/optimizations/require_hoist.js
+++ b/test/serializer/optimizations/require_hoist.js
@@ -1,0 +1,109 @@
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+      try {
+
+   var _moduleObject = { exports: exports };
+
+   factory(global, require, _moduleObject, exports, dependencyMap);
+
+      module.factory = undefined;
+
+   return module.exports = _moduleObject.exports;
+ } catch (e) {
+   module.hasError = true;
+   module.isInitialized = false;
+   module.exports = undefined;
+   throw e;
+ }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+let a = global.__abstract ? __abstract("boolean", "(false)") : false;
+let x = global.__abstract ? __abstract("number", "(42)") : 42;
+define(function(global, require, module, exports) {
+  module.exports = require(1);
+}, 0, null);
+define(function(global, require, module, exports) {
+   let y = x * 2;
+   if (a) {
+     global.z = y;
+   } else {
+     global.z = y;
+   }
+  module.exports = global.z;
+}, 1, null);
+require(0);
+inspect = function() { return global.z.toString(); }


### PR DESCRIPTION
Keep track of the parent generator of nested generators/functions. Use this parent edge to compute the common ancestor of a list of generators/functions. Emit declarations that are used in more than one nested scope in their closest common ancestor.

Issue: #482