### PR TITLE
Enable change tracking for $MapData arrays

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -314,6 +314,7 @@ function InternalCloneObject(realm: Realm, val: ObjectValue): ObjectValue {
       AbstractValue.reportIntrospectionError(val, key); // cannot handle accessors
       throw new FatalError();
     }
+    invariant(value instanceof Value);
     CreateDataProperty(realm, clone, key, InternalJSONClone(realm, value));
   }
   if (val.isPartialObject()) clone.makePartial();

--- a/src/intrinsics/ecma262/MapPrototype.js
+++ b/src/intrinsics/ecma262/MapPrototype.js
@@ -17,7 +17,6 @@ import {
   IsCallable,
   SameValueZeroPartial,
   ThrowIfMightHaveBeenDeleted,
-  ThrowIfInternalSlotNotWritable,
 } from "../../methods/index.js";
 import invariant from "../../invariant.js";
 
@@ -38,7 +37,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let entries be the List that is the value of M's [[MapData]] internal slot.
-    let entries = ThrowIfInternalSlotNotWritable(realm, M, "$MapData").$MapData;
+    realm.recordModifiedProperty((M: any).$MapData_binding);
+    let entries = M.$MapData;
     invariant(entries !== undefined);
 
     // 5. Repeat for each Record {[[Key]], [[Value]]} p that is an element of entries,
@@ -70,6 +70,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let entries be the List that is the value of M's [[MapData]] internal slot.
+    realm.recordModifiedProperty((M: any).$MapData_binding);
     let entries = M.$MapData;
     invariant(entries !== undefined);
 
@@ -77,8 +78,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
     for (let p of entries) {
       // a. If p.[[Key]] is not empty and SameValueZero(p.[[Key]], key) is true, then
       if (p.$Key !== undefined && SameValueZeroPartial(realm, p.$Key, key)) {
-        ThrowIfInternalSlotNotWritable(realm, M, "$MapData");
-
         // i. Set p.[[Key]] to empty.
         p.$Key = undefined;
 
@@ -232,7 +231,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let entries be the List that is the value of M's [[MapData]] internal slot.
-    let entries = ThrowIfInternalSlotNotWritable(realm, M, "$MapData").$MapData;
+    realm.recordModifiedProperty((M: any).$MapData_binding);
+    let entries = M.$MapData;
     invariant(entries !== undefined);
 
     // 5. Repeat for each Record {[[Key]], [[Value]]} p that is an element of entries,

--- a/src/methods/descriptor.js
+++ b/src/methods/descriptor.js
@@ -31,7 +31,10 @@ export function copyDescriptor(from: Descriptor, to: Descriptor) {
   if (from.hasOwnProperty("writable")) to.writable = from.writable;
   if (from.hasOwnProperty("enumerable")) to.enumerable = from.enumerable;
   if (from.hasOwnProperty("configurable")) to.configurable = from.configurable;
-  if (from.hasOwnProperty("value")) to.value = from.value;
+  if (from.hasOwnProperty("value")) {
+    if (from.value instanceof Array) to.value = from.value.slice();
+    else to.value = from.value;
+  }
   if (from.hasOwnProperty("get")) to.get = from.get;
   if (from.hasOwnProperty("set")) to.set = from.set;
 }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -100,6 +100,7 @@ export function OrdinaryGet(
   let descValue = !desc
     ? realm.intrinsics.undefined
     : desc.value === undefined ? realm.intrinsics.undefined : desc.value;
+  invariant(descValue instanceof Value);
 
   // 3. If desc is undefined, then
   if (!desc || descValue.mightHaveBeenDeleted()) {

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -346,10 +346,12 @@ function joinResults(
   }
   if (result1 instanceof ReturnCompletion && result2 instanceof ReturnCompletion) {
     let val = joinValues(realm, result1.value, result2.value, getAbstractValue);
+    invariant(val instanceof Value);
     return new ReturnCompletion(val, joinCondition.expressionLocation);
   }
   if (result1 instanceof ThrowCompletion && result2 instanceof ThrowCompletion) {
     let val = joinValues(realm, result1.value, result2.value, getAbstractValue);
+    invariant(val instanceof Value);
     return new ThrowCompletion(val, result1.location);
   }
   if (result1 instanceof AbruptCompletion && result2 instanceof AbruptCompletion) {
@@ -446,10 +448,12 @@ export function joinBindings(realm: Realm, joinCondition: AbstractValue, m1: Bin
   function getAbstractValue(v1: void | Value, v2: void | Value): Value {
     return joinValuesAsConditional(realm, joinCondition, v1, v2);
   }
-  function join(b: Binding, v1: void | Value, v2: void | Value) {
+  function join(b: Binding, v1: void | Value, v2: void | Value): Value {
     if (v1 === undefined) v1 = b.value;
     if (v2 === undefined) v2 = b.value;
-    return joinValues(realm, v1, v2, getAbstractValue);
+    let result = joinValues(realm, v1, v2, getAbstractValue);
+    invariant(result instanceof Value);
+    return result;
   }
   return joinMaps(m1, m2, join);
 }
@@ -458,10 +462,16 @@ export function joinBindings(realm: Realm, joinCondition: AbstractValue, m1: Bin
 // otherwise return getAbstractValue(v1, v2)
 export function joinValues(
   realm: Realm,
-  v1: void | Value,
-  v2: void | Value,
+  v1: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
+  v2: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
   getAbstractValue: (void | Value, void | Value) => Value
-): Value {
+): Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }> {
+  if (Array.isArray(v1)) {
+    invariant(Array.isArray(v2)); // This use of Array is restricted to internal properties that are always arrays
+    return joinArrays(realm, ((v1: any): Array<Value>), ((v2: any): Array<Value>), getAbstractValue);
+  }
+  invariant(v1 === undefined || v1 instanceof Value);
+  invariant(v2 === undefined || v2 instanceof Value);
   if (
     v1 !== undefined &&
     v2 !== undefined &&
@@ -473,6 +483,50 @@ export function joinValues(
   } else {
     return getAbstractValue(v1, v2);
   }
+}
+
+function joinArrays(
+  realm: Realm,
+  v1: Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
+  v2: Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
+  getAbstractValue: (void | Value, void | Value) => Value
+): Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }> {
+  let e = v1[0] || v2[0];
+  if (e instanceof Value) return joinArraysOfValues(realm, (v1: any), (v2: any), getAbstractValue);
+  else return joinArrayOfsMapEntries(realm, (v1: any), (v2: any), getAbstractValue);
+}
+
+function joinArrayOfsMapEntries(
+  realm: Realm,
+  a1: Array<{ $Key: void | Value, $Value: void | Value }>,
+  a2: Array<{ $Key: void | Value, $Value: void | Value }>,
+  getAbstractValue: (void | Value, void | Value) => Value
+): Array<{ $Key: void | Value, $Value: void | Value }> {
+  let empty = realm.intrinsics.empty;
+  let n = Math.max(a1.length, a2.length);
+  let result = [];
+  for (let i = 0; i < n; i++) {
+    let { $Key: key1, $Value: val1 } = a1[i] || { $Key: empty, $Value: empty };
+    let { $Key: key2, $Value: val2 } = a2[i] || { $Key: empty, $Value: empty };
+    let key3 = getAbstractValue(key1, key2);
+    let val3 = getAbstractValue(val1, val2);
+    result[i] = { $Key: key3, $Value: val3 };
+  }
+  return result;
+}
+
+function joinArraysOfValues(
+  realm: Realm,
+  a1: Array<Value>,
+  a2: Array<Value>,
+  getAbstractValue: (void | Value, void | Value) => Value
+): Array<Value> {
+  let n = Math.max(a1.length, a2.length);
+  let result = [];
+  for (let i = 0; i < n; i++) {
+    result[i] = getAbstractValue(a1[i], a2[i]);
+  }
+  return result;
 }
 
 export function joinValuesAsConditional(
@@ -543,7 +597,24 @@ export function joinDescriptors(
     if (!IsDataDescriptor(realm, d)) throw new FatalError("TODO #1015: join computed properties");
     let dc = cloneDescriptor(d);
     invariant(dc !== undefined);
-    dc.value = getAbstractValue(d.value, realm.intrinsics.empty);
+    let dcValue = dc.value;
+    if (Array.isArray(dcValue)) {
+      invariant(dcValue.length > 0);
+      let elem0 = dcValue[0];
+      if (elem0 instanceof Value) {
+        dc.value = dcValue.map(e => getAbstractValue((e: any), realm.intrinsics.empty));
+      } else {
+        dc.value = dcValue.map(e => {
+          let { $Key: key1, $Value: val1 } = (e: any);
+          let key3 = getAbstractValue(key1, realm.intrinsics.empty);
+          let val3 = getAbstractValue(val1, realm.intrinsics.empty);
+          return { $Key: key3, $Value: val3 };
+        });
+      }
+    } else {
+      invariant(dcValue === undefined || dcValue instanceof Value);
+      dc.value = getAbstractValue(dcValue, realm.intrinsics.empty);
+    }
     return dc;
   }
   if (d1 === undefined) {

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -159,6 +159,7 @@ export class ResidualHeapInspector {
     if (prototypeBinding === undefined) return undefined;
     let prototypeDesc = prototypeBinding.descriptor;
     if (prototypeDesc === undefined) return undefined;
+    invariant(prototypeDesc.value === undefined || prototypeDesc.value instanceof Value);
     return prototypeDesc.value;
   }
 

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -267,7 +267,7 @@ export class ResidualHeapSerializer {
     let prototype = ResidualHeapInspector.getPropertyValue(func, "prototype");
     if (prototype instanceof ObjectValue && this.residualValues.has(prototype)) {
       this.emitter.emitNowOrAfterWaitingForDependencies([func], () => {
-        invariant(prototype);
+        invariant(prototype instanceof Value);
         this.serializeValue(prototype);
       });
     }
@@ -581,6 +581,7 @@ export class ResidualHeapSerializer {
   }
 
   _getDescriptorValues(desc: Descriptor): Array<Value> {
+    invariant(desc.value === undefined || desc.value instanceof Value);
     if (desc.value !== undefined) return [desc.value];
     invariant(desc.get !== undefined);
     invariant(desc.set !== undefined);

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -192,6 +192,7 @@ export class ResidualHeapVisitor {
   }
 
   visitDescriptor(desc: Descriptor): void {
+    invariant(desc.value === undefined || desc.value instanceof Value);
     if (desc.value !== undefined) desc.value = this.visitEquivalentValue(desc.value);
     if (desc.get !== undefined) this.visitValue(desc.get);
     if (desc.set !== undefined) this.visitValue(desc.set);

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -315,7 +315,7 @@ export class Modules {
       let property = globalInitializedModulesMap.properties.get(moduleId);
       invariant(property);
       let moduleValue = property.descriptor && property.descriptor.value;
-      invariant(moduleValue);
+      invariant(moduleValue instanceof Value);
       this.initializedModules.set(moduleId, moduleValue);
     }
   }

--- a/src/types.js
+++ b/src/types.js
@@ -87,7 +87,8 @@ export type Descriptor = {
 
   // If value.IsEmpty is true then this descriptor indicates that the
   // corresponding property has been deleted.
-  value?: Value,
+  // Only internal properties (those starting with $) will ever have array values.
+  value?: Value | Array<any>,
 
   get?: UndefinedValue | CallableObjectValue | AbstractValue,
   set?: UndefinedValue | CallableObjectValue | AbstractValue,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -154,10 +154,12 @@ export class Generator {
       this.emitPropertyAssignment(object, key, descValue);
     } else {
       desc = Object.assign({}, desc);
+      let descValue = desc.value || object.$Realm.intrinsics.undefined;
+      invariant(descValue instanceof Value);
       this.addEntry({
         args: [
           object,
-          desc.value || object.$Realm.intrinsics.undefined,
+          descValue,
           desc.get || object.$Realm.intrinsics.undefined,
           desc.set || object.$Realm.intrinsics.undefined,
         ],

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -148,8 +148,13 @@ export default class AbstractObjectValue extends AbstractValue {
       }
       let desc = cloneDescriptor(d1);
       invariant(desc !== undefined);
-      if (IsDataDescriptor(this.$Realm, desc))
-        desc.value = joinValuesAsConditional(this.$Realm, cond, d1.value, d2.value);
+      if (IsDataDescriptor(this.$Realm, desc)) {
+        let d1Value = d1.value;
+        invariant(d1Value === undefined || d1Value instanceof Value);
+        let d2Value = d2.value;
+        invariant(d2Value === undefined || d2Value instanceof Value);
+        desc.value = joinValuesAsConditional(this.$Realm, cond, d1Value, d2Value);
+      }
       return desc;
     } else {
       let hasProp = false;
@@ -212,6 +217,7 @@ export default class AbstractObjectValue extends AbstractValue {
         configurable: "configurable" in Desc ? Desc.configurable : false,
       };
       let new_val = desc.value;
+      invariant(new_val instanceof Value);
       let sawTrue = false;
       let sawFalse = false;
       for (let cv of elements) {
@@ -222,6 +228,7 @@ export default class AbstractObjectValue extends AbstractValue {
           throw new FatalError();
         }
         let dval = d === undefined || d.vale === undefined ? this.$Realm.intrinsics.empty : d.value;
+        invariant(dval instanceof Value);
         let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
         desc.value = joinValuesAsConditional(this.$Realm, cond, new_val, dval);
         if (cv.$DefineOwnProperty(P, desc)) {
@@ -299,6 +306,8 @@ export default class AbstractObjectValue extends AbstractValue {
         AbstractValue.reportIntrospectionError(this, P);
         throw new FatalError();
       }
+      invariant(d1val instanceof Value);
+      invariant(d2val instanceof Value);
       return joinValuesAsConditional(this.$Realm, cond, d1val, d2val);
     } else {
       let result;

--- a/src/values/ArgumentsExotic.js
+++ b/src/values/ArgumentsExotic.js
@@ -106,6 +106,7 @@ export default class ArgumentsExotic extends ObjectValue {
         // i. If Desc.[[Value]] is present, then
         if (Desc.value !== undefined) {
           // 1. Let setStatus be Set(map, P, Desc.[[Value]], false).
+          invariant(Desc.value instanceof Value);
           let setStatus = Set(this.$Realm, map, P, Desc.value, false);
 
           // 2. Assert: setStatus is true because formal parameters mapped by argument objects are always writable.

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor, ObjectKind } from "../types.js";
-import { ObjectValue, StringValue, NumberValue } from "./index.js";
+import { ObjectValue, StringValue, NumberValue, Value } from "./index.js";
 import { ArraySetLength } from "../methods/properties.js";
 import {
   OrdinaryGetOwnProperty,
@@ -62,7 +62,7 @@ export default class ArrayValue extends ObjectValue {
 
       // c. Let oldLen be oldLenDesc.[[Value]].
       let oldLen = oldLenDesc.value;
-      invariant(oldLen !== undefined);
+      invariant(oldLen instanceof Value);
       oldLen = oldLen.throwIfNotConcrete();
       invariant(oldLen instanceof NumberValue, "expected number value");
       oldLen = oldLen.value;

--- a/src/values/IntegerIndexedExotic.js
+++ b/src/values/IntegerIndexedExotic.js
@@ -170,6 +170,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
         if (Desc.value) {
           // 1. Let value be Desc.[[Value]].
           let value = Desc.value;
+          invariant(value === undefined || value instanceof Value);
 
           // 2. Return ? IntegerIndexedElementSet(O, numericIndex, value).
           return IntegerIndexedElementSet(this.$Realm, O, numericIndex, value);

--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -87,6 +87,12 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
     }
   }
 
+  static trackedPropertyNames = ObjectValue.trackedPropertyNames.concat("$RevocableProxy");
+
+  getTrackedPropertyNames(): Array<string> {
+    return NativeFunctionValue.trackedPropertyNames;
+  }
+
   hasDefaultLength(): boolean {
     return this.getLength() === this.length;
   }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -61,7 +61,7 @@ export default class ObjectValue extends ConcreteValue {
   ) {
     super(realm, intrinsicName);
     realm.recordNewObject(this);
-    if (realm.useAbstractInterpretation) this.setupBindings();
+    if (realm.useAbstractInterpretation) this.setupBindings(this.getTrackedPropertyNames());
     this.$Prototype = proto || realm.intrinsics.null;
     this.$Extensible = realm.intrinsics.true;
     this._isPartial = realm.intrinsics.false;
@@ -71,32 +71,40 @@ export default class ObjectValue extends ConcreteValue {
     this.refuseSerialization = refuseSerialization;
   }
 
-  static trackedProperties = [
-    "$Prototype",
-    "$Extensible",
-    "$SetNextIndex",
-    "$IteratedSet",
-    "$MapNextIndex",
-    "$MapData",
-    "$Map",
-    "$DateValue",
-    "$ArrayIteratorNextIndex",
-    "$IteratedObject",
-    "$StringIteratorNextIndex",
-    "$IteratedString",
+  static trackedPropertyNames = [
     "_isPartial",
     "_isSimple",
+    "$ArrayIteratorNextIndex",
+    "$DateValue",
+    "$Extensible",
+    "$IteratedList",
+    "$IteratedObject",
+    "$IteratedSet",
+    "$IteratedString",
+    "$Map",
+    "$MapData",
+    "$MapNextIndex",
+    "$Prototype",
+    "$SetData",
+    "$SetNextIndex",
+    "$StringIteratorNextIndex",
+    "$WeakMapData",
+    "$WeakSetData",
   ];
 
-  setupBindings() {
-    for (let propName of ObjectValue.trackedProperties) {
+  getTrackedPropertyNames(): Array<string> {
+    return ObjectValue.trackedPropertyNames;
+  }
+
+  setupBindings(propertyNames: Array<string>) {
+    for (let propName of propertyNames) {
       let desc = { writeable: true, value: undefined };
       (this: any)[propName + "_binding"] = { descriptor: desc, object: this, key: propName };
     }
   }
 
-  static setupTrackedPropertyAccessors() {
-    for (let propName of ObjectValue.trackedProperties) {
+  static setupTrackedPropertyAccessors(propertyNames: Array<string>) {
+    for (let propName of propertyNames) {
       Object.defineProperty(ObjectValue.prototype, propName, {
         configurable: true,
         get: function() {
@@ -337,7 +345,8 @@ export default class ObjectValue extends ConcreteValue {
     );
   }
 
-  defineNativeProperty(name: SymbolValue | string, value?: Value, desc?: Descriptor = {}) {
+  defineNativeProperty(name: SymbolValue | string, value?: Value | Array<Value>, desc?: Descriptor = {}) {
+    invariant(!value || value instanceof Value);
     this.$DefineOwnProperty(name, {
       value,
       writable: true,
@@ -372,7 +381,8 @@ export default class ObjectValue extends ConcreteValue {
     });
   }
 
-  defineNativeConstant(name: SymbolValue | string, value?: Value, desc?: Descriptor = {}) {
+  defineNativeConstant(name: SymbolValue | string, value?: Value | Array<Value>, desc?: Descriptor = {}) {
+    invariant(!value || value instanceof Value);
     this.$DefineOwnProperty(name, {
       value,
       writable: false,
@@ -394,6 +404,7 @@ export default class ObjectValue extends ConcreteValue {
       if (!pb || pb.descriptor === undefined) return false;
       let pv = pb.descriptor.value;
       if (pv === undefined) return true;
+      invariant(pv instanceof Value);
       if (!pv.mightHaveBeenDeleted()) return true;
       // The property may or may not be there at runtime.
       // We can at best return an abstract keys array.
@@ -416,6 +427,7 @@ export default class ObjectValue extends ConcreteValue {
       let serializedDesc: any = { enumerable: desc.enumerable, configurable: desc.configurable };
       if (desc.value) {
         serializedDesc.writable = desc.writable;
+        invariant(desc.value instanceof Value);
         serializedDesc.value = desc.value.serialize(stack);
       } else {
         invariant(desc.get !== undefined);
@@ -530,6 +542,7 @@ export default class ObjectValue extends ConcreteValue {
       if (desc === undefined) continue; // deleted
       invariant(desc.value !== undefined); // otherwise this is not simple
       let val = desc.value;
+      invariant(val instanceof Value);
       let cond = AbstractValue.createFromBinaryOp(
         this.$Realm,
         "===",
@@ -617,7 +630,7 @@ export default class ObjectValue extends ConcreteValue {
     } else {
       // join V with current value of this.unknownProperty. I.e. weak update.
       let oldVal = desc.value;
-      invariant(oldVal !== undefined);
+      invariant(oldVal instanceof Value);
       let newVal = oldVal;
       if (!(V instanceof UndefinedValue)) {
         let cond = createTemplate(this.$Realm, P);
@@ -632,7 +645,7 @@ export default class ObjectValue extends ConcreteValue {
       let oldVal = this.$Realm.intrinsics.empty;
       if (propertyBinding.descriptor && propertyBinding.descriptor.value) {
         oldVal = propertyBinding.descriptor.value;
-        invariant(oldVal !== undefined); // otherwise this is not simple
+        invariant(oldVal instanceof Value); // otherwise this is not simple
       }
       let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", P, new StringValue(this.$Realm, key));
       let newVal = joinValuesAsConditional(this.$Realm, cond, V, oldVal);

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -49,6 +49,12 @@ export default class ProxyValue extends ObjectValue {
     this.realm = realm;
   }
 
+  static trackedPropertyNames = ObjectValue.trackedPropertyNames.concat("$ProxyTarget");
+
+  getTrackedBindings(): Array<string> {
+    return ProxyValue.trackedPropertyNames;
+  }
+
   isSimpleObject(): boolean {
     return false;
   }
@@ -553,7 +559,9 @@ export default class ProxyValue extends ObjectValue {
       // a. If IsDataDescriptor(targetDesc) is true and targetDesc.[[Configurable]] is false and targetDesc.[[Writable]] is false, then
       if (IsDataDescriptor(realm, targetDesc) && targetDesc.configurable === false && targetDesc.writable === false) {
         // i. If SameValue(trapResult, targetDesc.[[Value]]) is false, throw a TypeError exception.
-        if (!SameValuePartial(realm, trapResult, targetDesc.value || realm.intrinsics.undefined)) {
+        let targetValue = targetDesc.value || realm.intrinsics.undefined;
+        invariant(targetValue instanceof Value);
+        if (!SameValuePartial(realm, trapResult, targetValue)) {
           throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
         }
       }
@@ -626,7 +634,9 @@ export default class ProxyValue extends ObjectValue {
       // a. If IsDataDescriptor(targetDesc) is true and targetDesc.[[Configurable]] is false and targetDesc.[[Writable]] is false, then
       if (IsDataDescriptor(realm, targetDesc) && !targetDesc.configurable && !targetDesc.writable) {
         // i. If SameValue(V, targetDesc.[[Value]]) is false, throw a TypeError exception.
-        if (!SameValuePartial(realm, V, targetDesc.value || realm.intrinsics.undefined)) {
+        let targetValue = targetDesc.value || realm.intrinsics.undefined;
+        invariant(targetValue instanceof Value);
+        if (!SameValuePartial(realm, V, targetValue)) {
           throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
         }
       }

--- a/test/serializer/abstract/Map.js
+++ b/test/serializer/abstract/Map.js
@@ -1,0 +1,32 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+function makeMap(b) {
+  let m = new Map();
+  if (b) {
+    m.set("a", 1);
+    m.set("foo", 1);
+    m.set("bar", 2);
+  } else {
+    m.set("a", 2);
+    m.set("bar", 2);
+    m.set("foo", 1);
+  }
+  return m;
+}
+
+let m1 = makeMap(x);
+let m2 = makeMap(!x);
+
+x1 = m1.get("a");
+
+x2 = [];
+for (let [k, v] of m1) {
+  x2.push([k, v]);
+}
+
+x3 = [];
+for (let [k, v] of m2) {
+  x3.push([k, v]);
+}
+
+inspect = function() { return JSON.stringify([x1, x2, x3]); }


### PR DESCRIPTION
Map values that are updated in the context of unknown conditions now have change tracking for the elements of the $MapData property and the array values in these properties can now be joined.

Some rudimentary support for Flow typing property bindings with values of type Array is also provided. It resorts to using any for the element type because Flow seems unable to deal with the union of two array types.

Most uses of the value property of a property binding object come from properties that can never have (native) arrays as values, so many invariants to the effect are needed.

Partially addressed #573