### PR TITLE
Simplify path conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ build/
 coverage*/
 .vscode
 facebook/test
+facebook/tutorial
 prepack.min.js

--- a/src/environment.js
+++ b/src/environment.js
@@ -108,7 +108,7 @@ export type Binding = {
 export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
   constructor(realm: Realm) {
     super(realm);
-    this.bindings = Object.create(null);
+    this.bindings = (Object.create(null): any);
   }
 
   bindings: { [name: string]: Binding };

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -31,7 +31,7 @@ import {
   SameValue,
   TestIntegrityLevel,
 } from "../methods/index.js";
-import type { BabelNode, BabelNodeCallExpression, BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
+import type { BabelNodeCallExpression, BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
 import invariant from "../invariant.js";
 import * as t from "babel-types";
 import SuperCall from "./SuperCall";
@@ -116,7 +116,7 @@ function EvaluateCall(
     let [thisArg, propName] = ref instanceof Reference ? [ref.base, ref.referencedName] : [];
     if (thisArg instanceof Value) args = [thisArg];
     if (propName !== undefined && typeof propName !== "string") args.push(propName);
-    args = args.concat(ArgumentListEvaluation(realm, strictCode, env, ((ast.arguments: any): Array<BabelNode>)));
+    args = args.concat(ArgumentListEvaluation(realm, strictCode, env, ast.arguments));
     for (let arg of args) {
       if (arg !== func && arg instanceof ObjectValue && !TestIntegrityLevel(realm, arg, "frozen")) {
         let diag = new CompilerDiagnostic(
@@ -165,7 +165,7 @@ function EvaluateCall(
     // a. If SameValue(func, %eval%) is true, then
     if (SameValue(realm, func, realm.intrinsics.eval)) {
       // i. Let argList be ? ArgumentListEvaluation(Arguments).
-      let argList = ArgumentListEvaluation(realm, strictCode, env, ((ast.arguments: any): Array<BabelNode>));
+      let argList = ArgumentListEvaluation(realm, strictCode, env, ast.arguments);
       // ii. If argList has no elements, return undefined.
       if (argList.length === 0) return realm.intrinsics.undefined;
       // iii. Let evalText be the first element of argList.
@@ -216,14 +216,5 @@ function EvaluateCall(
   let tailCall = IsInTailPosition(realm, thisCall);
 
   // 8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
-  return EvaluateDirectCall(
-    realm,
-    strictCode,
-    env,
-    ref,
-    func,
-    thisValue,
-    ((ast.arguments: any): Array<BabelNode>),
-    tailCall
-  );
+  return EvaluateDirectCall(realm, strictCode, env, ref, func, thisValue, ast.arguments, tailCall);
 }

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -44,11 +44,9 @@ export default function(
   }
   invariant(lval instanceof AbstractValue);
 
-  if (!lval.mightNotBeFalse()) {
-    if (ast.operator === "&&") return env.evaluate(ast.right, strictCode);
-    else {
-      return lval;
-    }
+  if (!lval.isIntrinsic()) {
+    if (!lval.mightNotBeFalse()) return ast.operator === "||" ? env.evaluate(ast.right, strictCode) : lval;
+    if (!lval.mightNotBeTrue()) return ast.operator === "&&" ? env.evaluate(ast.right, strictCode) : lval;
   }
 
   // Create empty effects for the case where ast.right is not evaluated

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -53,7 +53,7 @@ export default function(
   } else {
     // 6. Else,
     // a. Let argList be ArgumentListEvaluation of arguments.
-    argsList = ArgumentListEvaluation(realm, strictCode, env, args);
+    argsList = ArgumentListEvaluation(realm, strictCode, env, (args: any)); // BabelNodeNewExpression needs updating
 
     // This step not necessary since we propagate completions with exceptions.
     // b. ReturnIfAbrupt(argList).

--- a/src/evaluators/SuperCall.js
+++ b/src/evaluators/SuperCall.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { FunctionEnvironmentRecord } from "../environment.js";
@@ -50,7 +51,7 @@ function GetSuperConstructor(realm: Realm) {
 
 // ECMA262 12.3.5.1
 export default function SuperCall(
-  Arguments: Array<BabelNode>,
+  Arguments: Array<BabelNodeExpression | BabelNodeSpreadElement>,
   strictCode: boolean,
   env: LexicalEnvironment,
   realm: Realm

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -825,7 +825,7 @@ export class ResidualHeapSerializer {
     invariant(residualBindings);
 
     invariant(val instanceof ECMAScriptSourceFunctionValue);
-    let serializedBindings = Object.create(null);
+    let serializedBindings = {};
     let instance: FunctionInstance = {
       serializedBindings,
       functionValue: val,

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -183,7 +183,7 @@ export class ResidualHeapVisitor {
   visitDeclarativeEnvironmentRecordBinding(r: DeclarativeEnvironmentRecord, n: string): VisitedBinding {
     let visitedBindings = this.declarativeEnvironmentRecordsBindings.get(r);
     if (!visitedBindings) {
-      visitedBindings = Object.create(null);
+      visitedBindings = (Object.create(null): any);
       this.declarativeEnvironmentRecordsBindings.set(r, visitedBindings);
     }
     let visitedBinding: ?VisitedBinding = visitedBindings[n];
@@ -278,8 +278,8 @@ export class ResidualHeapVisitor {
 
     if (!functionInfo) {
       functionInfo = {
-        unbound: Object.create(null),
-        modified: Object.create(null),
+        unbound: (Object.create(null): any),
+        modified: (Object.create(null): any),
         usesArguments: false,
         usesThis: false,
       };
@@ -312,7 +312,7 @@ export class ResidualHeapVisitor {
       }
     }
 
-    let visitedBindings = Object.create(null);
+    let visitedBindings = (Object.create(null): any);
     this._withScope(val, () => {
       invariant(functionInfo);
       for (let innerName in functionInfo.unbound) {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -45,7 +45,7 @@ export type SerializedBinding = {
   scope?: ScopeBinding,
 };
 
-export type VisitedBindings = { [key: string]: VisitedBinding };
+export type VisitedBindings = { [key: string]: VisitedBinding }; //todo: use a map
 export type VisitedBinding = {
   value: void | Value,
   modified: boolean,

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
+import invariant from "../invariant.js";
+import simplifyAbstractValue from "../utils/simplifier.js";
+
+export function withPathCondition<T>(condition: AbstractValue, evaluate: () => T): T {
+  let realm = condition.$Realm;
+  let savedPath = realm.pathConditions;
+  realm.pathConditions = [];
+  try {
+    pushPathCondition(condition);
+    pushRefinedConditions(savedPath);
+    return evaluate();
+  } finally {
+    realm.pathConditions = savedPath;
+  }
+}
+
+export function withInversePathCondition<T>(condition: AbstractValue, evaluate: () => T): T {
+  let realm = condition.$Realm;
+  let savedPath = realm.pathConditions;
+  realm.pathConditions = [];
+  try {
+    pushInversePathCondition(condition);
+    pushRefinedConditions(savedPath);
+    return evaluate();
+  } finally {
+    realm.pathConditions = savedPath;
+  }
+}
+
+// A path condition is an abstract value that is known to be true in a particular code path
+function pushPathCondition(condition: Value) {
+  invariant(condition.mightNotBeFalse()); // it is mistake to assert that false is true
+  if (condition instanceof ConcreteValue) return;
+  if (!condition.mightNotBeTrue()) return;
+  invariant(condition instanceof AbstractValue);
+  let realm = condition.$Realm;
+  if (condition.kind === "&&") {
+    let left = condition.args[0];
+    let right = condition.args[1];
+    invariant(left instanceof AbstractValue); // it is a mistake to create an abstract value when concrete value will do
+    pushPathCondition(left);
+    pushPathCondition(right);
+  } else {
+    realm.pathConditions.push(condition);
+  }
+}
+
+// An inverse path condition is an abstract value that is known to be false in a particular code path
+function pushInversePathCondition(condition: Value) {
+  invariant(condition.mightNotBeTrue()); // it is mistake to assert that true is false
+  if (condition instanceof ConcreteValue) return;
+  invariant(condition instanceof AbstractValue);
+  if (condition.kind === "||") {
+    let left = condition.args[0];
+    let right = condition.args[1];
+    invariant(left instanceof AbstractValue); // it is a mistake to create an abstract value when concrete value will do
+    pushInversePathCondition(left);
+    pushInversePathCondition(right);
+  } else {
+    let realm = condition.$Realm;
+    let inverseCondition = AbstractValue.createFromUnaryOp(realm, "!", condition);
+    pushPathCondition(inverseCondition);
+    let simplifiedInverseCondition = simplifyAbstractValue(realm, inverseCondition);
+    if (simplifiedInverseCondition !== inverseCondition) pushPathCondition(simplifiedInverseCondition);
+  }
+}
+
+function pushRefinedConditions(unrefinedConditions: Array<AbstractValue>) {
+  for (let unrefinedCond of unrefinedConditions) {
+    pushPathCondition(unrefinedCond.refineWithPathCondition());
+  }
+}

--- a/test/serializer/abstract/Refine3.js
+++ b/test/serializer/abstract/Refine3.js
@@ -1,0 +1,16 @@
+let x = global.__abstract ? __abstract("boolean", "false") : false;
+let f = function() { return 42; }
+let modules = [];
+if (x) {
+  modules[0] = { initialized: true, f: undefined, result: f() };
+} else {
+  modules[0] = { initialized: false, f, result: undefined};
+}
+let module = modules[0];
+if (module && module.initialized) {
+} else if (module) {
+  // (!module || !x)
+  modules[0] = { initialized: true, f: undefined, result: module.f() };
+}
+
+inspect = function() { return modules[0].result; }


### PR DESCRIPTION
Break up, simplify and refine path conditions. Also special case the property values obtained from joined objects to use the object's join condition, which is more likely to match the a path condition than the artificial "ob === ob1 ? ob1.prop : ob2.prop" that arises from the general case.

Finally, beef up the implementation of implies, to handle more complicated path conditions by breaking up && and || conditions.