### PR TITLE
Move away from object templates, part 3

### DIFF
--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -32,7 +32,6 @@ import { IsCallable } from "./is.js";
 import { Completion, ReturnCompletion, ThrowCompletion } from "../completions.js";
 import { GetMethod, Get } from "./get.js";
 import { HasCompatibleType } from "./has.js";
-import { ValuesDomain } from "../domains/index.js";
 import type { BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -327,11 +326,6 @@ export function SameValue(realm: Realm, x: ConcreteValue, y: ConcreteValue): boo
 }
 
 export function SameValuePartial(realm: Realm, x: Value, y: Value): boolean {
-  if (x instanceof AbstractValue || y instanceof AbstractValue) {
-    let values = ValuesDomain.meetValues(realm, x, y);
-    if (!values.isTop()) return values.getElements().size === 1;
-  }
-
   return SameValue(realm, x.throwIfNotConcrete(), y.throwIfNotConcrete());
 }
 

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -32,7 +32,7 @@ import { cloneDescriptor, IsDataDescriptor, StrictEqualityComparison } from "../
 import { construct_empty_effects } from "../realm.js";
 import { Generator } from "../utils/generator.js";
 import type { SerializationContext } from "../utils/generator.js";
-import { AbstractValue, Value } from "../values/index.js";
+import { AbstractValue, ObjectValue, Value } from "../values/index.js";
 
 import invariant from "../invariant.js";
 import * as t from "babel-types";
@@ -510,7 +510,7 @@ export function joinPropertyBindings(
   function join(b: PropertyBinding, d1: void | Descriptor, d2: void | Descriptor) {
     // If the PropertyBinding object has been freshly allocated do not join
     if (d1 === undefined) {
-      if (c2.has(b.object)) return d2; // no join
+      if (b.object instanceof ObjectValue && c2.has(b.object)) return d2; // no join
       if (b.descriptor !== undefined && m1.has(b)) {
         // property was deleted
         d1 = cloneDescriptor(b.descriptor);
@@ -522,7 +522,7 @@ export function joinPropertyBindings(
       }
     }
     if (d2 === undefined) {
-      if (c1.has(b.object)) return d1; // no join
+      if (b.object instanceof ObjectValue && c1.has(b.object)) return d1; // no join
       if (b.descriptor !== undefined && m2.has(b)) {
         // property was deleted
         d2 = cloneDescriptor(b.descriptor);

--- a/src/realm.js
+++ b/src/realm.js
@@ -46,7 +46,7 @@ export type Bindings = Map<Binding, void | Value>;
 export type EvaluationResult = Completion | Reference | Value;
 export type PropertyBindings = Map<PropertyBinding, void | Descriptor>;
 
-export type CreatedObjects = Set<ObjectValue | AbstractObjectValue>;
+export type CreatedObjects = Set<ObjectValue>;
 export type Effects = [EvaluationResult, Generator, Bindings, PropertyBindings, CreatedObjects];
 
 export class Tracer {
@@ -592,10 +592,7 @@ export class Realm {
   }
 
   isNewObject(object: AbstractObjectValue | ObjectValue): boolean {
-    if (object instanceof AbstractObjectValue) {
-      let realm = this;
-      return object.values.getElements().some(element => realm.isNewObject(element));
-    }
+    if (object instanceof AbstractObjectValue) return false;
     return this.createdObjects === undefined || this.createdObjects.has(object);
   }
 


### PR DESCRIPTION
The getElements function in the values domain requires its argument to not be Top. For AbstractObjectValues it is currently the case that the values domain is never Top. This will soon change, so I'm reviewing all of the places where getElements are called.

These two places are clearly wrong, so I'm just removing them.