### PR TITLE
Propagate conditional throw completions across calls

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -62,8 +62,6 @@ import {
   HasOwnProperty,
   IsDataDescriptor,
   ThrowIfMightHaveBeenDeleted,
-  composePossiblyNormalCompletions,
-  updatePossiblyNormalCompletionWithValue,
 } from "./methods/index.js";
 import * as t from "babel-types";
 
@@ -1240,20 +1238,6 @@ export class LexicalEnvironment {
     let evaluator = this.realm.evaluators[(ast.type: string)];
     if (evaluator) {
       let result = evaluator(ast, strictCode, this, this.realm, metadata);
-      let context = this.realm.getRunningContext();
-      let savedCompletion = context.savedCompletion;
-      if (savedCompletion !== undefined) {
-        if (result instanceof Value) {
-          updatePossiblyNormalCompletionWithValue(this.realm, savedCompletion, result);
-          result = savedCompletion;
-        } else if (result instanceof PossiblyNormalCompletion) {
-          result = composePossiblyNormalCompletions(this.realm, savedCompletion, result);
-        } else {
-          AbstractValue.reportIntrospectionError(savedCompletion.joinCondition);
-          throw new FatalError();
-        }
-        context.savedCompletion = undefined;
-      }
       return result;
     }
 

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -26,20 +26,20 @@ import {
   AbstractValue,
 } from "../values/index.js";
 import {
-  GetBase,
-  GetValue,
-  ToObjectPartial,
-  IsCallable,
-  IsPropertyReference,
-  IsPropertyKey,
+  composePossiblyNormalCompletions,
   FunctionDeclarationInstantiation,
-  NewFunctionEnvironment,
+  GetBase,
   GetIterator,
+  GetValue,
+  HasSomeCompatibleType,
+  IsCallable,
+  IsPropertyKey,
+  IsPropertyReference,
   IteratorStep,
   IteratorValue,
-  HasSomeCompatibleType,
-  composePossiblyNormalCompletions,
-  joinEffectsAndRemoveNestedReturnCompletions,
+  joinEffectsAndPromoteNestedReturnCompletions,
+  NewFunctionEnvironment,
+  ToObjectPartial,
   unbundleReturnCompletion,
 } from "./index.js";
 import { GeneratorStart } from "../methods/generator.js";
@@ -51,6 +51,7 @@ import {
   PossiblyNormalCompletion,
 } from "../completions.js";
 import { GetTemplateObject, GetV, GetThisValue } from "../methods/get.js";
+import { construct_empty_effects } from "../realm.js";
 import invariant from "../invariant.js";
 import type { BabelNodeExpression, BabelNodeSpreadElement, BabelNodeTemplateLiteral } from "babel-types";
 import * as t from "babel-types";
@@ -350,47 +351,63 @@ export function OrdinaryCallEvaluateBody(
       invariant(code !== undefined);
       let context = realm.getRunningContext();
       let c = context.lexicalEnvironment.evaluateAbstractCompletion(code, F.$Strict);
-      let e = realm.getCapturedEffects();
-      if (e !== undefined) {
+      // We are about the leave this function and this presents a join point where all non exeptional control flows
+      // converge into a single flow using the joined effects as the new state.
+      if (c instanceof PossiblyNormalCompletion) {
+        // There were earlier, conditional exits from the function
+        // We join together the current effects with the effects of any earlier returns that are tracked in c.
+        let e = realm.getCapturedEffects();
+        invariant(e !== undefined);
         realm.stopEffectCaptureAndUndoEffects();
+        let joinedEffects = joinEffectsAndPromoteNestedReturnCompletions(realm, c, e);
+        realm.applyEffects(joinedEffects);
+        c = joinedEffects[0];
       }
       if (c instanceof JoinedAbruptCompletions) {
-        if (e !== undefined) realm.applyEffects(e);
-        return c;
-      } else if (c instanceof PossiblyNormalCompletion) {
-        // If the abrupt part of the completion is a return completion, then the
-        // effects of its independent control path must be joined with the effects
-        // from the normal path, which is to say the currently tracked effects
-        // in the realm.
-        invariant(e !== undefined);
-        let joinedEffects = joinEffectsAndRemoveNestedReturnCompletions(realm, c, e);
+        // There are two or more returns and/or throws that unconditionally terminate the function
+        // We need to join the return flows together.
+        let e = construct_empty_effects(realm); // nothing happened since the components of c captured their effects
+        let joinedEffects = joinEffectsAndPromoteNestedReturnCompletions(realm, c, e);
         let result = joinedEffects[0];
-        if (result instanceof JoinedAbruptCompletions) {
-          // There are throw completions that conditionally escape from the the call.
-          // We need to carry on in normal mode (after arranging to capturing effects)
-          // while stashing away the throw completions so that the next completion we return
-          // incorporates them.
-          let possiblyNormalCompletion;
-          [joinedEffects, possiblyNormalCompletion] = unbundleReturnCompletion(realm, result);
-          if (context.savedCompletion !== undefined)
-            context.savedCompletion = composePossiblyNormalCompletions(
-              realm,
-              context.savedCompletion,
-              possiblyNormalCompletion
-            );
-          else context.savedCompletion = possiblyNormalCompletion;
-          realm.captureEffects();
-          result = joinedEffects[0];
+        if (result instanceof ReturnCompletion) {
+          realm.applyEffects(joinedEffects);
+          return result.value;
         }
+        invariant(result instanceof JoinedAbruptCompletions);
+        if (!(result.consequent instanceof ReturnCompletion || result.alternate instanceof ReturnCompletion)) {
+          // Control is leaving this function only via throw completions. This is not a joint point.
+          throw result;
+        }
+        // There is a normal return exit, but also one or more throw completions.
+        // The throw completions must be extracted into a saved possibly normal completion
+        // so that the caller can pick them up in its next completion.
+        joinedEffects = extractAndSavePossiblyNormalCompletion(result, context);
+        result = joinedEffects[0];
         invariant(result instanceof ReturnCompletion);
         realm.applyEffects(joinedEffects);
         return result;
       } else {
         invariant(c instanceof Value || c instanceof AbruptCompletion);
-        if (e !== undefined) realm.applyEffects(e);
         return c;
       }
     }
+  }
+
+  function extractAndSavePossiblyNormalCompletion(c: JoinedAbruptCompletions, context: ExecutionContext) {
+    // There are throw completions that conditionally escape from the the call.
+    // We need to carry on in normal mode (after arranging to capturing effects)
+    // while stashing away the throw completions so that the next completion we return
+    // incorporates them.
+    let [joinedEffects, possiblyNormalCompletion] = unbundleReturnCompletion(realm, c);
+    if (context.savedCompletion !== undefined)
+      context.savedCompletion = composePossiblyNormalCompletions(
+        realm,
+        context.savedCompletion,
+        possiblyNormalCompletion
+      );
+    else context.savedCompletion = possiblyNormalCompletion;
+    realm.captureEffects();
+    return joinedEffects;
   }
 }
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1130,6 +1130,33 @@ export function PerformEval(realm: Realm, x: Value, evalRealm: Realm, strictCall
   }
 }
 
+export function incorporateSavedCompletion(realm: Realm, c: void | Completion | Value): Completion | Value {
+  let context = realm.getRunningContext();
+  let savedCompletion = context.savedCompletion;
+  if (savedCompletion !== undefined) {
+    context.savedCompletion = undefined;
+    if (c === undefined) return savedCompletion;
+    if (c instanceof Value) {
+      updatePossiblyNormalCompletionWithValue(realm, savedCompletion, c);
+      return savedCompletion;
+    } else if (c instanceof PossiblyNormalCompletion) {
+      return composePossiblyNormalCompletions(realm, savedCompletion, c);
+    } else {
+      invariant(c instanceof AbruptCompletion);
+      let e = realm.getCapturedEffects();
+      invariant(e !== undefined);
+      realm.stopEffectCaptureAndUndoEffects();
+      e[0] = c;
+      let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, c, e);
+      realm.applyEffects(joined_effects);
+      let jc = joined_effects[0];
+      invariant(jc instanceof AbruptCompletion);
+      throw jc;
+    }
+  }
+  return c;
+}
+
 export function EvaluateStatements(
   body: Array<BabelNodeStatement>,
   blockValue: void | NormalCompletion | Value,
@@ -1140,28 +1167,8 @@ export function EvaluateStatements(
   for (let node of body) {
     if (node.type !== "FunctionDeclaration") {
       let res = blockEnv.evaluateAbstractCompletion(node, strictCode);
-      let context = realm.getRunningContext();
-      let savedCompletion = context.savedCompletion;
-      if (savedCompletion !== undefined) {
-        context.savedCompletion = undefined;
-        if (res instanceof Value) res = updatePossiblyNormalCompletionWithValue(realm, savedCompletion, res);
-        else if (res instanceof PossiblyNormalCompletion)
-          res = composePossiblyNormalCompletions(realm, savedCompletion, res);
-        else {
-          invariant(res instanceof AbruptCompletion);
-          let e = realm.getCapturedEffects();
-          invariant(e !== undefined);
-          realm.stopEffectCaptureAndUndoEffects();
-          invariant(context.savedCompletion !== undefined);
-          e[0] = res;
-          let joined_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, res, e);
-          realm.applyEffects(joined_effects);
-          res = joined_effects[0];
-          invariant(res instanceof AbruptCompletion);
-          throw res;
-        }
-      }
       invariant(!(res instanceof Reference));
+      res = incorporateSavedCompletion(realm, res);
       if (!(res instanceof EmptyValue)) {
         if (blockValue === undefined || blockValue instanceof Value) {
           if (res instanceof AbruptCompletion) throw UpdateEmpty(realm, res, blockValue || realm.intrinsics.empty);
@@ -1172,11 +1179,18 @@ export function EvaluateStatements(
           if (res instanceof AbruptCompletion) {
             throw stopEffectCaptureAndJoinCompletions(blockValue, res, realm);
           } else {
-            if (res instanceof Value) blockValue.value = res;
-            else {
+            if (res instanceof Value) {
+              updatePossiblyNormalCompletionWithValue(realm, blockValue, res);
+            } else {
               invariant(blockValue instanceof PossiblyNormalCompletion);
               invariant(res instanceof PossiblyNormalCompletion);
+              let e = realm.getCapturedEffects();
+              invariant(e !== undefined);
+              realm.stopEffectCaptureAndUndoEffects();
+              realm.addPriorEffects(e, res.consequent instanceof Value ? res.consequentEffects : res.alternateEffects);
               blockValue = composePossiblyNormalCompletions(realm, blockValue, res);
+              realm.applyEffects(e);
+              realm.captureEffects();
             }
           }
         }

--- a/test/serializer/abstract/Throw5.js
+++ b/test/serializer/abstract/Throw5.js
@@ -1,0 +1,14 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+function foo(b) {
+  if (b) throw new Error("is true");
+  return "is false";
+}
+
+try {
+  z = foo(x);
+} catch (e) {
+  z = e;
+}
+
+inspect = function() { return z; }


### PR DESCRIPTION
All of this complexity is because of the need to separate complex completions (containing conditional throw completions) that arrive at the join point at the end of a function body into a separate return completion with a joined value, along with a now possibly normal completion that collects all of the throw completions.

Since the call expression needs to return a value, not a completion, the return completion is thrown away and its value is returned, while the possibly normal completion is stashed in the current execution environment. From there the latter is eventually copied to the caller environment and it is joined with any further completions until the next join point arrives.

If this next join point is a catch, the possibly normal completion will be consumed and the field in the current execution environment will be cleared (unless of course, the catch clause has a conditional abrupt completion). 