### PR TITLE
Show message for thrown errors on site repl.html (fixes #985)

### DIFF
--- a/js/repl-worker.js
+++ b/js/repl-worker.js
@@ -34,9 +34,9 @@ onmessage = function(e) {
       postMessage({ type: 'error', data: buffer });
     }
   } catch (err) {
-    postMessage({
-      type: 'error',
-      data: err.message || 'An unknown error occurred'
+    buffer.push({
+      message: err.message || 'An unknown error occurred'
     });
+    postMessage({ type: 'error', data: buffer });
   }
 };

--- a/js/repl-worker.js
+++ b/js/repl-worker.js
@@ -34,6 +34,9 @@ onmessage = function(e) {
       postMessage({ type: 'error', data: buffer });
     }
   } catch (err) {
-    postMessage({ type: 'error', data: buffer });
+    postMessage({
+      type: 'error',
+      data: err.message || 'An unknown error occurred'
+    });
   }
 };

--- a/js/repl.js
+++ b/js/repl.js
@@ -75,6 +75,8 @@ function processError(errorOutput, error) {
     errorOutput.appendChild(document.createTextNode(' ('));
     errorOutput.appendChild(errorLineLink);
     errorOutput.appendChild(document.createTextNode('):  ' + error.message + '\n'));
+  } else if (!error.code) {
+    errorOutput.appendChild(document.createTextNode(error.message + '\n'));
   } else {
     errorOutput.appendChild(errorWikiLink);
     errorOutput.appendChild(document.createTextNode(': ' + error.message + '\n'));


### PR DESCRIPTION
Previously, exceptions thrown by workers and caught by the online REPL were handled by effectively posting no message to the UI, as the `data` component of the message was an empty array. We can instead post string data: the thrown error's `message` property if it's non-empty, or a generic message otherwise.