### PR TITLE
Move away from object templates, part 2

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -342,6 +342,7 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
       // b. If blocked is true, return false.
       if (blocked) return false;
     }
+    unscopables.throwIfNotConcrete();
 
     // 8. Return true.
     return true;

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -15,7 +15,6 @@ import { CompilerDiagnostic, FatalError } from "../errors.js";
 import {
   Value,
   AbstractValue,
-  AbstractObjectValue,
   ConcreteValue,
   UndefinedValue,
   NullValue,
@@ -132,9 +131,9 @@ export function getPureBinaryOperationResultType(
       }
       throw new FatalError();
     }
-    if (rval instanceof ObjectValue || rval instanceof AbstractObjectValue) {
+    if (!rval.mightNotBeObject()) {
       // Simple object won't throw here, aren't proxy objects or typed arrays and do not have @@hasInstance properties.
-      if (rval.isSimple()) return BooleanValue;
+      if (rval.isSimpleObject()) return BooleanValue;
     }
     let error = new CompilerDiagnostic(
       `might be an object that behaves badly for the ${op} operator`,

--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -68,7 +68,7 @@ export default function(
         // for (var ForBinding in Expression) Statement
         // 1. Let keyResult be ? ForIn/OfHeadEvaluation(« », Expression, enumerate).
         let keyResult = ForInOfHeadEvaluation(realm, env, [], right, "enumerate", strictCode);
-        if (keyResult instanceof AbstractObjectValue && keyResult.isSimple()) {
+        if (keyResult instanceof AbstractObjectValue && keyResult.isSimpleObject()) {
           return emitResidualLoopIfSafe(ast, strictCode, env, realm, left, right, keyResult, body);
         }
         reportErrorAndThrowIfNotConcrete(keyResult, right.loc);
@@ -123,7 +123,7 @@ function emitResidualLoopIfSafe(
   ob: AbstractObjectValue,
   body: BabelNodeStatement
 ) {
-  invariant(ob.isSimple());
+  invariant(ob.isSimpleObject());
   let oldEnv = realm.getRunningContext().lexicalEnvironment;
   let blockEnv = NewDeclarativeEnvironment(realm, oldEnv);
   realm.getRunningContext().lexicalEnvironment = blockEnv;
@@ -193,7 +193,7 @@ function emitResidualLoopIfSafe(
           o = ob;
         } else {
           for (let co of oe) o = co;
-          invariant(o !== undefined && o.isSimple());
+          invariant(o !== undefined && o.isSimpleObject());
         }
         let generator = realm.generator;
         invariant(generator !== undefined);
@@ -204,7 +204,7 @@ function emitResidualLoopIfSafe(
         if (sourceObject === o) {
           // Known enumerable properties of sourceObject can become known
           // properties of targetObject.
-          invariant(sourceObject.isPartial());
+          invariant(sourceObject.isPartialObject());
           sourceObject.makeNotPartial();
           // EnumerableOwnProperties is sufficient because sourceObject is simple
           let keyValPairs = EnumerableOwnProperties(realm, sourceObject, "key+value");

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -320,8 +320,8 @@ function InternalGetTemplate(realm: Realm, val: AbstractObjectValue): ObjectValu
     }
     CreateDataProperty(realm, template, key, InternalJSONClone(realm, value));
   }
-  if (valTemplate.isPartial()) template.makePartial();
-  if (valTemplate.isSimple()) template.makeSimple();
+  if (valTemplate.isPartialObject()) template.makePartial();
+  if (valTemplate.isSimpleObject()) template.makeSimple();
   return template;
 }
 

--- a/src/intrinsics/ecma262/Map.js
+++ b/src/intrinsics/ecma262/Map.js
@@ -11,9 +11,9 @@
 
 import type { Realm } from "../../realm.js";
 import {
-  NativeFunctionValue,
-  ObjectValue,
   AbstractObjectValue,
+  ObjectValue,
+  NativeFunctionValue,
   NullValue,
   UndefinedValue,
 } from "../../values/index.js";
@@ -86,13 +86,15 @@ export default function(realm: Realm): NativeFunctionValue {
       let nextItem = IteratorValue(realm, next);
 
       // d. If Type(nextItem) is not Object, then
-      if (!(nextItem instanceof ObjectValue) && !(nextItem instanceof AbstractObjectValue)) {
+      if (nextItem.mightNotBeObject()) {
+        if (nextItem.mightBeObject()) nextItem.throwIfNotConcrete();
         // i. Let error be Completion{[[Type]]: throw, [[Value]]: a newly created TypeError object, [[Target]]: empty}.
         let error = realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
 
         // ii. Return ? IteratorClose(iter, error).
         throw IteratorClose(realm, iter, error);
       }
+      invariant(nextItem instanceof ObjectValue || nextItem instanceof AbstractObjectValue);
 
       // e. Let k be Get(nextItem, "0").
       let k;

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -88,7 +88,7 @@ export default function(realm: Realm): NativeFunctionValue {
         // b. Else,
         // i. Let from be ToObject(nextSource).
         frm = ToObjectPartial(realm, nextSource);
-        let frm_was_partial = frm.isPartial();
+        let frm_was_partial = frm.isPartialObject();
         if (frm_was_partial) {
           to_must_be_partial = true;
           frm.makeNotPartial();

--- a/src/intrinsics/ecma262/Reflect.js
+++ b/src/intrinsics/ecma262/Reflect.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { AbstractObjectValue, BooleanValue, ObjectValue, NullValue } from "../../values/index.js";
+import { BooleanValue, ObjectValue, NullValue } from "../../values/index.js";
 import {
   CreateArrayFromList,
   FromPropertyDescriptor,
@@ -156,8 +156,8 @@ export default function(realm: Realm): ObjectValue {
   // ECMA262 26.1.8
   obj.defineNativeMethod("has", 2, (context, [target, propertyKey]) => {
     // 1. If Type(target) is not Object, throw a TypeError exception.
-    if (!(target instanceof ObjectValue || target instanceof AbstractObjectValue)) {
-      target.throwIfNotConcrete();
+    if (target.mightNotBeObject()) {
+      if (target.mightBeObject()) target.throwIfNotConcrete();
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
     }
 

--- a/src/intrinsics/node/utils.js
+++ b/src/intrinsics/node/utils.js
@@ -24,7 +24,7 @@ export function getNodeBufferFromTypedArray(realm: Realm, value: ObjectValue): U
 // Takes a value from the host realm and create it into a Prepack Realm.
 // TODO: Move this to a bigger general purpose proxy between the environments.
 // See issue #644 for more details.
-export function createDeepIntrinsic(realm: Realm, value: Value, intrinsicName: string) {
+export function createDeepIntrinsic(realm: Realm, value: mixed, intrinsicName: string) {
   switch (typeof value) {
     case "undefined":
       return realm.intrinsics.undefined;

--- a/src/methods/construct.js
+++ b/src/methods/construct.js
@@ -11,12 +11,12 @@
 
 import type { Realm } from "../realm.js";
 import {
+  AbstractObjectValue,
   ECMAScriptSourceFunctionValue,
   ObjectValue,
   UndefinedValue,
   NullValue,
   Value,
-  AbstractObjectValue,
   EmptyValue,
 } from "../values/index.js";
 import { IsConstructor, IsStatic } from "./is.js";
@@ -111,10 +111,11 @@ export function SpeciesConstructor(realm: Realm, O: ObjectValue, defaultConstruc
   if (C instanceof UndefinedValue) return defaultConstructor;
 
   // 4. If Type(C) is not Object, throw a TypeError exception.
-  if (!(C instanceof ObjectValue || C instanceof AbstractObjectValue)) {
-    C.throwIfNotConcrete();
+  if (C.mightNotBeObject()) {
+    if (C.mightBeObject()) C.throwIfNotConcrete();
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(C) is not an object");
   }
+  invariant(C instanceof ObjectValue || C instanceof AbstractObjectValue);
 
   // 5. Let S be ? Get(C, @@species).
   let S = Get(realm, C, realm.intrinsics.SymbolSpecies);

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -79,7 +79,6 @@ export function HasPrimitiveBase(realm: Realm, V: Reference): boolean {
   let base = GetBase(realm, V);
   // void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord | AbstractValue;
   if (!base || base instanceof EnvironmentRecord) return false;
-  if (base instanceof ObjectValue || base instanceof AbstractObjectValue) return false;
   let type = base.getType();
   return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
 }

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -61,7 +61,6 @@ export function HasName(realm: Realm, ast: BabelNodeExpression): boolean {
 // ECMA262 7.3.10
 export function HasProperty(realm: Realm, O: ObjectValue | AbstractObjectValue, P: PropertyKeyValue): boolean {
   // 1. Assert: Type(O) is Object.
-  invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue, "expected object");
 
   // 2. Assert: IsPropertyKey(P) is true.
   invariant(IsPropertyKey(realm, P), "expected property key");
@@ -73,7 +72,6 @@ export function HasProperty(realm: Realm, O: ObjectValue | AbstractObjectValue, 
 // ECMA262 7.3.11
 export function HasOwnProperty(realm: Realm, O: ObjectValue | AbstractObjectValue, P: PropertyKeyValue): boolean {
   // 1. Assert: Type(O) is Object.
-  invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue, "not an object");
 
   // 2. Assert: IsPropertyKey(P) is true.
   invariant(IsPropertyKey(realm, P), "not a valid property key");

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -94,7 +94,6 @@ export function OrdinaryIsExtensible(realm: Realm, O: ObjectValue): boolean {
 // ECMA262 7.2.5
 export function IsExtensible(realm: Realm, O: ObjectValue | AbstractObjectValue): boolean {
   // 1. Assert: Type(O) is Object.
-  invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue, "expected object value");
 
   // 2. Return ? O.[[IsExtensible]]().
   return O.$IsExtensible();

--- a/src/partial-evaluators/ArrayExpression.js
+++ b/src/partial-evaluators/ArrayExpression.js
@@ -74,7 +74,7 @@ export default function(
       partial_elements[nextIndex] = t.spreadElement((elemAst: any));
 
       // update the abstract state with the contents of spreadObj, if known
-      if (spreadObj instanceof ObjectValue && !spreadObj.isPartial()) {
+      if (spreadObj instanceof ObjectValue && !spreadObj.isPartialObject()) {
         // 3. Let iterator be ? GetIterator(spreadObj).
         let iterator = GetIterator(realm, spreadObj);
 
@@ -124,7 +124,7 @@ export default function(
         AbstractValue.reportIntrospectionError(spreadObj);
         throw new FatalError();
       }
-    } else if (array.isPartial()) {
+    } else if (array.isPartialObject()) {
       // Dealing with an array element that follows on a spread object that
       // could not be iterated at compile time, so the index that this element
       // will have at runtime is not known at this point.

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -42,7 +42,7 @@ export default class AbstractObjectValue extends AbstractValue {
   getTemplate(): ObjectValue {
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
-      if (element.isPartial()) {
+      if (element.isPartialObject()) {
         return element;
       } else {
         break;
@@ -52,13 +52,13 @@ export default class AbstractObjectValue extends AbstractValue {
     throw new FatalError();
   }
 
-  isPartial(): boolean {
+  isPartialObject(): boolean {
     let result;
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
       if (result === undefined) {
-        result = element.isPartial();
-      } else if (result !== element.isPartial()) {
+        result = element.isPartialObject();
+      } else if (result !== element.isPartialObject()) {
         AbstractValue.reportIntrospectionError(this);
         throw new FatalError();
       }
@@ -70,13 +70,13 @@ export default class AbstractObjectValue extends AbstractValue {
     return result;
   }
 
-  isSimple(): boolean {
+  isSimpleObject(): boolean {
     let result;
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
       if (result === undefined) {
-        result = element.isSimple();
-      } else if (result !== element.isSimple()) {
+        result = element.isSimpleObject();
+      } else if (result !== element.isSimpleObject()) {
         AbstractValue.reportIntrospectionError(this);
         throw new FatalError();
       }
@@ -263,7 +263,7 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        if (cv.isSimple() && typeof P === "string") {
+        if (cv.isSimpleObject() && typeof P === "string") {
           let generator = this.$Realm.generator;
           invariant(generator !== undefined);
           let pname = generator.getAsPropertyNameExpression(P);

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -31,7 +31,7 @@ export default class ArrayValue extends ObjectValue {
     return "Array";
   }
 
-  isSimple(): boolean {
+  isSimpleObject(): boolean {
     return this.$TypedArrayName === undefined;
   }
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -250,13 +250,13 @@ export default class ObjectValue extends ConcreteValue {
     this._isSimple = this.$Realm.intrinsics.true;
   }
 
-  isPartial(): boolean {
+  isPartialObject(): boolean {
     return this._isPartial.value;
   }
 
-  isSimple(): boolean {
+  isSimpleObject(): boolean {
     if (this._isSimple.value) return true;
-    if (this.isPartial()) return false;
+    if (this.isPartialObject()) return false;
     if (this.symbols.size > 0) return false;
     for (let propertyBinding of this.properties.values()) {
       let desc = propertyBinding.descriptor;
@@ -266,7 +266,7 @@ export default class ObjectValue extends ConcreteValue {
     }
     if (this.$Prototype instanceof NullValue) return true;
     if (this.$Prototype === this.$Realm.intrinsics.ObjectPrototype) return true;
-    return this.$Prototype.isSimple();
+    return this.$Prototype.isSimpleObject();
   }
 
   getExtensible(): boolean {
@@ -363,7 +363,7 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   getOwnPropertyKeysArray(): Array<string> {
-    if (this.isPartial() || this.unknownProperty !== undefined) {
+    if (this.isPartialObject() || this.unknownProperty !== undefined) {
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();
     }
@@ -480,13 +480,13 @@ export default class ObjectValue extends ConcreteValue {
   $GetPartial(P: AbstractValue | PropertyKeyValue, Receiver: Value): Value {
     if (!(P instanceof AbstractValue)) return this.$Get(P, Receiver);
     // We assume that simple objects have no getter/setter properties.
-    if (this !== Receiver || !this.isSimple() || P.mightNotBeString()) {
+    if (this !== Receiver || !this.isSimpleObject() || P.mightNotBeString()) {
       AbstractValue.reportIntrospectionError(P, "TODO");
       throw new FatalError();
     }
     // If all else fails, use this expression
     let result;
-    if (this.isPartial()) {
+    if (this.isPartialObject()) {
       result = this.$Realm.createAbstract(
         TypesDomain.topVal,
         ValuesDomain.topVal,
@@ -555,7 +555,7 @@ export default class ObjectValue extends ConcreteValue {
     if (!(P instanceof AbstractValue)) return this.$Set(P, V, Receiver);
     // We assume that simple objects have no getter/setter properties and
     // that all properties are writable.
-    if (this !== Receiver || !this.isSimple() || P.mightNotBeString()) {
+    if (this !== Receiver || !this.isSimpleObject() || P.mightNotBeString()) {
       AbstractValue.reportIntrospectionError(P, "TODO");
       throw new FatalError();
     }

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -49,7 +49,7 @@ export default class ProxyValue extends ObjectValue {
     this.realm = realm;
   }
 
-  isSimple(): boolean {
+  isSimpleObject(): boolean {
     return false;
   }
 

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -80,6 +80,14 @@ export default class Value {
     return !!this.intrinsicName;
   }
 
+  isPartialObject(): boolean {
+    return false;
+  }
+
+  isSimpleObject(): boolean {
+    return false;
+  }
+
   mightBeFalse(): boolean {
     invariant(false, "abstract method; please override");
   }


### PR DESCRIPTION
Reduce the number of places where we test if value is an instance of AbstractObjectValue.