### PR TITLE
Keep generators intact

### DIFF
--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1184,13 +1184,7 @@ export function EvaluateStatements(
             } else {
               invariant(blockValue instanceof PossiblyNormalCompletion);
               invariant(res instanceof PossiblyNormalCompletion);
-              let e = realm.getCapturedEffects();
-              invariant(e !== undefined);
-              realm.stopEffectCaptureAndUndoEffects();
-              realm.addPriorEffects(e, res.consequent instanceof Value ? res.consequentEffects : res.alternateEffects);
               blockValue = composePossiblyNormalCompletions(realm, blockValue, res);
-              realm.applyEffects(e);
-              realm.captureEffects();
             }
           }
         }

--- a/src/realm.js
+++ b/src/realm.js
@@ -29,6 +29,7 @@ import { LexicalEnvironment, Reference, GlobalEnvironmentRecord } from "./enviro
 import type { Binding } from "./environment.js";
 import {
   cloneDescriptor,
+  composeGenerators,
   Construct,
   GetValue,
   incorporateSavedCompletion,
@@ -320,9 +321,9 @@ export class Realm {
     let savedEffects = context.savedEffects;
     if (savedEffects !== undefined && this.contextStack.length > 0) {
       // when unwinding the stack after a fatal error, saved effects are not incorporated into completions
-      // and thus must be propogated to the calling context.
+      // and thus must be propagated to the calling context.
       let ctx = this.getRunningContext();
-      if (ctx.savedEffects !== undefined) this.addPriorEffects(ctx.savedEffects, savedEffects);
+      if (ctx.savedEffects !== undefined) savedEffects = this.composeEffects(ctx.savedEffects, savedEffects);
       ctx.savedEffects = savedEffects;
     }
   }
@@ -417,7 +418,7 @@ export class Realm {
         let savedEffects = context.savedEffects;
         if (savedEffects !== undefined) {
           // add prior effects that are not already present
-          this.addPriorEffects(savedEffects, result);
+          result = this.composeEffects(savedEffects, result);
           this.updateAbruptCompletions(savedEffects, c);
           context.savedEffects = undefined;
         }
@@ -440,44 +441,46 @@ export class Realm {
     }
   }
 
-  addPriorEffects(priorEffects: Effects, subsequentEffects: Effects) {
-    let [pc, pg, pb, pp, po] = priorEffects;
+  composeEffects(priorEffects: Effects, subsequentEffects: Effects): Effects {
+    let [, pg, pb, pp, po] = priorEffects;
     let [sc, sg, sb, sp, so] = subsequentEffects;
+    let result = construct_empty_effects(this);
+    let [, , rb, rp, ro] = result;
 
-    pc;
-    sc;
+    result[0] = sc;
 
-    let saved_generator = this.generator;
-    this.generator = pg === undefined ? pg : pg.clone();
-    this.appendGenerator(sg);
-    subsequentEffects[1] = pg;
-    this.generator = saved_generator;
+    result[1] = composeGenerators(this, pg || result[1], sg);
 
     if (pb) {
-      pb.forEach((val, key, m) => {
-        if (!sb.has(key)) sb.set(key, val);
-      });
+      pb.forEach((val, key, m) => rb.set(key, val));
     }
+    sb.forEach((val, key, m) => {
+      if (!rb.has(key)) rb.set(key, val);
+    });
+
     if (pp) {
-      pp.forEach((desc, propertyBinding, m) => {
-        if (!sp.has(propertyBinding)) sp.set(propertyBinding, desc);
-      });
+      pp.forEach((desc, propertyBinding, m) => sp.set(propertyBinding, desc));
     }
+    sp.forEach((val, key, m) => {
+      if (!rp.has(key)) rp.set(key, val);
+    });
+
     if (po) {
-      po.forEach((ob, a) => {
-        so.add(ob);
-      });
+      po.forEach((ob, a) => ro.add(ob));
     }
+    so.forEach((ob, a) => ro.add(ob));
+
+    return result;
   }
 
   updateAbruptCompletions(priorEffects: Effects, c: PossiblyNormalCompletion) {
     if (c.consequent instanceof AbruptCompletion) {
-      this.addPriorEffects(priorEffects, c.consequentEffects);
+      c.consequentEffects = this.composeEffects(priorEffects, c.consequentEffects);
       let alternate = c.alternate;
       if (alternate instanceof PossiblyNormalCompletion) this.updateAbruptCompletions(priorEffects, alternate);
     } else {
       invariant(c.alternate instanceof AbruptCompletion);
-      this.addPriorEffects(priorEffects, c.alternateEffects);
+      c.alternateEffects = this.composeEffects(priorEffects, c.alternateEffects);
       let consequent = c.consequent;
       if (consequent instanceof PossiblyNormalCompletion) this.updateAbruptCompletions(priorEffects, consequent);
     }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -536,8 +536,14 @@ export class ResidualHeapSerializer {
     // We can emit the initialization of this value into the body associated with their common ancestor.
     let commonAncestor = Array.from(scopes).reduce((x, y) => commonAncestorOf(x, y), generators[0]);
     invariant(commonAncestor instanceof Generator); // every scope is either the root, or a descendant
-    let body =
-      commonAncestor === this.generator ? this.currentFunctionBody : this.activeGeneratorBodies.get(commonAncestor);
+    let body;
+    while (true) {
+      if (commonAncestor === this.generator) body = this.currentFunctionBody;
+      else body = this.activeGeneratorBodies.get(commonAncestor);
+      if (body !== undefined) break;
+      commonAncestor = commonAncestor.parent;
+      invariant(commonAncestor !== undefined);
+    }
     invariant(body !== undefined);
     return { body: body };
   }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -421,6 +421,8 @@ export default class AbstractValue extends Value {
     loc?: ?BabelNodeSourceLocation
   ): Value {
     let types = TypesDomain.joinValues(left, right);
+    if (types.getType() === NullValue) return realm.intrinsics.null;
+    if (types.getType() === UndefinedValue) return realm.intrinsics.undefined;
     let values = ValuesDomain.joinValues(realm, left, right);
     let [hash, args] = hashTernary(condition, left || realm.intrinsics.undefined, right || realm.intrinsics.undefined);
     let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;


### PR DESCRIPTION
No longer copy entries from one generator to another and make realm.addPriorEffects into a functional version realm.composeEffects, which does not mutate its second argument. Also tweak ancestor logic so that generators that become nested via compose and join report the newly created generators as their parents.