### PR TITLE
Simplify ! operations.

### DIFF
--- a/src/domains/TypesDomain.js
+++ b/src/domains/TypesDomain.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import invariant from "../invariant.js";
-import type { BabelBinaryOperator, BabelUnaryOperator } from "babel-types";
+import type { BabelBinaryOperator, BabelNodeLogicalOperator, BabelUnaryOperator } from "babel-types";
 import {
   AbstractValue,
   BooleanValue,
@@ -105,6 +105,10 @@ export default class TypesDomain {
       return new TypesDomain(PrimitiveValue);
     }
     return TypesDomain.topVal;
+  }
+
+  static logicalOp(op: BabelNodeLogicalOperator, left: TypesDomain, right: TypesDomain): TypesDomain {
+    return TypesDomain.joinValues(left, right);
   }
 
   // return the type of the result in the case where there is no exception

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -93,5 +93,12 @@ export default function(
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof NormalCompletion || completion instanceof Value || completion instanceof Reference);
+  if (lval instanceof Value && compl2 instanceof Value) {
+    // joinEffects does the right thing for the side effects of the second expression but for the result the join
+    // produces a conditional expressions of the form (a ? b : a) for a && b and (a ? a : b) for a || b
+    // Rather than look for this pattern everywhere, we override this behavior and replace the completion with
+    // the actual logical operator. This helps with simplification and reasoning when dealing with path conditions.
+    completion = AbstractValue.createFromLogicalOp(realm, ast.operator, lval, compl2, ast.loc);
+  }
   return completion;
 }

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -42,6 +42,7 @@ import {
   IsPropertyReference,
   IsToNumberPure,
 } from "../methods/index.js";
+import simplifyAbstractValue from "../utils/simplifier.js";
 import type { BabelNodeUnaryExpression } from "babel-types";
 
 function isInstance(proto, Constructor): boolean {
@@ -131,7 +132,7 @@ export default function(
     if (value instanceof AbstractValue) {
       if (!value.mightNotBeTrue()) return realm.intrinsics.false;
       if (!value.mightNotBeFalse()) return realm.intrinsics.true;
-      return AbstractValue.createFromUnaryOp(realm, "!", value);
+      return simplifyAbstractValue(realm, AbstractValue.createFromUnaryOp(realm, "!", value));
     }
     invariant(value instanceof ConcreteValue);
     let oldValue = ToBoolean(realm, value);

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { FatalError } from "../errors.js";
+import { ValuesDomain } from "../domains/index.js";
+import invariant from "../invariant.js";
+import { Realm } from "../realm.js";
+import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
+
+export default function simplifyAbstractValue(realm: Realm, value: AbstractValue): Value {
+  let savedHandler = realm.errorHandler;
+  let savedIsReadOnly = realm.isReadOnly;
+  realm.isReadOnly = true;
+  try {
+    realm.errorHandler = () => {
+      throw new FatalError();
+    };
+    return simplify(realm, value);
+  } catch (e) {
+    return value;
+  } finally {
+    realm.errorHandler = savedHandler;
+    realm.isReadOnly = savedIsReadOnly;
+  }
+}
+
+function simplify(realm, value: Value): Value {
+  if (value instanceof ConcreteValue) return value;
+  invariant(value instanceof AbstractValue);
+  switch (value.kind) {
+    case "!":
+      return negate(realm, value.args[0]);
+    default:
+      return value;
+  }
+}
+
+function negate(realm: Realm, value: Value): Value {
+  if (value instanceof ConcreteValue) return ValuesDomain.computeUnary(realm, "!", value);
+  invariant(value instanceof AbstractValue);
+  if (value.kind === "!") return value.args[0];
+  // If NaN is not an issue, invert binary ops
+  if (value.args.length === 2 && !value.args[0].mightBeNumber() && !value.args[1].mightBeNumber()) {
+    let invertedComparison;
+    switch (value.kind) {
+      case "===":
+        invertedComparison = "!==";
+        break;
+      case "==":
+        invertedComparison = "!=";
+        break;
+      case "!==":
+        invertedComparison = "===";
+        break;
+      case "!=":
+        invertedComparison = "==";
+        break;
+      case "<":
+        invertedComparison = ">=";
+        break;
+      case "<=":
+        invertedComparison = ">";
+        break;
+      case ">":
+        invertedComparison = "<=";
+        break;
+      case ">=":
+        invertedComparison = "<";
+        break;
+      default:
+        break;
+    }
+    if (invertedComparison !== undefined) {
+      let left = simplify(realm, value.args[0]);
+      let right = simplify(realm, value.args[1]);
+      return AbstractValue.createFromBinaryOp(realm, invertedComparison, left, right, value.expressionLocation);
+    }
+    let invertedLogicalOp;
+    switch (value.kind) {
+      case "&&":
+        invertedLogicalOp = "||";
+        break;
+      case "||":
+        invertedLogicalOp = "&&";
+        break;
+      default:
+        break;
+    }
+    if (invertedLogicalOp !== undefined) {
+      let left = negate(realm, value.args[0]);
+      let right = negate(realm, value.args[1]);
+      return AbstractValue.createFromLogicalOp(realm, invertedLogicalOp, left, right, value.expressionLocation);
+    }
+  }
+  return AbstractValue.createFromUnaryOp(realm, "!", value, true, value.expressionLocation);
+}

--- a/test/serializer/abstract/Refine2.js
+++ b/test/serializer/abstract/Refine2.js
@@ -1,0 +1,13 @@
+let x = global.__abstract ? __abstract("boolean", "false") : false;
+let f = function() { return 42; }
+let initialized = false;
+if (x) {
+  f = undefined;
+  initialized = true;
+}
+let result;
+if (!initialized) {
+  result = f();
+}
+
+inspect = function() { return result; }


### PR DESCRIPTION
First little bit of expression simplification. Just enough to get the refinement to work for one of the cases where a conditional module import becomes unconditional because the importer does not know how to deal with an unrefined conditional module value.