### PR TITLE
Add missing check for invalid use of Map

### DIFF
--- a/src/intrinsics/ecma262/MapPrototype.js
+++ b/src/intrinsics/ecma262/MapPrototype.js
@@ -232,7 +232,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let entries be the List that is the value of M's [[MapData]] internal slot.
-    let entries = M.$MapData;
+    let entries = ThrowIfInternalSlotNotWritable(realm, M, "$MapData").$MapData;
     invariant(entries !== undefined);
 
     // 5. Repeat for each Record {[[Key]], [[Value]]} p that is an element of entries,


### PR DESCRIPTION
This check should always have been there. Because it is missing we are currently unable to land anything and our nightly builds are failing.