### PR TITLE
Print out call stack in default error handler

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -782,21 +782,25 @@ export class Realm {
         let loc_end = diagnostic.location.end;
         msg += ` at ${loc_start.line}:${loc_start.column} to ${loc_end.line}:${loc_end.column}`;
       }
-      switch (diagnostic.severity) {
-        case "Information":
-          console.log(`Info: ${msg}`);
-          return "Recover";
-        case "Warning":
-          console.warn(`Warn: ${msg}`);
-          return "Recover";
-        case "RecoverableError":
-          console.error(`Error: ${msg}`);
-          return "Fail";
-        case "FatalError":
-          console.error(`Fatal Error: ${msg}`);
-          return "Fail";
-        default:
-          invariant(false, "Unexpected error type");
+      try {
+        switch (diagnostic.severity) {
+          case "Information":
+            console.log(`Info: ${msg}`);
+            return "Recover";
+          case "Warning":
+            console.warn(`Warn: ${msg}`);
+            return "Recover";
+          case "RecoverableError":
+            console.error(`Error: ${msg}`);
+            return "Fail";
+          case "FatalError":
+            console.error(`Fatal Error: ${msg}`);
+            return "Fail";
+          default:
+            invariant(false, "Unexpected error type");
+        }
+      } finally {
+        console.log(diagnostic.callStack);
       }
     }
     return errorHandler(diagnostic);


### PR DESCRIPTION
We seem to have fewer errors these days so it is probably OK to also print out the call stack with each error.