### PR TITLE
prepack cli will terminate process when help option is passed

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -113,7 +113,7 @@ function run(
               "\n" +
               HELP_STR
           );
-          break;
+          return;
         default:
           if (arg in flags) {
             flags[arg] = true;


### PR DESCRIPTION
https://github.com/facebook/prepack/issues/889
Simply change behavior of `prepack-cli` when `--help` option is passed.
Process will be terminated if help option is passed even if other args are passed altogether.