### PR TITLE
Improve captured closure binding initial value serialization

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -22,8 +22,6 @@ import type {
   BabelNodeLVal,
   BabelNodeSpreadElement,
   BabelNodeFunctionExpression,
-  BabelNodeIfStatement,
-  BabelNodeVariableDeclaration,
 } from "babel-types";
 import { NameGenerator } from "../utils/generator.js";
 import traverse from "babel-traverse";
@@ -65,6 +63,7 @@ export class ResidualFunctions {
     this.scopeNameGenerator = scopeNameGenerator;
     this.capturedScopeInstanceIdx = 0;
     this.capturedScopesArray = t.identifier(this.scopeNameGenerator.generate("main"));
+    this._captureScopeAccessFunctionId = t.identifier("__get_scope_binding");
     this.serializedScopes = new Map();
     this.functionPrototypes = new Map();
     this.firstFunctionUsages = new Map();
@@ -88,6 +87,7 @@ export class ResidualFunctions {
   scopeNameGenerator: NameGenerator;
   capturedScopeInstanceIdx: number;
   capturedScopesArray: BabelNodeIdentifier;
+  _captureScopeAccessFunctionId: BabelNodeIdentifier;
   serializedScopes: Map<DeclarativeEnvironmentRecord, ScopeBinding>;
   functionPrototypes: Map<FunctionValue, BabelNodeIdentifier>;
   firstFunctionUsages: Map<FunctionValue, BodyReference>;
@@ -111,6 +111,41 @@ export class ResidualFunctions {
 
   addFunctionUsage(val: FunctionValue, bodyReference: BodyReference) {
     if (!this.firstFunctionUsages.has(val)) this.firstFunctionUsages.set(val, bodyReference);
+  }
+
+  // Generate a shared function for accessing captured scope bindings.
+  // TODO: skip generating this function if the captured scope is not shared by multiple residual funcitons.
+  _createCaptureScopeAccessFunction() {
+    const body = [];
+    const param = t.identifier("selector");
+    const captured = t.identifier("__captured");
+    const selectorExpression = t.memberExpression(this.capturedScopesArray, param, /*Indexer syntax*/ true);
+
+    const ifs = [];
+    for (const scopeBinding of this.serializedScopes.values()) {
+      const scopeObjectExpression = t.objectExpression(
+        Array.from(scopeBinding.initializationValues.entries()).map(([variableName, value]) =>
+          t.objectProperty(t.identifier(variableName), value)
+        )
+      );
+      ifs.push(
+        t.ifStatement(
+          t.binaryExpression("===", param, t.numericLiteral(scopeBinding.id)),
+          t.expressionStatement(t.assignmentExpression("=", selectorExpression, scopeObjectExpression))
+        )
+      );
+    }
+
+    body.push(t.variableDeclaration("var", [t.variableDeclarator(captured, selectorExpression)]));
+    body.push(
+      t.ifStatement(
+        t.unaryExpression("!", captured),
+        t.blockStatement([...ifs, t.expressionStatement(t.assignmentExpression("=", captured, selectorExpression))])
+      )
+    );
+    body.push(t.returnStatement(captured));
+    const factoryFunction = t.functionExpression(null, [param], t.blockStatement(body));
+    return t.variableDeclaration("var", [t.variableDeclarator(this._captureScopeAccessFunctionId, factoryFunction)]);
   }
 
   _getSerializedBindingScopeInstance(serializedBinding: SerializedBinding): ScopeBinding {
@@ -175,28 +210,15 @@ export class ResidualFunctions {
     }
   }
 
-  _getReferentializedScopeInitialization(scope: ScopeBinding): [BabelNodeVariableDeclaration, BabelNodeIfStatement] {
-    let properties = [];
-    for (let [variableName, value] of scope.initializationValues.entries()) {
-      properties.push(t.objectProperty(t.identifier(variableName), value));
-    }
-    let initExpression = t.memberExpression(this.capturedScopesArray, t.identifier(scope.name), true);
+  _getReferentializedScopeInitialization(scope: ScopeBinding) {
     invariant(scope.capturedScope);
-    let capturedScope = scope.capturedScope;
-    let capturedScopeId = t.identifier(capturedScope);
-
     return [
-      t.variableDeclaration("var", [t.variableDeclarator(capturedScopeId, initExpression)]),
-      t.ifStatement(
-        t.unaryExpression("!", capturedScopeId),
-        t.expressionStatement(
-          t.assignmentExpression(
-            "=",
-            initExpression,
-            t.assignmentExpression("=", capturedScopeId, t.objectExpression(properties))
-          )
-        )
-      ),
+      t.variableDeclaration("var", [
+        t.variableDeclarator(
+          t.identifier(scope.capturedScope),
+          t.callExpression(this._captureScopeAccessFunctionId, [t.identifier(scope.name)])
+        ),
+      ]),
     ];
   }
 
@@ -465,6 +487,7 @@ export class ResidualFunctions {
     }
 
     if (this.capturedScopeInstanceIdx) {
+      this.prelude.unshift(this._createCaptureScopeAccessFunction());
       let scopeVar = t.variableDeclaration("var", [
         t.variableDeclarator(
           this.capturedScopesArray,

--- a/test/serializer/basic/CaptureScope9.js
+++ b/test/serializer/basic/CaptureScope9.js
@@ -1,0 +1,8 @@
+// Verify only one copy of initialized scope values are generated.
+// Copies of x:13:1
+(function() {
+  let x = 13, y = 35;
+  let f = function() { x += 3; y -= 39; return x + y;};
+  let g = function() { x -= 2; y += 19; return x + y; }
+  inspect = function() { return f() + g(); };
+})();

--- a/test/serializer/basic/CaptureScope9.js
+++ b/test/serializer/basic/CaptureScope9.js
@@ -1,8 +1,0 @@
-// Verify only one copy of initialized scope values are generated.
-// Copies of x:13:1
-(function() {
-  let x = 13, y = 35;
-  let f = function() { x += 3; y -= 39; return x + y;};
-  let g = function() { x -= 2; y += 19; return x + y; }
-  inspect = function() { return f() + g(); };
-})();

--- a/test/serializer/basic/CapturedScope9.js
+++ b/test/serializer/basic/CapturedScope9.js
@@ -1,0 +1,8 @@
+// Verify only one copy of initialized scope values are generated.
+// Copies of 13:1
+(function() {
+  let x = 13, y = 35;
+  let f = function() { x += 3; y -= 39; return x + y;};
+  let g = function() { x -= 2; y += 19; return x + y; }
+  inspect = function() { return f() + g(); };
+})();


### PR DESCRIPTION
#935 
Testing shows, for a medium FB internal JavaScript program, this change can reduce bytecode size by 0.1% which is 10 times than the consolidate Object.defineProperty() change we did in #910 so I think it is a good one.(Also see 3 below for another reason).
Note:
1. if we really wanted to avoid this one additional function call, we can directly check scope array is initialized or not and skip the function if so. But I think it is a bit overkill for now. Let's do that if any profiling data shows it is a perf problem.
2. I generated if statement instead of switch in the shared function. I can change to switch if you think it matters.
3. With this change, one more optimization opportunity shows up -- for FunctionInstances sharing the same body, we used to have to divide them into sub-groups by modified closure bindings because their initial values may be different. After this change, that code is unnecessary and can be removed which further reduces duplicate function generation.(I will do this in a separate PR).

