### PR TITLE
fixed suspicious and duplicated codes

### DIFF
--- a/src/methods/construct.js
+++ b/src/methods/construct.js
@@ -139,7 +139,7 @@ export function MakeClassConstructor(realm: Realm, F: ECMAScriptSourceFunctionVa
   invariant(F instanceof ECMAScriptSourceFunctionValue, "expected function value");
 
   // 2. Assert: F’s [[FunctionKind]] internal slot is "normal".
-  invariant((F.$FunctionKind = "normal"));
+  invariant(F.$FunctionKind === "normal");
 
   // 3. Set F’s [[FunctionKind]] internal slot to "classConstructor".
   F.$FunctionKind = "classConstructor";

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -94,10 +94,6 @@ export default class ConcreteValue extends Value {
     return this.throwIfNotObject();
   }
 
-  throwIfNotConcreteString(): StringValue {
-    invariant(false, "expected this to be a string if concrete");
-  }
-
   throwIfNotObject(): ObjectValue {
     invariant(false, "expected this to be an object if concrete");
   }

--- a/src/values/StringValue.js
+++ b/src/values/StringValue.js
@@ -31,8 +31,4 @@ export default class StringValue extends PrimitiveValue {
   _serialize(): string {
     return this.value;
   }
-
-  throwIfNotConcreteString(): StringValue {
-    return this;
-  }
 }


### PR DESCRIPTION
I really love the Prepack project and tried to find some suspicious lines... In a quite conservative approach.

src/methods/construct.js: The assertion is supposed to perform Function kind, which is "normal" | "classConstructor" | "generator" defined in ECMAScriptFunctionValue. Not assigning that.

src/values/ConcreteValue.js / src/values/StringValue.js: The definition of throwIfNotConcreteString is duplicated. Removed redundent one.

test/std-in/StdInError.js: A missing bracket.

Plz, check. Thx.