### PR TITLE
Pass in the this object when calling an abstract function

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -192,7 +192,7 @@ export default function(realm: Realm): void {
   });
 
   // Helper function that identifies a variant of the residual function that has implicit dependencies. This version of residual will infer the dependencies
-  // and rewrite the function body to do the same thing as the orignal residual function.
+  // and rewrite the function body to do the same thing as the original residual function.
   global.$DefineOwnProperty("__residual_unsafe", {
     value: deriveNativeFunctionValue(true),
     writable: true,

--- a/test/error-handler/call2.js
+++ b/test/error-handler/call2.js
@@ -1,0 +1,12 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":8,"column":4},"end":{"line":8,"column":13},"source":"test/error-handler/call2.js"},"severity":"RecoverableError","errorCode":"PP0017"}]
+
+let bar = {x: 1};
+let foo = global.__abstract ? __abstract('function', '(function() { return this.x; })') : function() { return this.x; };
+
+bar.foo = foo;
+x = bar.foo();
+bar.foo = function() { return "abc"; }
+y = bar.foo();
+
+inspect = function() { return "" + x + y; }

--- a/test/serializer/abstract/QualifiedCall.js
+++ b/test/serializer/abstract/QualifiedCall.js
@@ -1,0 +1,24 @@
+// add at runtime: global.bar = {x: 1};
+let bar = global.__abstract ? __makeSimple(__abstract('object', 'bar')) : {x: 1};
+
+let foo = global.__abstract ? __abstract('function', '(function() { return this.x; })') : function() { return this.x; };
+bar.foo = foo;
+x = bar.foo();
+
+let foo2 = global.__abstract ? __abstract('function', '(function(a) { return this.x + a; })') : function(a) { return this.x + a; };
+bar[1] = foo2;
+y = bar[1](100);
+
+// Uncomment this when assignments to symbol properties are supported
+// let fooSym = Symbol.for("foo");
+// bar[fooSym] = foo2;
+// y1 = bar[fooSym](150);
+
+z = foo2(200);
+
+var c = global.__abstract ? __abstract("boolean", "true") : true;
+let foo3 = c ? foo2 : foo;
+
+z1 = foo3(300)
+
+inspect = function() { return "" + x + y + z + z1; }

--- a/test/serializer/abstract/QualifiedCall2.js
+++ b/test/serializer/abstract/QualifiedCall2.js
@@ -1,0 +1,10 @@
+// add at runtime: global.bar = {x: 1};
+let bar = global.__abstract ? __makeSimple(__abstract('object', 'bar')) : {x: 1};
+let foo = global.__abstract ? __abstract('function', '(function() { return this.x; })') : function() { return this.x; };
+
+bar.foo = foo;
+x = bar.foo();
+bar.foo = function() { return "abc"; }
+y = bar.foo();
+
+inspect = function() { return "" + x + y; }

--- a/test/serializer/abstract/QualifiedCall3.js
+++ b/test/serializer/abstract/QualifiedCall3.js
@@ -1,0 +1,10 @@
+let bar = {x: 1};
+let foo = global.__abstract ? __abstract('function', '(function() { return this.x; })') : function() { return this.x; };
+
+bar.foo = foo;
+Object.freeze(bar);
+x = bar.foo();
+bar.foo = function() { return "abc"; }
+y = bar.foo();
+
+inspect = function() { return "" + x + y; }


### PR DESCRIPTION
When an abstract function is called via a member expression, the generated code called the function directly instead of via the object. Fixed this.

Issue #942.
