### PR TITLE
Handle syntax errors

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { CompilerDiagnostic, ErrorHandlerResult } from "../lib/errors.js";
+import { type CompilerDiagnostic, type ErrorHandlerResult, FatalError } from "../lib/errors.js";
 import { prepackFileSync } from "../lib/prepack-node.js";
 import invariant from "../lib/invariant.js";
 
@@ -79,7 +79,9 @@ function runTest(name: string, code: string): boolean {
       return false;
     }
   } catch (e) {
-    // We expect serialization to fail, so catch the error and continue
+    if (!(e instanceof FatalError)) {
+      console.log(chalk.red(`Unexpected error: ${e.message}`));
+    }
   }
   if (errors.length !== expectedErrors.length) {
     console.log(chalk.red(`Expected ${expectedErrors.length} errors, but found ${errors.length}`));

--- a/src/environment.js
+++ b/src/environment.js
@@ -29,7 +29,7 @@ import {
   PossiblyNormalCompletion,
   ThrowCompletion,
 } from "./completions.js";
-import { FatalError } from "./errors.js";
+import { CompilerDiagnostic, FatalError } from "./errors.js";
 import { defaultOptions } from "./options";
 import type { PartialEvaluatorOptions } from "./options";
 import { ExecutionContext } from "./realm.js";
@@ -1090,7 +1090,16 @@ export class LexicalEnvironment {
         code[source.filePath] = source.fileContents;
         directives = directives.concat(node.program.directives);
       } catch (e) {
-        if (e instanceof ThrowCompletion) return e;
+        if (e instanceof ThrowCompletion) {
+          let error = e.value;
+          if (error instanceof ObjectValue) {
+            let message = error.$Get("message", error);
+            e.location.source = source.filePath;
+            let err = new CompilerDiagnostic(message.value, e.location, "PP1004", "FatalError");
+            this.realm.handleError(err);
+            throw new FatalError("syntax error");
+          }
+        }
         throw e;
       }
     }
@@ -1102,14 +1111,15 @@ export class LexicalEnvironment {
     sourceType: SourceType = "script",
     onParse: void | (BabelNodeFile => void) = undefined
   ): [AbruptCompletion | Value, any] {
-    let [ast, code] = this.concatenateAndParse(sources, sourceType);
     let context = new ExecutionContext();
     context.lexicalEnvironment = this;
     context.variableEnvironment = this;
     context.realm = this.realm;
     this.realm.pushContext(context);
-    let res;
+    let res, code;
     try {
+      let ast;
+      [ast, code] = this.concatenateAndParse(sources, sourceType);
       if (onParse) onParse(ast);
       res = this.evaluateCompletion(ast, false);
     } finally {

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -36,7 +36,7 @@ export default function(
     return ast;
   } catch (e) {
     if (e instanceof SyntaxError) {
-      // Babel reports all errors as syntax errors, even if a SyntaxError should be thrown.
+      // Babel reports all errors as syntax errors, even if a ReferenceError should be thrown.
       // What we do here is a totally robust way to address that issue.
       let referenceErrors = [
         "Invalid left-hand side in postfix operation",
@@ -60,7 +60,7 @@ export default function(
         loc: e.loc,
         stackDecorated: false,
       };
-      throw new ThrowCompletion(error, undefined);
+      throw new ThrowCompletion(error, e.loc);
     } else {
       throw e;
     }

--- a/test/error-handler/call.js
+++ b/test/error-handler/call.js
@@ -10,5 +10,5 @@ foo();
 o();
 o.m();
 
-var str = global.__abstract ? __abstract("string", "'xxx'") : "xxx";
+var str = global.__abstract ? __abstract("string", "('xxx')") : "xxx";
 eval(str);

--- a/test/error-handler/syntaxError.js
+++ b/test/error-handler/syntaxError.js
@@ -1,0 +1,3 @@
+// expected errors: [{"location":{"line":3,"column":3,"source":"test/error-handler/syntaxError.js"},"severity":"FatalError","errorCode":"PP1004","callStack":"Error\n    "}]
+
+if x then y


### PR DESCRIPTION
Set up an evaluation environment before parsing since the parse helper expects to be able to turn syntax errors into runtime errors.

Catch such errors and report them via handleError when not running eval.

Fixes issue: #900