### PR TITLE
Check undefined in addPriorityEffect and add max stack depth

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -105,7 +105,13 @@ function runTest(name, code, options, args) {
   if (code.includes("// exceeds stack limit")) options.maxStackDepth = 10;
   if (code.includes("// throws introspection error")) {
     try {
-      let realmOptions = { serialize: true, compatibility, uniqueSuffix: "", errorHandler: diag => "Fail" };
+      let realmOptions = {
+        serialize: true,
+        compatibility,
+        uniqueSuffix: "",
+        errorHandler: diag => "Fail",
+        maxStackDepth: options.maxStackDepth,
+      };
       let realm = construct_realm(realmOptions);
       initializeGlobals(realm);
       let serializerOptions = {

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -102,6 +102,7 @@ function runTest(name, code, options, args) {
   if (code.includes("// inline expressions")) options.inlineExpressions = true;
   if (code.includes("// do not inline expressions")) options.inlineExpressions = false;
   if (code.includes("// additional functions")) options.additionalFunctions = ["additional1", "additional2"];
+  if (code.includes("// exceeds stack limit")) options.maxStackDepth = 10;
   if (code.includes("// throws introspection error")) {
     try {
       let realmOptions = { serialize: true, compatibility, uniqueSuffix: "", errorHandler: diag => "Fail" };

--- a/src/options.js
+++ b/src/options.js
@@ -24,6 +24,7 @@ export type RealmOptions = {
   serialize?: boolean,
   strictlyMonotonicDateNow?: boolean,
   timeout?: number,
+  maxStackDepth?: number,
 };
 
 export type SerializerOptions = {

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -49,6 +49,7 @@ export function getRealmOptions({
   serialize = !residual,
   strictlyMonotonicDateNow,
   timeout,
+  maxStackDepth,
 }: PrepackOptions): RealmOptions {
   return {
     compatibility,
@@ -60,6 +61,7 @@ export function getRealmOptions({
     serialize,
     strictlyMonotonicDateNow,
     timeout,
+    maxStackDepth,
   };
 }
 

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -36,6 +36,7 @@ export type PrepackOptions = {|
   timeout?: number,
   trace?: boolean,
   uniqueSuffix?: string,
+  maxStackDepth?: number,
 |};
 
 export function getRealmOptions({

--- a/src/realm.js
+++ b/src/realm.js
@@ -144,7 +144,7 @@ export class Realm {
 
     this.start = Date.now();
     this.compatibility = opts.compatibility || "browser";
-    this.maxStackDepth = opts.maxStackDepth || 1000;
+    this.maxStackDepth = opts.maxStackDepth || 225;
 
     this.$TemplateMap = [];
 
@@ -174,7 +174,7 @@ export class Realm {
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;
-  maxStackDepth: void | number;
+  maxStackDepth: number;
 
   modifiedBindings: void | Bindings;
   modifiedProperties: void | PropertyBindings;
@@ -276,7 +276,7 @@ export class Realm {
   }
 
   pushContext(context: ExecutionContext): void {
-    if (this.maxStackDepth && this.contextStack.length >= this.maxStackDepth) {
+    if (this.contextStack.length >= this.maxStackDepth) {
       throw new FatalError("Maximum stack depth exceeded");
     }
     this.contextStack.push(context);

--- a/src/realm.js
+++ b/src/realm.js
@@ -410,17 +410,21 @@ export class Realm {
     subsequentEffects[1] = pg;
     this.generator = saved_generator;
 
-    pb.forEach((val, key, m) => {
-      if (!sb.has(key)) sb.set(key, val);
-    });
-
-    pp.forEach((desc, propertyBinding, m) => {
-      if (!sp.has(propertyBinding)) sp.set(propertyBinding, desc);
-    });
-
-    po.forEach((ob, a) => {
-      so.add(ob);
-    });
+    if (pb) {
+      pb.forEach((val, key, m) => {
+        if (!sb.has(key)) sb.set(key, val);
+      });
+    }
+    if (pp) {
+      pp.forEach((desc, propertyBinding, m) => {
+        if (!sp.has(propertyBinding)) sp.set(propertyBinding, desc);
+      });
+    }
+    if (po) {
+      po.forEach((ob, a) => {
+        so.add(ob);
+      });
+    }
   }
 
   updateAbruptCompletions(priorEffects: Effects, c: PossiblyNormalCompletion) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -144,6 +144,7 @@ export class Realm {
 
     this.start = Date.now();
     this.compatibility = opts.compatibility || "browser";
+    this.maxStackDepth = opts.maxStackDepth || 1000;
 
     this.$TemplateMap = [];
 
@@ -173,6 +174,7 @@ export class Realm {
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;
+  maxStackDepth: void | number;
 
   modifiedBindings: void | Bindings;
   modifiedProperties: void | PropertyBindings;
@@ -274,6 +276,9 @@ export class Realm {
   }
 
   pushContext(context: ExecutionContext): void {
+    if (this.maxStackDepth && this.contextStack.length >= this.maxStackDepth) {
+      throw new FatalError("Maximum stack depth exceeded");
+    }
     this.contextStack.push(context);
   }
 

--- a/test/serializer/basic/ExceedStackDepth.js
+++ b/test/serializer/basic/ExceedStackDepth.js
@@ -1,3 +1,4 @@
+// exceeds stack limit
 // throws introspection error
 let immediate = function (future) {
 if (Date.now() > future) {

--- a/test/serializer/basic/ExceedStackDepth.js
+++ b/test/serializer/basic/ExceedStackDepth.js
@@ -1,0 +1,12 @@
+// throws introspection error
+let immediate = function (future) {
+if (Date.now() > future) {
+return "exit value";
+}
+
+return immediate(future);
+};
+
+let n = immediate(Date.now() - 1);
+
+inspect = function() { return n; }


### PR DESCRIPTION
Issue: #520 

Check if components of priorEffects are null when referenced.
Add a maximum stack depth with a default value of 225 and check stack size against this.

Reran all tests via yarn validate.