### PR TITLE
Avoid duplicate nested function body(Part2)

### DIFF
--- a/test/serializer/basic/NestedFunctions3.js
+++ b/test/serializer/basic/NestedFunctions3.js
@@ -1,0 +1,12 @@
+// Copies of x0: 3
+f = function() {
+  return function() {
+    var x0 = 1;
+    var x1 = x0 + x0;
+    var x2 = x1 + x1;
+    var x3 = x2 + x2;
+    var x4 = x3 + x3;
+    return x4;
+  }
+}
+g = f();

--- a/test/serializer/basic/NestedFunctions4.js
+++ b/test/serializer/basic/NestedFunctions4.js
@@ -1,0 +1,16 @@
+// TODO: add copies checking after handling FunctionDeclaration
+f = function() {
+  function nested() {
+    var x0 = 1;
+    var x1 = x0 + x0;
+    var x2 = x1 + x1;
+    var x3 = x2 + x2;
+    var x4 = x3 + x3;
+    return x4;
+  }
+  return nested;
+}
+g = f();
+inspect = function() {
+  return g();
+}

--- a/test/serializer/basic/NestedFunctions5.js
+++ b/test/serializer/basic/NestedFunctions5.js
@@ -1,0 +1,15 @@
+f = function() {
+  return nested; // note that declaration comes later --- this is okay!
+  function nested() {
+    var x0 = 1;
+    var x1 = x0 + x0;
+    var x2 = x1 + x1;
+    var x3 = x2 + x2;
+    var x4 = x3 + x3;
+    return x4;
+  }
+}
+g = f();
+inspect = function() {  
+  return f()();
+}


### PR DESCRIPTION
Release Note: Avoid duplicate nested function body(Part2)
Deal with the situation that nested function duplicates with a residual function did not use factory function. 
This makes the sample code in issue #777 working.

TODO: Deal with function declaration.
