### PR TITLE
Concatenate all source files into a single program node

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1076,6 +1076,76 @@ export class LexicalEnvironment {
     }
   }
 
+  concatenateAndParse(sources: Array<SourceFile>, sourceType: SourceType = "script"): [BabelNodeFile, any] {
+    let asts = [];
+    let code = {};
+    let directives = [];
+    for (let source of sources) {
+      try {
+        let node = parse(this.realm, source.fileContents, source.filePath, sourceType);
+        if (source.sourceMapContents && source.sourceMapContents.length > 0)
+          this.fixup_source_locations(node, source.sourceMapContents);
+        this.fixup_filenames(node);
+        asts = asts.concat(node.program.body);
+        code[source.filePath] = source.fileContents;
+        directives = directives.concat(node.program.directives);
+      } catch (e) {
+        if (e instanceof ThrowCompletion) return e;
+        throw e;
+      }
+    }
+    return [t.file(t.program(asts, directives)), code];
+  }
+
+  executeSources(
+    sources: Array<SourceFile>,
+    sourceType: SourceType = "script",
+    onParse: void | (BabelNodeFile => void) = undefined
+  ): [AbruptCompletion | Value, any] {
+    let [ast, code] = this.concatenateAndParse(sources, sourceType);
+    let context = new ExecutionContext();
+    context.lexicalEnvironment = this;
+    context.variableEnvironment = this;
+    context.realm = this.realm;
+    this.realm.pushContext(context);
+    let res;
+    try {
+      if (onParse) onParse(ast);
+      res = this.evaluateCompletion(ast, false);
+    } finally {
+      this.realm.popContext(context);
+    }
+    if (res instanceof AbruptCompletion) return [res, code];
+
+    return [GetValue(this.realm, res), code];
+  }
+
+  executePartialEvaluator(
+    sources: Array<SourceFile>,
+    options: PartialEvaluatorOptions = defaultOptions,
+    sourceType: SourceType = "script"
+  ): AbruptCompletion | { code: string, map?: SourceMap } {
+    let [ast, code] = this.concatenateAndParse(sources, sourceType);
+    let context = new ExecutionContext();
+    context.lexicalEnvironment = this;
+    context.variableEnvironment = this;
+    context.realm = this.realm;
+    this.realm.pushContext(context);
+    let partialAST;
+    try {
+      let res;
+      [res, partialAST] = this.partiallyEvaluateCompletionDeref(ast, false);
+      if (res instanceof AbruptCompletion) return res;
+    } finally {
+      this.realm.popContext(context);
+    }
+    invariant(partialAST.type === "File");
+    let fileAst = ((partialAST: any): BabelNodeFile);
+    let prog = t.program(fileAst.program.body, ast.program.directives);
+    this.fixup_filenames(prog);
+    return generate(prog, { sourceMaps: options.sourceMaps }, (code: any));
+  }
+
   execute(
     code: string,
     filename: string,
@@ -1108,45 +1178,6 @@ export class LexicalEnvironment {
     if (res instanceof AbruptCompletion) return res;
 
     return GetValue(this.realm, res);
-  }
-
-  executePartialEvaluator(
-    sources: Array<SourceFile>,
-    options: PartialEvaluatorOptions = defaultOptions,
-    sourceType: SourceType = "script"
-  ): AbruptCompletion | { code: string, map?: SourceMap } {
-    let body: Array<BabelNodeStatement> = [];
-    let code = {};
-    for (let source of sources) {
-      let context = new ExecutionContext();
-      context.lexicalEnvironment = this;
-      context.variableEnvironment = this;
-      context.realm = this.realm;
-
-      this.realm.pushContext(context);
-      try {
-        let ast;
-        try {
-          ast = parse(this.realm, source.fileContents, source.filePath, sourceType);
-        } catch (e) {
-          if (e instanceof ThrowCompletion) return e;
-          throw e;
-        }
-        let [res, partialAST] = this.partiallyEvaluateCompletionDeref(ast, false);
-        if (res instanceof AbruptCompletion) return res;
-        invariant(partialAST.type === "File");
-        body = body.concat(((partialAST: any): BabelNodeFile).program.body);
-        if (source.sourceMapContents) {
-          this.fixup_source_locations(partialAST, source.sourceMapContents);
-        }
-        code[source.filePath] = source.fileContents;
-      } finally {
-        this.realm.popContext(context);
-      }
-    }
-    let prog = t.program(body);
-    this.fixup_filenames(prog);
-    return generate(prog, { sourceMaps: options.sourceMaps }, (code: any));
   }
 
   fixup_source_locations(ast: BabelNode, map: string) {

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -65,7 +65,7 @@ export function prepackSources(
     return result;
   } else {
     invariant(options.residual);
-    let result = realm.$GlobalEnv.executePartialEvaluator(sources);
+    let result = realm.$GlobalEnv.executePartialEvaluator(sources, options);
     if (result instanceof AbruptCompletion) throw result;
     // $FlowFixMe This looks like a Flow bug
     return result;


### PR DESCRIPTION
Instead of parsing each source file into a separate program node and executing each program node separately, rather produce the same AST as would have been produced if all the files were concatenated and then parsed.

This would matter if there were forward references from an earlier file to a later file. We probably won't see such cases, but better do the right thing than wait for some obscure and hard to debug issue from the wild.