### PR TITLE
Clean up how we memoize intrinsics that conceptually exist ahead of time

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -419,10 +419,12 @@ export class PreludeGenerator {
     if (ref) return ref;
 
     let init;
-    if (key.startsWith("(")) {
+    if (key.includes("(") || key.includes("[")) {
       // Horrible but effective hack:
       // Some internal object have intrinsic names such as
       //    ([][Symbol.iterator]().__proto__.__proto__)
+      // and
+      //    RegExp.prototype[Symbol.match]
       // which get turned into a babel node here.
       // TODO: We should properly parse such a string, and memoize all references in it separately.
       // Instead, we just turn it into a funky identifier, which Babel seems to accept.

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -34,7 +34,6 @@ import type {
   BabelNodeIdentifier,
   BabelNodeStatement,
   BabelNodeMemberExpression,
-  BabelNodeThisExpression,
 } from "babel-types";
 import { nullExpression } from "./internalizer.js";
 
@@ -388,7 +387,7 @@ export class PreludeGenerator {
 
   prelude: Array<BabelNodeStatement>;
   derivedIds: Map<string, Array<Value>>;
-  memoizedRefs: Map<string, BabelNodeIdentifier | BabelNodeMemberExpression | BabelNodeThisExpression>;
+  memoizedRefs: Map<string, BabelNodeIdentifier>;
   nameGenerator: NameGenerator;
   usesThis: boolean;
   declaredGlobals: Set<string>;
@@ -402,17 +401,10 @@ export class PreludeGenerator {
     );
   }
 
-  convertStringToMember(str: string): BabelNodeIdentifier | BabelNodeMemberExpression | BabelNodeThisExpression {
+  convertStringToMember(str: string): BabelNodeIdentifier | BabelNodeMemberExpression {
     return str
       .split(".")
-      .map(name => {
-        if (name === "global") {
-          this.usesThis = true;
-          return t.thisExpression();
-        } else {
-          return t.identifier(name);
-        }
-      })
+      .map(name => (name === "global" ? this.memoizeReference(name) : t.identifier(name)))
       .reduce((obj, prop) => t.memberExpression(obj, prop));
   }
 
@@ -422,12 +414,32 @@ export class PreludeGenerator {
     return t.memberExpression(this.memoizeReference("global"), keyNode, !t.isIdentifier(keyNode));
   }
 
-  memoizeReference(key: string): BabelNodeIdentifier | BabelNodeMemberExpression | BabelNodeThisExpression {
+  memoizeReference(key: string): BabelNodeIdentifier {
     let ref = this.memoizedRefs.get(key);
     if (ref) return ref;
 
+    let init;
+    if (key.startsWith("(")) {
+      // Horrible but effective hack:
+      // Some internal object have intrinsic names such as
+      //    ([][Symbol.iterator]().__proto__.__proto__)
+      // which get turned into a babel node here.
+      // TODO: We should properly parse such a string, and memoize all references in it separately.
+      // Instead, we just turn it into a funky identifier, which Babel seems to accept.
+      init = t.identifier(key);
+    } else if (key === "global") {
+      this.usesThis = true;
+      init = t.thisExpression();
+    } else {
+      let i = key.lastIndexOf(".");
+      if (i === -1) {
+        init = t.identifier(key);
+      } else {
+        init = t.memberExpression(this.memoizeReference(key.substr(0, i)), t.identifier(key.substr(i + 1)));
+      }
+    }
     ref = t.identifier(this.nameGenerator.generate(key));
-    this.prelude.push(t.variableDeclaration("var", [t.variableDeclarator(ref, this.convertStringToMember(key))]));
+    this.prelude.push(t.variableDeclaration("var", [t.variableDeclarator(ref, init)]));
     this.memoizedRefs.set(key, ref);
     return ref;
   }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -433,7 +433,7 @@ export class PreludeGenerator {
     } else {
       let i = key.lastIndexOf(".");
       if (i === -1) {
-        init = t.identifier(key);
+        init = t.memberExpression(this.memoizeReference("global"), t.identifier(key));
       } else {
         init = t.memberExpression(this.memoizeReference(key.substr(0, i)), t.identifier(key.substr(i + 1)));
       }

--- a/test/serializer/basic/IncrementalMemoization.js
+++ b/test/serializer/basic/IncrementalMemoization.js
@@ -1,0 +1,6 @@
+// Copies of String: 1
+(function() {
+    let indexOf = String.prototype.indexOf;
+    let substr = String.prototype.substr;
+    inspect = function() { return indexOf.name + substr.name; }
+})();


### PR DESCRIPTION
Always go through PreludeGenerator.memoizeReference.
Also, memoizeReference now does its job incrementally.
I discovered that we currently do something funky for some intrinsics whose names are not actually dotted identifiers, and I call that out in a comment.