### PR TITLE
Avoid duplicate nested function body(Part1)

### DIFF
--- a/flow-typed/npm/babel-traverse_vx.x.x.js
+++ b/flow-typed/npm/babel-traverse_vx.x.x.js
@@ -24,6 +24,7 @@ declare module 'babel-traverse' {
     scope: BabelTraverseScope;
     node: BabelNode;
     parent: BabelNode;
+    parentPath: BabelTraversePath;
   }
 
   declare export class BabelTraverseScope {

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { LexicalEnvironment } from "../environment.js";
-import type { PropertyKeyValue } from "../types.js";
+import type { PropertyKeyValue, FunctionBodyAstNode } from "../types.js";
 import type { Realm } from "../realm.js";
 import type { ECMAScriptFunctionValue } from "../values/index.js";
 import {
@@ -584,7 +584,7 @@ export function FunctionInitialize(
   F.$FormalParameters = ParameterList;
 
   // 7. Set the [[ECMAScriptCode]] internal slot of F to Body.
-  (Body: any).uniqueTag = realm.functionBodyUniqueTagSeed++;
+  ((Body: any): FunctionBodyAstNode).uniqueTag = realm.functionBodyUniqueTagSeed++;
   F.$ECMAScriptCode = Body;
 
   // 8. Set the [[ScriptOrModule]] internal slot of F to GetActiveScriptOrModule().

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -534,6 +534,7 @@ export function SetFunctionName(
   });
 }
 
+let functionBodyUniqueTagSeed = 1;
 // ECMA262 9.2.3
 export function FunctionInitialize(
   realm: Realm,
@@ -584,6 +585,7 @@ export function FunctionInitialize(
   F.$FormalParameters = ParameterList;
 
   // 7. Set the [[ECMAScriptCode]] internal slot of F to Body.
+  (Body: any).uniqueTag = functionBodyUniqueTagSeed++;
   F.$ECMAScriptCode = Body;
 
   // 8. Set the [[ScriptOrModule]] internal slot of F to GetActiveScriptOrModule().

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -534,7 +534,6 @@ export function SetFunctionName(
   });
 }
 
-let functionBodyUniqueTagSeed = 1;
 // ECMA262 9.2.3
 export function FunctionInitialize(
   realm: Realm,
@@ -585,7 +584,7 @@ export function FunctionInitialize(
   F.$FormalParameters = ParameterList;
 
   // 7. Set the [[ECMAScriptCode]] internal slot of F to Body.
-  (Body: any).uniqueTag = functionBodyUniqueTagSeed++;
+  (Body: any).uniqueTag = realm.functionBodyUniqueTagSeed++;
   F.$ECMAScriptCode = Body;
 
   // 8. Set the [[ScriptOrModule]] internal slot of F to GetActiveScriptOrModule().

--- a/src/realm.js
+++ b/src/realm.js
@@ -253,6 +253,10 @@ export class Realm {
   errorHandler: ?ErrorHandler;
   objectCount = 0;
   symbolCount = 867501803871088;
+  // Unique tag for identifying function body ast node. It is neeeded
+  // instead of ast node itself because we may perform ast tree deep clone
+  // during serialization which changes the ast identity.
+  functionBodyUniqueTagSeed = 1;
 
   globalSymbolRegistry: Array<{ $Key: string, $Symbol: SymbolValue }>;
 

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -119,8 +119,8 @@ export class ResidualFunctions {
 
   _shouldUseFactoryFunction(funcBody: BabelNodeBlockStatement, instances: Array<FunctionInstance>) {
     function shouldInlineFunction(): boolean {
-      let shouldInline = !funcBody;
-      if (!shouldInline && funcBody.start && funcBody.end) {
+      let shouldInline = true;
+      if (funcBody.start && funcBody.end) {
         let bodySize = funcBody.end - funcBody.start;
         shouldInline = bodySize <= 30;
       }
@@ -132,7 +132,8 @@ export class ResidualFunctions {
     return !shouldInlineFunction() && instances.length > 1 && !usesArguments;
   }
 
-  _hasRewrritenFunctionInstance(
+  // Note: this function takes linear time. Please do not call it inside loop.
+  _hasRewrittenFunctionInstance(
     rewrittenAdditionalFunctions: Map<FunctionValue, Array<BabelNodeStatement>>,
     instances: Array<FunctionInstance>
   ): boolean {
@@ -148,7 +149,7 @@ export class ResidualFunctions {
 
       if (this._shouldUseFactoryFunction(functionBody, instances)) {
         // Rewritten function should never use factory function.
-        invariant(!this._hasRewrritenFunctionInstance(rewrittenAdditionalFunctions, instances));
+        invariant(!this._hasRewrittenFunctionInstance(rewrittenAdditionalFunctions, instances));
 
         const functionUniqueTag: number = (functionBody: any).uniqueTag;
         invariant(functionUniqueTag);

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -22,6 +22,7 @@ import type {
   BabelNodeSpreadElement,
   BabelNodeFunctionExpression,
 } from "babel-types";
+import type { FunctionBodyAstNode } from "../types.js";
 import type { NameGenerator } from "../utils/generator.js";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";
@@ -151,7 +152,7 @@ export class ResidualFunctions {
         // Rewritten function should never use factory function.
         invariant(!this._hasRewrittenFunctionInstance(rewrittenAdditionalFunctions, instances));
 
-        const functionUniqueTag: number = (functionBody: any).uniqueTag;
+        const functionUniqueTag = ((functionBody: any): FunctionBodyAstNode).uniqueTag;
         invariant(functionUniqueTag);
         const suffix = instances[0].functionValue.__originalName || "";
         const factoryId = t.identifier(this.factoryNameGenerator.generate(suffix));
@@ -362,7 +363,9 @@ export class ResidualFunctions {
       if (!this._shouldUseFactoryFunction(funcBody, normalInstances)) {
         naiveProcessInstances(normalInstances);
       } else if (normalInstances.length > 0) {
-        const factoryInfo = factoryFunctionInfos.get((funcBody: any).uniqueTag);
+        const functionUniqueTag = ((funcBody: any): FunctionBodyAstNode).uniqueTag;
+        invariant(functionUniqueTag);
+        const factoryInfo = factoryFunctionInfos.get(functionUniqueTag);
         invariant(factoryInfo);
         const { factoryId } = factoryInfo;
 

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -22,10 +22,10 @@ import type {
   BabelNodeSpreadElement,
   BabelNodeFunctionExpression,
 } from "babel-types";
-import { NameGenerator } from "../utils/generator.js";
+import type { NameGenerator } from "../utils/generator.js";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";
-import type { FunctionInfo, FunctionInstance, AdditionalFunctionInfo } from "./types.js";
+import type { FunctionInfo, FactoryFunctionInfo, FunctionInstance, AdditionalFunctionInfo } from "./types.js";
 import { BodyReference, AreSameResidualBinding, SerializerStatistics } from "./types.js";
 import { ClosureRefReplacer } from "./visitors.js";
 import { Modules } from "./modules.js";
@@ -115,6 +115,51 @@ export class ResidualFunctions {
 
   addFunctionUsage(val: FunctionValue, bodyReference: BodyReference) {
     if (!this.firstFunctionUsages.has(val)) this.firstFunctionUsages.set(val, bodyReference);
+  }
+
+  _shouldUseFactoryFunction(funcBody: BabelNodeBlockStatement, instances: Array<FunctionInstance>) {
+    function shouldInlineFunction(): boolean {
+      let shouldInline = !funcBody;
+      if (!shouldInline && funcBody.start && funcBody.end) {
+        let bodySize = funcBody.end - funcBody.start;
+        shouldInline = bodySize <= 30;
+      }
+      return shouldInline;
+    }
+    let functionInfo = this.residualFunctionInfos.get(funcBody);
+    invariant(functionInfo);
+    let { usesArguments } = functionInfo;
+    return !shouldInlineFunction() && instances.length > 1 && !usesArguments;
+  }
+
+  _hasRewrritenFunctionInstance(
+    rewrittenAdditionalFunctions: Map<FunctionValue, Array<BabelNodeStatement>>,
+    instances: Array<FunctionInstance>
+  ): boolean {
+    return instances.find(instance => rewrittenAdditionalFunctions.has(instance.functionValue)) !== undefined;
+  }
+
+  _generateFactoryFunctionInfos(
+    rewrittenAdditionalFunctions: Map<FunctionValue, Array<BabelNodeStatement>>
+  ): Map<number, FactoryFunctionInfo> {
+    const factoryFunctionIds = new Map();
+    for (const [functionBody, instances] of this.functions) {
+      invariant(instances.length > 0);
+
+      if (this._shouldUseFactoryFunction(functionBody, instances)) {
+        // Rewritten function should never use factory function.
+        invariant(!this._hasRewrritenFunctionInstance(rewrittenAdditionalFunctions, instances));
+
+        const functionUniqueTag: number = (functionBody: any).uniqueTag;
+        invariant(functionUniqueTag);
+        const suffix = instances[0].functionValue.__originalName || "";
+        const factoryId = t.identifier(this.factoryNameGenerator.generate(suffix));
+        const functionInfo = this.residualFunctionInfos.get(functionBody);
+        invariant(functionInfo);
+        factoryFunctionIds.set(functionUniqueTag, { factoryId, functionInfo });
+      }
+    }
+    return factoryFunctionIds;
   }
 
   spliceFunctions(
@@ -252,18 +297,13 @@ export class ResidualFunctions {
     }
 
     // Process normal functions
+    const factoryFunctionInfos = this._generateFactoryFunctionInfos(rewrittenAdditionalFunctions);
     for (let [funcBody, instances] of functionEntries) {
       let functionInfo = this.residualFunctionInfos.get(funcBody);
       invariant(functionInfo);
-      let { unbound, modified, usesThis, usesArguments } = functionInfo;
+      let { unbound, modified, usesThis } = functionInfo;
       let params = instances[0].functionValue.$FormalParameters;
       invariant(params !== undefined);
-
-      let shouldInline = !funcBody;
-      if (!shouldInline && funcBody.start && funcBody.end) {
-        let bodySize = funcBody.end - funcBody.start;
-        shouldInline = bodySize <= 30;
-      }
 
       // Split instances into normal or nested in an additional function
       let normalInstances = [];
@@ -304,6 +344,7 @@ export class ResidualFunctions {
             requireReturns: this.requireReturns,
             requireStatistics,
             isRequire: this.modules.getIsRequire(funcParams, [functionValue]),
+            factoryFunctionInfos,
           });
 
           if (functionValue.$Strict) {
@@ -317,11 +358,12 @@ export class ResidualFunctions {
       };
 
       if (additionalFunctionNestedInstances.length > 0) naiveProcessInstances(additionalFunctionNestedInstances);
-      if (shouldInline || normalInstances.length === 1 || usesArguments) {
+      if (!this._shouldUseFactoryFunction(funcBody, normalInstances)) {
         naiveProcessInstances(normalInstances);
       } else if (normalInstances.length > 0) {
-        let suffix = normalInstances[0].functionValue.__originalName || "";
-        let factoryId = t.identifier(this.factoryNameGenerator.generate(suffix));
+        const factoryInfo = factoryFunctionInfos.get((funcBody: any).uniqueTag);
+        invariant(factoryInfo);
+        const { factoryId } = factoryInfo;
 
         // filter included variables to only include those that are different
         let factoryNames: Array<string> = [];
@@ -400,6 +442,7 @@ export class ResidualFunctions {
           requireReturns: this.requireReturns,
           requireStatistics,
           isRequire: this.modules.getIsRequire(factoryParams, normalInstances.map(instance => instance.functionValue)),
+          factoryFunctionInfos,
         });
 
         for (let instance of normalInstances) {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -43,6 +43,8 @@ export type FunctionInfo = {
   usesThis: boolean,
 };
 
+export type FactoryFunctionInfo = { factoryId: BabelNodeIdentifier, functionInfo: FunctionInfo };
+
 export type ResidualFunctionBinding = {
   value: void | Value,
   modified: boolean,

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -15,7 +15,8 @@ import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeCallExpression, BabelNodeFunctionExpression } from "babel-types";
 import { convertExpressionToJSXIdentifier } from "../utils/jsx";
 import type { BabelTraversePath } from "babel-traverse";
-import type { TryQuery, FunctionInfo, FactoryFunctionInfo, FunctionBodyAstNode, ResidualFunctionBinding } from "./types.js";
+import type { FunctionBodyAstNode } from "../types.js";
+import type { TryQuery, FunctionInfo, FactoryFunctionInfo, ResidualFunctionBinding } from "./types.js";
 import { nullExpression } from "../utils/internalizer.js";
 
 export type ClosureRefVisitorState = {
@@ -144,8 +145,7 @@ export let ClosureRefReplacer = {
 
   // TODO: handle FunctionDeclaration
   FunctionExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
-    // BabelTraversePath is missing flow typing for "parentPath" property so cast to any.
-    if (t.isProgram((path: any).parentPath.parentPath.node)) {
+    if (t.isProgram(path.parentPath.parentPath.node)) {
       // Our goal is replacing duplicate nested function so skip root residual function itself.
       // This assumes the root function is wrapped with: t.file(t.program([t.expressionStatement(rootFunction).
       return;

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -13,9 +13,9 @@ import { Realm } from "../realm.js";
 import { FunctionValue } from "../values/index.js";
 import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeCallExpression, BabelNodeFunctionExpression } from "babel-types";
-import { BabelTraversePath } from "babel-traverse";
 import { convertExpressionToJSXIdentifier } from "../utils/jsx";
-import type { TryQuery, FunctionInfo, FactoryFunctionInfo, ResidualFunctionBinding } from "./types.js";
+import type { BabelTraversePath } from "babel-traverse";
+import type { TryQuery, FunctionInfo, FactoryFunctionInfo, FunctionBodyAstNode, ResidualFunctionBinding } from "./types.js";
 import { nullExpression } from "../utils/internalizer.js";
 
 export type ClosureRefVisitorState = {
@@ -144,14 +144,15 @@ export let ClosureRefReplacer = {
 
   // TODO: handle FunctionDeclaration
   FunctionExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
+    // BabelTraversePath is missing flow typing for "parentPath" property so cast to any.
     if (t.isProgram((path: any).parentPath.parentPath.node)) {
-      // Skip root function itself.
+      // Our goal is replacing duplicate nested function so skip root residual function itself.
       // This assumes the root function is wrapped with: t.file(t.program([t.expressionStatement(rootFunction).
       return;
     }
 
     const functionExpression: BabelNodeFunctionExpression = path.node;
-    const functionTag: number = (functionExpression.body: any).uniqueTag;
+    const functionTag = ((functionExpression.body: any): FunctionBodyAstNode).uniqueTag;
     if (!functionTag) {
       // Un-interpreted nested function.
       return;

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -94,7 +94,7 @@ function canShareFunctionBody(duplicateFunctionInfo: FactoryFunctionInfo): boole
   return unbound.size === 0 && modified.size === 0 && !usesThis;
 }
 
-// TODO: enhance for nested functions accessing read-only free varaibles.
+// TODO: enhance for nested functions accessing read-only free variables.
 function replaceNestedFunction(functionTag: number, path: BabelTraversePath, state: ClosureRefReplacerState) {
   const duplicateFunctionInfo = state.factoryFunctionInfos.get(functionTag);
   if (duplicateFunctionInfo && canShareFunctionBody(duplicateFunctionInfo)) {
@@ -145,7 +145,8 @@ export let ClosureRefReplacer = {
   // TODO: handle FunctionDeclaration
   FunctionExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
     if (t.isProgram((path: any).parentPath.parentPath.node)) {
-      // Skip itself.
+      // Skip root function itself.
+      // This assumes the root function is wrapped with: t.file(t.program([t.expressionStatement(rootFunction).
       return;
     }
 

--- a/src/types.js
+++ b/src/types.js
@@ -96,7 +96,7 @@ export type Descriptor = {
 
 export type FunctionBodyAstNode = {
   // Function body ast node will have uniqueTag after interpreted.
-  uniqueTag: ?number,
+  uniqueTag?: number,
 };
 
 export type PropertyBinding = {

--- a/src/types.js
+++ b/src/types.js
@@ -94,6 +94,11 @@ export type Descriptor = {
   set?: UndefinedValue | CallableObjectValue | AbstractValue,
 };
 
+export type FunctionBodyAstNode = {
+  // Function body ast node will have uniqueTag after interpreted.
+  uniqueTag: ?number,
+};
+
 export type PropertyBinding = {
   descriptor?: Descriptor,
   object: ObjectValue | AbstractObjectValue,

--- a/test/serializer/basic/NestedFunctions1.js
+++ b/test/serializer/basic/NestedFunctions1.js
@@ -1,0 +1,15 @@
+// Copies of x: 2
+(function() {
+  global.f = function() {
+    return function() {
+      /* This makes the function too big to inline. */
+      var x = 10;
+      return 2 * x;
+    }
+  }
+  global.g1 = f();
+  global.g2 = f();
+  inspect = function() {
+    return g1() + g2();
+  }
+})();

--- a/test/serializer/basic/NestedFunctions2.js
+++ b/test/serializer/basic/NestedFunctions2.js
@@ -1,0 +1,19 @@
+// Copies of x: 2
+(function() {
+  global.f = function() {
+    return function() {
+      return function() {
+        /* This makes the function too big to inline. */
+        var x = 10;
+        return 2 * x;
+      }
+    }
+  }
+  global.g1 = f();
+  global.g2 = f();
+  global.h1 = g1();
+  global.h2 = g1();
+  inspect = function() {
+    return g1()() + g2()() + h1() + h2();
+  }
+})();


### PR DESCRIPTION
Release Note: Avoid duplicate nested function body(Part1)
#777
Avoids duplicating the nested function body with other residual functions. Currently the implementation has the following limitations:
1. Did not deal with the situation that nested function duplicates with a residual function did not use factory function.
2. Did not deal with function declaration

I will address these limitations in later PR.