### PR TITLE
Make it easier to combine abstract values via operators. Part 1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test-error-handler-with-coverage": "./node_modules/.bin/istanbul cover ./lib/test-error-handler.js --dir coverage.error && ./node_modules/.bin/remap-istanbul -i coverage.error/coverage.json -o coverage-sourcemapped.error -t html",
     "test-node-cli-mode": "bash < scripts/test-node-cli-mode.sh",
     "test-std-in": "bash < scripts/test-std-in.sh",
-    "test": "yarn test-residual && yarn test-serializer && yarn test-sourcemaps && yarn test-test262 && yarn test-internal && yarn test-error-handler && yarn test-std-in",
+    "test": "yarn test-residual && yarn test-serializer && yarn test-sourcemaps && yarn test-error-handler && yarn test-std-in && yarn test-test262 && yarn test-internal",
     "repl": "node lib/repl-cli.js",
     "prepack": "node lib/prepack-cli.js",
     "prepack-prepack": "node --stack_size=10000 --max_old_space_size=8096 ./bin/prepack.js ./lib/prepack-cli.js --out ./lib/prepack-cli.prepacked.js --compatibility node-cli --mathRandomSeed rnd",

--- a/src/domains/TypesDomain.js
+++ b/src/domains/TypesDomain.js
@@ -9,16 +9,20 @@
 
 /* @flow */
 
+import invariant from "../invariant.js";
+import type { BabelBinaryOperator } from "babel-types";
 import {
   AbstractValue,
+  BooleanValue,
   ConcreteValue,
   FunctionValue,
+  NumberValue,
   ObjectValue,
   PrimitiveValue,
+  StringValue,
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import invariant from "../invariant.js";
 
 /* An abstract domain for the type of value a variable might have.  */
 
@@ -34,6 +38,50 @@ export default class TypesDomain {
 
   getType(): typeof Value {
     return this._type || Value;
+  }
+
+  // return the type of the result in the case where there is no exception
+  static binaryOp(op: BabelBinaryOperator, left: TypesDomain, right: TypesDomain): TypesDomain {
+    let lType = left._type;
+    let rType = right._type;
+    if (lType === undefined || rType === undefined) return TypesDomain.topVal;
+    let resultType = Value;
+    switch (op) {
+      case "+":
+        if (Value.isTypeCompatibleWith(lType, StringValue) || Value.isTypeCompatibleWith(rType, StringValue))
+          resultType = StringValue;
+        else if (Value.isTypeCompatibleWith(lType, NumberValue) && Value.isTypeCompatibleWith(rType, NumberValue))
+          resultType = NumberValue;
+        break;
+      case "<":
+      case ">":
+      case ">=":
+      case "<=":
+      case "!=":
+      case "==":
+      case "!==":
+      case "===":
+      case "in":
+      case "instanceof":
+        resultType = BooleanValue;
+        break;
+      case ">>>":
+      case "<<":
+      case ">>":
+      case "&":
+      case "|":
+      case "^":
+      case "**":
+      case "%":
+      case "/":
+      case "*":
+      case "-":
+        resultType = NumberValue;
+        break;
+      default:
+        invariant(false);
+    }
+    return new TypesDomain(resultType);
   }
 
   static joinValues(v1: void | Value, v2: void | Value): TypesDomain {

--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -9,9 +9,36 @@
 
 /* @flow */
 
+import type { BabelBinaryOperator } from "babel-types";
+import { AbruptCompletion } from "../completions.js";
+import { FatalError } from "../errors.js";
 import invariant from "../invariant.js";
+import {
+  AbstractEqualityComparison,
+  AbstractRelationalComparison,
+  Add,
+  HasProperty,
+  InstanceofOperator,
+  StrictEqualityComparison,
+  ToInt32,
+  ToNumber,
+  ToPrimitive,
+  ToPropertyKey,
+  ToString,
+  ToUint32,
+} from "../methods/index.js";
 import type { Realm } from "../realm.js";
-import { AbstractValue, ConcreteValue, EmptyValue, Value } from "../values/index.js";
+import {
+  AbstractValue,
+  BooleanValue,
+  ConcreteValue,
+  EmptyValue,
+  NumberValue,
+  ObjectValue,
+  StringValue,
+  UndefinedValue,
+  Value,
+} from "../values/index.js";
 
 /* An abstract domain that collects together a set of concrete values
    that might be the value of a variable at runtime.
@@ -40,6 +67,188 @@ export default class ValuesDomain {
   getElements() {
     invariant(this._elements !== undefined);
     return this._elements;
+  }
+
+  // return a set of values that may be result of performing the given operation on each pair in the
+  // Cartesian product of the value sets of the operands.
+  static binaryOp(realm: Realm, op: BabelBinaryOperator, left: ValuesDomain, right: ValuesDomain): ValuesDomain {
+    let leftElements = left._elements;
+    let rightElements = right._elements;
+    // Return top if left and/or right are top or if the size of the value set would get to be quite large.
+    // Note: the larger the set of values, the less we know and therefore the less we get value from computing
+    // all of these values. TODO: probably the upper bound can be quite a bit smaller.
+    if (!leftElements || !rightElements || leftElements.size > 100 || rightElements.size > 100)
+      return ValuesDomain.topVal;
+    let resultSet = new Set();
+    let savedHandler = realm.errorHandler;
+    try {
+      realm.errorHandler = () => {
+        throw new FatalError();
+      };
+      for (let leftElem of leftElements) {
+        for (let rightElem of rightElements) {
+          let result = ValuesDomain.computeBinary(realm, op, leftElem, rightElem);
+          invariant(result instanceof ConcreteValue);
+          resultSet.add(result);
+        }
+      }
+    } catch (e) {
+      if (e instanceof AbruptCompletion) return ValuesDomain.topVal;
+    } finally {
+      realm.errorHandler = savedHandler;
+    }
+    return new ValuesDomain(resultSet);
+  }
+
+  static computeBinary(realm: Realm, op: BabelBinaryOperator, lval: ConcreteValue, rval: ConcreteValue): Value {
+    if (op === "+") {
+      // ECMA262 12.8.3 The Addition Operator
+      let lprim = ToPrimitive(realm, lval);
+      let rprim = ToPrimitive(realm, rval);
+
+      if (lprim instanceof StringValue || rprim instanceof StringValue) {
+        let lstr = ToString(realm, lprim);
+        let rstr = ToString(realm, rprim);
+        return new StringValue(realm, lstr + rstr);
+      }
+
+      let lnum = ToNumber(realm, lprim);
+      let rnum = ToNumber(realm, rprim);
+      return Add(realm, lnum, rnum);
+    } else if (op === "<" || op === ">" || op === ">=" || op === "<=") {
+      // ECMA262 12.10.3
+      if (op === "<") {
+        let r = AbstractRelationalComparison(realm, lval, rval, true);
+        if (r instanceof UndefinedValue) {
+          return realm.intrinsics.false;
+        } else {
+          return r;
+        }
+      } else if (op === "<=") {
+        let r = AbstractRelationalComparison(realm, rval, lval, false);
+        if (r instanceof UndefinedValue || (r instanceof BooleanValue && r.value)) {
+          return realm.intrinsics.false;
+        } else {
+          return realm.intrinsics.true;
+        }
+      } else if (op === ">") {
+        let r = AbstractRelationalComparison(realm, rval, lval, false);
+        if (r instanceof UndefinedValue) {
+          return realm.intrinsics.false;
+        } else {
+          return r;
+        }
+      } else if (op === ">=") {
+        let r = AbstractRelationalComparison(realm, lval, rval, true);
+        if (r instanceof UndefinedValue || (r instanceof BooleanValue && r.value)) {
+          return realm.intrinsics.false;
+        } else {
+          return realm.intrinsics.true;
+        }
+      }
+    } else if (op === ">>>") {
+      // ECMA262 12.9.5.1
+      let lnum = ToUint32(realm, lval);
+      let rnum = ToUint32(realm, rval);
+
+      return new NumberValue(realm, lnum >>> rnum);
+    } else if (op === "<<" || op === ">>") {
+      let lnum = ToInt32(realm, lval);
+      let rnum = ToUint32(realm, rval);
+
+      if (op === "<<") {
+        // ECMA262 12.9.3.1
+        return new NumberValue(realm, lnum << rnum);
+      } else if (op === ">>") {
+        // ECMA262 12.9.4.1
+        return new NumberValue(realm, lnum >> rnum);
+      }
+    } else if (op === "**") {
+      // ECMA262 12.6.3
+
+      // 5. Let base be ? ToNumber(leftValue).
+      let base = ToNumber(realm, lval);
+
+      // 6. Let exponent be ? ToNumber(rightValue).
+      let exponent = ToNumber(realm, rval);
+
+      // 7. Return the result of Applying the ** operator with base and exponent as specified in 12.7.3.4.
+      return new NumberValue(realm, Math.pow(base, exponent));
+    } else if (op === "%" || op === "/" || op === "*" || op === "-") {
+      // ECMA262 12.7.3
+      let lnum = ToNumber(realm, lval);
+      let rnum = ToNumber(realm, rval);
+
+      if (isNaN(rnum)) return realm.intrinsics.NaN;
+      if (isNaN(lnum)) return realm.intrinsics.NaN;
+
+      if (op === "-") {
+        return Add(realm, lnum, rnum, true);
+      } else if (op === "%") {
+        // The sign of the result equals the sign of the dividend.
+        // If the dividend is an infinity, or the divisor is a zero, or both, the result is NaN.
+        // If the dividend is finite and the divisor is an infinity, the result equals the dividend.
+        // If the dividend is a zero and the divisor is nonzero and finite, the result is the same as the dividend.
+        return new NumberValue(realm, lnum % rnum);
+      } else if (op === "/") {
+        // The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
+        // Division of an infinity by an infinity results in NaN.
+        // Division of an infinity by a zero results in an infinity. The sign is determined by the rule already stated above.
+        // Division of an infinity by a nonzero finite value results in a signed infinity. The sign is determined by the rule already stated above.
+        // Division of a finite value by an infinity results in zero. The sign is determined by the rule already stated above.
+        // Division of a zero by a zero results in NaN; division of zero by any other finite value results in zero, with the sign determined by the rule already stated above.
+        // Division of a nonzero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
+        return new NumberValue(realm, lnum / rnum);
+      } else if (op === "*") {
+        // The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
+        // Multiplication of an infinity by a zero results in NaN.
+        // Multiplication of an infinity by an infinity results in an infinity. The sign is determined by the rule already stated above.
+        // Multiplication of an infinity by a finite nonzero value results in a signed infinity. The sign is determined by the rule already stated above.
+        return new NumberValue(realm, lnum * rnum);
+      }
+    } else if (op === "!==") {
+      return new BooleanValue(realm, !StrictEqualityComparison(realm, lval, rval));
+    } else if (op === "===") {
+      return new BooleanValue(realm, StrictEqualityComparison(realm, lval, rval));
+    } else if (op === "!=") {
+      return new BooleanValue(realm, !AbstractEqualityComparison(realm, lval, rval));
+    } else if (op === "==") {
+      return new BooleanValue(realm, AbstractEqualityComparison(realm, lval, rval));
+    } else if (op === "&" || op === "|" || op === "^") {
+      // ECMA262 12.12.3
+
+      // 5. Let lnum be ? ToInt32(lval).
+      let lnum: number = ToInt32(realm, lval);
+
+      // 6. Let rnum be ? ToInt32(rval).
+      let rnum: number = ToInt32(realm, rval);
+
+      // 7. Return the result of applying the bitwise operator @ to lnum and rnum. The result is a signed 32 bit integer.
+      if (op === "&") {
+        return new NumberValue(realm, lnum & rnum);
+      } else if (op === "|") {
+        return new NumberValue(realm, lnum | rnum);
+      } else if (op === "^") {
+        return new NumberValue(realm, lnum ^ rnum);
+      }
+    } else if (op === "in") {
+      // ECMA262 12.10.3
+
+      // 5. If Type(rval) is not Object, throw a TypeError exception.
+      if (!(rval instanceof ObjectValue)) {
+        throw new FatalError();
+      }
+
+      // 6. Return ? HasProperty(rval, ToPropertyKey(lval)).
+      return new BooleanValue(realm, HasProperty(realm, rval, ToPropertyKey(realm, lval)));
+    } else if (op === "instanceof") {
+      // ECMA262 12.10.3
+
+      // 5. Return ? InstanceofOperator(lval, rval).;
+      return new BooleanValue(realm, InstanceofOperator(realm, lval, rval));
+    }
+
+    invariant(false, "unimplemented " + op);
   }
 
   includesValueNotOfType(type: typeof Value): boolean {

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -10,34 +10,23 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
+import { ValuesDomain } from "../domains/index.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import {
-  Value,
   AbstractValue,
-  ConcreteValue,
-  UndefinedValue,
-  NullValue,
   BooleanValue,
+  ConcreteValue,
+  NullValue,
   NumberValue,
   ObjectValue,
   StringValue,
+  UndefinedValue,
+  Value,
 } from "../values/index.js";
 import { GetValue } from "../methods/index.js";
-import { HasProperty, HasSomeCompatibleType } from "../methods/index.js";
-import {
-  Add,
-  AbstractEqualityComparison,
-  StrictEqualityComparison,
-  AbstractRelationalComparison,
-  InstanceofOperator,
-  IsToPrimitivePure,
-  GetToPrimitivePureResultType,
-  IsToNumberPure,
-} from "../methods/index.js";
-import { ToUint32, ToInt32, ToNumber, ToPrimitive, ToString, ToPropertyKey } from "../methods/index.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
-import * as t from "babel-types";
+import { HasSomeCompatibleType } from "../methods/index.js";
+import { IsToPrimitivePure, GetToPrimitivePureResultType, IsToNumberPure } from "../methods/index.js";
 import type { BabelNodeBinaryExpression, BabelBinaryOperator, BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -55,7 +44,7 @@ export default function(
   let rref = env.evaluate(ast.right, strictCode);
   let rval = GetValue(realm, rref);
 
-  return computeBinary(realm, ast.operator, lval, rval, ast.left.loc, ast.right.loc);
+  return computeBinary(realm, ast.operator, lval, rval, ast.left.loc, ast.right.loc, ast.loc);
 }
 
 let unknownValueOfOrToString = "might be an object with an unknown valueOf or toString or Symbol.toPrimitive method";
@@ -156,7 +145,8 @@ export function computeBinary(
   lval: Value,
   rval: Value,
   lloc: ?BabelNodeSourceLocation,
-  rloc: ?BabelNodeSourceLocation
+  rloc: ?BabelNodeSourceLocation,
+  loc?: ?BabelNodeSourceLocation
 ): Value {
   // partial evaluation shortcut for a particular pattern
   if (op === "==" || op === "===" || op === "!=" || op === "!==") {
@@ -168,161 +158,18 @@ export function computeBinary(
   }
 
   if (lval instanceof AbstractValue || rval instanceof AbstractValue) {
-    let type = getPureBinaryOperationResultType(realm, op, lval, rval, lloc, rloc);
-    return realm.createAbstract(new TypesDomain(type), ValuesDomain.topVal, [lval, rval], ([lnode, rnode]) =>
-      t.binaryExpression(op, lnode, rnode)
-    );
+    // generate error if binary operation might throw or have side effects
+    getPureBinaryOperationResultType(realm, op, lval, rval, lloc, rloc);
+    return AbstractValue.createFromBinaryOp(realm, op, lval, rval, loc);
   }
 
+  // ECMA262 12.10.3
+
+  // 5. If Type(rval) is not Object, throw a TypeError exception.
+  if (op === "in" && !(rval instanceof ObjectValue)) {
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+  }
   invariant(lval instanceof ConcreteValue);
   invariant(rval instanceof ConcreteValue);
-
-  if (op === "+") {
-    // ECMA262 12.8.3 The Addition Operator
-    let lprim = ToPrimitive(realm, lval);
-    let rprim = ToPrimitive(realm, rval);
-
-    if (lprim instanceof StringValue || rprim instanceof StringValue) {
-      let lstr = ToString(realm, lprim);
-      let rstr = ToString(realm, rprim);
-      return new StringValue(realm, lstr + rstr);
-    }
-
-    let lnum = ToNumber(realm, lprim);
-    let rnum = ToNumber(realm, rprim);
-    return Add(realm, lnum, rnum);
-  } else if (op === "<" || op === ">" || op === ">=" || op === "<=") {
-    // ECMA262 12.10.3
-    if (op === "<") {
-      let r = AbstractRelationalComparison(realm, lval, rval, true);
-      if (r instanceof UndefinedValue) {
-        return realm.intrinsics.false;
-      } else {
-        return r;
-      }
-    } else if (op === "<=") {
-      let r = AbstractRelationalComparison(realm, rval, lval, false);
-      if (r instanceof UndefinedValue || (r instanceof BooleanValue && r.value)) {
-        return realm.intrinsics.false;
-      } else {
-        return realm.intrinsics.true;
-      }
-    } else if (op === ">") {
-      let r = AbstractRelationalComparison(realm, rval, lval, false);
-      if (r instanceof UndefinedValue) {
-        return realm.intrinsics.false;
-      } else {
-        return r;
-      }
-    } else if (op === ">=") {
-      let r = AbstractRelationalComparison(realm, lval, rval, true);
-      if (r instanceof UndefinedValue || (r instanceof BooleanValue && r.value)) {
-        return realm.intrinsics.false;
-      } else {
-        return realm.intrinsics.true;
-      }
-    }
-  } else if (op === ">>>") {
-    // ECMA262 12.9.5.1
-    let lnum = ToUint32(realm, lval);
-    let rnum = ToUint32(realm, rval);
-
-    return new NumberValue(realm, lnum >>> rnum);
-  } else if (op === "<<" || op === ">>") {
-    let lnum = ToInt32(realm, lval);
-    let rnum = ToUint32(realm, rval);
-
-    if (op === "<<") {
-      // ECMA262 12.9.3.1
-      return new NumberValue(realm, lnum << rnum);
-    } else if (op === ">>") {
-      // ECMA262 12.9.4.1
-      return new NumberValue(realm, lnum >> rnum);
-    }
-  } else if (op === "**") {
-    // ECMA262 12.6.3
-
-    // 5. Let base be ? ToNumber(leftValue).
-    let base = ToNumber(realm, lval);
-
-    // 6. Let exponent be ? ToNumber(rightValue).
-    let exponent = ToNumber(realm, rval);
-
-    // 7. Return the result of Applying the ** operator with base and exponent as specified in 12.7.3.4.
-    return new NumberValue(realm, Math.pow(base, exponent));
-  } else if (op === "%" || op === "/" || op === "*" || op === "-") {
-    // ECMA262 12.7.3
-    let lnum = ToNumber(realm, lval);
-    let rnum = ToNumber(realm, rval);
-
-    if (isNaN(rnum)) return realm.intrinsics.NaN;
-    if (isNaN(lnum)) return realm.intrinsics.NaN;
-
-    if (op === "-") {
-      return Add(realm, lnum, rnum, true);
-    } else if (op === "%") {
-      // The sign of the result equals the sign of the dividend.
-      // If the dividend is an infinity, or the divisor is a zero, or both, the result is NaN.
-      // If the dividend is finite and the divisor is an infinity, the result equals the dividend.
-      // If the dividend is a zero and the divisor is nonzero and finite, the result is the same as the dividend.
-      return new NumberValue(realm, lnum % rnum);
-    } else if (op === "/") {
-      // The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
-      // Division of an infinity by an infinity results in NaN.
-      // Division of an infinity by a zero results in an infinity. The sign is determined by the rule already stated above.
-      // Division of an infinity by a nonzero finite value results in a signed infinity. The sign is determined by the rule already stated above.
-      // Division of a finite value by an infinity results in zero. The sign is determined by the rule already stated above.
-      // Division of a zero by a zero results in NaN; division of zero by any other finite value results in zero, with the sign determined by the rule already stated above.
-      // Division of a nonzero finite value by a zero results in a signed infinity. The sign is determined by the rule already stated above.
-      return new NumberValue(realm, lnum / rnum);
-    } else if (op === "*") {
-      // The sign of the result is positive if both operands have the same sign, negative if the operands have different signs.
-      // Multiplication of an infinity by a zero results in NaN.
-      // Multiplication of an infinity by an infinity results in an infinity. The sign is determined by the rule already stated above.
-      // Multiplication of an infinity by a finite nonzero value results in a signed infinity. The sign is determined by the rule already stated above.
-      return new NumberValue(realm, lnum * rnum);
-    }
-  } else if (op === "!==") {
-    return new BooleanValue(realm, !StrictEqualityComparison(realm, lval, rval));
-  } else if (op === "===") {
-    return new BooleanValue(realm, StrictEqualityComparison(realm, lval, rval));
-  } else if (op === "!=") {
-    return new BooleanValue(realm, !AbstractEqualityComparison(realm, lval, rval));
-  } else if (op === "==") {
-    return new BooleanValue(realm, AbstractEqualityComparison(realm, lval, rval));
-  } else if (op === "&" || op === "|" || op === "^") {
-    // ECMA262 12.12.3
-
-    // 5. Let lnum be ? ToInt32(lval).
-    let lnum: number = ToInt32(realm, lval);
-
-    // 6. Let rnum be ? ToInt32(rval).
-    let rnum: number = ToInt32(realm, rval);
-
-    // 7. Return the result of applying the bitwise operator @ to lnum and rnum. The result is a signed 32 bit integer.
-    if (op === "&") {
-      return new NumberValue(realm, lnum & rnum);
-    } else if (op === "|") {
-      return new NumberValue(realm, lnum | rnum);
-    } else if (op === "^") {
-      return new NumberValue(realm, lnum ^ rnum);
-    }
-  } else if (op === "in") {
-    // ECMA262 12.10.3
-
-    // 5. If Type(rval) is not Object, throw a TypeError exception.
-    if (!(rval instanceof ObjectValue)) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-    }
-
-    // 6. Return ? HasProperty(rval, ToPropertyKey(lval)).
-    return new BooleanValue(realm, HasProperty(realm, rval, ToPropertyKey(realm, lval)));
-  } else if (op === "instanceof") {
-    // ECMA262 12.10.3
-
-    // 5. Return ? InstanceofOperator(lval, rval).;
-    return new BooleanValue(realm, InstanceofOperator(realm, lval, rval));
-  }
-
-  invariant(false, "unimplemented " + op);
+  return ValuesDomain.computeBinary(realm, op, lval, rval);
 }

--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -130,12 +130,7 @@ function emitResidualLoopIfSafe(
   try {
     let envRec = blockEnv.environmentRecord;
     invariant(envRec instanceof DeclarativeEnvironmentRecord, "expected declarative environment record");
-    let absStr = realm.createAbstract(
-      new TypesDomain(StringValue),
-      ValuesDomain.topVal,
-      [],
-      t.stringLiteral("never used")
-    );
+    let absStr = realm.createAbstract(new TypesDomain(StringValue), ValuesDomain.topVal, []);
     let boundName;
     for (let n of BoundNames(realm, lh)) {
       invariant(boundName === undefined);

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -15,10 +15,8 @@ import type { Value } from "../values/index.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { Add, GetValue, ToNumber, PutValue, IsToNumberPure } from "../methods/index.js";
 import { AbstractValue, NumberValue } from "../values/index.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import type { BabelNodeUpdateExpression } from "babel-types";
 import invariant from "../invariant.js";
-import * as t from "babel-types";
 
 export default function(
   ast: BabelNodeUpdateExpression,
@@ -45,12 +43,7 @@ export default function(
     }
     invariant(ast.operator === "++" || ast.operator === "--"); // As per BabelNodeUpdateExpression
     let op = ast.operator === "++" ? "+" : "-";
-    let newAbstractValue = realm.createAbstract(
-      new TypesDomain(NumberValue),
-      ValuesDomain.topVal,
-      [oldExpr],
-      ([node]) => t.binaryExpression(op, node, t.numericLiteral(1))
-    );
+    let newAbstractValue = AbstractValue.createFromBinaryOp(realm, op, oldExpr, new NumberValue(realm, 1), ast.loc);
     PutValue(realm, expr, newAbstractValue);
     if (ast.prefix) {
       return newAbstractValue;

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -21,7 +21,6 @@ import {
   NormalCompletion,
   PossiblyNormalCompletion,
 } from "../completions.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord, Reference } from "../environment.js";
 import {
@@ -519,12 +518,7 @@ export function SetFunctionName(
     // a. Let name be the concatenation of prefix, code unit 0x0020 (SPACE), and name.
     if (name instanceof AbstractValue) {
       let prefixVal = new StringValue(realm, prefix + " ");
-      name = realm.createAbstract(
-        new TypesDomain(StringValue),
-        ValuesDomain.topVal,
-        [prefixVal, name],
-        ([lnode, rnode]) => t.binaryExpression("+", lnode, rnode)
-      );
+      name = AbstractValue.createFromBinaryOp(realm, "+", prefixVal, name, this.expressionLocation);
     } else {
       name = new StringValue(realm, `${prefix} ${name.value}`);
     }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -11,11 +11,9 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, CallableObjectValue } from "../types.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import {
   Value,
   AbstractValue,
-  BooleanValue,
   BoundFunctionValue,
   NumberValue,
   ProxyValue,
@@ -46,7 +44,6 @@ import {
 } from "./index.js";
 import invariant from "../invariant.js";
 import type { BabelNodeTemplateLiteral } from "babel-types";
-import * as t from "babel-types";
 
 // ECMA262 7.3.22
 export function GetFunctionRealm(realm: Realm, obj: ObjectValue): Realm {
@@ -128,12 +125,7 @@ export function OrdinaryGet(
       // descValue unless it is empty.
       // Only get the parent value if it does not involve a getter call.
       // Use a property get for the joined value since it does the check for empty.
-      let cond = realm.createAbstract(
-        new TypesDomain(BooleanValue),
-        ValuesDomain.topVal,
-        [descValue, realm.intrinsics.empty],
-        ([x, y]) => t.binaryExpression("!==", x, y)
-      );
+      let cond = AbstractValue.createFromBinaryOp(realm, "!==", descValue, realm.intrinsics.empty);
       return joinValuesAsConditional(realm, cond, descValue, parentVal);
     }
     invariant(!desc);

--- a/src/partial-evaluators/BinaryExpression.js
+++ b/src/partial-evaluators/BinaryExpression.js
@@ -21,7 +21,6 @@ import type { Realm } from "../realm.js";
 
 import { computeBinary, getPureBinaryOperationResultType } from "../evaluators/BinaryExpression.js";
 import { AbruptCompletion, Completion, NormalCompletion } from "../completions.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { FatalError } from "../errors.js";
 import { composeNormalCompletions, unbundleNormalCompletion } from "../methods/index.js";
 import { AbstractValue, BooleanValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
@@ -116,7 +115,7 @@ export function createAbstractValueForBinary(
       AbstractValue.reportIntrospectionError((val: any));
       throw new FatalError();
     }
-    resultValue = realm.createAbstract(new TypesDomain(resultType), ValuesDomain.topVal, []);
+    resultValue = AbstractValue.createFromBinaryOp(realm, op, lval, rval, ast.loc);
   }
   let r = composeNormalCompletions(leftCompletion, rightCompletion, resultValue, realm);
   return [r, ast, io];

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -12,7 +12,7 @@
 import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
-import { AbstractValue, BooleanValue, ObjectValue, StringValue, Value } from "./index.js";
+import { AbstractValue, ObjectValue, StringValue, Value } from "./index.js";
 import type { AbstractValueBuildNodeFunction } from "./AbstractValue.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { IsDataDescriptor, joinValuesAsConditional, cloneDescriptor, equalDescriptors } from "../methods/index.js";
@@ -145,12 +145,7 @@ export default class AbstractObjectValue extends AbstractValue {
             }
             if (!IsDataDescriptor(this.$Realm, desc)) continue;
             // values may be different
-            let cond = this.$Realm.createAbstract(
-              new TypesDomain(BooleanValue),
-              ValuesDomain.topVal,
-              [this, cv],
-              ([x, y]) => t.binaryExpression("===", x, y)
-            );
+            let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
             desc.value = joinValuesAsConditional(this.$Realm, cond, d.value, desc.value);
           }
         }
@@ -196,12 +191,7 @@ export default class AbstractObjectValue extends AbstractValue {
           throw new FatalError();
         }
         let dval = d === undefined || d.vale === undefined ? this.$Realm.intrinsics.empty : d.value;
-        let cond = this.$Realm.createAbstract(
-          new TypesDomain(BooleanValue),
-          ValuesDomain.topVal,
-          [this, cv],
-          ([x, y]) => t.binaryExpression("===", x, y)
-        );
+        let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
         desc.value = joinValuesAsConditional(this.$Realm, cond, new_val, dval);
         if (cv.$DefineOwnProperty(P, desc)) {
           sawTrue = true;
@@ -277,12 +267,7 @@ export default class AbstractObjectValue extends AbstractValue {
         let cvVal = d === undefined ? this.$Realm.intrinsics.undefined : d.value;
         if (result === undefined) result = cvVal;
         else {
-          let cond = this.$Realm.createAbstract(
-            new TypesDomain(BooleanValue),
-            ValuesDomain.topVal,
-            [this, cv],
-            ([x, y]) => t.binaryExpression("===", x, y)
-          );
+          let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
           result = joinValuesAsConditional(this.$Realm, cond, cvVal, result);
         }
       }
@@ -307,12 +292,7 @@ export default class AbstractObjectValue extends AbstractValue {
         let cvVal = cv.$GetPartial(P, cv);
         if (result === undefined) result = cvVal;
         else {
-          let cond = this.$Realm.createAbstract(
-            new TypesDomain(BooleanValue),
-            ValuesDomain.topVal,
-            [this, cv],
-            ([x, y]) => t.binaryExpression("===", x, y)
-          );
+          let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
           result = joinValuesAsConditional(this.$Realm, cond, cvVal, result);
         }
       }
@@ -344,12 +324,7 @@ export default class AbstractObjectValue extends AbstractValue {
           throw new FatalError();
         }
         let oldVal = d === undefined ? this.$Realm.intrinsics.empty : d.value;
-        let cond = this.$Realm.createAbstract(
-          new TypesDomain(BooleanValue),
-          ValuesDomain.topVal,
-          [this, cv],
-          ([x, y]) => t.binaryExpression("===", x, y)
-        );
+        let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
         let v = joinValuesAsConditional(this.$Realm, cond, V, oldVal);
         if (cv.$Set(P, v, cv)) sawTrue = true;
         else sawFalse = true;
@@ -377,12 +352,7 @@ export default class AbstractObjectValue extends AbstractValue {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
         let oldVal = this.$GetPartial(P, Receiver);
-        let cond = this.$Realm.createAbstract(
-          new TypesDomain(BooleanValue),
-          ValuesDomain.topVal,
-          [this, cv],
-          ([x, y]) => t.binaryExpression("===", x, y)
-        );
+        let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
         let v = joinValuesAsConditional(this.$Realm, cond, V, oldVal);
         cv.$SetPartial(P, v, cv);
       }
@@ -412,12 +382,7 @@ export default class AbstractObjectValue extends AbstractValue {
           AbstractValue.reportIntrospectionError(this, P);
           throw new FatalError();
         }
-        let cond = this.$Realm.createAbstract(
-          new TypesDomain(BooleanValue),
-          ValuesDomain.topVal,
-          [this, cv],
-          ([x, y]) => t.binaryExpression("===", x, y)
-        );
+        let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
         let v = joinValuesAsConditional(this.$Realm, cond, this.$Realm.intrinsics.empty, d.value);
         if (cv.$Set(P, v, cv)) sawTrue = true;
         else sawFalse = true;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -515,13 +515,8 @@ export default class ObjectValue extends ConcreteValue {
       if (desc === undefined) continue; // deleted
       invariant(desc.value !== undefined); // otherwise this is not simple
       let val = desc.value;
-      let cond = this.$Realm.createAbstract(
-        new TypesDomain(BooleanValue),
-        ValuesDomain.topVal,
-        [P],
-        ([x]) => t.binaryExpression("===", x, t.stringLiteral(key)),
-        "check for known property"
-      );
+      let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", P, new StringValue(this.$Realm, key));
+      cond.kind = "check for known property";
       result = joinValuesAsConditional(this.$Realm, cond, val, result);
     }
     return result;
@@ -577,13 +572,8 @@ export default class ObjectValue extends ConcreteValue {
       let newVal = V;
       if (!(V instanceof UndefinedValue)) {
         // join V with undefined, using a property name test as the condition
-        let cond = this.$Realm.createAbstract(
-          new TypesDomain(BooleanValue),
-          ValuesDomain.topVal,
-          [P, new StringValue(this.$Realm, "")],
-          ([x, y]) => t.binaryExpression("===", x, y),
-          "template for property name condition"
-        );
+        let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", P, new StringValue(this.$Realm, ""));
+        cond.kind = "template for property name condition";
         newVal = joinValuesAsConditional(this.$Realm, cond, V, this.$Realm.intrinsics.undefined);
       }
       prop.descriptor = {
@@ -598,13 +588,8 @@ export default class ObjectValue extends ConcreteValue {
       invariant(oldVal !== undefined);
       let newVal = oldVal;
       if (!(V instanceof UndefinedValue)) {
-        let cond = this.$Realm.createAbstract(
-          new TypesDomain(BooleanValue),
-          ValuesDomain.topVal,
-          [P, new StringValue(this.$Realm, "")],
-          ([x, y]) => t.binaryExpression("===", x, y),
-          "template for property name condition"
-        );
+        let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", P, new StringValue(this.$Realm, ""));
+        cond.kind = "template for property name condition";
         newVal = joinValuesAsConditional(this.$Realm, cond, V, oldVal);
       }
       desc.value = newVal;
@@ -618,9 +603,7 @@ export default class ObjectValue extends ConcreteValue {
         oldVal = propertyBinding.descriptor.value;
         invariant(oldVal !== undefined); // otherwise this is not simple
       }
-      let cond = this.$Realm.createAbstract(new TypesDomain(BooleanValue), ValuesDomain.topVal, [P], ([x]) =>
-        t.binaryExpression("===", x, t.stringLiteral(key))
-      );
+      let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", P, new StringValue(this.$Realm, key));
       let newVal = joinValuesAsConditional(this.$Realm, cond, V, oldVal);
       OrdinarySet(this.$Realm, this, key, newVal, Receiver);
     }


### PR DESCRIPTION
In this part, the code for creating an abstract value that results from a binary operator is centralized into AbstractValue.createFromBinaryOp. As part of this, TypeDomain and ValuesDomain now have transfer functions for computing the domain values that result from binary operations.

If this pattern is acceptable, I'll extend it to the other operators.