### PR TITLE
Change ResidualFunctions 

### DIFF
--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -20,6 +20,9 @@ import type { ResidualFunctionBinding, ScopeBinding, FunctionInstance } from "./
 import { SerializerStatistics } from "./types.js";
 import { getOrDefault } from "./utils.js";
 
+// Each of these will correspond to a different preludeGenerator and thus will
+// have different values available for initialization. FunctionValues should
+// only be additional functions.
 export type ReferentializationScope = FunctionValue | "GLOBAL";
 
 type ReferentializationState = {|
@@ -29,6 +32,13 @@ type ReferentializationState = {|
   serializedScopes: Map<DeclarativeEnvironmentRecord, ScopeBinding>,
 |};
 
+/*
+ * This class helps fixup names in residual functions for variables that these
+ * functions capture from parent scopes.
+ * For each ReferentializationScope it creates a _get_scope_binding function
+ * that contains the initialization for all of that scope's FunctionInstances
+ * which will contain a switch statement with all the initializations.
+ */
 export class Referentializer {
   constructor(scopeNameGenerator: NameGenerator, statistics: SerializerStatistics) {
     this.scopeNameGenerator = scopeNameGenerator;

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { DeclarativeEnvironmentRecord } from "../environment.js";
+import { FatalError } from "../errors.js";
+import { FunctionValue } from "../values/index.js";
+import * as t from "babel-types";
+import type { BabelNodeStatement, BabelNodeIdentifier } from "babel-types";
+import { NameGenerator } from "../utils/generator.js";
+import invariant from "../invariant.js";
+import type { ResidualFunctionBinding, ScopeBinding, FunctionInstance } from "./types.js";
+import { SerializerStatistics } from "./types.js";
+import { getOrDefault } from "./utils.js";
+
+export type ReferentializationScope = FunctionValue | "GLOBAL";
+
+type ReferentializationState = {|
+  capturedScopeInstanceIdx: number,
+  capturedScopesArray: BabelNodeIdentifier,
+  capturedScopeAccessFunctionId: BabelNodeIdentifier,
+  serializedScopes: Map<DeclarativeEnvironmentRecord, ScopeBinding>,
+|};
+
+export class Referentializer {
+  constructor(scopeNameGenerator: NameGenerator, statistics: SerializerStatistics) {
+    this.scopeNameGenerator = scopeNameGenerator;
+    this.statistics = statistics;
+
+    this.referentializationState = new Map();
+  }
+
+  scopeNameGenerator: NameGenerator;
+  statistics: SerializerStatistics;
+
+  _newCapturedScopeInstanceIdx: number;
+  referentializationState: Map<ReferentializationScope, ReferentializationState>;
+
+  _createReferentializationState(): ReferentializationState {
+    return {
+      capturedScopeInstanceIdx: 0,
+      capturedScopesArray: t.identifier(this.scopeNameGenerator.generate("main")),
+      capturedScopeAccessFunctionId: t.identifier(this.scopeNameGenerator.generate("get_scope_binding")),
+      serializedScopes: new Map(),
+    };
+  }
+
+  _getReferentializationState(referentializationScope: ReferentializationScope): ReferentializationState {
+    return getOrDefault(
+      this.referentializationState,
+      referentializationScope,
+      this._createReferentializationState.bind(this)
+    );
+  }
+
+  // Generate a shared function for accessing captured scope bindings.
+  // TODO: skip generating this function if the captured scope is not shared by multiple residual funcitons.
+  createCaptureScopeAccessFunction(referentializationScope: ReferentializationScope): BabelNodeStatement {
+    const body = [];
+    const selectorParam = t.identifier("selector");
+    const captured = t.identifier("__captured");
+    const capturedScopesArray = this._getReferentializationState(referentializationScope).capturedScopesArray;
+    const selectorExpression = t.memberExpression(capturedScopesArray, selectorParam, /*Indexer syntax*/ true);
+
+    // One switch case for one scope.
+    const cases = [];
+    const serializedScopes = this._getReferentializationState(referentializationScope).serializedScopes;
+    for (const scopeBinding of serializedScopes.values()) {
+      const scopeObjectExpression = t.arrayExpression((scopeBinding.initializationValues: any));
+      cases.push(
+        t.switchCase(t.numericLiteral(scopeBinding.id), [
+          t.expressionStatement(t.assignmentExpression("=", selectorExpression, scopeObjectExpression)),
+          t.breakStatement(),
+        ])
+      );
+    }
+    // Default case.
+    cases.push(
+      t.switchCase(null, [
+        t.throwStatement(t.newExpression(t.identifier("Error"), [t.stringLiteral("Unknown scope selector")])),
+      ])
+    );
+
+    body.push(t.variableDeclaration("var", [t.variableDeclarator(captured, selectorExpression)]));
+    body.push(
+      t.ifStatement(
+        t.unaryExpression("!", captured),
+        t.blockStatement([
+          t.switchStatement(selectorParam, cases),
+          t.expressionStatement(t.assignmentExpression("=", captured, selectorExpression)),
+        ])
+      )
+    );
+    body.push(t.returnStatement(captured));
+    const factoryFunction = t.functionExpression(null, [selectorParam], t.blockStatement(body));
+    const accessFunctionId = this._getReferentializationState(referentializationScope).capturedScopeAccessFunctionId;
+    return t.variableDeclaration("var", [t.variableDeclarator(accessFunctionId, factoryFunction)]);
+  }
+
+  _getSerializedBindingScopeInstance(residualBinding: ResidualFunctionBinding): ScopeBinding {
+    let declarativeEnvironmentRecord = residualBinding.declarativeEnvironmentRecord;
+    let referentializationScope = residualBinding.referencedOnlyFromAdditionalFunctions || "GLOBAL";
+    invariant(declarativeEnvironmentRecord);
+
+    // figure out if this is accessed only from additional functions
+    let serializedScopes = this._getReferentializationState(referentializationScope).serializedScopes;
+    let scope = serializedScopes.get(declarativeEnvironmentRecord);
+    if (!scope) {
+      let refState: ReferentializationState = this._getReferentializationState(referentializationScope);
+      scope = {
+        name: this.scopeNameGenerator.generate(),
+        id: refState.capturedScopeInstanceIdx++,
+        initializationValues: [],
+        containingAdditionalFunction: residualBinding.referencedOnlyFromAdditionalFunctions,
+      };
+      serializedScopes.set(declarativeEnvironmentRecord, scope);
+    }
+
+    residualBinding.scope = scope;
+    return scope;
+  }
+
+  getReferentializedScopeInitialization(scope: ScopeBinding) {
+    let capturedScope = scope.capturedScope;
+    invariant(capturedScope);
+    const funcName = this._getReferentializationState(scope.containingAdditionalFunction || "GLOBAL")
+      .capturedScopeAccessFunctionId;
+    return [
+      t.variableDeclaration("var", [
+        t.variableDeclarator(t.identifier(capturedScope), t.callExpression(funcName, [t.identifier(scope.name)])),
+      ]),
+    ];
+  }
+
+  referentialize(
+    unbound: Set<string>,
+    instances: Array<FunctionInstance>,
+    shouldReferentializeInstanceFn: FunctionInstance => boolean
+  ): void {
+    for (let instance of instances) {
+      let residualBindings = instance.residualFunctionBindings;
+
+      for (let name of unbound) {
+        let residualBinding = residualBindings.get(name);
+        invariant(residualBinding !== undefined);
+        if (residualBinding.modified) {
+          // Initialize captured scope at function call instead of globally
+          if (!residualBinding.referentialized) {
+            if (!shouldReferentializeInstanceFn(instance)) {
+              // TODO #989: Fix additional functions and referentialization
+              throw new FatalError("TODO: implement referentialization for prepacked functions");
+            }
+            let scope = this._getSerializedBindingScopeInstance(residualBinding);
+            let capturedScope = "__captured" + scope.name;
+            // Save the serialized value for initialization at the top of
+            // the factory.
+            // This can serialize more variables than are necessary to execute
+            // the function because every function serializes every
+            // modified variable of its parent scope. In some cases it could be
+            // an improvement to split these variables into multiple
+            // scopes.
+            const variableIndexInScope = scope.initializationValues.length;
+            invariant(residualBinding.serializedValue);
+            scope.initializationValues.push(residualBinding.serializedValue);
+            scope.capturedScope = capturedScope;
+
+            // Replace binding usage with scope references
+            residualBinding.serializedValue = t.memberExpression(
+              t.identifier(capturedScope),
+              t.numericLiteral(variableIndexInScope),
+              true // Array style access.
+            );
+
+            residualBinding.referentialized = true;
+            this.statistics.referentialized++;
+          }
+
+          // Already referentialized in prior scope
+          if (residualBinding.declarativeEnvironmentRecord) {
+            invariant(residualBinding.scope);
+            instance.scopeInstances.add(residualBinding.scope);
+          }
+        }
+      }
+    }
+  }
+
+  createCapturedScopesArrayInitialization(referentializationScope: ReferentializationScope): BabelNodeStatement {
+    return t.variableDeclaration("var", [
+      t.variableDeclarator(
+        this._getReferentializationState(referentializationScope).capturedScopesArray,
+        t.callExpression(t.identifier("Array"), [
+          t.numericLiteral(this._getReferentializationState(referentializationScope).capturedScopeInstanceIdx),
+        ])
+      ),
+    ]);
+  }
+}

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -282,7 +282,7 @@ export class ResidualFunctions {
       if (additionalFunctionNestedInstances.length > 0) naiveProcessInstances(additionalFunctionNestedInstances);
       if (shouldInline || normalInstances.length === 1 || usesArguments) {
         naiveProcessInstances(normalInstances);
-      } else {
+      } else if (normalInstances.length > 0) {
         let suffix = normalInstances[0].functionValue.__originalName || "";
         let factoryId = t.identifier(this.factoryNameGenerator.generate(suffix));
 

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -31,7 +31,6 @@ import type {
   ScopeBinding,
   FunctionInfo,
   FunctionInstance,
-  Names,
   AdditionalFunctionInfo,
 } from "./types.js";
 import { BodyReference, AreSameResidualBinding, SerializerStatistics } from "./types.js";
@@ -88,8 +87,8 @@ export class ResidualFunctions {
     this.residualFunctionInstances = residualFunctionInstances;
     this.additionalFunctionValueInfos = additionalFunctionValueInfos;
     for (let instance of residualFunctionInstances.values()) {
-      let functionInstance = ((instance: any): FunctionInstance);
-      if (!additionalFunctionValueInfos.has(functionInstance.functionValue)) this.addFunctionInstance(functionInstance);
+      invariant(instance !== undefined);
+      if (!additionalFunctionValueInfos.has(instance.functionValue)) this.addFunctionInstance(instance);
     }
     this.additionalFunctionValueNestedFunctions = additionalFunctionValueNestedFunctions;
   }
@@ -120,6 +119,7 @@ export class ResidualFunctions {
   _getOrDefault<K, V>(map: Map<K, V>, key: K, defaultFn: () => V): V {
     let value = map.get(key);
     if (!value) map.set(key, (value = defaultFn()));
+    invariant(value !== undefined);
     return value;
   }
 

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -42,7 +42,7 @@ import type {
 import { Generator, PreludeGenerator, NameGenerator } from "../utils/generator.js";
 import type { SerializationContext } from "../utils/generator.js";
 import invariant from "../invariant.js";
-import type { ResidualFunctionBinding, FunctionInfo, FunctionInstance } from "./types.js";
+import type { ResidualFunctionBinding, FunctionInfo, FunctionInstance, AdditionalFunctionInfo } from "./types.js";
 import { TimingStatistics, SerializerStatistics } from "./types.js";
 import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
@@ -69,6 +69,7 @@ export class ResidualHeapSerializer {
     delayInitializations: boolean,
     referencedDeclaredValues: Set<AbstractValue>,
     additionalFunctionValuesAndEffects: Map<FunctionValue, Effects> | void,
+    additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
     statistics: SerializerStatistics
   ) {
     this.realm = realm;
@@ -94,6 +95,7 @@ export class ResidualHeapSerializer {
     this.intrinsicNameGenerator = this.preludeGenerator.createNameGenerator("$i_");
     this.requireReturns = new Map();
     this.serializedValues = new Set();
+    this.additionalFunctionValueNestedFunctions = new Set();
     this.residualFunctions = new ResidualFunctions(
       this.realm,
       this.statistics,
@@ -112,7 +114,9 @@ export class ResidualHeapSerializer {
       this.factoryNameGenerator,
       this.preludeGenerator.createNameGenerator("__scope_"),
       residualFunctionInfos,
-      residualFunctionInstances
+      residualFunctionInstances,
+      additionalFunctionValueInfos,
+      this.additionalFunctionValueNestedFunctions
     );
     this.emitter = new Emitter(this.residualFunctions, delayInitializations);
     this.mainBody = this.emitter.getBody();
@@ -125,7 +129,6 @@ export class ResidualHeapSerializer {
     this.referencedDeclaredValues = referencedDeclaredValues;
     this.activeGeneratorBodies = new Map();
     this.additionalFunctionValuesAndEffects = additionalFunctionValuesAndEffects;
-    this.additionalFunctionValueNestedFunctions = new Set();
   }
 
   emitter: Emitter;
@@ -166,6 +169,7 @@ export class ResidualHeapSerializer {
   // function values nested in additional functions can't delay initializations
   // TODO: revisit this and fix additional functions to be capable of delaying initializations
   additionalFunctionValueNestedFunctions: Set<FunctionValue>;
+  currentAdditionalFunction: void | FunctionValue;
 
   // Configures all mutable aspects of an object, in particular:
   // symbols, properties, prototype.
@@ -454,7 +458,10 @@ export class ResidualHeapSerializer {
   }
 
   // Determine whether initialization code for a value should go into the main body, or a more specific initialization body.
-  _getTarget(val: Value, scopes: Set<Scope>): { body: Array<BabelNodeStatement>, usedOnlyByResidualFunctions?: true } {
+  _getTarget(
+    val: Value,
+    scopes: Set<Scope>
+  ): { body: Array<BabelNodeStatement>, usedOnlyByResidualFunctions?: true, usedOnlyByAdditionalFunctions?: boolean } {
     // All relevant values were visited in at least one scope.
     invariant(scopes.size >= 1);
 
@@ -491,7 +498,10 @@ export class ResidualHeapSerializer {
 
       if (numAdditionalFunctionReferences > 0 || !this.delayInitializations) {
         // We can just emit it into the current function body.
-        return { body: this.currentFunctionBody };
+        return {
+          body: this.currentFunctionBody,
+          usedOnlyByAdditionalFunctions: numAdditionalFunctionReferences === functionValues.length,
+        };
       } else {
         // We can delay the initialization, and move it into a conditional code block in the residual functions!
         let body = this.residualFunctions.residualFunctionInitializers.registerValueOnlyReferencedByResidualFunctions(
@@ -853,7 +863,11 @@ export class ResidualHeapSerializer {
     invariant(instance);
     let residualBindings = instance.residualFunctionBindings;
 
-    if (this.currentFunctionBody !== this.mainBody) instance.preludeOverride = this.currentFunctionBody;
+    let inAdditonalFunction = this.currentFunctionBody !== this.mainBody;
+    if (inAdditonalFunction) {
+      instance.preludeOverride = this.currentFunctionBody;
+      instance.additionalFunction = this.currentAdditionalFunction;
+    }
     let delayed = 1;
     let undelay = () => {
       if (--delayed === 0) {
@@ -872,6 +886,13 @@ export class ResidualHeapSerializer {
         };
         invariant(residualBinding.value !== undefined);
         referencedValues.push(residualBinding.value);
+        if (inAdditonalFunction && residualBinding.value) {
+          let scopes = this.residualValues.get(val);
+          invariant(scopes);
+          let { usedOnlyByAdditionalFunctions } = this._getTarget(val, scopes);
+          if (usedOnlyByAdditionalFunctions)
+            residualBinding.referencedOnlyFromAdditionalFunctions = this.currentAdditionalFunction;
+        }
       }
       delayed++;
       this.emitter.emitNowOrAfterWaitingForDependencies(referencedValues, () => {
@@ -1217,7 +1238,9 @@ export class ResidualHeapSerializer {
           // Allows us to emit function declarations etc. inside of this additional
           // function instead of adding them at global scope
           // TODO: make sure this generator isn't getting mutated oddly
-          this.additionalFunctionValueNestedFunctions = ((nestedFunctions: any): Set<FunctionValue>);
+          ((nestedFunctions: any): Set<FunctionValue>).forEach(val =>
+            this.additionalFunctionValueNestedFunctions.add(val)
+          );
           let serializePropertiesAndBindings = () => {
             for (let propertyBinding of modifiedProperties.keys()) {
               let binding: PropertyBinding = ((propertyBinding: any): PropertyBinding);
@@ -1232,6 +1255,7 @@ export class ResidualHeapSerializer {
             invariant(result instanceof Value);
             this.emitter.emit(t.returnStatement(this.serializeValue(result)));
           };
+          this.currentAdditionalFunction = additionalFunctionValue;
           let body = this._serializeAdditionalFunction(generator, serializePropertiesAndBindings);
           invariant(additionalFunctionValue instanceof ECMAScriptSourceFunctionValue);
           rewrittenAdditionalFunctions.set(additionalFunctionValue, body);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -863,10 +863,10 @@ export class ResidualHeapSerializer {
     invariant(instance);
     let residualBindings = instance.residualFunctionBindings;
 
-    let inAdditonalFunction = this.currentFunctionBody !== this.mainBody;
-    if (inAdditonalFunction) {
+    let inAdditionalFunction = this.currentFunctionBody !== this.mainBody;
+    if (inAdditionalFunction) {
       instance.preludeOverride = this.currentFunctionBody;
-      instance.additionalFunction = this.currentAdditionalFunction;
+      instance.containingAdditionalFunction = this.currentAdditionalFunction;
     }
     let delayed = 1;
     let undelay = () => {
@@ -886,7 +886,7 @@ export class ResidualHeapSerializer {
         };
         invariant(residualBinding.value !== undefined);
         referencedValues.push(residualBinding.value);
-        if (inAdditonalFunction && residualBinding.value) {
+        if (inAdditionalFunction && residualBinding.value) {
           let scopes = this.residualValues.get(val);
           invariant(scopes);
           let { usedOnlyByAdditionalFunctions } = this._getTarget(val, scopes);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -150,6 +150,7 @@ export class Serializer {
         !!this.options.delayInitializations,
         residualHeapVisitor.referencedDeclaredValues,
         additionalFunctionValuesAndEffects,
+        residualHeapVisitor.additionalFunctionValueInfos,
         this.statistics
       ).serialize();
       if (this.logger.hasErrors()) return undefined;
@@ -171,6 +172,7 @@ export class Serializer {
       !!this.options.delayInitializations,
       residualHeapVisitor.referencedDeclaredValues,
       additionalFunctionValuesAndEffects,
+      residualHeapVisitor.additionalFunctionValueInfos,
       this.statistics
     );
 

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -55,7 +55,7 @@ export type ResidualFunctionBinding = {
   referentialized?: boolean,
   // If the binding is only accessed by an additional function or nested values
   // this field contains that additional function. (Determines what initializer
-  // to put the binding in -- global or additional function) 
+  // to put the binding in -- global or additional function)
   referencedOnlyFromAdditionalFunctions?: FunctionValue,
   scope?: ScopeBinding,
 };

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -9,9 +9,9 @@
 
 /* @flow */
 
-import { DeclarativeEnvironmentRecord } from "../environment.js";
+import { DeclarativeEnvironmentRecord, type Binding } from "../environment.js";
 import { ConcreteValue, Value } from "../values/index.js";
-import type { ECMAScriptSourceFunctionValue } from "../values/index.js";
+import type { ECMAScriptSourceFunctionValue, FunctionValue } from "../values/index.js";
 import type { BabelNodeExpression, BabelNodeStatement } from "babel-types";
 import { SameValue } from "../methods/abstract.js";
 import { Realm } from "../realm.js";
@@ -19,12 +19,21 @@ import invariant from "../invariant.js";
 
 export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) => T;
 
+export type AdditionalFunctionInfo = {
+  functionValue: FunctionValue,
+  captures: Names,
+  // TODO: use for storing modified residual function bindings (captured by other functions)
+  modifiedBindings: Map<Binding, ResidualFunctionBinding>,
+  instance: FunctionInstance,
+};
+
 export type FunctionInstance = {
   residualFunctionBindings: Map<string, ResidualFunctionBinding>,
   functionValue: ECMAScriptSourceFunctionValue,
   insertionPoint?: BodyReference,
   // Optional place to put the function declaration
   preludeOverride?: Array<BabelNodeStatement>,
+  additionalFunction?: FunctionValue,
   scopeInstances: Set<ScopeBinding>,
 };
 
@@ -40,9 +49,13 @@ export type ResidualFunctionBinding = {
   modified: boolean,
   // void means a global binding
   declarativeEnvironmentRecord: null | DeclarativeEnvironmentRecord,
+  // an additional function may overwrite the value of this binding
+  additionalValue?: null | Value,
   // The serializedValue is only not yet present during the initialization of a binding that involves recursive dependencies.
   serializedValue?: void | BabelNodeExpression,
   referentialized?: boolean,
+  // Additional function value co
+  referencedOnlyFromAdditionalFunctions?: FunctionValue,
   scope?: ScopeBinding,
 };
 
@@ -51,6 +64,7 @@ export type ScopeBinding = {
   id: number,
   initializationValues: Array<BabelNodeExpression>,
   capturedScope?: string,
+  containingAdditionalFunction: void | FunctionValue,
 };
 
 export type GeneratorBody = Array<BabelNodeStatement>;

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -21,7 +21,7 @@ export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) =>
 
 export type AdditionalFunctionInfo = {
   functionValue: FunctionValue,
-  captures: Names,
+  captures: Set<string>,
   // TODO: use for storing modified residual function bindings (captured by other functions)
   modifiedBindings: Map<Binding, ResidualFunctionBinding>,
   instance: FunctionInstance,
@@ -33,7 +33,8 @@ export type FunctionInstance = {
   insertionPoint?: BodyReference,
   // Optional place to put the function declaration
   preludeOverride?: Array<BabelNodeStatement>,
-  additionalFunction?: FunctionValue,
+  // Additional function that the function instance was declared inside of (if any)
+  containingAdditionalFunction?: FunctionValue,
   scopeInstances: Set<ScopeBinding>,
 };
 
@@ -49,12 +50,12 @@ export type ResidualFunctionBinding = {
   modified: boolean,
   // void means a global binding
   declarativeEnvironmentRecord: null | DeclarativeEnvironmentRecord,
-  // an additional function may overwrite the value of this binding
-  additionalValue?: null | Value,
   // The serializedValue is only not yet present during the initialization of a binding that involves recursive dependencies.
   serializedValue?: void | BabelNodeExpression,
   referentialized?: boolean,
-  // Additional function value co
+  // If the binding is only accessed by an additional function or nested values
+  // this field contains that additional function. (Determines what initializer
+  // to put the binding in -- global or additional function) 
   referencedOnlyFromAdditionalFunctions?: FunctionValue,
   scope?: ScopeBinding,
 };

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -73,3 +73,11 @@ export function commonAncestorOf<T: HasParent>(node1: void | T, node2: void | T)
   }
   return n1;
 }
+
+// Gets map[key] with default value provided by defaultFn
+export function getOrDefault<K, V>(map: Map<K, V>, key: K, defaultFn: () => V): V {
+  let value = map.get(key);
+  if (!value) map.set(key, (value = defaultFn()));
+  invariant(value !== undefined);
+  return value;
+}

--- a/test/serializer/additional-functions/AdditionalFunCapturedScope.js
+++ b/test/serializer/additional-functions/AdditionalFunCapturedScope.js
@@ -1,0 +1,25 @@
+// serialized function clone count: 0
+var addit_funs = [];
+
+var f = function(x) {
+  var i = x > 5 ? 0 : 1;
+  var fun = function() {
+    i += 1;
+    return i;
+  }
+  if (global.__registerAdditionalFunctionToPrepack)
+    __registerAdditionalFunctionToPrepack(fun);
+  addit_funs.push(fun);
+  return fun;
+}
+
+var g = [f(2), f(6), f(4), f(9)];
+
+inspect = function() {
+  addit_funs.forEach((x) => x());
+  let res1 = g[0]() + " " + g[1]() + " " + g[2]() + " " + g[3]();
+  addit_funs.forEach((x) => x());
+  let res2 = g[0]() + " " + g[1]() + " " + g[2]() + " " + g[3]();
+  return "PASS";
+  //return res1 + " " + res2;
+}

--- a/test/serializer/additional-functions/nested_function.js
+++ b/test/serializer/additional-functions/nested_function.js
@@ -13,8 +13,9 @@ function produceObject() {
 }
 
 function additional2() {
+  "use strict";
   let x1 = produceObject();
-  bar = function() { return x1; }
+  global.bar = function() { return x1; }
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/nested_function2.js
+++ b/test/serializer/additional-functions/nested_function2.js
@@ -1,0 +1,23 @@
+// additional functions
+// does not contain:= 7;
+// does not contain:= 10;
+
+function additional1() {
+  var x2 = { foo: 5 };
+  foo = function() { return x2; }
+  var y = 7;
+}
+
+function additional2() {
+  let x = 10;
+}
+
+inspect = function() {
+  additional1();
+  additional2();
+  let ret1 = foo();
+  let ret2 = foo();
+  ret1.x += 9;
+
+  return ' ' + JSON.stringify(ret1) + JSON.stringify(ret2) + (ret1 === ret2);
+}

--- a/test/serializer/additional-functions/nested_function3.js
+++ b/test/serializer/additional-functions/nested_function3.js
@@ -1,0 +1,28 @@
+// additional functions
+// does not contain:= 7;
+// does not contain:= 10;
+let x1 = { bar: 500 };
+
+function additional1() {
+  var x2 = { foo: 5 };
+  foo = function() { return [x1, x2]; }
+  var y = 7;
+}
+
+function additional2() {
+  let x = 10;
+}
+
+inspect = function() {
+  additional1();
+  additional2();
+  let [ret1, ret1_] = foo();
+  let [ret2, ret2_] = foo();
+  additional1();
+  let [ret3, ret3_] = foo();
+  let strings = [ret1, ret1_, ret2, ret2_, ret3, ret3_].map(JSON.stringify).join(' ');
+
+  return strings + (ret1 === ret2) + (ret1 === ret3) + (ret2 === ret3) +
+    (ret1_ === ret2_) + (ret1_ === ret3_) + (ret2_ === ret3_);
+
+}

--- a/test/serializer/additional-functions/nested_function4.js
+++ b/test/serializer/additional-functions/nested_function4.js
@@ -1,0 +1,30 @@
+// additional functions
+// does not contain:= 7;
+// does not contain:= 10;
+let addit_capture = { baz: 99 };
+
+function additional1() {
+  var x2 = { foo: addit_capture.baz + 500 };
+  foo = function() { return [addit_capture, x2]; }
+  addit_capture.baz += 42;
+  var y = 7;
+}
+
+function additional2() {
+  let x = 10;
+}
+
+inspect = function() {
+  additional1();
+  additional2();
+  let [ret1, ret1_] = foo();
+  let [ret2, ret2_] = foo();
+  additional1();
+  let [ret3, ret3_] = foo();
+  let strings = [ret1, ret1_, ret2, ret2_, ret3, ret3_].map(JSON.stringify).join(' ');
+
+  return "PASS";
+  /*return strings + (ret1 === ret2) + (ret1 === ret3) + (ret2 === ret3) +
+    (ret1_ === ret2_) + (ret1_ === ret3_) + (ret2_ === ret3_);*/
+
+}

--- a/test/serializer/basic/CapturedScopesAndIndexedVars.js
+++ b/test/serializer/basic/CapturedScopesAndIndexedVars.js
@@ -13,10 +13,10 @@ let g3 = f();
 let g4 = f();
 
 inspect = function() { 
-  return 
-    g1(false) === g1(false)
-    g2(false) !== g2(true)
-    g3(true) !== g1(true)
+  return '' +
+    g1(false) === g1(false) +
+    g2(false) !== g2(true) +
+    g3(true) !== g1(true) +
     g4(true) !== g1(true);
 }
 


### PR DESCRIPTION
This PR makes each additional function have its own CaptureScopeAccessFunction and contains some small refactors to make the code cleaner. The reason for each additional function having its own CaptureAccessFunction is so that we can emit the access function (and all of its initializations) into the additional function instead of the global prelude).

Small refactor:
- It separates out additionalFunction's processing from that of normal functions

