### PR TITLE
Unify simplifyAbstractValue and AbstractValue.refineWithPathCondition.

### DIFF
--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -17,6 +17,7 @@ import * as evaluators from "./evaluators/index.js";
 import * as partialEvaluators from "./partial-evaluators/index.js";
 import { NewGlobalEnvironment } from "./methods/index.js";
 import { ObjectValue } from "./values/index.js";
+import simplifyAbstractValue from "./utils/simplifier.js";
 
 export default function(opts: RealmOptions = {}): Realm {
   let r = new Realm(opts);
@@ -28,6 +29,7 @@ export default function(opts: RealmOptions = {}): Realm {
   initializeGlobal(r);
   for (let name in evaluators) r.evaluators[name] = evaluators[name];
   for (let name in partialEvaluators) r.partialEvaluators[name] = partialEvaluators[name];
+  r.simplifyAbstractValue = simplifyAbstractValue.bind(null, r);
   r.$GlobalEnv = NewGlobalEnvironment(r, r.$GlobalObject, r.$GlobalObject);
   return r;
 }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -100,7 +100,7 @@ export function GetReferencedNamePartial(realm: Realm, V: Reference): AbstractVa
 // ECMA262 6.2.3.1
 export function GetValue(realm: Realm, V: Reference | Value): Value {
   let val = dereference(realm, V);
-  if (val instanceof AbstractValue) return val.refineWithPathCondition();
+  if (val instanceof AbstractValue) return realm.simplifyAbstractValue(val);
   return val;
 }
 

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -594,12 +594,7 @@ export function joinValuesAsConditional(
   v1: void | Value,
   v2: void | Value
 ): Value {
-  let result = AbstractValue.createFromConditionalOp(realm, condition, v1, v2);
-  if (result instanceof AbstractValue) {
-    if (v1) result.mightBeEmpty = v1.mightHaveBeenDeleted();
-    if (v2 && !result.mightBeEmpty) result.mightBeEmpty = v2.mightHaveBeenDeleted();
-  }
-  return result;
+  return AbstractValue.createFromConditionalOp(realm, condition, v1, v2);
 }
 
 export function joinPropertyBindings(

--- a/src/realm.js
+++ b/src/realm.js
@@ -232,6 +232,7 @@ export class Realm {
       metadata?: any
     ) => [Completion | Reference | Value, BabelNode, Array<BabelNodeStatement>],
   };
+  simplifyAbstractValue: AbstractValue => Value;
 
   tracers: Array<Tracer>;
 

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -118,6 +118,6 @@ function pushInversePathCondition(condition: Value) {
 
 function pushRefinedConditions(unrefinedConditions: Array<AbstractValue>) {
   for (let unrefinedCond of unrefinedConditions) {
-    pushPathCondition(unrefinedCond.refineWithPathCondition());
+    pushPathCondition(unrefinedCond.$Realm.simplifyAbstractValue(unrefinedCond));
   }
 }


### PR DESCRIPTION
Release notes: none

This is a no new functionality refactor that gets rid of the duplication of logic between these two functions.

Addresses #1019.

I don't think I'm quite done with the issue, since the factory functions also contain simplification logic.