### PR TITLE
Handle PossiblyNormal completions inside try

### DIFF
--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -11,21 +11,55 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { AbruptCompletion, ThrowCompletion } from "../completions.js";
-import { UpdateEmpty } from "../methods/index.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
+import { joinEffects, UpdateEmpty } from "../methods/index.js";
 import { Value } from "../values/index.js";
 import type { BabelNodeTryStatement } from "babel-types";
 import invariant from "../invariant.js";
 
-export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value {
+export default function(
+  ast: BabelNodeTryStatement,
+  strictCode: boolean,
+  env: LexicalEnvironment,
+  realm: Realm
+): PossiblyNormalCompletion | Value {
   let completions = [];
 
-  let blockRes = env.evaluateCompletion(ast.block, strictCode);
-
-  if (blockRes instanceof ThrowCompletion && ast.handler) {
-    completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));
+  let blockRes = env.evaluateAbstractCompletion(ast.block, strictCode);
+  if (blockRes instanceof PossiblyNormalCompletion) {
+    let abruptCompletion;
+    let abruptEffects;
+    if (blockRes.consequent instanceof AbruptCompletion) {
+      abruptCompletion = blockRes.consequent;
+      abruptEffects = blockRes.consequentEffects;
+    } else {
+      abruptCompletion = blockRes.alternate;
+      abruptEffects = blockRes.alternateEffects;
+    }
+    if (abruptCompletion instanceof ThrowCompletion && ast.handler) {
+      let normalEffects = realm.getCapturedEffects(blockRes.value);
+      invariant(normalEffects !== undefined);
+      realm.stopEffectCaptureAndUndoEffects();
+      let handlerEffects = realm.evaluateForEffects(() => {
+        realm.applyEffects(abruptEffects);
+        invariant(ast.handler);
+        return env.evaluateAbstractCompletion(ast.handler, strictCode, abruptCompletion);
+      });
+      let jointEffects;
+      if (blockRes.consequent instanceof AbruptCompletion)
+        jointEffects = joinEffects(realm, blockRes.joinCondition, handlerEffects, normalEffects);
+      else jointEffects = joinEffects(realm, blockRes.joinCondition, normalEffects, handlerEffects);
+      realm.applyEffects(jointEffects);
+      completions.unshift(jointEffects[0]);
+    } else {
+      completions.unshift(blockRes);
+    }
   } else {
-    completions.unshift(blockRes);
+    if (blockRes instanceof ThrowCompletion && ast.handler) {
+      completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));
+    } else {
+      completions.unshift(blockRes);
+    }
   }
 
   if (ast.finalizer) {
@@ -34,7 +68,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
 
   // use the last completion record
   for (let completion of completions) {
-    if (completion && completion instanceof AbruptCompletion) throw completion;
+    if (completion instanceof AbruptCompletion) throw completion;
   }
 
   if (ast.finalizer) {
@@ -43,7 +77,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
 
   // otherwise use the last returned value
   for (let completion of completions) {
-    if (completion && completion instanceof Value)
+    if (completion instanceof Value || completion instanceof Completion)
       return (UpdateEmpty(realm, completion, realm.intrinsics.undefined): any);
   }
 

--- a/test/serializer/abstract/PossibleThrow.js
+++ b/test/serializer/abstract/PossibleThrow.js
@@ -1,4 +1,3 @@
-// throws introspection error
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 let y;
 try {

--- a/test/serializer/abstract/Throw3.js
+++ b/test/serializer/abstract/Throw3.js
@@ -1,9 +1,9 @@
-// throws introspection error
-
-let x = __abstract("boolean", "true");
+let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 try {
-  if (x) z = "is true"; else throw "is false";  
+  if (x) z = "is true"; else throw "is false";
 } catch (e) {
   z = e;
 }
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Throw4.js
+++ b/test/serializer/abstract/Throw4.js
@@ -1,10 +1,11 @@
+// throws introspection error
+
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 try {
-  if (x) throw  new Error("is true");
-  z = "is false";
-} catch (e) {
-  z = e;
+  if (x) z = "is true"; else throw "is false";
+} finally {
+  z = "is finally";
 }
 
 inspect = function() { return z; }


### PR DESCRIPTION
If the try block of a try-catch statement possibly throws an exception, bring the effects of the catch handler into the state of the exceptional control flow and carry on.