### PR TITLE
Provides an additionalGlobal initialization option

### DIFF
--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -13,6 +13,7 @@ import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility } from "./options";
 
 export type PrepackOptions = {|
+  additionalGlobals?: Function,
   additionalFunctions?: Array<string>,
   compatibility?: Compatibility,
   debugNames?: boolean,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -13,7 +13,7 @@ import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility } from "./options";
 
 export type PrepackOptions = {|
-  additionalGlobals?: Function,
+  additionalGlobals?: Realm => void,
   additionalFunctions?: Array<string>,
   compatibility?: Compatibility,
   debugNames?: boolean,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -11,6 +11,7 @@
 
 import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility } from "./options";
+import { Realm } from "./realm.js";
 
 export type PrepackOptions = {|
   additionalGlobals?: Realm => void,

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -44,6 +44,9 @@ export function prepackSources(
   realmOptions.errorHandler = options.errorHandler;
   let realm = construct_realm(realmOptions);
   initializeGlobals(realm);
+  if (typeof options.additionalGlobals === "function") {
+    options.additionalGlobals(realm);
+  }
 
   if (options.serialize || !options.residual) {
     let serializer = new Serializer(realm, getSerializerOptions(options));


### PR DESCRIPTION
Release Note: none

This PR should provide external tooling, that wraps Prepack Node, the ability to define Prepack globals. This will allow the React compiler to use standalone Prepack with the only differences being specific globals that are added (for React related stubs).

The `additionalGlobals` is a function that passes through `realm` like other globals are handled.