### PR TITLE
Append Github error code wiki page to error log

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -197,6 +197,7 @@ function run(
         console.log(
           `${loc.source || ""}(${loc.start.line}:${loc.start.column +
             1}) ${error.severity} ${error.errorCode}: ${error.message}`
+            + ` (github.com/facebook/prepack/wiki/${error.errorCode})`
         );
       }
       if (foundFatal) process.exit(1);

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -196,8 +196,8 @@ function run(
         foundFatal = foundFatal || error.severity === "FatalError";
         console.log(
           `${loc.source || ""}(${loc.start.line}:${loc.start.column +
-            1}) ${error.severity} ${error.errorCode}: ${error.message}`
-            + ` (github.com/facebook/prepack/wiki/${error.errorCode})`
+            1}) ${error.severity} ${error.errorCode}: ${error.message}` +
+            ` (github.com/facebook/prepack/wiki/${error.errorCode})`
         );
       }
       if (foundFatal) process.exit(1);

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -197,7 +197,7 @@ function run(
         console.log(
           `${loc.source || ""}(${loc.start.line}:${loc.start.column +
             1}) ${error.severity} ${error.errorCode}: ${error.message}` +
-            ` (github.com/facebook/prepack/wiki/${error.errorCode})`
+            ` (https://github.com/facebook/prepack/wiki/${error.errorCode})`
         );
       }
       if (foundFatal) process.exit(1);


### PR DESCRIPTION
The last line of the error log now looks like this:

`script.js(2:1) FatalError PP0012: member expression object is unknown (https://github.com/facebook/prepack/wiki/PP0012)`

and the link in parentheses is command-clickable.

It doesn't appear that there are any error codes in the repo that aren't documented in the wiki, but if it did happen (e.g. github.com/facebook/prepack/wiki/PP00XX) a user with permissions would be sent to create a new page PP00XX and a user without permissions would be redirected to the wiki homepage.

Here's the full sample output:
```
node --max_old_space_size=8192 lib/prepack-cli.js --out output.js --compatibility jsc-600-1-4-17 ../T22161296/script.js
A fatal error occurred while prepacking.
Error: A fatal error occurred while prepacking.
    at new FatalError (/Users/patxu/code/prepack/lib/errors.js:48:14)
    at RequireObjectCoercible (/Users/patxu/code/prepack/lib/methods/abstract.js:94:13)
    at exports.default (/Users/patxu/code/prepack/lib/evaluators/MemberExpression.js:31:47)
    at LexicalEnvironment.evaluateAbstract (/Users/patxu/code/prepack/lib/environment.js:1456:22)
    at LexicalEnvironment.evaluate (/Users/patxu/code/prepack/lib/environment.js:1439:22)
    at exports.default (/Users/patxu/code/prepack/lib/evaluators/AssignmentExpression.js:23:23)
    at LexicalEnvironment.evaluateAbstract (/Users/patxu/code/prepack/lib/environment.js:1456:22)
    at LexicalEnvironment.evaluate (/Users/patxu/code/prepack/lib/environment.js:1439:22)
    at exports.default (/Users/patxu/code/prepack/lib/evaluators/ExpressionStatement.js:10:21)
    at LexicalEnvironment.evaluateAbstract (/Users/patxu/code/prepack/lib/environment.js:1456:22)
../T22161296/script.js(2:1) FatalError PP0012: member expression object is unknown (https://github.com/facebook/prepack/wiki/PP0012)
```

Fixes #993 