### PR TITLE
Proper serialization of Symbols in global registry

### DIFF
--- a/src/intrinsics/ecma262/Symbol.js
+++ b/src/intrinsics/ecma262/Symbol.js
@@ -14,8 +14,6 @@ import { AbstractValue, NativeFunctionValue, StringValue, SymbolValue, Undefined
 import { ToStringPartial } from "../../methods/index.js";
 import { SameValue } from "../../methods/abstract.js";
 
-let GlobalSymbolRegistry: Array<{ $Key: string, $Symbol: SymbolValue }> = [];
-
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.4.1.1
   let func = new NativeFunctionValue(realm, "Symbol", "Symbol", 0, (context, [description], argCount, NewTarget) => {
@@ -46,7 +44,7 @@ export default function(realm: Realm): NativeFunctionValue {
     stringKey = new StringValue(realm, stringKey);
 
     // 2. For each element e of the GlobalSymbolRegistry List,
-    for (let e of GlobalSymbolRegistry) {
+    for (let e of realm.globalSymbolRegistry) {
       // a. If SameValue(e.[[Key]], stringKey) is true, return e.[[Symbol]].
       if (e.$Key === stringKey.value) {
         return e.$Symbol;
@@ -59,7 +57,7 @@ export default function(realm: Realm): NativeFunctionValue {
     let newSymbol = new SymbolValue(realm, stringKey);
 
     // 5. Append the Record { [[Key]]: stringKey, [[Symbol]]: newSymbol } to the GlobalSymbolRegistry List.
-    GlobalSymbolRegistry.push({ $Key: stringKey.value, $Symbol: newSymbol });
+    realm.globalSymbolRegistry.push({ $Key: stringKey.value, $Symbol: newSymbol });
 
     // 6. Return newSymbol.
     return newSymbol;
@@ -73,7 +71,7 @@ export default function(realm: Realm): NativeFunctionValue {
     }
 
     // 2. For each element e of the GlobalSymbolRegistry List (see 19.4.2.1),
-    for (let e of GlobalSymbolRegistry) {
+    for (let e of realm.globalSymbolRegistry) {
       // a. If SameValue(e.[[Symbol]], sym) is true, return e.[[Key]].
       if (SameValue(realm, e.$Symbol, sym) === true) {
         return new StringValue(realm, e.$Key);

--- a/src/realm.js
+++ b/src/realm.js
@@ -20,6 +20,7 @@ import {
   StringValue,
   ConcreteValue,
   UndefinedValue,
+  SymbolValue,
 } from "./values/index.js";
 import { TypesDomain, ValuesDomain } from "./domains/index.js";
 import { LexicalEnvironment, Reference, GlobalEnvironmentRecord } from "./environment.js";
@@ -168,6 +169,8 @@ export class Realm {
     this.$GlobalEnv = ((undefined: any): LexicalEnvironment);
 
     this.errorHandler = opts.errorHandler;
+
+    this.globalSymbolRegistry = [];
   }
 
   start: number;
@@ -223,6 +226,8 @@ export class Realm {
   MOBILE_JSC_VERSION = "jsc-600-1-4-17";
 
   errorHandler: ?ErrorHandler;
+
+  globalSymbolRegistry: Array<{ $Key: string, $Symbol: SymbolValue }>;
 
   // to force flow to type the annotations
   isCompatibleWith(compatibility: Compatibility): boolean {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1029,13 +1029,10 @@ export class ResidualHeapSerializer {
     // check if symbol value exists in the global symbol map, in that case we emit an invocation of System.for
     // to look it up
     let globalReg = this.realm.globalSymbolRegistry.find(e => e.$Symbol === val) !== undefined;
-    if (globalReg === undefined) {
-      return t.callExpression(this.preludeGenerator.memoizeReference("Symbol"), args);
+    if (globalReg) {
+      return t.callExpression(this.preludeGenerator.memoizeReference("Symbol.for"), args);
     } else {
-      return t.callExpression(
-        t.memberExpression(this.preludeGenerator.memoizeReference("Symbol"), t.identifier("for"), false),
-        args
-      );
+      return t.callExpression(this.preludeGenerator.memoizeReference("Symbol"), args);
     }
   }
 

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1026,7 +1026,17 @@ export class ResidualHeapSerializer {
       invariant(serializedArg);
       args.push(serializedArg);
     }
-    return t.callExpression(this.preludeGenerator.memoizeReference("Symbol"), args);
+    // check if symbol value exists in the global symbol map, in that case we emit an invocation of System.for
+    // to look it up
+    let globalReg = this.realm.globalSymbolRegistry.find(e => e.$Symbol === val) !== undefined;
+    if (globalReg === undefined) {
+      return t.callExpression(this.preludeGenerator.memoizeReference("Symbol"), args);
+    } else {
+      return t.callExpression(
+        t.memberExpression(this.preludeGenerator.memoizeReference("Symbol"), t.identifier("for"), false),
+        args
+      );
+    }
   }
 
   _serializeValueProxy(val: ProxyValue): BabelNodeExpression {

--- a/test/serializer/basic/Symbols2.js
+++ b/test/serializer/basic/Symbols2.js
@@ -1,0 +1,7 @@
+(function() {
+    let a = Symbol.for("test");
+    let b = Symbol.for("test");
+    inspect = function() {
+        return "" + (a === Symbol.for("test"));
+    }
+})();


### PR DESCRIPTION
When serializing a symbol value first check if it is present in the
GlobalSymbolRegistry, if so emit a Symbol.for(..) lookup instead.
Minor refactoring also included: Change GlobalSymbolRegistry from global
to property of Realm.
Issue #855 