### PR TITLE
Changing default of --singlePass (and renaming option)

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -99,6 +99,7 @@ function runTest(name, code, options, args) {
     serialize: true,
     uniqueSuffix: "",
   });
+  if (code.includes("// inline expression")) options.inlineExpressions = true;
   if (code.includes("// additional functions")) options.additionalFunctions = ["additional1", "additional2"];
   if (code.includes("// throws introspection error")) {
     try {
@@ -293,9 +294,9 @@ function run(args) {
     //only run specific tests if desired
     if (!test.name.includes(args.filter)) continue;
 
-    for (let delayInitializations of [false, true]) {
+    for (let [delayInitializations, inlineExpressions] of [[false, false], [true, true]]) {
       total++;
-      let options = { delayInitializations: delayInitializations };
+      let options = { delayInitializations, inlineExpressions };
       if (runTest(test.name, test.file, options, args)) passed++;
       else failed++;
     }

--- a/src/options.js
+++ b/src/options.js
@@ -35,7 +35,7 @@ export type SerializerOptions = {
   logStatistics?: boolean,
   logModules?: boolean,
   profile?: boolean,
-  singlePass?: boolean,
+  inlineExpressions?: boolean,
   trace?: boolean,
 };
 

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -36,19 +36,25 @@ function run(
   fs
 ) {
   let HELP_STR = `
-    input            The name of the file to run Prepack over (for web please provide the single js bundle file)
-    --out            The name of the output file
-    --compatibility  The target environment for Prepack [${CompatibilityValues.map(v => `"${v}"`).join(", ")}]
-    --mathRandomSeed If you want Prepack to evaluate Math.random() calls, please provide a seed.
-    --srcmapIn       The input sourcemap filename. If present, Prepack will output a sourcemap that maps from the original file (pre-input sourcemap) to Prepack's output
-    --srcmapOut      The output sourcemap filename.
-    --debugNames     Changes the output of Prepack so that for named functions and variables that get emitted into Prepack's output, the original name is appended as a suffix to Prepack's generated identifier.
-    --speculate      Enable speculative initialization of modules (for the module system Prepack has builtin knowledge about). Prepack will try to execute all factory functions it is able to.
-    --trace          Traces the order of module initialization.
-    --serialize      Serializes the partially evaluated global environment as a program that recreates it. (default = true)
-    --residual       Produces the residual program that results after constant folding.
-    --profile        Enables console logging of profile information of different phases of prepack.
-    --statsFile      The name of the output file where statistics will be written to.
+    input               The name of the file to run Prepack over (for web please provide the single js bundle file)
+    --out               The name of the output file
+    --compatibility     The target environment for Prepack [${CompatibilityValues.map(v => `"${v}"`).join(", ")}]
+    --mathRandomSeed    If you want Prepack to evaluate Math.random() calls, please provide a seed.
+    --srcmapIn          The input sourcemap filename. If present, Prepack will output a sourcemap that maps from
+                        the original file (pre-input sourcemap) to Prepack's output
+    --srcmapOut         The output sourcemap filename.
+    --debugNames        Changes the output of Prepack so that for named functions and variables that get emitted into
+                        Prepack's output, the original name is appended as a suffix to Prepack's generated identifier.
+    --speculate         Enable speculative initialization of modules (for the module system Prepack has builtin
+                        knowledge about). Prepack will try to execute all factory functions it is able to.
+    --trace             Traces the order of module initialization.
+    --serialize         Serializes the partially evaluated global environment as a program that recreates it.
+                        (default = true)
+    --residual          Produces the residual program that results after constant folding.
+    --profile           Enables console logging of profile information of different phases of prepack.
+    --statsFile         The name of the output file where statistics will be written to.
+    --inlineExpressions When generating code, tells prepack to avoid naming expressions when they are only used once,
+                        and instead inline them where they are used.
   `;
   let args = Array.from(process.argv);
   args.splice(0, 2);

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -43,7 +43,6 @@ function run(
     --srcmapIn       The input sourcemap filename. If present, Prepack will output a sourcemap that maps from the original file (pre-input sourcemap) to Prepack's output
     --srcmapOut      The output sourcemap filename.
     --debugNames     Changes the output of Prepack so that for named functions and variables that get emitted into Prepack's output, the original name is appended as a suffix to Prepack's generated identifier.
-    --singlePass     Perform only one serialization pass. Disables some optimizations on Prepack's output. This will speed up Prepacking but result in code with less inlining.
     --speculate      Enable speculative initialization of modules (for the module system Prepack has builtin knowledge about). Prepack will try to execute all factory functions it is able to.
     --trace          Traces the order of module initialization.
     --serialize      Serializes the partially evaluated global environment as a program that recreates it. (default = true)
@@ -64,7 +63,7 @@ function run(
     initializeMoreModules: false,
     trace: false,
     debugNames: false,
-    singlePass: false,
+    inlineExpressions: false,
     logStatistics: false,
     logModules: false,
     delayInitializations: false,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -28,7 +28,7 @@ export type PrepackOptions = {|
   profile?: boolean,
   residual?: boolean,
   serialize?: boolean,
-  singlePass?: boolean,
+  inlineExpressions?: boolean,
   sourceMaps?: boolean,
   initializeMoreModules?: boolean,
   statsFile?: string,
@@ -70,7 +70,7 @@ export function getSerializerOptions({
   logStatistics = false,
   logModules = false,
   profile = false,
-  singlePass = false,
+  inlineExpressions = false,
   initializeMoreModules = false,
   trace = false,
 }: PrepackOptions): SerializerOptions {
@@ -82,7 +82,7 @@ export function getSerializerOptions({
     logStatistics,
     logModules,
     profile,
-    singlePass,
+    inlineExpressions,
     trace,
   };
   if (additionalFunctions) result.additionalFunctions = additionalFunctions;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -125,7 +125,7 @@ export class Serializer {
     // Phase 2: Let's serialize the heap and generate code.
     // Serialize for the first time in order to gather reference counts
     let residualHeapValueIdentifiers = new ResidualHeapValueIdentifiers();
-    if (!this.options.singlePass) {
+    if (this.options.inlineExpressions) {
       if (timingStats !== undefined) timingStats.referenceCountsTime = Date.now();
       residualHeapValueIdentifiers.initPass1();
       new ResidualHeapSerializer(


### PR DESCRIPTION
Internal data indicates that doing two passes to eliminate unneeded identifiers does not help performance or code size at the bytecode level.
Therefore, I swap the default, and rename the option.
--singlePass is no longer an option, and instead, the old two-pass behavior can be triggered via
--inlineExpressions.

Tweaked test runner to run all serialization tests with inline expressions and without,
marked one test that required inline expressions for its test objective.

This addresses #848.