### PR TITLE
Factory for simple abstract values for which only the type is known

### DIFF
--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -12,7 +12,6 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { BreakCompletion } from "../completions.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { DeclarativeEnvironmentRecord } from "../environment.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { ForInOfHeadEvaluation, ForInOfBodyEvaluation } from "./ForOfStatement.js";
@@ -130,7 +129,7 @@ function emitResidualLoopIfSafe(
   try {
     let envRec = blockEnv.environmentRecord;
     invariant(envRec instanceof DeclarativeEnvironmentRecord, "expected declarative environment record");
-    let absStr = realm.createAbstract(new TypesDomain(StringValue), ValuesDomain.topVal, []);
+    let absStr = AbstractValue.createFromType(realm, StringValue);
     let boundName;
     for (let n of BoundNames(realm, lh)) {
       invariant(boundName === undefined);

--- a/src/partial-evaluators/ArrayExpression.js
+++ b/src/partial-evaluators/ArrayExpression.js
@@ -14,7 +14,6 @@ import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { FatalError } from "../errors.js";
 import {
   ArrayCreate,
@@ -129,7 +128,7 @@ export default function(
       // could not be iterated at compile time, so the index that this element
       // will have at runtime is not known at this point.
 
-      let abstractIndex = realm.createAbstract(new TypesDomain(NumberValue), ValuesDomain.topVal, []);
+      let abstractIndex = AbstractValue.createFromType(realm, NumberValue);
       array.$SetPartial(abstractIndex, elemValue, array);
     } else {
       // Redundant steps.

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -14,7 +14,6 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
 import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
-import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { EnvironmentRecord, Reference } from "../environment.js";
 import {
   composeNormalCompletions,
@@ -180,7 +179,7 @@ function EvaluateCall(
     // such functions have no visible side-effects. Hence we can carry on
     // by returning a call node with the arguments updated with their partial counterparts.
     // TODO: obtain the type of the return value from the abstract function.
-    return realm.createAbstract(TypesDomain.topVal, ValuesDomain.topVal, []);
+    return AbstractValue.createFromType(realm, Value);
   }
   // If func is abstract and not known to be a safe function, we can't safely continue.
   func = func.throwIfNotConcrete();

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -364,13 +364,13 @@ export default class AbstractValue extends Value {
     return result;
   }
 
-  static generateErrorInformationForAbstractVal(val: AbstractValue): string {
-    let names = [];
-    val.addSourceNamesTo(names);
-    if (names.length === 0) {
-      val.addSourceNamesTo(names);
-    }
-    return `abstract value${names.length > 1 ? "s" : ""} ${names.join(" and ")}`;
+  static createFromType(realm: Realm, resultType: typeof Value, kind?: string): AbstractValue {
+    let types = new TypesDomain(resultType);
+    let Constructor = Value.isTypeCompatibleWith(resultType, ObjectValue) ? AbstractObjectValue : AbstractValue;
+    let result = new Constructor(realm, types, ValuesDomain.topVal, []);
+    if (kind) result.kind = kind;
+    result.expressionLocation = realm.currentLocation;
+    return result;
   }
 
   /* Emits a declaration for an identifier into the generator at the current point in time
@@ -393,6 +393,15 @@ export default class AbstractValue extends Value {
     let buildNode_ = temp.getBuildNode();
     invariant(realm.generator !== undefined);
     return realm.generator.derive(types, values, args, buildNode_, optionalArgs);
+  }
+
+  static generateErrorInformationForAbstractVal(val: AbstractValue): string {
+    let names = [];
+    val.addSourceNamesTo(names);
+    if (names.length === 0) {
+      val.addSourceNamesTo(names);
+    }
+    return `abstract value${names.length > 1 ? "s" : ""} ${names.join(" and ")}`;
   }
 
   static reportIntrospectionError(val: Value, propertyName: void | PropertyKeyValue) {


### PR DESCRIPTION
A few more cases where createAbstract was called directly.