### PR TITLE
Do not create empty templates for __abstract("object"...

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -22,7 +22,6 @@ import {
   Value,
 } from "../../values/index.js";
 import { ToStringPartial } from "../../methods/index.js";
-import { ObjectCreate } from "../../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import * as t from "babel-types";
@@ -52,12 +51,7 @@ export default function(realm: Realm): void {
       if (type === undefined) {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown typeNameOrTemplate");
       }
-      return {
-        type,
-        template: Value.isTypeCompatibleWith(type, ObjectValue)
-          ? ObjectCreate(realm, realm.intrinsics.ObjectPrototype)
-          : undefined,
-      };
+      return { type, template: undefined };
     } else if (typeNameOrTemplate instanceof FunctionValue) {
       return { type: FunctionValue, template: typeNameOrTemplate };
     } else if (typeNameOrTemplate instanceof ObjectValue) {
@@ -114,7 +108,6 @@ export default function(realm: Realm): void {
         if (template && !(template instanceof FunctionValue)) {
           // why exclude functions?
           template.makePartial();
-          invariant(realm.generator);
           if (nameString) realm.rebuildNestedProperties(result, nameString);
         }
         return result;

--- a/src/realm.js
+++ b/src/realm.js
@@ -668,10 +668,11 @@ export class Realm {
 
   rebuildNestedProperties(abstractValue: AbstractValue | UndefinedValue, path: string) {
     if (!(abstractValue instanceof AbstractObjectValue)) return;
+    if (abstractValue.values.isTop()) return;
     let template = abstractValue.getTemplate();
     invariant(!template.intrinsicName || template.intrinsicName === path);
     // TODO #882: We are using the concept of "intrinsic values" to mark the template
-    // object as intrinsic, so that we'll never emit code that creates it, as it instead is mapConstructorDoesntTakeArguments
+    // object as intrinsic, so that we'll never emit code that creates it, as it instead is used
     // to refer to an unknown but existing object.
     // However, it's not really an intrinsic object, and it might not exist ahead of time, but only starting
     // from this point on, which might be tied to some nested generator.

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -51,6 +51,7 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   isSimpleObject(): boolean {
+    if (this.values.isTop()) return false;
     let result;
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
@@ -77,6 +78,10 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   makeNotPartial(): void {
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this);
+      throw new FatalError();
+    }
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
       element.makeNotPartial();
@@ -84,6 +89,10 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   makePartial(): void {
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this);
+      throw new FatalError();
+    }
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
       element.makePartial();
@@ -91,6 +100,10 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   makeSimple(): void {
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this);
+      throw new FatalError();
+    }
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
       return element.makeSimple();
@@ -154,6 +167,10 @@ export default class AbstractObjectValue extends AbstractValue {
   // ECMA262 9.1.6
   $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor): boolean {
     if (P instanceof StringValue) P = P.value;
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this, P);
+      throw new FatalError();
+    }
 
     let elements = this.values.getElements();
     if (elements.size === 1) {
@@ -201,6 +218,10 @@ export default class AbstractObjectValue extends AbstractValue {
   // ECMA262 9.1.7
   $HasProperty(P: PropertyKeyValue): boolean {
     if (P instanceof StringValue) P = P.value;
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this, P);
+      throw new FatalError();
+    }
 
     let elements = this.values.getElements();
     if (elements.size === 1) {
@@ -228,6 +249,10 @@ export default class AbstractObjectValue extends AbstractValue {
   // ECMA262 9.1.8
   $Get(P: PropertyKeyValue, Receiver: Value): Value {
     if (P instanceof StringValue) P = P.value;
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this, P);
+      throw new FatalError();
+    }
 
     let elements = this.values.getElements();
     if (elements.size === 1) {
@@ -261,6 +286,10 @@ export default class AbstractObjectValue extends AbstractValue {
   $GetPartial(P: AbstractValue | PropertyKeyValue, Receiver: Value): Value {
     if (!(P instanceof AbstractValue)) return this.$Get(P, Receiver);
     invariant(this === Receiver, "TODO");
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this);
+      throw new FatalError();
+    }
 
     let elements = this.values.getElements();
     if (elements.size === 1) {
@@ -287,6 +316,10 @@ export default class AbstractObjectValue extends AbstractValue {
   $Set(P: PropertyKeyValue, V: Value, Receiver: Value): boolean {
     if (P instanceof StringValue) P = P.value;
     invariant(this === Receiver, "TODO");
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this, P);
+      throw new FatalError();
+    }
 
     let elements = this.values.getElements();
     if (elements.size === 1) {
@@ -322,6 +355,10 @@ export default class AbstractObjectValue extends AbstractValue {
   $SetPartial(P: AbstractValue | PropertyKeyValue, V: Value, Receiver: Value): boolean {
     if (!(P instanceof AbstractValue)) return this.$Set(P, V, Receiver);
     invariant(this === Receiver, "TODO");
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this);
+      throw new FatalError();
+    }
 
     let elements = this.values.getElements();
     if (elements.size === 1) {
@@ -345,6 +382,10 @@ export default class AbstractObjectValue extends AbstractValue {
   // ECMA262 9.1.10
   $Delete(P: PropertyKeyValue): boolean {
     if (P instanceof StringValue) P = P.value;
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this, P);
+      throw new FatalError();
+    }
 
     let elements = this.values.getElements();
     if (elements.size === 1) {
@@ -378,6 +419,10 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   $OwnPropertyKeys(): Array<PropertyKeyValue> {
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this);
+      throw new FatalError();
+    }
     let elements = this.values.getElements();
     if (elements.size === 1) {
       for (let cv of elements) {

--- a/test/error-handler/call.js
+++ b/test/error-handler/call.js
@@ -2,8 +2,8 @@
 // expected errors: [{"location":{"start":{"line":10,"column":0},"end":{"line":10,"column":1},"identifierName":"o","source":"test/error-handler/call.js"},"severity":"RecoverableError","errorCode":"PP0005"}, {"location":{"start":{"line":11,"column":2},"end":{"line":11,"column":3},"identifierName":"m","source":"test/error-handler/call.js"},"severity":"RecoverableError","errorCode":"PP0005"}, {"location":{"start":{"line":14,"column":5},"end":{"line":14,"column":8},"identifierName":"str","source":"test/error-handler/call.js"},"severity":"RecoverableError","errorCode":"PP0006"}]
 
 function foo(){};
-var f = global.__abstract ? __abstract("object", "foo") : foo;
-var o = global.__abstract ? __abstract("object", "({})") : {};
+var f = global.__abstract ? __abstract(foo, "foo") : foo;
+var o = global.__abstract ? __abstract(({}), "({})") : {};
 if (global.__makeSimple) global.__makeSimple(o);
 
 foo();

--- a/test/serializer/abstract/ForInStatement10.js
+++ b/test/serializer/abstract/ForInStatement10.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let tgt = {};

--- a/test/serializer/abstract/ForInStatement11.js
+++ b/test/serializer/abstract/ForInStatement11.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let tgt = {};

--- a/test/serializer/abstract/ForInStatement3.js
+++ b/test/serializer/abstract/ForInStatement3.js
@@ -1,5 +1,5 @@
 // throws introspection error
-let ob = __abstract("object", "({})")
+let ob = __abstract({}, "({})")
 if (global.__makeSimple) __makeSimple(ob);
 let x = __abstract("string");
 

--- a/test/serializer/abstract/ForInStatement3a.js
+++ b/test/serializer/abstract/ForInStatement3a.js
@@ -1,5 +1,5 @@
 // throws introspection error
-let ob = __abstract("object", "({})")
+let ob = __abstract({}, "({})")
 if (global.__makeSimple) __makeSimple(ob);
 let x = __abstract("string");
 

--- a/test/serializer/abstract/ForInStatement4.js
+++ b/test/serializer/abstract/ForInStatement4.js
@@ -1,4 +1,4 @@
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let tgt = {};

--- a/test/serializer/abstract/ForInStatement5.js
+++ b/test/serializer/abstract/ForInStatement5.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let tgt = {};

--- a/test/serializer/abstract/ForInStatement6.js
+++ b/test/serializer/abstract/ForInStatement6.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let tgt = {};

--- a/test/serializer/abstract/ForInStatement7.js
+++ b/test/serializer/abstract/ForInStatement7.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let tgt = {};

--- a/test/serializer/abstract/ForInStatement8.js
+++ b/test/serializer/abstract/ForInStatement8.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 
 let tgt = {};

--- a/test/serializer/abstract/ForInStatement9.js
+++ b/test/serializer/abstract/ForInStatement9.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-let ob = global.__abstract ? __abstract("object", "({ x: 1 })") : { x: 1 };
+let ob = global.__abstract ? __abstract({ x: 1 }, "({ x: 1 })") : { x: 1 };
 if (global.__makeSimple) __makeSimple(ob);
 function f() { }
 

--- a/test/serializer/abstract/ObjectAssign3.js
+++ b/test/serializer/abstract/ObjectAssign3.js
@@ -1,4 +1,4 @@
-let ob = global.__abstract ? __abstract("object", "({p: 1})") : {p: 1};
+let ob = global.__abstract ? __abstract({p: 1}, "({p: 1})") : {p: 1};
 if (global.__makeSimple) __makeSimple(ob);
 
 Object.assign = function(target, sources) {

--- a/test/serializer/abstract/QualifiedCall.js
+++ b/test/serializer/abstract/QualifiedCall.js
@@ -1,5 +1,5 @@
 // add at runtime: global.bar = {x: 1};
-let bar = global.__abstract ? __makeSimple(__abstract('object', 'bar')) : {x: 1};
+let bar = global.__abstract ? __makeSimple(__abstract({x: 1}, 'bar')) : {x: 1};
 
 let foo = global.__abstract ? __abstract('function', '(function() { return this.x; })') : function() { return this.x; };
 bar.foo = foo;

--- a/test/serializer/abstract/QualifiedCall2.js
+++ b/test/serializer/abstract/QualifiedCall2.js
@@ -1,5 +1,5 @@
 // add at runtime: global.bar = {x: 1};
-let bar = global.__abstract ? __makeSimple(__abstract('object', 'bar')) : {x: 1};
+let bar = global.__abstract ? __makeSimple(__abstract({x: 1}, 'bar')) : {x: 1};
 let foo = global.__abstract ? __abstract('function', '(function() { return this.x; })') : function() { return this.x; };
 
 bar.foo = foo;

--- a/test/serializer/abstract/QualifiedCall3.js
+++ b/test/serializer/abstract/QualifiedCall3.js
@@ -1,5 +1,5 @@
 let bar = {x: 1};
-let foo = global.__abstract ? __abstract('function', '(function() { return this.x; })') : function() { return this.x; };
+let foo = global.__abstract ? __abstract(function() { return this.x; }, '(function() { return this.x; })') : function() { return this.x; };
 
 bar.foo = foo;
 Object.freeze(bar);

--- a/test/serializer/optimizations/require_delay.js
+++ b/test/serializer/optimizations/require_delay.js
@@ -94,7 +94,7 @@ function moduleThrewError(id) {
 // === End require code ===
 
 define(function(global, require, module, exports) {
-  var obj = global.__abstract ? __abstract("object", "({unsupported: true})") : ({unsupported: true});
+  var obj = global.__abstract ? __abstract({unsupported: true}, "({unsupported: true})") : ({unsupported: true});
   if (obj.unsupported) {
     exports.magic = 42;
   } else {

--- a/test/serializer/optimizations/require_unsupported.js
+++ b/test/serializer/optimizations/require_unsupported.js
@@ -94,7 +94,7 @@ function moduleThrewError(id) {
 // === End require code ===
 
 define(function(global, require, module, exports) {
-  if (__abstract("object").unsupported) {}
+  if (__abstract({}, "({})").unsupported) {}
 }, 0, null);
 
 define(function(global, require, module, exports) {


### PR DESCRIPTION
If a call to __abstract does not explicitly provide a template object, just use ValuesDomain.topVal instead of creating an empty object template.

Eventually, intrinsic objects that are modeled by template objects will have to be created via something other than __abstract. This is just another baby step in that direction.