### PR TITLE
Add comments/testcase for delay initializations referring to different initial values

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -427,6 +427,9 @@ export class ResidualFunctions {
           let firstUsage = this.firstFunctionUsages.get(functionValue);
           invariant(insertionPoint !== undefined);
           if (
+            // The same free variables in shared instances may refer to objects with different initialization values
+            // so a stub forward function is needed during delay initializations.
+            this.residualFunctionInitializers.hasInitializerStatement(functionValue) ||
             usesThis ||
             (firstUsage !== undefined && !firstUsage.isNotEarlierThan(insertionPoint)) ||
             this.functionPrototypes.get(functionValue) !== undefined

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -427,7 +427,6 @@ export class ResidualFunctions {
           let firstUsage = this.firstFunctionUsages.get(functionValue);
           invariant(insertionPoint !== undefined);
           if (
-            this.residualFunctionInitializers.hasInitializerStatement(functionValue) ||
             usesThis ||
             (firstUsage !== undefined && !firstUsage.isNotEarlierThan(insertionPoint)) ||
             this.functionPrototypes.get(functionValue) !== undefined

--- a/test/serializer/basic/DelayInitWithDifferentValues.js
+++ b/test/serializer/basic/DelayInitWithDifferentValues.js
@@ -1,0 +1,12 @@
+(function() {
+    function f(y) {
+        let x = 0;
+        return function() {
+            return [x++, y.value];
+        };
+    }
+    let f1 = f({value: 1});
+    let f2 = f({value: 2});
+    let f3 = f({value: 3});
+    inspect = function() { f1()[1] + f2()[1] + f3()[1]; }
+})();


### PR DESCRIPTION
I can not think of a scenario/reason why delay initializations code should generate a forward stub function while sharing multiple instances instead of a single bind() call.
Remove it does not cause any tests to fail.