### PR TITLE
Make "caller" a restricted property in strict mode.

### DIFF
--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -635,7 +635,7 @@ function handleFinished(args: MasterProgramArgs, groups: GroupsMap, earlierNumSk
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 11798 || numPassedES6 < 5244 || numTimeouts > 0)) {
+  if (!args.filterString && (numPassedES5 < 11798 || numPassedES6 < 5245 || numTimeouts > 0)) {
     console.log(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {
@@ -1117,9 +1117,6 @@ function testFilterByMetadata(test: TestFileInfo): boolean {
 
   // disable SharedArrayBuffer tests
   if (test.location.includes("sharedarraybuffer") || test.location.includes("SharedArrayBuffer")) return false;
-
-  // disable outdated arguments.caller test
-  if (test.location.includes("StrictFunction_restricted-properties.js")) return false;
 
   return true;
 }

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -25,15 +25,16 @@ import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord, Reference } from "../environment.js";
 import {
   AbstractValue,
-  Value,
   BoundFunctionValue,
+  ECMAScriptSourceFunctionValue,
   EmptyValue,
   FunctionValue,
-  ECMAScriptSourceFunctionValue,
+  NumberValue,
   ObjectValue,
   StringValue,
   SymbolValue,
-  NumberValue,
+  UndefinedValue,
+  Value,
 } from "../values/index.js";
 import { DefinePropertyOrThrow, NewDeclarativeEnvironment } from "./index.js";
 import { OrdinaryCreateFromConstructor, CreateUnmappedArgumentsObject, CreateMappedArgumentsObject } from "./create.js";
@@ -567,6 +568,14 @@ export function FunctionInitialize(
 
   // 4. Let Strict be the value of the [[Strict]] internal slot of F.
   let Strict = F.$Strict;
+  if (!Strict) {
+    DefinePropertyOrThrow(realm, F, "caller", {
+      value: new UndefinedValue(realm),
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  }
 
   // 5. Set the [[Environment]] internal slot of F to the value of Scope.
   F.$Environment = Scope;
@@ -627,7 +636,9 @@ export function AddRestrictedFunctionProperties(F: FunctionValue, realm: Realm) 
     enumerable: false,
     configurable: true,
   };
-  // 3. Return ! DefinePropertyOrThrow(F, "arguments", PropertyDescriptor {[[Get]]: thrower, [[Set]]: thrower, [[Enumerable]]: false, [[Configurable]]: true}).
+  // 3. Perform ! DefinePropertyOrThrow(F, "caller", PropertyDescriptor {[[Get]]: thrower, [[Set]]: thrower, [[Enumerable]]: false, [[Configurable]]: true}).
+  DefinePropertyOrThrow(realm, F, "caller", desc);
+  // 4. Return ! DefinePropertyOrThrow(F, "arguments", PropertyDescriptor {[[Get]]: thrower, [[Set]]: thrower, [[Enumerable]]: false, [[Configurable]]: true}).
   return DefinePropertyOrThrow(realm, F, "arguments", desc);
 }
 


### PR DESCRIPTION
This seems to have been added to the standard since the last time a looked. Re-enable a test that was already looking for it. Mask "caller" for non strict functions, lest more tests fall over.