### PR TITLE
Add testcases for function body clone

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -62,8 +62,6 @@ import {
   HasOwnProperty,
   IsDataDescriptor,
   ThrowIfMightHaveBeenDeleted,
-  composePossiblyNormalCompletions,
-  updatePossiblyNormalCompletionWithValue,
 } from "./methods/index.js";
 import * as t from "babel-types";
 
@@ -1240,20 +1238,6 @@ export class LexicalEnvironment {
     let evaluator = this.realm.evaluators[(ast.type: string)];
     if (evaluator) {
       let result = evaluator(ast, strictCode, this, this.realm, metadata);
-      let context = this.realm.getRunningContext();
-      let savedCompletion = context.savedCompletion;
-      if (savedCompletion !== undefined) {
-        if (result instanceof Value) {
-          updatePossiblyNormalCompletionWithValue(this.realm, savedCompletion, result);
-          result = savedCompletion;
-        } else if (result instanceof PossiblyNormalCompletion) {
-          result = composePossiblyNormalCompletions(this.realm, savedCompletion, result);
-        } else {
-          AbstractValue.reportIntrospectionError(savedCompletion.joinCondition);
-          throw new FatalError();
-        }
-        context.savedCompletion = undefined;
-      }
       return result;
     }
 

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -11,21 +11,55 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { AbruptCompletion, ThrowCompletion } from "../completions.js";
-import { UpdateEmpty } from "../methods/index.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
+import { joinEffects, UpdateEmpty } from "../methods/index.js";
 import { Value } from "../values/index.js";
 import type { BabelNodeTryStatement } from "babel-types";
 import invariant from "../invariant.js";
 
-export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value {
+export default function(
+  ast: BabelNodeTryStatement,
+  strictCode: boolean,
+  env: LexicalEnvironment,
+  realm: Realm
+): PossiblyNormalCompletion | Value {
   let completions = [];
 
-  let blockRes = env.evaluateCompletion(ast.block, strictCode);
-
-  if (blockRes instanceof ThrowCompletion && ast.handler) {
-    completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));
+  let blockRes = env.evaluateAbstractCompletion(ast.block, strictCode);
+  if (blockRes instanceof PossiblyNormalCompletion) {
+    let abruptCompletion;
+    let abruptEffects;
+    if (blockRes.consequent instanceof AbruptCompletion) {
+      abruptCompletion = blockRes.consequent;
+      abruptEffects = blockRes.consequentEffects;
+    } else {
+      abruptCompletion = blockRes.alternate;
+      abruptEffects = blockRes.alternateEffects;
+    }
+    if (abruptCompletion instanceof ThrowCompletion && ast.handler) {
+      let normalEffects = realm.getCapturedEffects(blockRes.value);
+      invariant(normalEffects !== undefined);
+      realm.stopEffectCaptureAndUndoEffects();
+      let handlerEffects = realm.evaluateForEffects(() => {
+        realm.applyEffects(abruptEffects);
+        invariant(ast.handler);
+        return env.evaluateAbstractCompletion(ast.handler, strictCode, abruptCompletion);
+      });
+      let jointEffects;
+      if (blockRes.consequent instanceof AbruptCompletion)
+        jointEffects = joinEffects(realm, blockRes.joinCondition, handlerEffects, normalEffects);
+      else jointEffects = joinEffects(realm, blockRes.joinCondition, normalEffects, handlerEffects);
+      realm.applyEffects(jointEffects);
+      completions.unshift(jointEffects[0]);
+    } else {
+      completions.unshift(blockRes);
+    }
   } else {
-    completions.unshift(blockRes);
+    if (blockRes instanceof ThrowCompletion && ast.handler) {
+      completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));
+    } else {
+      completions.unshift(blockRes);
+    }
   }
 
   if (ast.finalizer) {
@@ -34,7 +68,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
 
   // use the last completion record
   for (let completion of completions) {
-    if (completion && completion instanceof AbruptCompletion) throw completion;
+    if (completion instanceof AbruptCompletion) throw completion;
   }
 
   if (ast.finalizer) {
@@ -43,7 +77,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
 
   // otherwise use the last returned value
   for (let completion of completions) {
-    if (completion && completion instanceof Value)
+    if (completion instanceof Value || completion instanceof Completion)
       return (UpdateEmpty(realm, completion, realm.intrinsics.undefined): any);
   }
 

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -26,20 +26,20 @@ import {
   AbstractValue,
 } from "../values/index.js";
 import {
-  GetBase,
-  GetValue,
-  ToObjectPartial,
-  IsCallable,
-  IsPropertyReference,
-  IsPropertyKey,
+  composePossiblyNormalCompletions,
   FunctionDeclarationInstantiation,
-  NewFunctionEnvironment,
+  GetBase,
   GetIterator,
+  GetValue,
+  HasSomeCompatibleType,
+  IsCallable,
+  IsPropertyKey,
+  IsPropertyReference,
   IteratorStep,
   IteratorValue,
-  HasSomeCompatibleType,
-  composePossiblyNormalCompletions,
-  joinEffectsAndRemoveNestedReturnCompletions,
+  joinEffectsAndPromoteNestedReturnCompletions,
+  NewFunctionEnvironment,
+  ToObjectPartial,
   unbundleReturnCompletion,
 } from "./index.js";
 import { GeneratorStart } from "../methods/generator.js";
@@ -51,6 +51,7 @@ import {
   PossiblyNormalCompletion,
 } from "../completions.js";
 import { GetTemplateObject, GetV, GetThisValue } from "../methods/get.js";
+import { construct_empty_effects } from "../realm.js";
 import invariant from "../invariant.js";
 import type { BabelNodeExpression, BabelNodeSpreadElement, BabelNodeTemplateLiteral } from "babel-types";
 import * as t from "babel-types";
@@ -350,47 +351,63 @@ export function OrdinaryCallEvaluateBody(
       invariant(code !== undefined);
       let context = realm.getRunningContext();
       let c = context.lexicalEnvironment.evaluateAbstractCompletion(code, F.$Strict);
-      let e = realm.getCapturedEffects();
-      if (e !== undefined) {
+      // We are about the leave this function and this presents a join point where all non exeptional control flows
+      // converge into a single flow using the joined effects as the new state.
+      if (c instanceof PossiblyNormalCompletion) {
+        // There were earlier, conditional exits from the function
+        // We join together the current effects with the effects of any earlier returns that are tracked in c.
+        let e = realm.getCapturedEffects();
+        invariant(e !== undefined);
         realm.stopEffectCaptureAndUndoEffects();
+        let joinedEffects = joinEffectsAndPromoteNestedReturnCompletions(realm, c, e);
+        realm.applyEffects(joinedEffects);
+        c = joinedEffects[0];
       }
       if (c instanceof JoinedAbruptCompletions) {
-        if (e !== undefined) realm.applyEffects(e);
-        return c;
-      } else if (c instanceof PossiblyNormalCompletion) {
-        // If the abrupt part of the completion is a return completion, then the
-        // effects of its independent control path must be joined with the effects
-        // from the normal path, which is to say the currently tracked effects
-        // in the realm.
-        invariant(e !== undefined);
-        let joinedEffects = joinEffectsAndRemoveNestedReturnCompletions(realm, c, e);
+        // There are two or more returns and/or throws that unconditionally terminate the function
+        // We need to join the return flows together.
+        let e = construct_empty_effects(realm); // nothing happened since the components of c captured their effects
+        let joinedEffects = joinEffectsAndPromoteNestedReturnCompletions(realm, c, e);
         let result = joinedEffects[0];
-        if (result instanceof JoinedAbruptCompletions) {
-          // There are throw completions that conditionally escape from the the call.
-          // We need to carry on in normal mode (after arranging to capturing effects)
-          // while stashing away the throw completions so that the next completion we return
-          // incorporates them.
-          let possiblyNormalCompletion;
-          [joinedEffects, possiblyNormalCompletion] = unbundleReturnCompletion(realm, result);
-          if (context.savedCompletion !== undefined)
-            context.savedCompletion = composePossiblyNormalCompletions(
-              realm,
-              context.savedCompletion,
-              possiblyNormalCompletion
-            );
-          else context.savedCompletion = possiblyNormalCompletion;
-          realm.captureEffects();
-          result = joinedEffects[0];
+        if (result instanceof ReturnCompletion) {
+          realm.applyEffects(joinedEffects);
+          return result.value;
         }
+        invariant(result instanceof JoinedAbruptCompletions);
+        if (!(result.consequent instanceof ReturnCompletion || result.alternate instanceof ReturnCompletion)) {
+          // Control is leaving this function only via throw completions. This is not a joint point.
+          throw result;
+        }
+        // There is a normal return exit, but also one or more throw completions.
+        // The throw completions must be extracted into a saved possibly normal completion
+        // so that the caller can pick them up in its next completion.
+        joinedEffects = extractAndSavePossiblyNormalCompletion(result, context);
+        result = joinedEffects[0];
         invariant(result instanceof ReturnCompletion);
         realm.applyEffects(joinedEffects);
         return result;
       } else {
         invariant(c instanceof Value || c instanceof AbruptCompletion);
-        if (e !== undefined) realm.applyEffects(e);
         return c;
       }
     }
+  }
+
+  function extractAndSavePossiblyNormalCompletion(c: JoinedAbruptCompletions, context: ExecutionContext) {
+    // There are throw completions that conditionally escape from the the call.
+    // We need to carry on in normal mode (after arranging to capturing effects)
+    // while stashing away the throw completions so that the next completion we return
+    // incorporates them.
+    let [joinedEffects, possiblyNormalCompletion] = unbundleReturnCompletion(realm, c);
+    if (context.savedCompletion !== undefined)
+      context.savedCompletion = composePossiblyNormalCompletions(
+        realm,
+        context.savedCompletion,
+        possiblyNormalCompletion
+      );
+    else context.savedCompletion = possiblyNormalCompletion;
+    realm.captureEffects();
+    return joinedEffects;
   }
 }
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1130,6 +1130,33 @@ export function PerformEval(realm: Realm, x: Value, evalRealm: Realm, strictCall
   }
 }
 
+export function incorporateSavedCompletion(realm: Realm, c: void | Completion | Value): Completion | Value {
+  let context = realm.getRunningContext();
+  let savedCompletion = context.savedCompletion;
+  if (savedCompletion !== undefined) {
+    context.savedCompletion = undefined;
+    if (c === undefined) return savedCompletion;
+    if (c instanceof Value) {
+      updatePossiblyNormalCompletionWithValue(realm, savedCompletion, c);
+      return savedCompletion;
+    } else if (c instanceof PossiblyNormalCompletion) {
+      return composePossiblyNormalCompletions(realm, savedCompletion, c);
+    } else {
+      invariant(c instanceof AbruptCompletion);
+      let e = realm.getCapturedEffects();
+      invariant(e !== undefined);
+      realm.stopEffectCaptureAndUndoEffects();
+      e[0] = c;
+      let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, c, e);
+      realm.applyEffects(joined_effects);
+      let jc = joined_effects[0];
+      invariant(jc instanceof AbruptCompletion);
+      throw jc;
+    }
+  }
+  return c;
+}
+
 export function EvaluateStatements(
   body: Array<BabelNodeStatement>,
   blockValue: void | NormalCompletion | Value,
@@ -1140,28 +1167,8 @@ export function EvaluateStatements(
   for (let node of body) {
     if (node.type !== "FunctionDeclaration") {
       let res = blockEnv.evaluateAbstractCompletion(node, strictCode);
-      let context = realm.getRunningContext();
-      let savedCompletion = context.savedCompletion;
-      if (savedCompletion !== undefined) {
-        context.savedCompletion = undefined;
-        if (res instanceof Value) res = updatePossiblyNormalCompletionWithValue(realm, savedCompletion, res);
-        else if (res instanceof PossiblyNormalCompletion)
-          res = composePossiblyNormalCompletions(realm, savedCompletion, res);
-        else {
-          invariant(res instanceof AbruptCompletion);
-          let e = realm.getCapturedEffects();
-          invariant(e !== undefined);
-          realm.stopEffectCaptureAndUndoEffects();
-          invariant(context.savedCompletion !== undefined);
-          e[0] = res;
-          let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, res, e);
-          realm.applyEffects(joined_effects);
-          res = joined_effects[0];
-          invariant(res instanceof AbruptCompletion);
-          throw res;
-        }
-      }
       invariant(!(res instanceof Reference));
+      res = incorporateSavedCompletion(realm, res);
       if (!(res instanceof EmptyValue)) {
         if (blockValue === undefined || blockValue instanceof Value) {
           if (res instanceof AbruptCompletion) throw UpdateEmpty(realm, res, blockValue || realm.intrinsics.empty);
@@ -1172,11 +1179,18 @@ export function EvaluateStatements(
           if (res instanceof AbruptCompletion) {
             throw stopEffectCaptureAndJoinCompletions(blockValue, res, realm);
           } else {
-            if (res instanceof Value) blockValue.value = res;
-            else {
+            if (res instanceof Value) {
+              updatePossiblyNormalCompletionWithValue(realm, blockValue, res);
+            } else {
               invariant(blockValue instanceof PossiblyNormalCompletion);
               invariant(res instanceof PossiblyNormalCompletion);
+              let e = realm.getCapturedEffects();
+              invariant(e !== undefined);
+              realm.stopEffectCaptureAndUndoEffects();
+              realm.addPriorEffects(e, res.consequent instanceof Value ? res.consequentEffects : res.alternateEffects);
               blockValue = composePossiblyNormalCompletions(realm, blockValue, res);
+              realm.applyEffects(e);
+              realm.captureEffects();
             }
           }
         }

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -26,7 +26,7 @@ import type {
 import { NameGenerator } from "../utils/generator.js";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";
-import type { ResidualFunctionBinding, ScopeBinding, FunctionInfo, FunctionInstance, Names } from "./types.js";
+import type { ResidualFunctionBinding, ScopeBinding, FunctionInfo, FunctionInstance } from "./types.js";
 import { BodyReference, AreSameResidualBinding, SerializerStatistics } from "./types.js";
 import { ClosureRefReplacer } from "./visitors.js";
 import { Modules } from "./modules.js";
@@ -178,14 +178,14 @@ export class ResidualFunctions {
   }
 
   _referentialize(
-    unbound: Names,
+    unbound: Set<string>,
     instances: Array<FunctionInstance>,
     shouldReferentializeInstanceFn: FunctionInstance => boolean
   ): void {
     for (let instance of instances) {
       let residualBindings = instance.residualFunctionBindings;
 
-      for (let name in unbound) {
+      for (let name of unbound) {
         let residualBinding = residualBindings.get(name);
         invariant(residualBinding !== undefined);
         if (residualBinding.modified) {
@@ -393,7 +393,7 @@ export class ResidualFunctions {
         // filter included variables to only include those that are different
         let factoryNames: Array<string> = [];
         let sameResidualBindings = new Map();
-        for (let name in unbound) {
+        for (let name of unbound) {
           let isDifferent = false;
           let lastBinding;
 
@@ -439,13 +439,7 @@ export class ResidualFunctions {
 
         factoryParams = factoryParams.concat(params).slice();
 
-        // The Replacer below mutates the AST, so let's clone the original AST to avoid modifying it
-        let factoryNode = t.functionExpression(
-          null,
-          factoryParams,
-          ((t.cloneDeep(funcBody): any): BabelNodeBlockStatement)
-        );
-
+        let factoryNode = t.functionExpression(null, factoryParams, funcBody);
         if (normalInstances[0].functionValue.$Strict) {
           strictFunctionBodies.push(factoryNode);
         } else {

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -439,7 +439,13 @@ export class ResidualFunctions {
 
         factoryParams = factoryParams.concat(params).slice();
 
-        let factoryNode = t.functionExpression(null, factoryParams, funcBody);
+        // The Replacer below mutates the AST, so let's clone the original AST to avoid modifying it
+        let factoryNode = t.functionExpression(
+          null,
+          factoryParams,
+          ((t.cloneDeep(funcBody): any): BabelNodeBlockStatement)
+        );
+
         if (normalInstances[0].functionValue.$Strict) {
           strictFunctionBodies.push(factoryNode);
         } else {

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -439,7 +439,8 @@ export class ResidualFunctions {
 
         factoryParams = factoryParams.concat(params).slice();
 
-        // The Replacer below mutates the AST, so let's clone the original AST to avoid modifying it
+        // The Replacer below mutates the AST while the original AST may still be referenced
+        // by another outer residual function so let's clone the original AST to avoid modifying it.
         let factoryNode = t.functionExpression(
           null,
           factoryParams,

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -296,8 +296,8 @@ export class ResidualHeapVisitor {
 
     if (!functionInfo) {
       functionInfo = {
-        unbound: (Object.create(null): any),
-        modified: (Object.create(null): any),
+        unbound: new Set(),
+        modified: new Set(),
         usesArguments: false,
         usesThis: false,
       };
@@ -317,7 +317,7 @@ export class ResidualHeapVisitor {
         state
       );
 
-      if (val.isResidual && Object.keys(functionInfo.unbound).length) {
+      if (val.isResidual && functionInfo.unbound.size) {
         if (!val.isUnsafeResidual) {
           this.logger.logError(
             val,
@@ -333,7 +333,7 @@ export class ResidualHeapVisitor {
     let residualFunctionBindings = new Map();
     this._withScope(val, () => {
       invariant(functionInfo);
-      for (let innerName in functionInfo.unbound) {
+      for (let innerName of functionInfo.unbound) {
         let residualFunctionBinding;
         let doesNotMatter = true;
         let reference = this.logger.tryQuery(
@@ -358,7 +358,7 @@ export class ResidualHeapVisitor {
           residualFunctionBinding = this.visitDeclarativeEnvironmentRecordBinding(referencedBase, referencedName);
         }
         residualFunctionBindings.set(innerName, residualFunctionBinding);
-        if (functionInfo.modified[innerName]) residualFunctionBinding.modified = true;
+        if (functionInfo.modified.has(innerName)) residualFunctionBinding.modified = true;
       }
     });
 

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -28,10 +28,9 @@ export type FunctionInstance = {
   scopeInstances: Set<ScopeBinding>,
 };
 
-export type Names = { [key: string]: true };
 export type FunctionInfo = {
-  unbound: Names,
-  modified: Names,
+  unbound: Set<string>,
+  modified: Set<string>,
   usesArguments: boolean,
   usesThis: boolean,
 };

--- a/test/serializer/abstract/PossibleThrow.js
+++ b/test/serializer/abstract/PossibleThrow.js
@@ -1,4 +1,3 @@
-// throws introspection error
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 let y;
 try {

--- a/test/serializer/abstract/Throw3.js
+++ b/test/serializer/abstract/Throw3.js
@@ -1,9 +1,9 @@
-// throws introspection error
-
-let x = __abstract("boolean", "true");
+let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 try {
-  if (x) z = "is true"; else throw "is false";  
+  if (x) z = "is true"; else throw "is false";
 } catch (e) {
   z = e;
 }
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Throw4.js
+++ b/test/serializer/abstract/Throw4.js
@@ -1,10 +1,11 @@
+// throws introspection error
+
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 try {
-  if (x) throw  new Error("is true");
-  z = "is false";
-} catch (e) {
-  z = e;
+  if (x) z = "is true"; else throw "is false";
+} finally {
+  z = "is finally";
 }
 
 inspect = function() { return z; }

--- a/test/serializer/abstract/Throw5.js
+++ b/test/serializer/abstract/Throw5.js
@@ -1,0 +1,14 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+function foo(b) {
+  if (b) throw new Error("is true");
+  return "is false";
+}
+
+try {
+  z = foo(x);
+} catch (e) {
+  z = e;
+}
+
+inspect = function() { return z; }

--- a/test/serializer/basic/FunctionBodyClone1.js
+++ b/test/serializer/basic/FunctionBodyClone1.js
@@ -1,0 +1,16 @@
+(function () {
+  function foo() {
+    var mutable = 10;
+    return function() {
+      return ++mutable;
+    }
+  }
+  
+  global.g = foo();
+  // Put parent residual function after nested function
+  // to make sure any AST change to nested function does not affect parent.
+  global.f = foo;
+  inspect = function() {
+    return f()();
+  };
+})();

--- a/test/serializer/basic/FunctionBodyClone2.js
+++ b/test/serializer/basic/FunctionBodyClone2.js
@@ -1,0 +1,17 @@
+(function () {
+  function foo() {
+    var mutable = 10;
+    return function() {
+      return ++mutable;
+    }
+  }
+  
+  global.g1 = foo();
+  global.g2 = foo();
+  // Put parent residual function after nested function
+  // to make sure any AST change to nested function does not affect parent.
+  global.f = foo;
+  inspect = function() {
+    return f()();
+  };
+})();


### PR DESCRIPTION
This clone is needed before because we may not be able to completely share the function bodies due to mutable binding captured scope array access. With my changes associated with #935, all function instances can be shared now, so this clone is unnecessary.