### PR TITLE
 Remove simplification code from abstract value factories

### DIFF
--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -19,7 +19,7 @@ import { NewGlobalEnvironment } from "./methods/index.js";
 import { ObjectValue } from "./values/index.js";
 import { DebugServer } from "./debugger/Debugger.js";
 import { DebugChannel } from "./DebugChannel.js";
-import simplifyAbstractValue from "./utils/simplifier.js";
+import simplifyAndRefineAbstractValue from "./utils/simplifier.js";
 
 export default function(opts: RealmOptions = {}, debugChannel: void | DebugChannel = undefined): Realm {
   let r = new Realm(opts);
@@ -37,7 +37,8 @@ export default function(opts: RealmOptions = {}, debugChannel: void | DebugChann
   initializeGlobal(r);
   for (let name in evaluators) r.evaluators[name] = evaluators[name];
   for (let name in partialEvaluators) r.partialEvaluators[name] = partialEvaluators[name];
-  r.simplifyAbstractValue = simplifyAbstractValue.bind(null, r);
+  r.simplifyAndRefineAbstractValue = simplifyAndRefineAbstractValue.bind(null, r, false);
+  r.simplifyAndRefineAbstractCondition = simplifyAndRefineAbstractValue.bind(null, r, true);
   r.$GlobalEnv = NewGlobalEnvironment(r, r.$GlobalObject, r.$GlobalObject);
   return r;
 }

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -28,7 +28,6 @@ import { GetValue } from "../methods/index.js";
 import { IsToPrimitivePure, GetToPrimitivePureResultType, IsToNumberPure } from "../methods/index.js";
 import type { BabelNodeBinaryExpression, BabelBinaryOperator, BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
-import simplifyAbstractValue from "../utils/simplifier.js";
 
 export default function(
   ast: BabelNodeBinaryExpression,
@@ -172,7 +171,7 @@ export function computeBinary(
   if (lval instanceof AbstractValue || rval instanceof AbstractValue) {
     // generate error if binary operation might throw or have side effects
     getPureBinaryOperationResultType(realm, op, lval, rval, lloc, rloc);
-    return simplifyAbstractValue(realm, AbstractValue.createFromBinaryOp(realm, op, lval, rval, loc));
+    return AbstractValue.createFromBinaryOp(realm, op, lval, rval, loc);
   }
 
   // ECMA262 12.10.3

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -42,7 +42,6 @@ import {
   IsPropertyReference,
   IsToNumberPure,
 } from "../methods/index.js";
-import simplifyAbstractValue from "../utils/simplifier.js";
 import type { BabelNodeUnaryExpression } from "babel-types";
 
 function isInstance(proto, Constructor): boolean {
@@ -129,11 +128,7 @@ export default function(
 
     // 2. Let oldValue be ToBoolean(? GetValue(expr)).
     let value = GetValue(realm, expr);
-    if (value instanceof AbstractValue) {
-      if (!value.mightNotBeTrue()) return realm.intrinsics.false;
-      if (!value.mightNotBeFalse()) return realm.intrinsics.true;
-      return simplifyAbstractValue(realm, AbstractValue.createFromUnaryOp(realm, "!", value));
-    }
+    if (value instanceof AbstractValue) return AbstractValue.createFromUnaryOp(realm, "!", value);
     invariant(value instanceof ConcreteValue);
     let oldValue = ToBoolean(realm, value);
 

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -100,7 +100,7 @@ export function GetReferencedNamePartial(realm: Realm, V: Reference): AbstractVa
 // ECMA262 6.2.3.1
 export function GetValue(realm: Realm, V: Reference | Value): Value {
   let val = dereference(realm, V);
-  if (val instanceof AbstractValue) return realm.simplifyAbstractValue(val);
+  if (val instanceof AbstractValue) return realm.simplifyAndRefineAbstractValue(val);
   return val;
 }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -243,7 +243,8 @@ export class Realm {
       metadata?: any
     ) => [Completion | Reference | Value, BabelNode, Array<BabelNodeStatement>],
   };
-  simplifyAbstractValue: AbstractValue => Value;
+  simplifyAndRefineAbstractValue: AbstractValue => Value;
+  simplifyAndRefineAbstractCondition: AbstractValue => Value;
 
   tracers: Array<Tracer>;
 

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -18,7 +18,6 @@ import {
   Value,
 } from "../values/index.js";
 import invariant from "../invariant.js";
-import simplifyAbstractValue from "../utils/simplifier.js";
 
 export function withPathCondition<T>(condition: AbstractValue, evaluate: () => T): T {
   let realm = condition.$Realm;
@@ -111,13 +110,15 @@ function pushInversePathCondition(condition: Value) {
     }
     let inverseCondition = AbstractValue.createFromUnaryOp(realm, "!", condition);
     pushPathCondition(inverseCondition);
-    let simplifiedInverseCondition = simplifyAbstractValue(realm, inverseCondition);
-    if (!simplifiedInverseCondition.equals(inverseCondition)) pushPathCondition(simplifiedInverseCondition);
+    if (inverseCondition instanceof AbstractValue) {
+      let simplifiedInverseCondition = realm.simplifyAndRefineAbstractCondition(inverseCondition);
+      if (!simplifiedInverseCondition.equals(inverseCondition)) pushPathCondition(simplifiedInverseCondition);
+    }
   }
 }
 
 function pushRefinedConditions(unrefinedConditions: Array<AbstractValue>) {
   for (let unrefinedCond of unrefinedConditions) {
-    pushPathCondition(unrefinedCond.$Realm.simplifyAbstractValue(unrefinedCond));
+    pushPathCondition(unrefinedCond.$Realm.simplifyAndRefineAbstractCondition(unrefinedCond));
   }
 }

--- a/test/serializer/abstract/NegateObject.js
+++ b/test/serializer/abstract/NegateObject.js
@@ -1,5 +1,6 @@
 y = global.__abstract ? __abstract("object", "({})") : {};
 let z = !y;
-if (global.__isAbstract && __isAbstract(z)) throw new Error("bug!");
+// Once intrinsic objects can be designated not null/undefined, invert the condition below: see issue #1001
+if (global.__isAbstract && !__isAbstract(z)) throw new Error("bug!");
 x = z;
 inspect = function() { return x; }


### PR DESCRIPTION
Rather than do some simplifications inside the factory functions, let the factory functions call simplifyAbstractValue. Some precautions are needed to avoid unbounded recursion.