### PR TITLE
 Emit code for exceptions that make it to the top level.

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -209,8 +209,12 @@ function runTest(name, code, options, args) {
     let unique = 27277;
     let oldUniqueSuffix = "";
     try {
-      expected = exec(`${addedCode}\n(function () {${code} // keep newline here as code may end with comment
-}).call(this);`);
+      try {
+        expected = exec(`${addedCode}\n(function () {${code} // keep newline here as code may end with comment
+  }).call(this);`);
+      } catch (e) {
+        expected = e;
+      }
 
       let i = 0;
       let max = addedCode ? 1 : 4;
@@ -237,7 +241,11 @@ function runTest(name, code, options, args) {
           }
         }
         if (markersIssue) break;
-        actual = exec(addedCode + newCode);
+        try {
+          actual = exec(addedCode + newCode);
+        } catch (e) {
+          actual = e;
+        }
         if (expected !== actual) {
           console.log(chalk.red("Output mismatch!"));
           break;

--- a/src/domains/TypesDomain.js
+++ b/src/domains/TypesDomain.js
@@ -109,7 +109,7 @@ export default class TypesDomain {
   }
 
   static logicalOp(op: BabelNodeLogicalOperator, left: TypesDomain, right: TypesDomain): TypesDomain {
-    return TypesDomain.joinValues(left, right);
+    return left.joinWith(right.getType());
   }
 
   // return the type of the result in the case where there is no exception

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -1078,6 +1078,6 @@ export function KeyedBindingInitialization(
     }
 
     // 3. Return the result of performing BindingInitialization for BindingPattern passing v and environment as arguments.
-    return BindingInitialization(realm, node, v, strictCode, environment);
+    return BindingInitialization(realm, node, v, strictCode, env);
   }
 }

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1130,7 +1130,7 @@ export function PerformEval(realm: Realm, x: Value, evalRealm: Realm, strictCall
   }
 }
 
-export function incorporateSavedCompletion(realm: Realm, c: void | Completion | Value): Completion | Value {
+export function incorporateSavedCompletion(realm: Realm, c: void | Completion | Value): void | Completion | Value {
   let context = realm.getRunningContext();
   let savedCompletion = context.savedCompletion;
   if (savedCompletion !== undefined) {

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -413,7 +413,9 @@ function joinResults(
     return new JoinedAbruptCompletions(realm, joinCondition, result1, e1, result2, e2);
   }
   if (result1 instanceof Value && result2 instanceof Value) {
-    return joinValues(realm, result1, result2, getAbstractValue);
+    let val = joinValues(realm, result1, result2, getAbstractValue);
+    invariant(val instanceof Value);
+    return val;
   }
   if (result1 instanceof PossiblyNormalCompletion && result2 instanceof PossiblyNormalCompletion) {
     return composePossiblyNormalCompletions(realm, result1, result2);

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -710,6 +710,7 @@ export function ToPropertyKeyPartial(
 ): AbstractValue | SymbolValue | string /* but not StringValue */ {
   if (arg instanceof ConcreteValue) return ToPropertyKey(realm, arg);
   if (arg.mightNotBeString()) arg.throwIfNotConcrete();
+  invariant(arg instanceof AbstractValue);
   return arg;
 }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -343,7 +343,7 @@ export class Realm {
     return this.evaluateForEffects(() => env.evaluateAbstractCompletion(ast, strictCode), state);
   }
 
-  evaluateAndRevertInGlobalEnv(func: () => void): void {
+  evaluateAndRevertInGlobalEnv(func: () => Value): void {
     this.wrapInGlobalEnv(() => this.evaluateForEffects(func));
   }
 
@@ -386,6 +386,7 @@ export class Realm {
       c = f();
       if (c instanceof Reference) c = GetValue(this, c);
       c = incorporateSavedCompletion(this, c);
+      invariant(c !== undefined);
 
       invariant(this.generator !== undefined);
       invariant(this.modifiedBindings !== undefined);
@@ -476,10 +477,10 @@ export class Realm {
     }
     context.savedEffects = [
       this.intrinsics.undefined,
-      this.generator,
-      this.modifiedBindings,
-      this.modifiedProperties,
-      this.createdObjects,
+      (this.generator: any),
+      (this.modifiedBindings: any),
+      (this.modifiedProperties: any),
+      (this.createdObjects: any),
     ];
     this.generator = new Generator(this);
     this.modifiedBindings = new Map();

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1273,6 +1273,7 @@ export class ResidualHeapSerializer {
           this.realm.restoreProperties(modifiedProperties);
         }
       }
+      return this.realm.intrinsics.undefined;
     };
     this.realm.evaluateAndRevertInGlobalEnv(processAdditionalFunctionValuesFn);
     return rewrittenAdditionalFunctions;

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -616,6 +616,7 @@ export class ResidualHeapVisitor {
         });
       }
     }
+    return this.realm.intrinsics.undefined;
   }
 
   visitRoots(): void {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -226,7 +226,9 @@ export class Generator {
     args: Array<Value>,
     kind?: string
   ): AbstractValue {
-    return this.derive(types, values, args, nodes => t.callExpression(createCallee(), nodes));
+    return this.derive(types, values, args, (nodes: any) =>
+      t.callExpression(createCallee(), nodes)
+    );
   }
 
   emitVoidExpression(

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -226,9 +226,14 @@ export class Generator {
     args: Array<Value>,
     kind?: string
   ): AbstractValue {
-    return this.derive(types, values, args, (nodes: any) =>
-      t.callExpression(createCallee(), nodes)
-    );
+    return this.derive(types, values, args, (nodes: any) => t.callExpression(createCallee(), nodes));
+  }
+
+  emitStatement(args: Array<Value>, buildNode_: (Array<BabelNodeExpression>) => BabelNodeStatement) {
+    this.addEntry({
+      args,
+      buildNode: buildNode_,
+    });
   }
 
   emitVoidExpression(

--- a/test/serializer/abstract/Return3.js
+++ b/test/serializer/abstract/Return3.js
@@ -1,5 +1,4 @@
-// throws introspection error
-let x = __abstract("boolean", "true")
+let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 y = 1;
 y1 = 2;
@@ -16,3 +15,5 @@ function f(b) {
 }
 
 z = f(!x);
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Return3a.js
+++ b/test/serializer/abstract/Return3a.js
@@ -1,5 +1,4 @@
-// throws introspection error
-let x = __abstract("boolean", "true")
+let x = global.__abstract ? __abstract("boolean", "true") : true
 
 y = 1;
 y1 = 2;
@@ -16,3 +15,5 @@ function f(b) {
 }
 
 z = f(!x);
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Return6.js
+++ b/test/serializer/abstract/Return6.js
@@ -1,5 +1,4 @@
-// throws introspection error
-let x = __abstract("boolean", "true");
+let x = global.__abstract ? __abstract("boolean", "true") : true
 
 y = 1;
 
@@ -9,3 +8,5 @@ function f(b) {
 }
 
 z = f(!x);
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Return8.js
+++ b/test/serializer/abstract/Return8.js
@@ -1,5 +1,4 @@
-// throws introspection error
-let x = __abstract("boolean", "true");
+let x = global.__abstract ? __abstract("boolean", "true") : true
 
 y = 1;
 
@@ -13,3 +12,5 @@ function g(b) {
 }
 
 z = g(x);
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Throw6.js
+++ b/test/serializer/abstract/Throw6.js
@@ -1,0 +1,10 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+function foo(b) {
+  if (b) throw new Error("is true");
+  return "is false";
+}
+
+z = foo(!x);
+
+inspect = function() { return z; }


### PR DESCRIPTION
Release note: Generate code for uncaught exceptions

This is a high priority fix for a land blocking issue. Please review ASAP.

Exceptions that (conditionally or unconditionally) propagate to the top level program used to cause Prepack to fail.

The new behavior is to generate top level code that will (conditionally) throw the exceptions at runtime.

