### PR TITLE
Fix property lookup on simple partial objects

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -18,7 +18,6 @@ import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { IsDataDescriptor, joinValuesAsConditional, cloneDescriptor, equalDescriptors } from "../methods/index.js";
 import type { BabelNodeExpression } from "babel-types";
 import invariant from "../invariant.js";
-import * as t from "babel-types";
 
 export default class AbstractObjectValue extends AbstractValue {
   constructor(
@@ -240,17 +239,6 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        if (cv.isSimpleObject() && typeof P === "string") {
-          let generator = this.$Realm.generator;
-          invariant(generator !== undefined);
-          let pname = generator.getAsPropertyNameExpression(P);
-          let d = cv.$GetOwnProperty(P);
-          if (d === undefined) {
-            return this.$Realm.deriveAbstract(TypesDomain.topVal, ValuesDomain.topVal, [cv], ([node]) =>
-              t.memberExpression(node, pname, !t.isIdentifier(pname))
-            );
-          }
-        }
         return cv.$Get(P, Receiver);
       }
       invariant(false);

--- a/test/error-handler/with.js
+++ b/test/error-handler/with.js
@@ -1,7 +1,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":7,"column":5},"end":{"line":7,"column":8},"identifierName":"obj","source":"test/error-handler/with.js"},"severity":"RecoverableError","errorCode":"PP0007"}]
 
-let obj = global.__abstract ? __abstract({x:1}, '({x:1,y:3})') : {x:1,y:3};
+let obj = global.__abstract ? __abstract({x:1,y:3}, '({x:1,y:3})') : {x:1,y:3};
 if (global.__makeSimple) global.__makeSimple(obj);
 let y = 2;
 with(obj) {

--- a/test/serializer/abstract/GetValue6.js
+++ b/test/serializer/abstract/GetValue6.js
@@ -1,4 +1,5 @@
-let ob = global.__makePartial ? __makeSimple(__makePartial({})) : {};
+let ob = global.__makePartial ? __makeSimple(__makePartial({})) : { a: 123 };
+if (global.__residual) __residual("void", (o) => { o.a = 123; }, ob);
 
 z = ob.a;
 


### PR DESCRIPTION
OrdinaryGetOwnProperty used to just return undefined when asked for the value of a non existent property of a simple partial object. That meant that getting the value "__makeSimple(__makePartial({})).gotcha" deterministically evaluated to undefined at Prepack time, which is all sorts of wrong, as well as inconsistent with what happened in the case of "__makeSimple(__abstract({}, "xxx").gotcha".

Things should now be consistent and the property should evaluate to an abstract value at Prepack time.

This still leaves a whole lot of other broken behaviors when doing Reflection on simple partial objects. But that is already broken, something of a corner case and a whole lot harder to check for, so it will have to wait.