### PR TITLE
If "use strict" is in the global code, emit it there

### DIFF
--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -27,6 +27,8 @@ export function GlobalDeclarationInstantiation(
   env: LexicalEnvironment,
   strictCode: boolean
 ) {
+  realm.getRunningContext().isStrict = realm.isStrict = strictCode;
+
   // 1. Let envRec be env's EnvironmentRecord.
   let envRec = env.environmentRecord;
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1053,6 +1053,7 @@ export function PerformEval(realm: Realm, x: Value, evalRealm: Realm, strictCall
 
   // 13. Let evalCxt be a new ECMAScript code execution context.
   let evalCxt = new ExecutionContext();
+  evalCxt.isStrict = strictEval;
 
   // 14. Set the evalCxt's Function to null.
   evalCxt.setFunction(null);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -117,7 +117,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
   let propertyBinding = InternalGetPropertiesMap(O, P).get(P);
   let desc = propertyBinding === undefined ? undefined : propertyBinding.descriptor;
   if (desc === undefined) {
-    if (O === realm.$GlobalObject) {
+    if (O === realm.$GlobalObject && !realm.getRunningContext().isStrict) {
       generator.emitGlobalDelete(P);
     } else {
       generator.emitPropertyDelete(O, P);
@@ -125,7 +125,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
   } else if (!desc.configurable && desc.enumerable && O === realm.$GlobalObject && desc.value !== undefined) {
     generator.emitGlobalDeclaration(P, desc.value);
   } else if (desc.configurable && desc.enumerable && desc.value !== undefined) {
-    if (O === realm.$GlobalObject) {
+    if (O === realm.$GlobalObject && !realm.getRunningContext().isStrict) {
       generator.emitGlobalAssignment(P, desc.value);
     } else {
       generator.emitPropertyAssignment(O, P, desc.value);

--- a/src/realm.js
+++ b/src/realm.js
@@ -11,7 +11,7 @@
 
 import type { Intrinsics, PropertyBinding, Descriptor } from "./types.js";
 import { CompilerDiagnostic, type ErrorHandlerResult, type ErrorHandler, FatalError } from "./errors.js";
-import type { NativeFunctionValue, FunctionValue } from "./values/index.js";
+import { NativeFunctionValue, ECMAScriptSourceFunctionValue, FunctionValue } from "./values/index.js";
 import {
   Value,
   ObjectValue,
@@ -83,6 +83,7 @@ export class ExecutionContext {
   variableEnvironment: LexicalEnvironment;
   lexicalEnvironment: LexicalEnvironment;
   isReadOnly: boolean;
+  isStrict: boolean;
   savedEffects: void | Effects;
   savedCompletion: void | PossiblyNormalCompletion;
 
@@ -91,6 +92,7 @@ export class ExecutionContext {
   }
 
   setFunction(F: null | FunctionValue) {
+    if (F instanceof ECMAScriptSourceFunctionValue) this.isStrict = F.$Strict;
     this.function = F;
   }
 
@@ -170,6 +172,7 @@ export class Realm {
 
   start: number;
   isReadOnly: boolean;
+  isStrict: boolean;
   useAbstractInterpretation: boolean;
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
@@ -289,6 +292,7 @@ export class Realm {
 
   wrapInGlobalEnv<T>(callback: () => T): T {
     let context = new ExecutionContext();
+    context.isStrict = this.isStrict;
     context.lexicalEnvironment = this.$GlobalEnv;
     context.variableEnvironment = this.$GlobalEnv;
     context.realm = this;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1200,7 +1200,7 @@ export class ResidualHeapSerializer {
     // add strict modes
     let strictDirective = t.directive(t.directiveLiteral("use strict"));
     let globalDirectives = [];
-    if (!unstrictFunctionBodies.length && strictFunctionBodies.length) {
+    if (!this.realm.isStrict && !unstrictFunctionBodies.length && strictFunctionBodies.length) {
       // no unstrict functions, only strict ones
       globalDirectives.push(strictDirective);
     } else if (unstrictFunctionBodies.length && strictFunctionBodies.length) {
@@ -1271,6 +1271,8 @@ export class ResidualHeapSerializer {
       "serialized " + this.serializedValues.size + " of " + this.residualValues.size
     );
 
-    return t.file(t.program(ast_body));
+    let program_directives = [];
+    if (this.realm.isStrict) program_directives.push(strictDirective);
+    return t.file(t.program(ast_body, program_directives));
   }
 }

--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -29,8 +29,9 @@ export class Logger {
 
   // Wraps a query that might potentially execute user code.
   tryQuery<T>(f: () => T, defaultValue: T, logFailures: boolean): T {
-    let context = new ExecutionContext();
     let realm = this.realm;
+    let context = new ExecutionContext();
+    context.isStrict = realm.isStrict;
     let env = realm.$GlobalEnv;
     context.lexicalEnvironment = env;
     context.variableEnvironment = env;

--- a/test/serializer/basic/GlobalPropertyStrict.js
+++ b/test/serializer/basic/GlobalPropertyStrict.js
@@ -1,0 +1,4 @@
+"use strict";
+global.foo = 42;
+
+global.inspect = function() { return foo; }

--- a/test/serializer/basic/GlobalPropertyStrict2.js
+++ b/test/serializer/basic/GlobalPropertyStrict2.js
@@ -1,0 +1,8 @@
+(function() {
+  "use strict";
+  function a(x) {
+    return x;
+  }
+  global.a = a;
+})();
+inspect = function() { return a(22); }


### PR DESCRIPTION
Record the presence of a global "use strict" directive in the realm and then use that to ensure that assignments to ad hoc global properties are qualified, as required by strict mode. 

Resolves #454