### PR TITLE
Skip delayInitializations for `require' function

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -124,6 +124,7 @@ export class ResidualHeapSerializer {
     this.delayInitializations = delayInitializations;
     this.referencedDeclaredValues = referencedDeclaredValues;
     this.activeGeneratorBodies = new Map();
+    this.requireFunction = modules.getRequire();
     this.additionalFunctionValuesAndEffects = additionalFunctionValuesAndEffects;
     this.additionalFunctionValueNestedFunctions = new Set();
   }
@@ -163,6 +164,7 @@ export class ResidualHeapSerializer {
   delayInitializations: boolean;
   referencedDeclaredValues: Set<AbstractValue>;
   activeGeneratorBodies: Map<Generator, Array<BabelNodeStatement>>;
+  requireFunction: Value;
   additionalFunctionValuesAndEffects: Map<FunctionValue, Effects> | void;
   // function values nested in additional functions can't delay initializations
   // TODO: revisit this and fix additional functions to be capable of delaying initializations
@@ -473,8 +475,14 @@ export class ResidualHeapSerializer {
     let functionValues = [];
     let generators = [];
     for (let scope of scopes) {
-      if (scope instanceof FunctionValue) functionValues.push(scope);
-      else {
+      if (scope instanceof FunctionValue) {
+        if (scope === this.requireFunction) {
+          // This value is used from the `require` function. While we could possibly delay it, it is highly likely
+          // that the `require` function will get called, and thus we keep targetting the main body.
+          return { body: this.mainBody };
+        }
+        functionValues.push(scope);
+      } else {
         invariant(scope instanceof Generator);
         if (scope === this.realm.generator) {
           // This value is used from the main generator scope. This means that we need to emit the value and its


### PR DESCRIPTION
See the comment for the reason. The benefit:
1. It reduces overall startup speed by not delaying the initialization that is going to be executed anyway.
2. It prevents the module table being generated in `require` residual function which significant reduces code size for real world application.