### PR TITLE
Add testcase to cover FunctionValue undelay closure binding ordering

### DIFF
--- a/test/serializer/basic/FunctionUndelayOrdering.js
+++ b/test/serializer/basic/FunctionUndelayOrdering.js
@@ -11,5 +11,5 @@ var g1 = f(obj1);
 obj1.foo = g1;
 var g2 = f(obj2);
 obj1.bar = g2;
-inspect = function() {  return obj1.foo(); };
+inspect = function() {  return JSON.stringify(obj1.foo()); };
 })();

--- a/test/serializer/basic/FunctionUndelayOrdering.js
+++ b/test/serializer/basic/FunctionUndelayOrdering.js
@@ -1,0 +1,15 @@
+(function() {
+var f = function(obj) {
+  return function() {
+    /*This comment will make the function too big to inline*/
+    return obj;
+  }
+}
+var obj1 = {};
+var obj2 = {};
+var g1 = f(obj1);
+obj1.foo = g1;
+var g2 = f(obj2);
+obj1.bar = g2;
+inspect = function() {  return obj1.foo(); };
+})();


### PR DESCRIPTION
I did some change in _serializeValueFunction() which did not wait for closure binding, then removed firstUsgae checking. This is clearly wrong but no tests failed which means we are missing some tests for covering this scenario.
I came up with this testcase to cover the test coverage gap.