### PR TITLE
Provide a way to join Undefined with an AbstractValue

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -25,7 +25,6 @@ import {
   Value,
 } from "../values/index.js";
 import { GetValue } from "../methods/index.js";
-import { HasSomeCompatibleType } from "../methods/index.js";
 import { IsToPrimitivePure, GetToPrimitivePureResultType, IsToNumberPure } from "../methods/index.js";
 import type { BabelNodeBinaryExpression, BabelBinaryOperator, BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
@@ -151,8 +150,8 @@ export function computeBinary(
   // partial evaluation shortcut for a particular pattern
   if (op === "==" || op === "===" || op === "!=" || op === "!==") {
     if (
-      (!lval.mightNotBeObject() && HasSomeCompatibleType(rval, NullValue, UndefinedValue)) ||
-      (HasSomeCompatibleType(lval, NullValue, UndefinedValue) && !rval.mightNotBeObject())
+      (!lval.mightNotBeObject() && (rval instanceof NullValue || rval instanceof UndefinedValue)) ||
+      ((lval instanceof NullValue || lval instanceof UndefinedValue) && !rval.mightNotBeObject())
     )
       return new BooleanValue(realm, op[0] !== "=");
   }

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -23,7 +23,7 @@ import {
 } from "../../values/index.js";
 import { ToStringPartial } from "../../methods/index.js";
 import { ObjectCreate } from "../../methods/index.js";
-import { ValuesDomain } from "../../domains/index.js";
+import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
@@ -207,6 +207,28 @@ export default function(realm: Realm): void {
   global.$DefineOwnProperty("__isAbstract", {
     value: new NativeFunctionValue(realm, "global.__isAbstract", "__isAbstract", 1, (context, [value]) => {
       return new BooleanValue(realm, value instanceof AbstractValue);
+    }),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  global.$DefineOwnProperty("__optional", {
+    value: new NativeFunctionValue(realm, "global.__optional", "__optional", 1, (context, [value]) => {
+      if (!realm.useAbstractInterpretation) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
+      }
+      if (value instanceof AbstractValue && value.isIntrinsic()) {
+        let result = AbstractValue.createFromConditionalOp(realm, value, value, realm.intrinsics.undefined);
+        let condition = AbstractValue.createFromBinaryOp(realm, "!==", result, realm.intrinsics.undefined);
+        condition.types = new TypesDomain(BooleanValue);
+        result.args[0] = condition;
+        result.intrinsicName = value.intrinsicName;
+        invariant(value.intrinsicName !== undefined);
+        result._buildNode = t.identifier(value.intrinsicName);
+        return result;
+      }
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an intrinsic abstract value");
     }),
     writable: true,
     enumerable: false,

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -81,12 +81,14 @@ export default class AbstractValue extends Value {
   args: Array<Value>;
   _buildNode: void | AbstractValueBuildNodeFunction | BabelNodeExpression;
 
-  addSourceLocationsTo(locations: Array<BabelNodeSourceLocation>) {
+  addSourceLocationsTo(locations: Array<BabelNodeSourceLocation>, seenValues?: Set<AbstractValue> = new Set()) {
+    if (seenValues.has(this)) return;
+    seenValues.add(this);
     if (this._buildNode && !(this._buildNode instanceof Function)) {
       if (this._buildNode.loc) locations.push(this._buildNode.loc);
     }
     for (let val of this.args) {
-      if (val instanceof AbstractValue) val.addSourceLocationsTo(locations);
+      if (val instanceof AbstractValue) val.addSourceLocationsTo(locations, seenValues);
     }
   }
 

--- a/test/serializer/abstract/Optional.js
+++ b/test/serializer/abstract/Optional.js
@@ -1,0 +1,7 @@
+// throws introspection error
+
+function f() { return 123; }
+var g = global.__abstract ? __optional(__abstract("function", "f")) : f;
+z = g();
+
+inspect = function() { return "" + z }

--- a/test/serializer/abstract/Optional2.js
+++ b/test/serializer/abstract/Optional2.js
@@ -1,0 +1,6 @@
+function f() { return 123; }
+var g = global.__abstract ? __optional(__abstract("function", "f")) : f;
+if (g !== undefined)
+  z = g();
+
+inspect = function() { return "" + z }


### PR DESCRIPTION
The feature (#931) we need is to have a way to specify that properties obtained from the environment may be undefined. The proposal here is to introduce "global.__optional" which returns an abstract value that can be undefined (and thus does not cause comparisons to undefined to constant fold to false). For example "__optional(__abstract("function", "foo"))".

To make this useful, the result of __optional needs to be refined inside the true branch of a check that foo is not undefined. See Optional2.js for a test case that will not work without refinement.

Unfortunately, refinement is currently extremely simplistic, so the result of __optional must be expressed as a join between undefined and the argument of __optional, leading to an AbstractValue with kind === "conditional" and with a condition that has the same hash code and structure as "foo !== undefined".

This leads to a rather disconcerting self reference, which uncovered a weakness in the code for extracting error information from abstract values. (Also fixed in this request.)

I don't see a better way to things in the near future, so I'd like to go with this until it (hopefully) becomes easy to get back to a situation where every abstract value is a tree.