### PR TITLE
Trivial dead code elimination in residual functions

### DIFF
--- a/flow-typed/npm/babel-traverse_vx.x.x.js
+++ b/flow-typed/npm/babel-traverse_vx.x.x.js
@@ -20,6 +20,7 @@ declare module 'babel-traverse' {
     getBindingIdentifierPaths(): { [key: string]: BabelTraversePath };
     getBindingIdentifiers(): { [key: string]: BabelNodeIdentifier };
     replaceWith(node: BabelNode): void;
+    remove(): void;
     scope: BabelTraverseScope;
     node: BabelNode;
     parent: BabelNode;

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -56,8 +56,8 @@ function replaceName(path, residualFunctionBinding, name, data) {
   }
 }
 
-function getLiteralTruthiness(node) {
-  // Returns { known: boolean, value?: boolean }. 'known' is true only if this is a literal of known truthiness and with no side effects; if 'known' is true, 'value' is its truthiness.
+function getLiteralTruthiness(node): { known: boolean, value?: boolean } {
+  // In the return value, 'known' is true only if this is a literal of known truthiness and with no side effects; if 'known' is true, 'value' is its truthiness.
   if (t.isBooleanLiteral(node) || t.isNumericLiteral(node) || t.isStringLiteral(node)) {
     return { known: true, value: !!node.value };
   }

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -160,6 +160,26 @@ export let ClosureRefReplacer = {
       }
     },
   },
+
+  WhileStatement: {
+    exit: function(path: BabelTraversePath, state: ClosureRefReplacerState) {
+      let node = path.node;
+      let testTruthiness = getLiteralTruthiness(node.test);
+      if (testTruthiness.known && !testTruthiness.value) {
+        path.remove();
+      }
+    },
+  },
+
+  DoWhileStatement: {
+    exit: function(path: BabelTraversePath, state: ClosureRefReplacerState) {
+      let node = path.node;
+      let testTruthiness = getLiteralTruthiness(node.test);
+      if (testTruthiness.known && !testTruthiness.value) {
+        path.replaceWith(node.body);
+      }
+    },
+  },
 };
 
 function visitName(path, state, name, modified) {

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -65,7 +65,7 @@ function getLiteralTruthiness(node): { known: boolean, value?: boolean } {
     t.isFunctionExpression(node) ||
     t.isArrowFunctionExpression(node) ||
     t.isRegExpLiteral(node) ||
-    (t.isClassExpression(node) && node.superClass === null) ||
+    (t.isClassExpression(node) && node.superClass === null && node.body.body.length === 0) ||
     (t.isObjectExpression(node) && node.properties.length === 0) ||
     (t.isArrayExpression(node) && node.elements.length === 0)
   ) {

--- a/test/serializer/optimizations/residualDeadCode.js
+++ b/test/serializer/optimizations/residualDeadCode.js
@@ -1,4 +1,5 @@
 // does not contain:eliminate
+// does not contain:while
 // contains:preserve
 (function () {
   let f = false;
@@ -16,6 +17,7 @@
     t || console.log("eliminate me");
 
     while (f) console.log("eliminate me");
+    do { } while (f);
 
     0 ? console.log("eliminate me") : null;
     1 ? null : console.log("eliminate me");

--- a/test/serializer/optimizations/residualDeadCode.js
+++ b/test/serializer/optimizations/residualDeadCode.js
@@ -6,7 +6,7 @@
 
   global.inspect = function () {
     if (f) { console.log("eliminate me"); }
-    if (f) { console.log("eliminate me"); } else { console.log('preserve'); }
+    if (f) { console.log("eliminate me"); } else { console.log("preserve"); }
     if (t) { } else { console.log("eliminate me"); }
 
     f ? console.log("eliminate me") : null;
@@ -14,6 +14,8 @@
 
     f && console.log("eliminate me");
     t || console.log("eliminate me");
+
+    while (f) console.log("eliminate me");
 
     0 ? console.log("eliminate me") : null;
     1 ? null : console.log("eliminate me");
@@ -25,6 +27,7 @@
     (class {}) ? null : console.log("eliminate me");
     ({}) ? null : console.log("eliminate me");
     [] ? null : console.log("eliminate me");
+    null ? console.log("eliminate me") : null;
 
     return 42;
   }

--- a/test/serializer/optimizations/residualDeadCode.js
+++ b/test/serializer/optimizations/residualDeadCode.js
@@ -1,0 +1,17 @@
+// does not contain:eliminate
+(function () {
+  let f = false;
+  let t = true;
+  global.inspect = function () {
+    if (f) { console.log("eliminate me"); }
+    if (t) { } else { console.log("eliminate me"); }
+
+    f ? console.log("eliminate me") : null;
+    t ? null : console.log("eliminate me");
+
+    f && console.log("eliminate me");
+    t || console.log("eliminate me");
+
+    return 42;
+  }
+})();

--- a/test/serializer/optimizations/residualDeadCode.js
+++ b/test/serializer/optimizations/residualDeadCode.js
@@ -2,6 +2,7 @@
 (function () {
   let f = false;
   let t = true;
+
   global.inspect = function () {
     if (f) { console.log("eliminate me"); }
     if (t) { } else { console.log("eliminate me"); }
@@ -11,6 +12,17 @@
 
     f && console.log("eliminate me");
     t || console.log("eliminate me");
+
+    0 ? console.log("eliminate me") : null;
+    1 ? null : console.log("eliminate me");
+    '' ? console.log("eliminate me") : null;
+    ' ' ? null : console.log("eliminate me");
+    (function (){}) ? null : console.log("eliminate me");
+    (() => {}) ? null : console.log("eliminate me");
+    /a/ ? null : console.log("eliminate me");
+    (class {}) ? null : console.log("eliminate me");
+    ({}) ? null : console.log("eliminate me");
+    [] ? null : console.log("eliminate me");
 
     return 42;
   }

--- a/test/serializer/optimizations/residualDeadCode.js
+++ b/test/serializer/optimizations/residualDeadCode.js
@@ -1,10 +1,12 @@
 // does not contain:eliminate
+// contains:preserve
 (function () {
   let f = false;
   let t = true;
 
   global.inspect = function () {
     if (f) { console.log("eliminate me"); }
+    if (f) { console.log("eliminate me"); } else { console.log('preserve'); }
     if (t) { } else { console.log("eliminate me"); }
 
     f ? console.log("eliminate me") : null;


### PR DESCRIPTION
Progress towards #632.

There's a lot more that can be done here - for example, we could also eliminate `if (0) foo()` - but presumably that should be done by partial evaluators in a less ad-hoc way.