### PR TITLE
Change error message when evaluating PossiblyNormalCompletion

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1255,16 +1255,7 @@ export class LexicalEnvironment {
   evaluate(ast: BabelNode, strictCode: boolean, metadata?: any): Value | Reference {
     let res = this.evaluateAbstract(ast, strictCode, metadata);
     if (res instanceof PossiblyNormalCompletion) {
-<<<<<<< HEAD
       let error = new CompilerDiagnostic("Global code may end abruptly", res.location, "PP0016", "FatalError");
-=======
-      let error = new CompilerDiagnostic(
-        "Global code may end abruptly",
-        res.location,
-        "PP0016",
-        "FatalError"
-      );
->>>>>>> fbf3359fd8c246662e49cc619d4b5e06905f073c
       if (this.realm.handleError(error) === "Fail") throw new FatalError();
     }
     invariant(res instanceof Value || res instanceof Reference, ast.type);

--- a/src/environment.js
+++ b/src/environment.js
@@ -1255,8 +1255,13 @@ export class LexicalEnvironment {
   evaluate(ast: BabelNode, strictCode: boolean, metadata?: any): Value | Reference {
     let res = this.evaluateAbstract(ast, strictCode, metadata);
     if (res instanceof PossiblyNormalCompletion) {
-      AbstractValue.reportIntrospectionError(res.joinCondition);
-      throw new FatalError();
+      let error = new CompilerDiagnostic(
+        "Global code may end abruptly",
+        res.location,
+        "PP0016",
+        "FatalError"
+      );
+      if (this.realm.handleError(error) === "Fail") throw new FatalError();
     }
     invariant(res instanceof Value || res instanceof Reference, ast.type);
     return res;

--- a/src/environment.js
+++ b/src/environment.js
@@ -1256,7 +1256,8 @@ export class LexicalEnvironment {
     let res = this.evaluateAbstract(ast, strictCode, metadata);
     if (res instanceof PossiblyNormalCompletion) {
       let error = new CompilerDiagnostic("Global code may end abruptly", res.location, "PP0016", "FatalError");
-      if (this.realm.handleError(error) === "Fail") throw new FatalError();
+      this.realm.handleError(error);
+      throw new FatalError();
     }
     invariant(res instanceof Value || res instanceof Reference, ast.type);
     return res;

--- a/test/serializer/abstract/PossibleThrow.js
+++ b/test/serializer/abstract/PossibleThrow.js
@@ -1,0 +1,15 @@
+// throws introspection error
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let y;
+try {
+  if (x) {
+    y = 1;
+    throw Error();
+  } else {
+    y = 0;
+  }
+}
+catch(e) {
+}
+
+inspect = function(){return y}


### PR DESCRIPTION
Issue: #976
Summary: Use handleError with an message instead of reportIntrospectionError
Test Plan:
Use a test case to trigger the error and saw the error message.