### PR TITLE
Move away from object templates, part 4

### DIFF
--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -68,7 +68,7 @@ export default function(
         // for (var ForBinding in Expression) Statement
         // 1. Let keyResult be ? ForIn/OfHeadEvaluation(« », Expression, enumerate).
         let keyResult = ForInOfHeadEvaluation(realm, env, [], right, "enumerate", strictCode);
-        if (keyResult instanceof AbstractObjectValue && keyResult.isSimpleObject()) {
+        if (keyResult.isPartialObject() && keyResult.isSimpleObject()) {
           return emitResidualLoopIfSafe(ast, strictCode, env, realm, left, right, keyResult, body);
         }
         reportErrorAndThrowIfNotConcrete(keyResult, right.loc);
@@ -120,7 +120,7 @@ function emitResidualLoopIfSafe(
   realm: Realm,
   lh: BabelNodeVariableDeclaration,
   obexpr: BabelNodeExpression,
-  ob: AbstractObjectValue,
+  ob: ObjectValue | AbstractObjectValue,
   body: BabelNodeStatement
 ) {
   invariant(ob.isSimpleObject());
@@ -187,13 +187,9 @@ function emitResidualLoopIfSafe(
         }
       });
       if (targetObject instanceof ObjectValue && sourceObject !== undefined) {
-        let o;
-        let oe = ob.values.getElements();
-        if (oe.size !== 1) {
-          o = ob;
-        } else {
-          for (let co of oe) o = co;
-          invariant(o !== undefined && o.isSimpleObject());
+        let o = ob;
+        if (ob instanceof AbstractObjectValue && !ob.values.isTop() && ob.values.getElements().size === 1) {
+          for (let oe of ob.values.getElements()) o = oe;
         }
         let generator = realm.generator;
         invariant(generator !== undefined);

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -15,7 +15,15 @@ import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { DeclarativeEnvironmentRecord } from "../environment.js";
 import { Reference } from "../environment.js";
 import { BreakCompletion, AbruptCompletion, ContinueCompletion } from "../completions.js";
-import { AbstractValue, EmptyValue, NullValue, ObjectValue, UndefinedValue, Value } from "../values/index.js";
+import {
+  AbstractObjectValue,
+  AbstractValue,
+  EmptyValue,
+  NullValue,
+  ObjectValue,
+  UndefinedValue,
+  Value,
+} from "../values/index.js";
 import invariant from "../invariant.js";
 import {
   InitializeReferencedBinding,
@@ -155,7 +163,7 @@ export function ForInOfHeadEvaluation(
     let obj = ToObjectPartial(realm, exprValue);
 
     // c. Return ? EnumerateObjectProperties(obj).
-    if (obj instanceof AbstractValue) {
+    if (obj.isPartialObject() || obj instanceof AbstractObjectValue) {
       return obj;
     } else {
       return EnumerateObjectProperties(realm, obj);

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -53,21 +53,8 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   isPartialObject(): boolean {
-    let result;
-    for (let element of this.values.getElements()) {
-      invariant(element instanceof ObjectValue);
-      if (result === undefined) {
-        result = element.isPartialObject();
-      } else if (result !== element.isPartialObject()) {
-        AbstractValue.reportIntrospectionError(this);
-        throw new FatalError();
-      }
-    }
-    if (result === undefined) {
-      AbstractValue.reportIntrospectionError(this);
-      throw new FatalError();
-    }
-    return result;
+    // At the very least, the identity of the object is unknown
+    return true;
   }
 
   isSimpleObject(): boolean {

--- a/test/serializer/abstract/ForInStatement11a.js
+++ b/test/serializer/abstract/ForInStatement11a.js
@@ -1,5 +1,5 @@
-let ob = global.__abstract ? __abstract("object", "{ x: 1 }") : { x: 1 };
-let ob2 = global.__abstract ? __abstract("object", "{ x: 2 }") : { x: 2 };
+let ob = global.__makePartial ? __makePartial({ x: 1 }) : { x: 1 };
+let ob2 = global.__makePartial ? __makePartial({ x: 2 }) : { x: 2 };
 if (global.__makeSimple) __makeSimple(ob);
 if (global.__makeSimple) __makeSimple(ob2);
 

--- a/test/serializer/abstract/ForInStatement11b.js
+++ b/test/serializer/abstract/ForInStatement11b.js
@@ -1,4 +1,4 @@
-let ob = global.__abstract ? __abstract("object", "{ x: 1 }") : { x: 1 };
+let ob = global.__makePartial ? __makePartial({ x: 1 }) : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let ob2 = {};

--- a/test/serializer/abstract/ForInStatement2a.js
+++ b/test/serializer/abstract/ForInStatement2a.js
@@ -1,6 +1,6 @@
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 let ob = x ? { a: 1 } : { b: 2 };
-let src = global.__abstract ? __abstract("object", "({})") : {};
+let src = global.__makePartial ? __makePartial({}) : {};
 if (global.__makeSimple) __makeSimple(src);
 let tgt = {};
 for (var p in ob) {


### PR DESCRIPTION
The for-in special case is meant to work with partial objects, not abstract objects. Make it so, and remove yet another case where the values domain of an abstract object is assumed to be not Top.

#882