### PR TITLE
Move away from object templates, part 5

### DIFF
--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -183,6 +183,9 @@ function emitResidualLoopIfSafe(
       if (targetObject instanceof ObjectValue && sourceObject !== undefined) {
         let o = ob;
         if (ob instanceof AbstractObjectValue && !ob.values.isTop() && ob.values.getElements().size === 1) {
+          // Note that it is not safe, in general, to extract a concrete object from the values domain of
+          // an abstract object. We can get away with it here only because the concrete object does not
+          // escape the code below and is thus never referenced directly in generated code because of this logic.
           for (let oe of ob.values.getElements()) o = oe;
         }
         let generator = realm.generator;
@@ -192,8 +195,7 @@ function emitResidualLoopIfSafe(
         targetObject.makeSimple();
         targetObject.makePartial();
         if (sourceObject === o) {
-          // Known enumerable properties of sourceObject can become known
-          // properties of targetObject.
+          // Known enumerable properties of sourceObject can become known properties of targetObject.
           invariant(sourceObject.isPartialObject());
           sourceObject.makeNotPartial();
           // EnumerableOwnProperties is sufficient because sourceObject is simple

--- a/src/evaluators/WithStatement.js
+++ b/src/evaluators/WithStatement.js
@@ -13,7 +13,7 @@ import type { Realm } from "../realm.js";
 import { LexicalEnvironment, ObjectEnvironmentRecord } from "../environment.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion } from "../completions.js";
-import { AbstractValue, Value } from "../values/index.js";
+import { AbstractValue, ObjectValue, Value } from "../values/index.js";
 import { ToObjectPartial, GetValue, NewObjectEnvironment, UpdateEmpty } from "../methods/index.js";
 import invariant from "../invariant.js";
 import type { BabelNodeWithStatement } from "babel-types";
@@ -30,7 +30,7 @@ export default function(
 
   // 2. Let obj be ? ToObject(? GetValue(val)).
   val = GetValue(realm, val);
-  if (val instanceof AbstractValue) {
+  if (val instanceof AbstractValue || (val instanceof ObjectValue && val.isPartialObject())) {
     let loc = ast.object.loc;
     let error = new CompilerDiagnostic("with object must be a known value", loc, "PP0007", "RecoverableError");
     if (realm.handleError(error) === "Fail") throw new FatalError();

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -552,15 +552,7 @@ export class ResidualHeapSerializer {
     invariant(intrinsicName);
     if (val instanceof ObjectValue && val.intrinsicNameGenerated) {
       // The intrinsic was generated at a particular point in time.
-      let intrinsicId = t.identifier(this.valueNameGenerator.generate(intrinsicName));
-      let declar = t.variableDeclaration("var", [
-        t.variableDeclarator(intrinsicId, this.preludeGenerator.convertStringToMember(intrinsicName)),
-      ]);
-      // TODO #882: The value came into existance as a template for an abstract object.
-      // Unfortunately, we are not properly tracking which generate it's associated with.
-      // Until this gets fixed, let's stick to the historical behavior: Emit to the current emitter body.
-      this.emitter.emit(declar);
-      return intrinsicId;
+      return this.preludeGenerator.convertStringToMember(intrinsicName);
     } else {
       // The intrinsic conceptually exists ahead of time.
       invariant(this.emitter.getBody() === this.mainBody);

--- a/test/error-handler/call.js
+++ b/test/error-handler/call.js
@@ -2,8 +2,8 @@
 // expected errors: [{"location":{"start":{"line":10,"column":0},"end":{"line":10,"column":1},"identifierName":"o","source":"test/error-handler/call.js"},"severity":"RecoverableError","errorCode":"PP0005"}, {"location":{"start":{"line":11,"column":2},"end":{"line":11,"column":3},"identifierName":"m","source":"test/error-handler/call.js"},"severity":"RecoverableError","errorCode":"PP0005"}, {"location":{"start":{"line":14,"column":5},"end":{"line":14,"column":8},"identifierName":"str","source":"test/error-handler/call.js"},"severity":"RecoverableError","errorCode":"PP0006"}]
 
 function foo(){};
-var f = global.__abstract ? __abstract(foo, "foo") : foo;
-var o = global.__abstract ? __abstract({}, "({})") : {};
+var f = global.__abstract ? __abstract("object", "foo") : foo;
+var o = global.__abstract ? __abstract("object", "({})") : {};
 if (global.__makeSimple) global.__makeSimple(o);
 
 foo();

--- a/test/error-handler/class.js
+++ b/test/error-handler/class.js
@@ -2,7 +2,7 @@
 // expected errors: [{"location":{"start":{"line":7,"column":18},"end":{"line":7,"column":26},"identifierName":"absSuper","source":"test/error-handler/class.js"},"severity":"RecoverableError","errorCode":"PP0009"}, {"location":{"start":{"line":11,"column":18},"end":{"line":11,"column":28},"identifierName":"superClass","source":"test/error-handler/class.js"},"severity":"RecoverableError","errorCode":"PP0010"}]
 
 let superClass = function() { };
-let absSuper = __abstract(superClass);
+let absSuper = __abstract("object");
 
 class foo extends absSuper{}
 

--- a/test/error-handler/forInStatement.js
+++ b/test/error-handler/forInStatement.js
@@ -1,6 +1,6 @@
 // expected errors: [{"location":{"start":{"line":6,"column":14},"end":{"line":6,"column":16},"identifierName":"ob","source":"test/error-handler/forInStatement.js"},"severity":"FatalError","errorCode":"PP0013"}]
 
-let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
 
 let tgt = {};
 for (var p in ob) {

--- a/test/error-handler/in2.js
+++ b/test/error-handler/in2.js
@@ -6,7 +6,7 @@ var a0 = { "4": 5 };
 var a1 = global.__makeSimple ? __makeSimple({ '4': 5 }) : a0;
 
 var tArr = new Int8Array(4);
-var a2 = global.__abstract ? __abstract(tArr, "tArr"): tArr;
+var a2 = global.__abstract ? __abstract("object", "tArr"): tArr;
 
 x0 = "4" in a0;
 x1 = "4" in a1;

--- a/test/error-handler/instanceof.js
+++ b/test/error-handler/instanceof.js
@@ -4,7 +4,7 @@
 var b = global.__abstract ? __abstract("boolean", true) : true;
 function foo(){};
 Object.defineProperty(foo, Symbol.hasInstance, { value: function() { throw 123; } })
-var f = global.__abstract ? __abstract(foo, "foo") : foo;
+var f = global.__abstract ? __abstract("object", "foo") : foo;
 var o = global.__abstract ? __abstract("object", "({})") : {};
 
 try {

--- a/test/error-handler/member.js
+++ b/test/error-handler/member.js
@@ -2,7 +2,7 @@
 // expected errors: [{"location":{"start":{"line":8,"column":0},"end":{"line":8,"column":2},"identifierName":"oq","source":"test/error-handler/member.js"},"severity":"FatalError","errorCode":"PP0012"}]
 
 var b = global.__abstract ? __abstract("boolean", true) : true;
-var o = global.__abstract ? __abstract({}, "({})") : {};
+var o = global.__abstract ? __abstract("object", "({})") : {};
 var oq = b ? o : null;
 
 oq.foo = 123;

--- a/test/error-handler/member2.js
+++ b/test/error-handler/member2.js
@@ -2,7 +2,7 @@
 // expected errors: [{"location":{"start":{"line":8,"column":4},"end":{"line":8,"column":6},"identifierName":"oq","source":"test/error-handler/member2.js"},"severity":"FatalError","errorCode":"PP0012"}]
 
 var b = global.__abstract ? __abstract("boolean", true) : true;
-var o = global.__abstract ? __abstract({}, "({})") : {};
+var o = global.__abstract ? __abstract("object", "({})") : {};
 var oq = b ? o : null;
 
 x = oq.foo;

--- a/test/error-handler/with.js
+++ b/test/error-handler/with.js
@@ -1,7 +1,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":7,"column":5},"end":{"line":7,"column":8},"identifierName":"obj","source":"test/error-handler/with.js"},"severity":"RecoverableError","errorCode":"PP0007"}]
 
-let obj = global.__abstract ? __abstract({x:1,y:3}, '({x:1,y:3})') : {x:1,y:3};
+let obj = global.__abstract ? __makePartial({x:1,y:3}, '({x:1,y:3})') : {x:1,y:3};
 if (global.__makeSimple) global.__makeSimple(obj);
 let y = 2;
 with(obj) {

--- a/test/error-handler/with2.js
+++ b/test/error-handler/with2.js
@@ -1,0 +1,9 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":6,"column":5},"end":{"line":6,"column":8},"identifierName":"obj","source":"test/error-handler/with2.js"},"severity":"RecoverableError","errorCode":"PP0007"}, {"location":{"start":{"line":7,"column":2},"end":{"line":7,"column":3},"identifierName":"z","source":"test/error-handler/with2.js"},"severity":"FatalError","errorCode":"PP0001"}]
+
+let obj = global.__abstract ? __makePartial({x:1,y:3}, '({x:1,y:3})') : {x:1,y:3};
+let y = 2;
+with(obj) {
+  z = x + y;
+}
+inspect = function() { return z; }

--- a/test/serializer/abstract/JSONparse.js
+++ b/test/serializer/abstract/JSONparse.js
@@ -1,0 +1,13 @@
+// add at runtime: let t = { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "t") : { x: 1 };
+str = JSON.stringify(ob);
+ob.x = 3;
+let ob2 = JSON.parse(str);
+let ob2x = ob2.x;
+ob2.x++;
+x = ob2.x;
+let ob3 = JSON.parse(str);
+y = ob3.x;
+z = ob2x;
+
+inspect = function() { return "" + str + ob.x + ob2.x + ob3.x + z }

--- a/test/serializer/abstract/JSONparse2.js
+++ b/test/serializer/abstract/JSONparse2.js
@@ -1,0 +1,12 @@
+let ob = global.__makePartial ? __makePartial({ x: 1 }) : { x: 1 };
+str = JSON.stringify(ob);
+ob.x = 3;
+let ob2 = JSON.parse(str);
+let ob2x = ob2.x;
+ob2.x++;
+x = ob2.x;
+let ob3 = JSON.parse(str);
+y = ob3.x;
+z = ob2x;
+
+inspect = function() { return "" + str + ob.x + ob2.x + ob3.x + z }

--- a/test/serializer/optimizations/require_delay.js
+++ b/test/serializer/optimizations/require_delay.js
@@ -94,7 +94,7 @@ function moduleThrewError(id) {
 // === End require code ===
 
 define(function(global, require, module, exports) {
-  var obj = global.__abstract ? __abstract(undefined, "({unsupported: true})") : ({unsupported: true});
+  var obj = global.__abstract ? __abstract("object", "({unsupported: true})") : ({unsupported: true});
   if (obj.unsupported) {
     exports.magic = 42;
   } else {

--- a/test/serializer/optimizations/require_unsupported.js
+++ b/test/serializer/optimizations/require_unsupported.js
@@ -94,7 +94,7 @@ function moduleThrewError(id) {
 // === End require code ===
 
 define(function(global, require, module, exports) {
-  if (__abstract().unsupported) {}
+  if (__abstract("object").unsupported) {}
 }, 0, null);
 
 define(function(global, require, module, exports) {


### PR DESCRIPTION
Modify JSON.stringify to work on partial objects rather than with the template object of an abstract object. Modify JSON.parse to produce a partial object rather than an abstract object when parsing the output of stringify called on a partial object.

The relevant test cases for this need partial objects with intrinsic names, so also add a new model function "__makeIntrinsic" that adds an intrinsic name to a given object and fixes up all of the properties so that they are referenced via expressions rooted in the intrinsic name.

With this in place, remove all of the remaining uses of __abstract applied to a model object.

#882