### PR TITLE
Tweak domains

### DIFF
--- a/src/domains/TypesDomain.js
+++ b/src/domains/TypesDomain.js
@@ -108,9 +108,8 @@ export default class TypesDomain {
   }
 
   // return the type of the result in the case where there is no exception
-  static unaryOp(op: BabelUnaryOperator, operand: TypesDomain): TypesDomain {
-    let oType = operand._type;
-    if (oType === undefined) return TypesDomain.topVal;
+  // note that the type of the operand has no influence on the type of the non exceptional result
+  static unaryOp(op: BabelUnaryOperator): TypesDomain {
     let resultType = Value;
     switch (op) {
       case "-":

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -313,7 +313,7 @@ export default class AbstractValue extends Value {
     prefix?: boolean,
     loc?: ?BabelNodeSourceLocation
   ): AbstractValue {
-    let resultTypes = TypesDomain.unaryOp(op, operand.types);
+    let resultTypes = TypesDomain.unaryOp(op);
     let resultValues = ValuesDomain.unaryOp(realm, op, operand.values);
     let result = new AbstractValue(realm, resultTypes, resultValues, [operand], ([x]) =>
       t.unaryExpression(op, x, prefix)


### PR DESCRIPTION
TypesDomain.unaryOp was too pessimistic for operands of unknown type. In fact, the type of the operand is immaterial, so just stop checking it.

Also tweak the ValuesDomain to perform operations with the Realm in read only mode. This is less conservative than unaryOp is now and fixes the hole in binaryOp while still allowing BinaryExpression to use computeBinary in its effect-full evaluation.