### PR TITLE
Reduce places where a PossiblyNormalCompletion can be returned.

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -81,6 +81,18 @@ export class JoinedAbruptCompletions extends AbruptCompletion {
   consequentEffects: Effects;
   alternate: AbruptCompletion;
   alternateEffects: Effects;
+
+  containsBreakOrContinue(): boolean {
+    if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;
+    if (this.alternate instanceof BreakCompletion || this.alternate instanceof ContinueCompletion) return true;
+    if (this.consequent instanceof JoinedAbruptCompletions) {
+      if (this.consequent.containsBreakOrContinue()) return true;
+    }
+    if (this.alternate instanceof JoinedAbruptCompletions) {
+      if (this.alternate.containsBreakOrContinue()) return true;
+    }
+    return false;
+  }
 }
 
 // Possibly normal completions have to be treated like normal completions
@@ -129,4 +141,16 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   consequentEffects: Effects;
   alternate: Completion | Value;
   alternateEffects: Effects;
+
+  containsBreakOrContinue(): boolean {
+    if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;
+    if (this.alternate instanceof BreakCompletion || this.alternate instanceof ContinueCompletion) return true;
+    if (this.consequent instanceof JoinedAbruptCompletions || this.consequent instanceof PossiblyNormalCompletion) {
+      if (this.consequent.containsBreakOrContinue()) return true;
+    }
+    if (this.alternate instanceof JoinedAbruptCompletions || this.alternate instanceof PossiblyNormalCompletion) {
+      if (this.alternate.containsBreakOrContinue()) return true;
+    }
+    return false;
+  }
 }

--- a/src/evaluators/BlockStatement.js
+++ b/src/evaluators/BlockStatement.js
@@ -13,7 +13,6 @@ import type { BabelNodeBlockStatement } from "babel-types";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
-import { NormalCompletion } from "../completions.js";
 import { StringValue, Value } from "../values/index.js";
 import { EvaluateStatements, NewDeclarativeEnvironment, BlockDeclarationInstantiation } from "../methods/index.js";
 
@@ -23,7 +22,7 @@ export default function(
   strictCode: boolean,
   env: LexicalEnvironment,
   realm: Realm
-): NormalCompletion | Value {
+): Value {
   // 1. Let oldEnv be the running execution context's LexicalEnvironment.
   let oldEnv = realm.getRunningContext().lexicalEnvironment;
 
@@ -38,7 +37,7 @@ export default function(
 
   try {
     // 5. Let blockValue be the result of evaluating StatementList.
-    let blockValue: void | NormalCompletion | Value;
+    let blockValue: void | Value;
 
     if (ast.directives) {
       for (let directive of ast.directives) {

--- a/src/evaluators/ConditionalExpression.js
+++ b/src/evaluators/ConditionalExpression.js
@@ -9,7 +9,6 @@
 
 /* @flow */
 
-import type { NormalCompletion } from "../completions.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
 import type { Reference } from "../environment.js";
@@ -24,7 +23,7 @@ export default function(
   strictCode: boolean,
   env: LexicalEnvironment,
   realm: Realm
-): NormalCompletion | Value | Reference {
+): Value | Reference {
   let exprRef = env.evaluate(ast.test, strictCode);
   let exprValue = GetValue(realm, exprRef);
 

--- a/src/evaluators/SuperCall.js
+++ b/src/evaluators/SuperCall.js
@@ -13,7 +13,6 @@ import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { FunctionEnvironmentRecord } from "../environment.js";
-import { Completion } from "../completions.js";
 import { Value, UndefinedValue, ObjectValue } from "../values/index.js";
 import {
   GetNewTarget,
@@ -55,7 +54,7 @@ export default function SuperCall(
   strictCode: boolean,
   env: LexicalEnvironment,
   realm: Realm
-): Completion | Value {
+): Value {
   // 1. Let newTarget be GetNewTarget().
   let newTarget = GetNewTarget(realm);
 

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -9,62 +9,60 @@
 
 /* @flow */
 
-import type { Realm } from "../realm.js";
-import type { LexicalEnvironment } from "../environment.js";
-import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
-import { joinEffects, UpdateEmpty } from "../methods/index.js";
+import type { Effects, Realm } from "../realm.js";
+import { type LexicalEnvironment } from "../environment.js";
+import {
+  AbruptCompletion,
+  JoinedAbruptCompletions,
+  PossiblyNormalCompletion,
+  ThrowCompletion,
+} from "../completions.js";
+import {
+  incorporateSavedCompletion,
+  joinEffects,
+  UpdateEmpty,
+  updatePossiblyNormalCompletionWithSubsequentEffects,
+} from "../methods/index.js";
 import { Value } from "../values/index.js";
 import type { BabelNodeTryStatement } from "babel-types";
 import invariant from "../invariant.js";
 
-export default function(
-  ast: BabelNodeTryStatement,
-  strictCode: boolean,
-  env: LexicalEnvironment,
-  realm: Realm
-): PossiblyNormalCompletion | Value {
+export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value {
   let completions = [];
 
-  let blockRes = env.evaluateAbstractCompletion(ast.block, strictCode);
+  let blockRes = env.evaluateCompletionDeref(ast.block, strictCode);
+  blockRes = incorporateSavedCompletion(realm, blockRes);
   if (blockRes instanceof PossiblyNormalCompletion) {
-    let abruptCompletion;
-    let abruptEffects;
-    if (blockRes.consequent instanceof AbruptCompletion) {
-      abruptCompletion = blockRes.consequent;
-      abruptEffects = blockRes.consequentEffects;
-    } else {
-      abruptCompletion = blockRes.alternate;
-      abruptEffects = blockRes.alternateEffects;
+    // The current state may have advanced since the time control forked into the various paths recorded in blockRes.
+    // Update the normal path and restore the global state to what it was at the time of the fork.
+    let subsequentEffects = realm.getCapturedEffects(blockRes.value);
+    invariant(subsequentEffects !== undefined);
+    realm.stopEffectCaptureAndUndoEffects();
+    updatePossiblyNormalCompletionWithSubsequentEffects(realm, blockRes, subsequentEffects);
+  }
+
+  if (ast.handler) {
+    if (blockRes instanceof ThrowCompletion) {
+      blockRes = env.evaluateCompletionDeref(ast.handler, strictCode, blockRes);
+    } else if (blockRes instanceof JoinedAbruptCompletions || blockRes instanceof PossiblyNormalCompletion) {
+      let handlerEffects = composeNestedThrowEffectsWithHandler(blockRes);
+      blockRes = handlerEffects[0];
+      // If there is a normal execution path following the handler, we need to update the current state
+      if (blockRes instanceof Value || blockRes instanceof PossiblyNormalCompletion) realm.applyEffects(handlerEffects);
     }
-    if (abruptCompletion instanceof ThrowCompletion && ast.handler) {
-      let normalEffects = realm.getCapturedEffects(blockRes.value);
-      invariant(normalEffects !== undefined);
-      realm.stopEffectCaptureAndUndoEffects();
-      let handlerEffects = realm.evaluateForEffects(() => {
-        realm.applyEffects(abruptEffects);
-        invariant(ast.handler);
-        return env.evaluateAbstractCompletion(ast.handler, strictCode, abruptCompletion);
-      });
-      let jointEffects;
-      if (blockRes.consequent instanceof AbruptCompletion)
-        jointEffects = joinEffects(realm, blockRes.joinCondition, handlerEffects, normalEffects);
-      else jointEffects = joinEffects(realm, blockRes.joinCondition, normalEffects, handlerEffects);
-      realm.applyEffects(jointEffects);
-      completions.unshift(jointEffects[0]);
+  }
+  completions.unshift(blockRes);
+
+  if (ast.finalizer) {
+    if (blockRes instanceof PossiblyNormalCompletion || blockRes instanceof JoinedAbruptCompletions) {
+      completions.unshift(composeNestedEffectsWithFinalizer(blockRes));
     } else {
-      completions.unshift(blockRes);
-    }
-  } else {
-    if (blockRes instanceof ThrowCompletion && ast.handler) {
-      completions.unshift(env.evaluateCompletion(ast.handler, strictCode, blockRes));
-    } else {
-      completions.unshift(blockRes);
+      completions.unshift(env.evaluateCompletion(ast.finalizer, strictCode));
     }
   }
 
-  if (ast.finalizer) {
-    completions.unshift(env.evaluateCompletion(ast.finalizer, strictCode));
-  }
+  // Restart effect capture if one of the paths may continue
+  if (blockRes instanceof PossiblyNormalCompletion) realm.captureEffects();
 
   // use the last completion record
   for (let completion of completions) {
@@ -77,9 +75,86 @@ export default function(
 
   // otherwise use the last returned value
   for (let completion of completions) {
-    if (completion instanceof Value || completion instanceof Completion)
-      return (UpdateEmpty(realm, completion, realm.intrinsics.undefined): any);
+    if (completion instanceof PossiblyNormalCompletion)
+      completion = realm.getRunningContext().composeWithSavedCompletion(completion);
+    if (completion instanceof Value) return (UpdateEmpty(realm, completion, realm.intrinsics.undefined): any);
   }
 
   invariant(false);
+
+  // The finalizer is not a join point, so update each path in the completion separately.
+  function composeNestedEffectsWithFinalizer(
+    c: PossiblyNormalCompletion | JoinedAbruptCompletions,
+    priorEffects: Array<Effects> = []
+  ) {
+    priorEffects.push(c.consequentEffects);
+    let consequent = c.consequent;
+    if (consequent instanceof PossiblyNormalCompletion || consequent instanceof JoinedAbruptCompletions) {
+      composeNestedEffectsWithFinalizer(consequent, priorEffects);
+    } else {
+      c.consequentEffects = realm.evaluateForEffects(() => {
+        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+        invariant(ast.finalizer);
+        return env.evaluateCompletionDeref(ast.finalizer, strictCode);
+      });
+      let fc = c.consequentEffects[0];
+      // If the finalizer had an abrupt completion, it overrides the try-block's completion.
+      if (fc instanceof AbruptCompletion) c.consequent = fc;
+      else c.consequentEffects[0] = consequent;
+    }
+    priorEffects.pop();
+    priorEffects.push(c.alternateEffects);
+    let alternate = c.alternate;
+    if (alternate instanceof PossiblyNormalCompletion || alternate instanceof JoinedAbruptCompletions) {
+      composeNestedEffectsWithFinalizer(alternate, priorEffects);
+    } else {
+      c.alternateEffects = realm.evaluateForEffects(() => {
+        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+        invariant(ast.finalizer);
+        return env.evaluateCompletionDeref(ast.finalizer, strictCode);
+      });
+      let fc = c.alternateEffects[0];
+      // If the finalizer had an abrupt completion, it overrides the try-block's completion.
+      if (fc instanceof AbruptCompletion) c.alternate = fc;
+      else c.alternateEffects[0] = alternate;
+    }
+  }
+
+  // The handler is a potential join point for all throw completions, but is easier to not do the join here because
+  // it is tricky to join the joined and composed result of the throw completions with the non exceptional completions.
+  // Unfortunately, things are still complicated because the handler may turn abrupt completions into normal
+  // completions and the other way around. When this happens the container has to change its type.
+  // We do this by call joinEffects to create a new container at every level of the recursion.
+  function composeNestedThrowEffectsWithHandler(
+    c: PossiblyNormalCompletion | JoinedAbruptCompletions,
+    priorEffects: Array<Effects> = []
+  ): Effects {
+    let consequent = c.consequent;
+    let consequentEffects = c.consequentEffects;
+    priorEffects.push(consequentEffects);
+    if (consequent instanceof JoinedAbruptCompletions || consequent instanceof PossiblyNormalCompletion) {
+      consequentEffects = composeNestedThrowEffectsWithHandler(consequent, priorEffects);
+    } else if (consequent instanceof ThrowCompletion) {
+      consequentEffects = realm.evaluateForEffects(() => {
+        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+        invariant(ast.handler);
+        return env.evaluateCompletionDeref(ast.handler, strictCode, consequent);
+      });
+    }
+    priorEffects.pop();
+    let alternate = c.alternate;
+    let alternateEffects = c.alternateEffects;
+    priorEffects.push(alternateEffects);
+    if (alternate instanceof PossiblyNormalCompletion || alternate instanceof JoinedAbruptCompletions) {
+      alternateEffects = composeNestedThrowEffectsWithHandler(alternate, priorEffects);
+    } else if (alternate instanceof ThrowCompletion) {
+      alternateEffects = realm.evaluateForEffects(() => {
+        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+        invariant(ast.handler);
+        return env.evaluateCompletionDeref(ast.handler, strictCode, alternate);
+      });
+    }
+    priorEffects.pop();
+    return joinEffects(realm, c.joinCondition, consequentEffects, alternateEffects);
+  }
 }

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -517,7 +517,7 @@ export function SymbolDescriptiveString(realm: Realm, sym: SymbolValue): string 
 }
 
 // ECMA262 6.2.2.5
-export function UpdateEmpty(realm: Realm, completionRecord: Value | Completion, value: Value): Value | Completion {
+export function UpdateEmpty(realm: Realm, completionRecord: Completion | Value, value: Value): Completion | Value {
   // 1. Assert: If completionRecord.[[Type]] is either return or throw, then completionRecord.[[Value]] is not empty.
   if (completionRecord instanceof ReturnCompletion || completionRecord instanceof ThrowCompletion) {
     invariant(completionRecord.value, "expected completion record to have a value");

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -12,16 +12,17 @@
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, CallableObjectValue } from "../types.js";
 import {
-  Value,
+  AbstractObjectValue,
   AbstractValue,
   BoundFunctionValue,
-  NumberValue,
-  ProxyValue,
-  UndefinedValue,
-  StringValue,
-  ObjectValue,
+  EmptyValue,
   NullValue,
-  AbstractObjectValue,
+  NumberValue,
+  ObjectValue,
+  ProxyValue,
+  StringValue,
+  UndefinedValue,
+  Value,
 } from "../values/index.js";
 import { Reference } from "../environment.js";
 import { FatalError } from "../errors.js";
@@ -115,9 +116,8 @@ export function OrdinaryGet(
     }
 
     // c. Return ? parent.[[Get]](P, Receiver).
-    if (descValue.mightHaveBeenDeleted()) {
+    if (descValue.mightHaveBeenDeleted() && descValue instanceof AbstractValue) {
       // We don't know for sure that O.P does not exist.
-      invariant(descValue instanceof AbstractValue);
       let parentVal = OrdinaryGet(realm, parent, P, descValue, true);
       if (parentVal instanceof UndefinedValue)
         // even O.P returns undefined it is still the right value.
@@ -129,7 +129,7 @@ export function OrdinaryGet(
       let cond = AbstractValue.createFromBinaryOp(realm, "!==", descValue, realm.intrinsics.empty);
       return joinValuesAsConditional(realm, cond, descValue, parentVal);
     }
-    invariant(!desc);
+    invariant(!desc || descValue instanceof EmptyValue);
     return parent.$Get(P, Receiver);
   }
 

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -158,21 +158,40 @@ export function updatePossiblyNormalCompletionWithValue(realm: Realm, pnc: Possi
   }
 }
 
+// Returns the joined effects of all of the paths in pnc.
+// The normal path in pnc is modified to become terminated by ac,
+// so the overall completion will always be an instance of JoinedAbruptCompletions
 export function joinPossiblyNormalCompletionWithAbruptCompletion(
   realm: Realm,
-  pnc: PossiblyNormalCompletion,
-  ac: AbruptCompletion,
-  e: Effects
+  pnc: PossiblyNormalCompletion, // a forked path with a non abrupt (normal) component
+  ac: AbruptCompletion, // an abrupt completion that completes the normal path
+  e: Effects // effects collected after pnc was constructed
 ): Effects {
+  // set up e with ac as the completion. It's OK to do this repeatedly since ac is not changed by recursive calls.
+  e[0] = ac;
   if (pnc.consequent instanceof AbruptCompletion) {
-    if (pnc.alternate instanceof Value) return joinEffects(realm, pnc.joinCondition, pnc.consequentEffects, e);
+    if (pnc.alternate instanceof Value) {
+      return joinEffects(
+        realm,
+        pnc.joinCondition,
+        pnc.consequentEffects,
+        realm.composeEffects(pnc.alternateEffects, e)
+      );
+    }
     invariant(pnc.alternate instanceof PossiblyNormalCompletion);
     let alternate_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, pnc.alternate, ac, e);
     invariant(pnc.consequent instanceof AbruptCompletion);
     return joinEffects(realm, pnc.joinCondition, pnc.consequentEffects, alternate_effects);
   } else {
     invariant(pnc.alternate instanceof AbruptCompletion);
-    if (pnc.consequent instanceof Value) return joinEffects(realm, pnc.joinCondition, e, pnc.alternateEffects);
+    if (pnc.consequent instanceof Value) {
+      return joinEffects(
+        realm,
+        pnc.joinCondition,
+        realm.composeEffects(pnc.consequentEffects, e),
+        pnc.alternateEffects
+      );
+    }
     invariant(pnc.consequent instanceof PossiblyNormalCompletion);
     let consequent_effects = joinPossiblyNormalCompletionWithAbruptCompletion(realm, pnc.consequent, ac, e);
     invariant(pnc.alternate instanceof AbruptCompletion);
@@ -266,14 +285,10 @@ export function joinEffectsAndPromoteNestedReturnCompletions(
     let e1 = joinEffectsAndPromoteNestedReturnCompletions(realm, c.consequent, e, c.consequentEffects);
     let e2 = joinEffectsAndPromoteNestedReturnCompletions(realm, c.alternate, e, c.alternateEffects);
     if (e1[0] instanceof AbruptCompletion) {
-      if (!(e2[0] instanceof ReturnCompletion)) {
-        invariant(e2[0] instanceof Value); // otherwise c cannot possibly be normal
-        e2[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
-      }
+      if (e2[0] instanceof Value) e2[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
       return joinEffects(realm, c.joinCondition, e1, e2);
     } else if (e2[0] instanceof AbruptCompletion) {
-      invariant(e1[0] instanceof Value); // otherwise c cannot possibly be normal
-      e1[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
+      if (e1[0] instanceof Value) e1[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
       return joinEffects(realm, c.joinCondition, e1, e2);
     }
   }
@@ -444,8 +459,6 @@ function joinResults(
 
 export function composeGenerators(realm: Realm, generator1: Generator, generator2: Generator): Generator {
   let result = new Generator(realm);
-  generator1.parent = result;
-  generator2.parent = result;
   if (!generator1.empty() || !generator2.empty()) {
     result.composeGenerators(generator1, generator2);
   }
@@ -459,8 +472,6 @@ function joinGenerators(
   generator2: Generator
 ): Generator {
   let result = new Generator(realm);
-  generator1.parent = result;
-  generator2.parent = result;
   if (!generator1.empty() || !generator2.empty()) {
     result.joinGenerators(joinCondition, generator1, generator2);
   }
@@ -515,9 +526,10 @@ export function joinValues(
   v2: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
   getAbstractValue: (void | Value, void | Value) => Value
 ): Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }> {
-  if (Array.isArray(v1)) {
-    invariant(Array.isArray(v2)); // This use of Array is restricted to internal properties that are always arrays
-    return joinArrays(realm, ((v1: any): Array<Value>), ((v2: any): Array<Value>), getAbstractValue);
+  if (Array.isArray(v1) || Array.isArray(v2)) {
+    invariant(v1 === undefined || Array.isArray(v1));
+    invariant(v2 === undefined || Array.isArray(v2));
+    return joinArrays(realm, ((v1: any): void | Array<Value>), ((v2: any): void | Array<Value>), getAbstractValue);
   }
   invariant(v1 === undefined || v1 instanceof Value);
   invariant(v2 === undefined || v2 instanceof Value);
@@ -536,27 +548,27 @@ export function joinValues(
 
 function joinArrays(
   realm: Realm,
-  v1: Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
-  v2: Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
+  v1: void | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
+  v2: void | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
   getAbstractValue: (void | Value, void | Value) => Value
 ): Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }> {
-  let e = v1[0] || v2[0];
+  let e = (v1 && v1[0]) || (v2 && v2[0]);
   if (e instanceof Value) return joinArraysOfValues(realm, (v1: any), (v2: any), getAbstractValue);
   else return joinArrayOfsMapEntries(realm, (v1: any), (v2: any), getAbstractValue);
 }
 
 function joinArrayOfsMapEntries(
   realm: Realm,
-  a1: Array<{ $Key: void | Value, $Value: void | Value }>,
-  a2: Array<{ $Key: void | Value, $Value: void | Value }>,
+  a1: void | Array<{ $Key: void | Value, $Value: void | Value }>,
+  a2: void | Array<{ $Key: void | Value, $Value: void | Value }>,
   getAbstractValue: (void | Value, void | Value) => Value
 ): Array<{ $Key: void | Value, $Value: void | Value }> {
   let empty = realm.intrinsics.empty;
-  let n = Math.max(a1.length, a2.length);
+  let n = Math.max((a1 && a1.length) || 0, (a2 && a2.length) || 0);
   let result = [];
   for (let i = 0; i < n; i++) {
-    let { $Key: key1, $Value: val1 } = a1[i] || { $Key: empty, $Value: empty };
-    let { $Key: key2, $Value: val2 } = a2[i] || { $Key: empty, $Value: empty };
+    let { $Key: key1, $Value: val1 } = (a1 && a1[i]) || { $Key: empty, $Value: empty };
+    let { $Key: key2, $Value: val2 } = (a2 && a2[i]) || { $Key: empty, $Value: empty };
     if (key1 === undefined && key2 === undefined) {
       result[i] = { $Key: undefined, $Value: undefined };
     } else {
@@ -570,14 +582,14 @@ function joinArrayOfsMapEntries(
 
 function joinArraysOfValues(
   realm: Realm,
-  a1: Array<Value>,
-  a2: Array<Value>,
+  a1: void | Array<Value>,
+  a2: void | Array<Value>,
   getAbstractValue: (void | Value, void | Value) => Value
 ): Array<Value> {
-  let n = Math.max(a1.length, a2.length);
+  let n = Math.max((a1 && a1.length) || 0, (a2 && a2.length) || 0);
   let result = [];
   for (let i = 0; i < n; i++) {
-    result[i] = getAbstractValue(a1[i], a2[i]);
+    result[i] = getAbstractValue((a1 && a1[i]) || undefined, (a2 && a2[i]) || undefined);
   }
   return result;
 }

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -311,12 +311,11 @@ export class Modules {
     this.initializedModules.clear();
     let globalInitializedModulesMap = this._getGlobalProperty("__initializedModules");
     invariant(globalInitializedModulesMap instanceof ObjectValue);
-    for (let moduleId of globalInitializedModulesMap.getOwnPropertyKeysArray()) {
+    for (let moduleId of globalInitializedModulesMap.properties.keys()) {
       let property = globalInitializedModulesMap.properties.get(moduleId);
       invariant(property);
       let moduleValue = property.descriptor && property.descriptor.value;
-      invariant(moduleValue instanceof Value);
-      this.initializedModules.set(moduleId, moduleValue);
+      if (moduleValue instanceof Value) this.initializedModules.set(moduleId, moduleValue);
     }
   }
 

--- a/test/serializer/abstract/Throw4.js
+++ b/test/serializer/abstract/Throw4.js
@@ -1,5 +1,3 @@
-// throws introspection error
-
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 try {


### PR DESCRIPTION
Release note: none

A PossiblyNormalCompletion is neither normal nor abrupt but a weird entanglement of the two. Hence such a completion should neither be returned from an evaluation function nor thrown, unless of course, a completion is actually expected (evaluateCompletion), in which case it is returned just like any other completion.

This request establishes this behavior and changes the return types of the evaluate functions accordingly. In terms of behavior, it now consistently stores possibly normal completions in the current context and updates them there as appropriate. Only when a completion is explicitly requested, does the wave function collapse.

One side effect of this is that joined abrupt completions are also better supported now and they turn into possibly normal completions when incorporate one or more return completions and become the return value of a call. This means that early termination is no longer necessary when a joined abrupt completion is encountered.