### PR TITLE
Refactor 2: Combine VisitedBindings and SerializedBindings

### DIFF
--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -20,8 +20,7 @@ import invariant from "../invariant.js";
 export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) => T;
 
 export type FunctionInstance = {
-  serializedBindings: Map<string, SerializedBinding>,
-  visitedBindings: Map<string, VisitedBinding>,
+  residualFunctionBindings: Map<string, ResidualFunctionBinding>,
   functionValue: ECMAScriptSourceFunctionValue,
   insertionPoint?: BodyReference,
   // Optional place to put the function declaration
@@ -37,20 +36,15 @@ export type FunctionInfo = {
   usesThis: boolean,
 };
 
-export type SerializedBinding = {
+export type ResidualFunctionBinding = {
   value: void | Value,
+  modified: boolean,
+  // void means a global binding
+  declarativeEnvironmentRecord: null | DeclarativeEnvironmentRecord,
   // The serializedValue is only not yet present during the initialization of a binding that involves recursive dependencies.
-  serializedValue: void | BabelNodeExpression,
-  referentialized: boolean,
-  modified: boolean,
-  declarativeEnvironmentRecord?: DeclarativeEnvironmentRecord,
+  serializedValue?: void | BabelNodeExpression,
+  referentialized?: boolean,
   scope?: ScopeBinding,
-};
-
-export type VisitedBinding = {
-  value: void | Value,
-  modified: boolean,
-  declarativeEnvironmentRecord?: DeclarativeEnvironmentRecord,
 };
 
 export type ScopeBinding = {
@@ -62,7 +56,7 @@ export type ScopeBinding = {
 
 export type GeneratorBody = Array<BabelNodeStatement>;
 
-export function AreSameSerializedBindings(realm: Realm, x: SerializedBinding, y: SerializedBinding) {
+export function AreSameResidualBinding(realm: Realm, x: ResidualFunctionBinding, y: ResidualFunctionBinding) {
   if (x.serializedValue === y.serializedValue) return true;
   if (x.value && x.value === y.value) return true;
   if (x.value instanceof ConcreteValue && y.value instanceof ConcreteValue) {

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -14,7 +14,7 @@ import { FunctionValue } from "../values/index.js";
 import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeCallExpression } from "babel-types";
 import { BabelTraversePath } from "babel-traverse";
-import type { TryQuery, FunctionInfo, Names, SerializedBinding } from "./types.js";
+import type { TryQuery, FunctionInfo, Names, ResidualFunctionBinding } from "./types.js";
 
 export type ClosureRefVisitorState = {
   tryQuery: TryQuery<*>,
@@ -24,7 +24,7 @@ export type ClosureRefVisitorState = {
 };
 
 export type ClosureRefReplacerState = {
-  serializedBindings: Map<string, SerializedBinding>,
+  residualFunctionBindings: Map<string, ResidualFunctionBinding>,
   modified: Names,
   requireReturns: Map<number | string, BabelNodeExpression>,
   requireStatistics: { replaced: 0, count: 0 },
@@ -47,12 +47,12 @@ function shouldVisit(node, data) {
 //       they will be visited again and possibly transformed.
 //       If necessary we could implement this by following node.parentPath and checking
 //       if any parent nodes are marked visited, but that seem unnecessary right now.let closureRefReplacer = {
-function replaceName(path, serializedBinding, name, data) {
+function replaceName(path, residualFunctionBinding, name, data) {
   if (path.scope.hasBinding(name, /*noGlobals*/ true)) return;
 
-  if (serializedBinding && shouldVisit(path.node, data)) {
-    markVisited(serializedBinding.serializedValue, data);
-    path.replaceWith(serializedBinding.serializedValue);
+  if (residualFunctionBinding && shouldVisit(path.node, data)) {
+    markVisited(residualFunctionBinding.serializedValue, data);
+    path.replaceWith(residualFunctionBinding.serializedValue);
   }
 }
 
@@ -60,10 +60,10 @@ export let ClosureRefReplacer = {
   ReferencedIdentifier(path: BabelTraversePath, state: ClosureRefReplacerState) {
     if (ignorePath(path)) return;
 
-    let serializedBindings = state.serializedBindings;
+    let residualFunctionBindings = state.residualFunctionBindings;
     let name = path.node.name;
-    let serializedBinding = serializedBindings.get(name);
-    if (serializedBinding) replaceName(path, serializedBinding, name, serializedBindings);
+    let residualFunctionBinding = residualFunctionBindings.get(name);
+    if (residualFunctionBinding) replaceName(path, residualFunctionBinding, name, residualFunctionBindings);
   },
 
   CallExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
@@ -77,20 +77,20 @@ export let ClosureRefReplacer = {
     let moduleId = "" + path.node.arguments[0].value;
     let new_node = requireReturns.get(moduleId);
     if (new_node !== undefined) {
-      markVisited(new_node, state.serializedBindings);
+      markVisited(new_node, state.residualFunctionBindings);
       path.replaceWith(new_node);
       state.requireStatistics.replaced++;
     }
   },
 
   "AssignmentExpression|UpdateExpression"(path: BabelTraversePath, state: ClosureRefReplacerState) {
-    let serializedBindings = state.serializedBindings;
+    let residualFunctionBindings = state.residualFunctionBindings;
     let ids = path.getBindingIdentifierPaths();
     for (let name in ids) {
-      let serializedBinding = serializedBindings.get(name);
-      if (serializedBinding) {
+      let residualFunctionBinding = residualFunctionBindings.get(name);
+      if (residualFunctionBinding) {
         let nestedPath = ids[name];
-        replaceName(nestedPath, serializedBinding, name, serializedBindings);
+        replaceName(nestedPath, residualFunctionBinding, name, residualFunctionBindings);
       }
     }
   },


### PR DESCRIPTION
Now we have all the information about bindings in one place as well as a correspondence between `FunctionValue`, `FunctionInstance` and their related `VisitedBindings` and `SerializedBindings` which are now just `ResidualFunctionBindings`.