### PR TITLE
Fix serializer wait for generator issue

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -19,6 +19,7 @@ import {
   SymbolValue,
 } from "../values/index.js";
 import type { BabelNodeStatement } from "babel-types";
+import type { GeneratorBody } from "./types.js";
 import { Generator } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import { BodyReference } from "./types.js";
@@ -49,32 +50,34 @@ export class Emitter {
     this._waitingForValues = new Map();
     this._waitingForBodies = new Map();
     this._body = mainBody;
-    this._declaredAbstractValues = new Set();
+    this._declaredAbstractValues = new Map();
     this._residualFunctions = residualFunctions;
     this._activeStack = [];
     this._activeValues = new Set();
-    this._activeBodies = new Set([mainBody]);
+    this._activeBodies = [mainBody];
     this._finalized = false;
   }
 
   _finalized: boolean;
   _activeStack: Array<string | Generator | Value>;
   _activeValues: Set<Value>;
-  _activeBodies: Set<Array<BabelNodeStatement>>;
+  _activeBodies: Array<GeneratorBody>;
   _residualFunctions: ResidualFunctions;
-  _waitingForValues: Map<
-    Value,
-    Array<{ body: Array<BabelNodeStatement>, dependencies: Array<Value>, func: () => void }>
-  >;
-  _waitingForBodies: Map<Array<BabelNodeStatement>, Array<{ dependencies: Array<Value>, func: () => void }>>;
-  _declaredAbstractValues: Set<AbstractValue>;
-  _body: Array<BabelNodeStatement>;
+  _waitingForValues: Map<Value, Array<{ body: GeneratorBody, dependencies: Array<Value>, func: () => void }>>;
+  _waitingForBodies: Map<GeneratorBody, Array<{ dependencies: Array<Value>, func: () => void }>>;
+  _declaredAbstractValues: Map<AbstractValue, GeneratorBody>;
+  _body: GeneratorBody;
 
-  beginEmitting(dependency: string | Generator | Value, targetBody: Array<BabelNodeStatement>) {
+  beginEmitting(dependency: string | Generator | Value, targetBody: GeneratorBody) {
     invariant(!this._finalized);
     this._activeStack.push(dependency);
-    if (dependency instanceof Value) this._activeValues.add(dependency);
-    else if (dependency instanceof Generator) this._activeBodies.add(targetBody);
+    if (dependency instanceof Value) {
+      invariant(!this._activeValues.has(dependency));
+      this._activeValues.add(dependency);
+    } else if (dependency instanceof Generator) {
+      invariant(!this._activeBodies.includes(targetBody));
+      this._activeBodies.push(targetBody);
+    }
     let oldBody = this._body;
     this._body = targetBody;
     return oldBody;
@@ -84,7 +87,7 @@ export class Emitter {
     this._body.push(statement);
     this._processCurrentBody();
   }
-  endEmitting(dependency: string | Generator | Value, oldBody: Array<BabelNodeStatement>) {
+  endEmitting(dependency: string | Generator | Value, oldBody: GeneratorBody) {
     invariant(!this._finalized);
     let lastDependency = this._activeStack.pop();
     invariant(dependency === lastDependency);
@@ -93,8 +96,8 @@ export class Emitter {
       this._activeValues.delete(dependency);
       this._processValue(dependency);
     } else if (dependency instanceof Generator) {
-      invariant(this._activeBodies.has(this._body));
-      this._activeBodies.delete(this._body);
+      invariant(this._isEmittingActiveGenerator());
+      this._activeBodies.pop();
     }
     let lastBody = this._body;
     this._body = oldBody;
@@ -102,18 +105,31 @@ export class Emitter {
   }
   finalize() {
     invariant(!this._finalized);
-    invariant(this._activeBodies.size === 1);
-    invariant(this._activeBodies.has(this._body));
-    this._activeBodies.delete(this._body);
+    invariant(this._activeBodies.length === 1);
+    invariant(this._activeBodies[0] === this._body);
     this._processCurrentBody();
+    this._activeBodies.pop();
     this._finalized = true;
     invariant(this._waitingForBodies.size === 0);
     invariant(this._waitingForValues.size === 0);
     invariant(this._activeStack.length === 0);
     invariant(this._activeValues.size === 0);
-    invariant(this._activeBodies.size === 0);
+    invariant(this._activeBodies.length === 0);
+  }
+  /**
+   * Emitter is emitting in two modes:
+   * 1. Emitting to entries in current active generator
+   * 2. Emitting to body of another scope(generator or residual function)
+   * This function checks the first condition above.
+   */
+  _isEmittingActiveGenerator(): boolean {
+    invariant(this._activeBodies.length > 0);
+    return this._activeBodies[this._activeBodies.length - 1] === this._body;
   }
   _processCurrentBody() {
+    if (!this._isEmittingActiveGenerator()) {
+      return;
+    }
     let a = this._waitingForBodies.get(this._body);
     if (a === undefined) return;
     while (a.length > 0) {
@@ -129,10 +145,7 @@ export class Emitter {
     while (a.length > 0) {
       let { body, dependencies, func } = a.shift();
       if (body !== oldBody) {
-        invariant(this._activeBodies.has(body));
-        let b = this._waitingForBodies.get(body);
-        if (b === undefined) this._waitingForBodies.set(body, (b = []));
-        b.push({ dependencies, func });
+        this._emitAfterWaitingGeneratorBody(body, dependencies, func);
       } else {
         this.emitNowOrAfterWaitingForDependencies(dependencies, func);
       }
@@ -147,7 +160,7 @@ export class Emitter {
   //    (tracked by the `_declaredAbstractValues` set), or
   // 2. a value that is also currently being serialized
   //    (tracked by the `_activeStack`).
-  getReasonToWaitForDependencies(dependencies: Value | Array<Value>): void | Value {
+  getReasonToWaitForDependencies(dependencies: Value | Array<Value>): void | Value | GeneratorBody {
     invariant(!this._finalized);
     if (Array.isArray(dependencies)) {
       let values = ((dependencies: any): Array<Value>);
@@ -175,7 +188,28 @@ export class Emitter {
       this._residualFunctions.addFunctionUsage(val, this.getBodyReference());
       return undefined;
     } else if (val instanceof AbstractValue) {
-      if (val.hasIdentifier() && !this._declaredAbstractValues.has(val)) return val;
+      if (val.hasIdentifier()) {
+        const valSerializeBody = this._declaredAbstractValues.get(val);
+        if (!valSerializeBody) {
+          // Hasn't been serialized yet.
+          return val;
+        } else {
+          // The dependency has already been serialized(declared). But we may still have to wait for
+          // current generator body to be available, under following conditions:
+          // 1. It is not delay initializations scenario(which this._body points to residual function)
+          // 2. Not emitting in current active generator.(otherwise no need to wait)
+          // 3. Dependency's generator body is still active.
+          // 4. and dependency generator body is lower in active generator stack than current body.
+          if (
+            this._activeBodies.includes(this._body) &&
+            !this._isEmittingActiveGenerator() &&
+            this._activeBodies.includes(valSerializeBody) &&
+            this._activeBodies.indexOf(valSerializeBody) > this._activeBodies.indexOf(this._body)
+          ) {
+            return this._body;
+          }
+        }
+      }
       for (let arg of val.args) {
         delayReason = this.getReasonToWaitForDependencies(arg);
         if (delayReason) return delayReason;
@@ -218,7 +252,20 @@ export class Emitter {
     invariant(this._activeValues.has(value));
     return condition ? value : undefined;
   }
-  emitAfterWaiting(reason: Value, dependencies: Array<Value>, func: () => void) {
+  emitAfterWaiting(delayReason: void | Value | GeneratorBody, dependencies: Array<Value>, func: () => void) {
+    if (!delayReason) {
+      func();
+    } else if (delayReason instanceof Value) {
+      this._emitAfterWaitingValue(delayReason, dependencies, func);
+    } else if (Array.isArray(delayReason)) {
+      // delayReason is GeneratorBody.
+      this._emitAfterWaitingGeneratorBody(delayReason, dependencies, func);
+    } else {
+      // Unknown delay reason.
+      invariant(false);
+    }
+  }
+  _emitAfterWaitingValue(reason: Value, dependencies: Array<Value>, func: () => void) {
     invariant(!this._finalized);
     invariant(
       !(reason instanceof AbstractValue && this._declaredAbstractValues.has(reason)) || this._activeValues.has(reason)
@@ -227,27 +274,29 @@ export class Emitter {
     if (a === undefined) this._waitingForValues.set(reason, (a = []));
     a.push({ body: this._body, dependencies, func });
   }
+  _emitAfterWaitingGeneratorBody(reason: GeneratorBody, dependencies: Array<Value>, func: () => void) {
+    invariant(!this._finalized);
+    invariant(this._activeBodies.includes(reason));
+    let b = this._waitingForBodies.get(reason);
+    if (b === undefined) this._waitingForBodies.set(reason, (b = []));
+    b.push({ dependencies, func });
+  }
   emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void) {
     invariant(!this._finalized);
-    let delayReason = this.getReasonToWaitForDependencies(dependencies);
-    if (delayReason) {
-      this.emitAfterWaiting(delayReason, dependencies, func);
-    } else {
-      func();
-    }
+    this.emitAfterWaiting(this.getReasonToWaitForDependencies(dependencies), dependencies, func);
   }
   declare(value: AbstractValue) {
     invariant(!this._finalized);
     invariant(!this._activeValues.has(value));
     invariant(value.hasIdentifier());
-    this._declaredAbstractValues.add(value);
+    this._declaredAbstractValues.set(value, this._body);
     this._processValue(value);
   }
   hasBeenDeclared(value: AbstractValue) {
     invariant(!this._finalized);
     return this._declaredAbstractValues.has(value);
   }
-  getBody(): Array<BabelNodeStatement> {
+  getBody(): GeneratorBody {
     return this._body;
   }
   getBodyReference() {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -111,7 +111,7 @@ export class ResidualHeapSerializer {
       this.preludeGenerator.createNameGenerator("__scope_"),
       residualFunctionInfos
     );
-    this.emitter = new Emitter(this.residualFunctions);
+    this.emitter = new Emitter(this.residualFunctions, delayInitializations);
     this.mainBody = this.emitter.getBody();
     this.residualHeapInspector = residualHeapInspector;
     this.residualValues = residualValues;

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -59,6 +59,8 @@ export type ScopeBinding = {
   capturedScope?: string,
 };
 
+export type GeneratorBody = Array<BabelNodeStatement>;
+
 export function AreSameSerializedBindings(realm: Realm, x: SerializedBinding, y: SerializedBinding) {
   if (x.serializedValue === y.serializedValue) return true;
   if (x.value && x.value === y.value) return true;

--- a/test/serializer/abstract/WaitGenerator1.js
+++ b/test/serializer/abstract/WaitGenerator1.js
@@ -1,0 +1,11 @@
+(function() {
+    let x = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let obj = { time: 99 };
+    if (x) {
+        obj.time = Date.now();
+        f = function() { return obj; }
+    } else {
+        f = function() { return obj; }
+    }
+    inspect = function() { return f().time > 0; };
+})();

--- a/test/serializer/abstract/WaitGenerator2.js
+++ b/test/serializer/abstract/WaitGenerator2.js
@@ -1,0 +1,11 @@
+(function() {
+    let x = global.__abstract ? __abstract("boolean", "(true)") : true;
+    global.obj = {};
+    if (x) {
+        var scope = Date.now();
+        global.obj.time = scope;
+    } else {
+        global.obj.time = 33;
+    }
+    inspect = function() { return global.obj.time > 0; };
+})();

--- a/test/serializer/abstract/WaitGenerator3.js
+++ b/test/serializer/abstract/WaitGenerator3.js
@@ -1,0 +1,12 @@
+(function() {
+  let x = global.__abstract ? __abstract("boolean", "true") : true;
+  global.obj = { time: 99 };
+  let dummy = {};  // Dummy closure binding to trigger global scope serialization in the middle of sub-generator.
+  if (x) {
+    global.obj.time = Date.now();
+    expose = function() { return dummy; };
+  } else {
+    global.obj.time = 33;
+  }
+  inspect = function() { return global.obj.time > 0; };
+})();

--- a/test/serializer/abstract/WaitGenerator4.js
+++ b/test/serializer/abstract/WaitGenerator4.js
@@ -1,0 +1,17 @@
+(function() {
+    let x = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let y = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let obj = { time: 99 };
+    if (x) {
+      if (y) {
+        // Wait for abstract value in sub-generator more than one depth.
+        obj.time = Date.now();
+      } else {
+        delete obj.time;
+      }
+      f = function() { return obj; }
+    } else {
+      f = function() { return obj; }
+    }
+    inspect = function() { return f().time > 0; };
+})();


### PR DESCRIPTION
Fix #892
After long investigation, I found the root cause is not that residual function is generated in global scope but the closure binding being emitted in global scope needs to wait for it's dependencies in sub-generator to be inserted in final code stream.
Our emitter can only check if the dependencies are declared(serialized) or not, but it has no capability to know if the sub-generator body that the dependencies emitted in has been inserted into global generator or not. This caused all sort of ordering issue.(All the tests added in this PR failed in master).

To fix this issue, I did the following changes:
1.  Modify Emitter._activeBodies to be a generator stack so that we know the ordering of different generator.
2. Add GeneratorBody as a second reason for waiting dependency if the dependency value is emitting in an active generator lower in generator stack.
3. Distinguish two modes of emitter: emitting in random generator/function or emitting in current active generator(top in the stack).
