### PR TITLE
WeakMap, WeakSet, Set

### DIFF
--- a/src/intrinsics/ecma262/SetPrototype.js
+++ b/src/intrinsics/ecma262/SetPrototype.js
@@ -17,7 +17,6 @@ import {
   IsCallable,
   SameValueZeroPartial,
   ThrowIfMightHaveBeenDeleted,
-  ThrowIfInternalSlotNotWritable,
 } from "../../methods/index.js";
 import invariant from "../../invariant.js";
 
@@ -38,7 +37,9 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let entries be the List that is the value of S's [[SetData]] internal slot.
+    realm.recordModifiedProperty((S: any).$SetData_binding);
     let entries = S.$SetData;
+    invariant(entries !== undefined);
 
     // 5. Repeat for each e that is an element of entries,
     for (let e of entries) {
@@ -56,7 +57,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 7. Append value as the last element of entries.
-    ThrowIfInternalSlotNotWritable(realm, S, "$SetData");
     entries.push(value);
 
     // 8. Return S.
@@ -82,7 +82,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 4. Let entries be the List that is the value of S's [[SetData]] internal slot.
     // 5. Repeat for each e that is an element of entries,
     // 5.a Replace the element of entries whose value is e with an element whose value is empty.
-    ThrowIfInternalSlotNotWritable(realm, S, "$SetData").$SetData = [];
+    realm.recordModifiedProperty((S: any).$SetData_binding);
+    S.$SetData = [];
 
     // 6. Return undefined.
     return realm.intrinsics.undefined;
@@ -104,6 +105,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let entries be the List that is the value of S's [[SetData]] internal slot.
+    realm.recordModifiedProperty((S: any).$SetData_binding);
     let entries = S.$SetData;
     invariant(entries !== undefined);
 
@@ -114,7 +116,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // a. If e is not empty and SameValueZero(e, value) is true, then
       if (e !== undefined && SameValueZeroPartial(realm, e, value)) {
         // i. Replace the element of entries whose value is e with an element whose value is empty.
-        ThrowIfInternalSlotNotWritable(realm, S, "$SetData");
         entries[i] = undefined;
 
         // ii. Return true.

--- a/src/intrinsics/ecma262/WeakMapPrototype.js
+++ b/src/intrinsics/ecma262/WeakMapPrototype.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { StringValue, ObjectValue } from "../../values/index.js";
-import { SameValuePartial, ThrowIfInternalSlotNotWritable } from "../../methods/index.js";
+import { SameValuePartial } from "../../methods/index.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -35,6 +35,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
     // 4. Let entries be the List that is the value of M's [[WeakMapData]] internal slot.
     let entries = M.$WeakMapData;
+    realm.recordModifiedProperty((M: any).$WeakMapData_binding);
     invariant(entries !== undefined);
 
     // 5. If Type(key) is not Object, return false.
@@ -47,8 +48,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
     for (let p of entries) {
       // a. If p.[[Key]] is not empty and SameValue(p.[[Key]], key) is true, then
       if (p.$Key !== undefined && SameValuePartial(realm, p.$Key, key)) {
-        ThrowIfInternalSlotNotWritable(realm, M, "$WeakMapData");
-
         // i. Set p.[[Key]] to empty.
         p.$Key = undefined;
 
@@ -153,7 +152,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let entries be the List that is the value of M's [[WeakMapData]] internal slot.
-    let entries = ThrowIfInternalSlotNotWritable(realm, M, "$WeakMapData").$WeakMapData;
+    realm.recordModifiedProperty((M: any).$WeakMapData_binding);
+    let entries = M.$WeakMapData;
     invariant(entries !== undefined);
 
     // 5. If Type(key) is not Object, throw a TypeError exception.

--- a/src/intrinsics/ecma262/WeakSetPrototype.js
+++ b/src/intrinsics/ecma262/WeakSetPrototype.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { StringValue, ObjectValue } from "../../values/index.js";
-import { SameValuePartial, ThrowIfInternalSlotNotWritable } from "../../methods/index.js";
+import { SameValuePartial } from "../../methods/index.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -40,6 +40,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 5. Let entries be the List that is S.[[WeakSetData]].
+    realm.recordModifiedProperty((S: any).$WeakSetData_binding);
     let entries = S.$WeakSetData;
     invariant(entries != null);
 
@@ -53,7 +54,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 7. Append value as the last element of entries.
-    ThrowIfInternalSlotNotWritable(realm, S, "$WeakSetData");
     entries.push(value);
 
     // 8. Return S.
@@ -83,6 +83,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (!(value instanceof ObjectValue)) return realm.intrinsics.false;
 
     // 5. Let entries be the List that is S.[[WeakSetData]].
+    realm.recordModifiedProperty((S: any).$WeakSetData_binding);
     let entries = S.$WeakSetData;
     invariant(entries != null);
 
@@ -92,8 +93,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
       // a. If e is not empty and SameValue(e, value) is true, then
       if (e !== undefined && SameValuePartial(realm, e, value) === true) {
-        ThrowIfInternalSlotNotWritable(realm, S, "$WeakSetData");
-
         // i. Replace the element of entries whose value is e with an element whose value is empty.
         entries[i] = undefined;
 

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -508,9 +508,13 @@ function joinArrayOfsMapEntries(
   for (let i = 0; i < n; i++) {
     let { $Key: key1, $Value: val1 } = a1[i] || { $Key: empty, $Value: empty };
     let { $Key: key2, $Value: val2 } = a2[i] || { $Key: empty, $Value: empty };
-    let key3 = getAbstractValue(key1, key2);
-    let val3 = getAbstractValue(val1, val2);
-    result[i] = { $Key: key3, $Value: val3 };
+    if (key1 === undefined && key2 === undefined) {
+      result[i] = { $Key: undefined, $Value: undefined };
+    } else {
+      let key3 = getAbstractValue(key1, key2);
+      let val3 = getAbstractValue(val1, val2);
+      result[i] = { $Key: key3, $Value: val3 };
+    }
   }
   return result;
 }

--- a/test/serializer/abstract/Set.js
+++ b/test/serializer/abstract/Set.js
@@ -1,0 +1,44 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let bar0 = { y: 0 };
+let bar1 = { y: 1 };
+let bar2 = { y: 2 };
+
+function makeSet(b) {
+  let s = new Set();
+  if (b) {
+    s.add(bar0);
+    s.add(bar1);
+    s.add(bar2);
+  } else {
+    s.add(bar0);
+    s.add(bar2);
+    s.add(bar1);
+  }
+  return s;
+}
+
+let s1 = makeSet(x);
+let s2 = makeSet(!x);
+
+x1 = s1.add(bar0);
+x2 = s2.has(bar0);
+
+x3 = [];
+for (let v of s1) {
+  x3.push(v);
+}
+
+x4 = [];
+for (let v of s2) {
+  x4.push(v);
+}
+
+x5 = s1.delete(bar0);
+
+x6 = [];
+for (let v of s1) {
+  x6.push(v);
+}
+
+
+inspect = function() { return JSON.stringify([x1, x2, x3, x4, x5, x6]); }

--- a/test/serializer/abstract/WeakMap.js
+++ b/test/serializer/abstract/WeakMap.js
@@ -1,0 +1,20 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let foo = { x: "yz" };
+let bar1 = { y: 1 };
+let bar2 = { y: 2 };
+
+let wm = new WeakMap();
+
+if (x) wm.set(foo, bar1); else wm.set(foo, bar2);
+
+x1 = wm.get(foo);
+x2 = wm.has(foo);
+x3 = wm.has(bar1);
+x4 = wm.delete(foo);
+x5 = wm.has(foo);
+x6 = wm.get(foo);
+x7 = x ? wm.set(bar1, foo) : wm.set(bar2, foo);
+// The code below does not currently work but could be made to work with a bit more effort. See #1047.
+// x8 = wm.delete(bar1);
+
+inspect = function() { return JSON.stringify([x1, x2, x3, x4, x5, x6, x7, "x8"]); }

--- a/test/serializer/abstract/WeakSet.js
+++ b/test/serializer/abstract/WeakSet.js
@@ -1,0 +1,18 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let bar0 = { y: 0 };
+let bar1 = { y: 1 };
+let bar2 = { y: 2 };
+
+let ws = new WeakSet();
+x1 = ws.add(bar0);
+
+if (x) ws.add(bar1); else ws.add(bar2);
+
+x2 = ws.has(bar0);
+x3 = ws.delete(bar0);
+// The code below does not currently work but could be made to work with a bit more effort. See #1047.
+// x4 = ws.has(bar0);
+// x5 = ws.delete(bar0);
+// x6 = ws.has(bar0);
+
+inspect = function() { return JSON.stringify([x1, x2, x3, "x4", "x5", "x6"]); }


### PR DESCRIPTION
Remove calls to ThrowIfInternalSlotNotWritable from these types because their internal properties are now tracked. Add some rudimentary tests for them.

Note that a lot of operations still fall over because the linear searching code gives up as soon as it encounters an abstract value. Fixing that will be a bit more work.

#573