### PR TITLE
Simplify if conditions

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -28,6 +28,7 @@ import { GetValue } from "../methods/index.js";
 import { IsToPrimitivePure, GetToPrimitivePureResultType, IsToNumberPure } from "../methods/index.js";
 import type { BabelNodeBinaryExpression, BabelBinaryOperator, BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
+import simplifyAbstractValue from "../utils/simplifier.js";
 
 export default function(
   ast: BabelNodeBinaryExpression,
@@ -171,7 +172,7 @@ export function computeBinary(
   if (lval instanceof AbstractValue || rval instanceof AbstractValue) {
     // generate error if binary operation might throw or have side effects
     getPureBinaryOperationResultType(realm, op, lval, rval, lloc, rloc);
-    return AbstractValue.createFromBinaryOp(realm, op, lval, rval, loc);
+    return simplifyAbstractValue(realm, AbstractValue.createFromBinaryOp(realm, op, lval, rval, loc));
   }
 
   // ECMA262 12.10.3

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -18,6 +18,7 @@ import { Reference } from "../environment.js";
 import { GetValue, joinEffects, ToBoolean, UpdateEmpty } from "../methods/index.js";
 import type { BabelNode, BabelNodeIfStatement } from "babel-types";
 import invariant from "../invariant.js";
+import simplifyAbstractValue from "../utils/simplifier.js";
 import { withPathCondition, withInversePathCondition } from "../utils/paths.js";
 
 export function evaluate(
@@ -30,6 +31,7 @@ export function evaluate(
   let exprRef = env.evaluate(ast.test, strictCode);
   // 2. Let exprValue be ToBoolean(? GetValue(exprRef))
   let exprValue = GetValue(realm, exprRef);
+  if (exprValue instanceof AbstractValue) exprValue = simplifyAbstractValue(realm, exprValue);
 
   if (exprValue instanceof ConcreteValue) {
     let stmtCompletion;

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -12,8 +12,9 @@
 import { FatalError } from "../errors.js";
 import { ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
+import { ToBoolean } from "../methods/index.js";
 import { Realm } from "../realm.js";
-import { AbstractObjectValue, AbstractValue, ConcreteValue, Value } from "../values/index.js";
+import { AbstractObjectValue, AbstractValue, BooleanValue, ConcreteValue, Value } from "../values/index.js";
 
 export default function simplifyAbstractValue(realm: Realm, value: AbstractValue): Value {
   let savedHandler = realm.errorHandler;
@@ -38,15 +39,68 @@ function simplify(realm, value: Value): Value {
   switch (value.kind) {
     case "!":
       return negate(realm, value.args[0]);
+    case "||":
+    case "&&":
+      let x = simplify(realm, value.args[0]);
+      let y = simplify(realm, value.args[1]);
+      if (x instanceof AbstractValue && x.equals(y)) return x;
+      return AbstractValue.createFromLogicalOp(realm, (value.kind: any), x, y, value.expressionLocation);
+    case "==":
+    case "!=":
+    case "===":
+    case "!==":
+      return simplifyEquality(realm, value);
     default:
       return value;
   }
 }
 
+function simplifyEquality(realm: Realm, equality: AbstractValue): Value {
+  let op = equality.kind;
+  let [x, y] = equality.args;
+  if (x instanceof ConcreteValue) [x, y] = [y, x];
+  if (x instanceof AbstractValue && x.kind === "conditional" && (!y.mightNotBeUndefined() || !y.mightNotBeNull())) {
+    // try to simplify "(cond ? xx : xy) op undefined/null" to just "cond" or "!cond"
+    let [cond, xx, xy] = x.args;
+    invariant(cond instanceof AbstractValue); // otherwise the the conditional should not have been created
+    if (op === "===" || op === "!==") {
+      // if xx === undefined && xy !== undefined then cond <=> x === undefined
+      if (!y.mightNotBeUndefined() && !xx.mightNotBeUndefined() && !xy.mightBeUndefined())
+        return op === "===" ? makeBoolean(realm, cond) : negate(realm, cond);
+      // if xx !== undefined && xy === undefined then !cond <=> x === undefined
+      if (!y.mightNotBeUndefined() && !xx.mightBeUndefined() && !xy.mightNotBeUndefined())
+        return op === "===" ? negate(realm, cond) : makeBoolean(realm, cond);
+      // if xx === null && xy !== null then cond <=> x === null
+      if (!y.mightNotBeNull() && !xx.mightNotBeNull() && !xy.mightBeNull())
+        return op === "===" ? makeBoolean(realm, cond) : negate(realm, cond);
+      // if xx !== null && xy === null then !cond <=> x === null
+      if (!y.mightNotBeNull() && !xx.mightBeNull() && !xy.mightNotBeNull())
+        return op === "===" ? negate(realm, cond) : makeBoolean(realm, cond);
+    } else {
+      invariant(op === "==" || op === "!=");
+      // if xx cannot be undefined/null and xy is undefined/null then !cond <=> x == undefined/null
+      if (!xx.mightBeUndefined() && !xx.mightBeNull() && (!xy.mightNotBeUndefined() || !xy.mightNotBeNull()))
+        return op === "==" ? negate(realm, cond) : makeBoolean(realm, cond);
+      // if xx is undefined/null and xy cannot be undefined/null then cond <=> x == undefined/null
+      if ((!xx.mightNotBeUndefined() || !xx.mightNotBeNull()) && !xy.mightBeUndefined() && !xy.mightBeNull())
+        return op === "==" ? makeBoolean(realm, cond) : negate(realm, cond);
+    }
+  }
+  return equality;
+}
+
+function makeBoolean(realm: Realm, value: Value): Value {
+  if (value.getType() === BooleanValue) return value;
+  if (value instanceof ConcreteValue) return new BooleanValue(realm, ToBoolean(realm, value));
+  invariant(value instanceof AbstractValue);
+  let v = AbstractValue.createFromUnaryOp(realm, "!", value, true, value.expressionLocation);
+  return AbstractValue.createFromUnaryOp(realm, "!", v, true, value.expressionLocation);
+}
+
 function negate(realm: Realm, value: Value): Value {
   if (value instanceof ConcreteValue) return ValuesDomain.computeUnary(realm, "!", value);
   invariant(value instanceof AbstractValue);
-  if (value.kind === "!") return value.args[0];
+  if (value.kind === "!") return makeBoolean(realm, value.args[0]);
   // todo: remove this check once intrinsic objects can be properly nullable
   if (!(value instanceof AbstractObjectValue) || !value.isIntrinsic()) {
     if (!value.mightNotBeTrue()) return realm.intrinsics.false;

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -252,6 +252,14 @@ export default class AbstractValue extends Value {
     return this.values.includesValueOfType(NullValue);
   }
 
+  mightNotBeNull(): boolean {
+    let valueType = this.getType();
+    if (valueType === NullValue) return false;
+    if (valueType !== Value) return true;
+    if (this.values.isTop()) return true;
+    return this.values.includesValueNotOfType(NullValue);
+  }
+
   mightBeNumber(): boolean {
     let valueType = this.getType();
     if (valueType === NumberValue) return true;
@@ -306,6 +314,14 @@ export default class AbstractValue extends Value {
     if (valueType !== Value) return false;
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(UndefinedValue);
+  }
+
+  mightNotBeUndefined(): boolean {
+    let valueType = this.getType();
+    if (valueType === UndefinedValue) return false;
+    if (valueType !== Value) return true;
+    if (this.values.isTop()) return true;
+    return this.values.includesValueNotOfType(UndefinedValue);
   }
 
   mightHaveBeenDeleted(): boolean {

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -37,6 +37,10 @@ export default class ConcreteValue extends Value {
     return this instanceof NullValue;
   }
 
+  mightNotBeNull(): boolean {
+    return !(this instanceof NullValue);
+  }
+
   mightBeNumber(): boolean {
     return this instanceof NumberValue;
   }
@@ -63,6 +67,10 @@ export default class ConcreteValue extends Value {
 
   mightBeUndefined(): boolean {
     return this instanceof UndefinedValue;
+  }
+
+  mightNotBeUndefined(): boolean {
+    return !(this instanceof UndefinedValue);
   }
 
   mightHaveBeenDeleted(): boolean {

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -108,6 +108,10 @@ export default class Value {
     invariant(false, "abstract method; please override");
   }
 
+  mightNotBeNull(): boolean {
+    invariant(false, "abstract method; please override");
+  }
+
   mightBeNumber(): boolean {
     invariant(false, "abstract method; please override");
   }
@@ -141,6 +145,10 @@ export default class Value {
   }
 
   mightBeUndefined(): boolean {
+    invariant(false, "abstract method; please override");
+  }
+
+  mightNotBeUndefined(): boolean {
     invariant(false, "abstract method; please override");
   }
 

--- a/test/serializer/optimizations/simplify.js
+++ b/test/serializer/optimizations/simplify.js
@@ -1,0 +1,19 @@
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+let ob1 = b ? { foo: 42 } : undefined;
+let ob2 = b ? { foo: 24 } : null;
+
+x = "no can do";
+if (ob1 == null || undefined == ob2)
+  x = "no can do";
+else {
+  x = ob1.foo;
+  y = ob2.foo;
+}
+if (ob1 != null) {
+  x = ob1.foo;
+}
+if (null == ob1) {
+  x = "no can do";
+}
+
+inspect = function() { return x + " " + y; }

--- a/test/serializer/optimizations/simplify2.js
+++ b/test/serializer/optimizations/simplify2.js
@@ -1,0 +1,12 @@
+let b = global.__abstract ? __abstract("boolean", "false") : false;
+let ob1 = b ? undefined : { foo: 42 };
+let ob2 = b ? null : { foo: 24 };
+
+if (undefined === ob1 || ob2 === null)
+  x = "no can do";
+else {
+  x = ob1.foo;
+  y = ob2.foo;
+}
+
+inspect = function() { return x + " " + y; }

--- a/test/serializer/optimizations/simplify3.js
+++ b/test/serializer/optimizations/simplify3.js
@@ -1,0 +1,32 @@
+let b = global.__abstract ? __abstract("boolean", "false") : false;
+let ob1 = b ? undefined : { foo: 42 };
+let ob1a = !b ? { foo: 422 } : undefined;
+let ob2 = b ? null : { foo: 24 };
+let ob2a = !b ? { foo: 244 } : null;
+let ob3 = b ? ob1 : ob2;
+
+x = "no can do";
+if (undefined != ob1) {
+  x = ob1.foo;
+}
+if (undefined != ob1a) {
+  x = ob1a.foo;
+}
+if (ob1a == undefined) {
+  x = "no can do";
+}
+y = "no can do";
+if (ob2 != null) {
+  y = ob2.foo;
+}
+if (ob2a != null) {
+  y = ob2a.foo;
+}
+if (ob2a == null) {
+  y = "no can do";
+}
+if (ob3 != null) {
+  y = "no can do";
+}
+
+inspect = function() { return x + " " + y; }

--- a/test/serializer/optimizations/simplify4.js
+++ b/test/serializer/optimizations/simplify4.js
@@ -1,0 +1,32 @@
+let b = global.__abstract ? __abstract("boolean", "false") : false;
+let ob1 = b ? undefined : { foo: 42 };
+let ob1a = !b ? { foo: 422 } : undefined;
+let ob2 = b ? null : { foo: 24 };
+let ob2a = !b ? { foo: 244 } : null;
+let ob3 = b ? ob1 : ob2;
+
+x = "no can do";
+if (undefined !== ob1) {
+  x = ob1.foo;
+}
+if (undefined !== ob1a) {
+  x = ob1a.foo;
+}
+if (ob1a === undefined) {
+  x = "no can do";
+}
+y = "no can do";
+if (ob2 !== null) {
+  y = ob2.foo;
+}
+if (ob2a !== null) {
+  y = ob2a.foo;
+}
+if (ob2a === null) {
+  y = "no can do";
+}
+if (ob3 !== null) {
+  y = "no can do";
+}
+
+inspect = function() { return x + " " + y; }

--- a/test/serializer/optimizations/simplify5.js
+++ b/test/serializer/optimizations/simplify5.js
@@ -1,0 +1,8 @@
+let n = global.__abstract ? __abstract("number", "1") : 1;
+let o = global.__abstract ? __abstract("object", "({})") : {};
+let opt = n ? o : undefined;
+
+x = !!n;
+y = opt !== undefined;
+
+inspect = function() { return "" + x + " " + y; }


### PR DESCRIPTION
Simplify if conditions before using them as the join condition for the true and else branches.

Beef up simplifier to simplify && and || expressions and to try to simplify equality expressions of the form "(cond ? xx : yy) (==|!=|===|!==) (undefined|null)" to just "cond" or "!cond"