### PR TITLE
Make buildNode optional

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -26,7 +26,7 @@ import { ObjectCreate } from "../../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import * as t from "babel-types";
-import type { BabelNodeExpression, BabelNodeSpreadElement, BabelNodeIdentifier } from "babel-types";
+import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
 import invariant from "../../invariant.js";
 import { describeLocation } from "../ecma262/Error.js";
 
@@ -170,7 +170,7 @@ export default function(realm: Realm): void {
           );
           template.makePartial();
           invariant(realm.generator);
-          realm.rebuildNestedProperties(result, ((result._buildNode: any): BabelNodeIdentifier).name);
+          realm.rebuildNestedProperties(result, result.getIdentifier().name);
         }
         return result;
       }

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1027,7 +1027,7 @@ export function OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: Property
     if (O.isPartialObject() && value instanceof AbstractValue && value.kind !== "resolved") {
       let realmGenerator = realm.generator;
       invariant(realmGenerator);
-      value = realmGenerator.derive(value.types, value.values, value.args, value._buildNode, { kind: "resolved" });
+      value = realmGenerator.derive(value.types, value.values, value.args, value.getBuildNode(), { kind: "resolved" });
       InternalSetProperty(realm, O, P, {
         value: value,
         writable: "writable" in X ? X.writable : false,

--- a/src/partial-evaluators/ArrayExpression.js
+++ b/src/partial-evaluators/ArrayExpression.js
@@ -129,12 +129,7 @@ export default function(
       // could not be iterated at compile time, so the index that this element
       // will have at runtime is not known at this point.
 
-      let abstractIndex = realm.createAbstract(
-        new TypesDomain(NumberValue),
-        ValuesDomain.topVal,
-        [],
-        t.identifier("never used")
-      );
+      let abstractIndex = realm.createAbstract(new TypesDomain(NumberValue), ValuesDomain.topVal, []);
       array.$SetPartial(abstractIndex, elemValue, array);
     } else {
       // Redundant steps.

--- a/src/partial-evaluators/BinaryExpression.js
+++ b/src/partial-evaluators/BinaryExpression.js
@@ -116,12 +116,7 @@ export function createAbstractValueForBinary(
       AbstractValue.reportIntrospectionError((val: any));
       throw new FatalError();
     }
-    resultValue = realm.createAbstract(
-      new TypesDomain(resultType),
-      ValuesDomain.topVal,
-      [],
-      t.identifier("never used")
-    );
+    resultValue = realm.createAbstract(new TypesDomain(resultType), ValuesDomain.topVal, []);
   }
   let r = composeNormalCompletions(leftCompletion, rightCompletion, resultValue, realm);
   return [r, ast, io];

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -180,7 +180,7 @@ function EvaluateCall(
     // such functions have no visible side-effects. Hence we can carry on
     // by returning a call node with the arguments updated with their partial counterparts.
     // TODO: obtain the type of the return value from the abstract function.
-    return realm.createAbstract(TypesDomain.topVal, ValuesDomain.topVal, [], t.identifier("never used"));
+    return realm.createAbstract(TypesDomain.topVal, ValuesDomain.topVal, []);
   }
   // If func is abstract and not known to be a safe function, we can't safely continue.
   func = func.throwIfNotConcrete();

--- a/src/realm.js
+++ b/src/realm.js
@@ -653,7 +653,7 @@ export class Realm {
     types: TypesDomain,
     values: ValuesDomain,
     args: Array<Value>,
-    buildNode: ((Array<BabelNodeExpression>) => BabelNodeExpression) | BabelNodeExpression,
+    buildNode?: ((Array<BabelNodeExpression>) => BabelNodeExpression) | BabelNodeExpression,
     kind?: string,
     intrinsicName?: string
   ) {

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -26,7 +26,7 @@ export default class AbstractObjectValue extends AbstractValue {
     types: TypesDomain,
     values: ValuesDomain,
     args: Array<Value>,
-    buildNode: AbstractValueBuildNodeFunction | BabelNodeExpression,
+    buildNode?: AbstractValueBuildNodeFunction | BabelNodeExpression,
     optionalArgs?: {| kind?: string, intrinsicName?: string, isPure?: boolean |}
   ) {
     super(realm, types, values, args, buildNode, optionalArgs);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -40,7 +40,7 @@ export default class AbstractValue extends Value {
     types: TypesDomain,
     values: ValuesDomain,
     args: Array<Value>,
-    buildNode: AbstractValueBuildNodeFunction | BabelNodeExpression,
+    buildNode?: AbstractValueBuildNodeFunction | BabelNodeExpression,
     optionalArgs?: {| kind?: string, intrinsicName?: string, isPure?: boolean |}
   ) {
     invariant(realm.useAbstractInterpretation);
@@ -73,16 +73,22 @@ export default class AbstractValue extends Value {
   values: ValuesDomain;
   mightBeEmpty: boolean;
   args: Array<Value>;
-  _buildNode: AbstractValueBuildNodeFunction | BabelNodeExpression;
+  _buildNode: void | AbstractValueBuildNodeFunction | BabelNodeExpression;
+
+  getBuildNode(): AbstractValueBuildNodeFunction | BabelNodeExpression {
+    invariant(this._buildNode);
+    return this._buildNode;
+  }
 
   buildNode(args: Array<BabelNodeExpression>): BabelNodeExpression {
-    return this._buildNode instanceof Function
-      ? ((this._buildNode: any): AbstractValueBuildNodeFunction)(args)
-      : ((this._buildNode: any): BabelNodeExpression);
+    let buildNode = this.getBuildNode();
+    return buildNode instanceof Function
+      ? ((buildNode: any): AbstractValueBuildNodeFunction)(args)
+      : ((buildNode: any): BabelNodeExpression);
   }
 
   hasIdentifier() {
-    return this._buildNode.type === "Identifier";
+    return this._buildNode && this._buildNode.type === "Identifier";
   }
 
   getIdentifier() {
@@ -91,7 +97,7 @@ export default class AbstractValue extends Value {
   }
 
   addSourceLocationsTo(locations: Array<BabelNodeSourceLocation>) {
-    if (!(this._buildNode instanceof Function)) {
+    if (this._buildNode && !(this._buildNode instanceof Function)) {
       if (this._buildNode.loc) locations.push(this._buildNode.loc);
     }
     for (let val of this.args) {


### PR DESCRIPTION
Not all AbstractValues end up in the serializer and there are a going to be more of those in the future. Such values do not need to have values in their _buildNode properties, so make the property optional and add the necessary checks.