### PR TITLE
Set up flow-libs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,7 @@
 [include]
 
 [libs]
+flow-libs
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/flow-libs/vscode-debugadapter.js.flow
+++ b/flow-libs/vscode-debugadapter.js.flow
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
 import DebugProtocol from 'vscode-debugprotocol'
 import * as ee from 'events';
 declare module 'vscode-debugadapter' {

--- a/flow-libs/vscode-debugadapter.js.flow
+++ b/flow-libs/vscode-debugadapter.js.flow
@@ -1,0 +1,184 @@
+import DebugProtocol from 'vscode-debugprotocol'
+import * as ee from 'events';
+declare module 'vscode-debugadapter' {
+
+  declare export class Message mixins DebugProtocol.ProtocolMessage {
+      seq: number;
+      type: string;
+      constructor(type: string): this
+  }
+  declare export class Response mixins Message, DebugProtocol.Response {
+      request_seq: number;
+      success: boolean;
+      command: string;
+      constructor(request: DebugProtocol.Request, message?: string): this
+  }
+  declare export class Event mixins Message, DebugProtocol.Event {
+      event: string;
+      constructor(event: string, body?: any): this
+  }
+  declare export class InitializedEvent mixins Event, DebugProtocol.InitializedEvent {
+      constructor(): this
+  }
+  declare export class ProtocolServer mixins ee.EventEmitter {
+      constructor(): this;
+      start(inStream: ee.EventEmitter.ReadableStream, outStream: ee.EventEmitter.WritableStream): void;
+      stop(): void;
+      sendEvent(event: DebugProtocol.Event): void;
+      sendResponse(response: DebugProtocol.Response): void;
+      sendRequest(
+          command: string,
+          args: any,
+          timeout: number,
+          cb: (response: DebugProtocol.Response) => void): void;
+      dispatchRequest(request: DebugProtocol.Request): void
+  }
+  declare export type ErrorDestination = {
+    User: 1,
+    Telemetry: 2,
+  }
+  declare export class DebugSession mixins ProtocolServer {
+      _isServer: boolean;
+      constructor(obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean): this;
+      setDebuggerPathFormat(format: string): void;
+      setDebuggerLinesStartAt1(enable: boolean): void;
+      setDebuggerColumnsStartAt1(enable: boolean): void;
+      setRunAsServer(enable: boolean): void;
+
+      /**
+       * A virtual constructor...
+       */
+      static run(debugSession: typeof DebugSession): void;
+      shutdown(): void;
+      sendErrorResponse(
+          response: DebugProtocol.Response,
+          codeOrMessage: number | DebugProtocol.Message,
+          format?: string,
+          variables?: any,
+          dest?: ErrorDestination): void;
+      runInTerminalRequest(
+          args: DebugProtocol.RunInTerminalRequestArguments,
+          timeout: number,
+          cb: (response: DebugProtocol.RunInTerminalResponse) => void): void;
+      dispatchRequest(request: DebugProtocol.Request): void;
+      initializeRequest(
+          response: DebugProtocol.InitializeResponse,
+          args: DebugProtocol.InitializeRequestArguments): void;
+      disconnectRequest(
+          response: DebugProtocol.DisconnectResponse,
+          args: DebugProtocol.DisconnectArguments): void;
+      launchRequest(
+          response: DebugProtocol.LaunchResponse,
+          args: DebugProtocol.LaunchRequestArguments): void;
+      attachRequest(
+          response: DebugProtocol.AttachResponse,
+          args: DebugProtocol.AttachRequestArguments): void;
+      restartRequest(
+          response: DebugProtocol.RestartResponse,
+          args: DebugProtocol.RestartArguments): void;
+      setBreakPointsRequest(
+          response: DebugProtocol.SetBreakpointsResponse,
+          args: DebugProtocol.SetBreakpointsArguments): void;
+      setFunctionBreakPointsRequest(
+          response: DebugProtocol.SetFunctionBreakpointsResponse,
+          args: DebugProtocol.SetFunctionBreakpointsArguments): void;
+      setExceptionBreakPointsRequest(
+          response: DebugProtocol.SetExceptionBreakpointsResponse,
+          args: DebugProtocol.SetExceptionBreakpointsArguments): void;
+      configurationDoneRequest(
+          response: DebugProtocol.ConfigurationDoneResponse,
+          args: DebugProtocol.ConfigurationDoneArguments): void;
+      continueRequest(
+          response: DebugProtocol.ContinueResponse,
+          args: DebugProtocol.ContinueArguments): void;
+      nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments): void;
+      stepInRequest(
+          response: DebugProtocol.StepInResponse,
+          args: DebugProtocol.StepInArguments): void;
+      stepOutRequest(
+          response: DebugProtocol.StepOutResponse,
+          args: DebugProtocol.StepOutArguments): void;
+      stepBackRequest(
+          response: DebugProtocol.StepBackResponse,
+          args: DebugProtocol.StepBackArguments): void;
+      reverseContinueRequest(
+          response: DebugProtocol.ReverseContinueResponse,
+          args: DebugProtocol.ReverseContinueArguments): void;
+      restartFrameRequest(
+          response: DebugProtocol.RestartFrameResponse,
+          args: DebugProtocol.RestartFrameArguments): void;
+      gotoRequest(response: DebugProtocol.GotoResponse, args: DebugProtocol.GotoArguments): void;
+      pauseRequest(
+          response: DebugProtocol.PauseResponse,
+          args: DebugProtocol.PauseArguments): void;
+      sourceRequest(
+          response: DebugProtocol.SourceResponse,
+          args: DebugProtocol.SourceArguments): void;
+      threadsRequest(response: DebugProtocol.ThreadsResponse): void;
+      stackTraceRequest(
+          response: DebugProtocol.StackTraceResponse,
+          args: DebugProtocol.StackTraceArguments): void;
+      scopesRequest(
+          response: DebugProtocol.ScopesResponse,
+          args: DebugProtocol.ScopesArguments): void;
+      variablesRequest(
+          response: DebugProtocol.VariablesResponse,
+          args: DebugProtocol.VariablesArguments): void;
+      setVariableRequest(
+          response: DebugProtocol.SetVariableResponse,
+          args: DebugProtocol.SetVariableArguments): void;
+      evaluateRequest(
+          response: DebugProtocol.EvaluateResponse,
+          args: DebugProtocol.EvaluateArguments): void;
+      stepInTargetsRequest(
+          response: DebugProtocol.StepInTargetsResponse,
+          args: DebugProtocol.StepInTargetsArguments): void;
+      gotoTargetsRequest(
+          response: DebugProtocol.GotoTargetsResponse,
+          args: DebugProtocol.GotoTargetsArguments): void;
+      completionsRequest(
+          response: DebugProtocol.CompletionsResponse,
+          args: DebugProtocol.CompletionsArguments): void;
+      exceptionInfoRequest(
+          response: DebugProtocol.ExceptionInfoResponse,
+          args: DebugProtocol.ExceptionInfoArguments): void;
+      loadedSourcesRequest(
+          response: DebugProtocol.LoadedSourcesResponse,
+          args: DebugProtocol.LoadedSourcesArguments): void;
+
+      /**
+       * Override this hook to implement custom requests.
+       */
+      customRequest(command: string, response: DebugProtocol.Response, args: any): void;
+      convertClientLineToDebugger(line: number): number;
+      convertDebuggerLineToClient(line: number): number;
+      convertClientColumnToDebugger(column: number): number;
+      convertDebuggerColumnToClient(column: number): number;
+      convertClientPathToDebugger(clientPath: string): string;
+      convertDebuggerPathToClient(debuggerPath: string): string
+  }
+  declare export class LoggingDebugSession mixins DebugSession {
+      constructor(_logFilePath: string, obsolete_debuggerLinesAndColumnsStartAt1?: boolean, obsolete_isServer?: boolean): this;
+      start(inStream: ee.EventEmitter.ReadableStream, outStream: ee.EventEmitter.WritableStream): void;
+
+      /**
+       * Overload sendEvent to log
+       */
+      sendEvent(event: DebugProtocol.Event): void;
+
+      /**
+       * Overload sendRequest to log
+       */
+      sendRequest(
+          command: string,
+          args: any,
+          timeout: number,
+          cb: (response: DebugProtocol.Response) => void): void;
+
+      /**
+       * Overload sendResponse to log
+       */
+      sendResponse(response: DebugProtocol.Response): void;
+      dispatchRequest(request: DebugProtocol.Request): void
+  }
+}

--- a/flow-libs/vscode-debugprotocol.js.flow
+++ b/flow-libs/vscode-debugprotocol.js.flow
@@ -1,13 +1,13 @@
 /**
- * Copyright (c) 2015-present, Facebook, Inc.
+ * Copyright (c) 2017-present, Facebook, Inc.
  * All rights reserved.
  *
- * This source code is licensed under the license found in the LICENSE file in
- * the root directory of this source tree.
- *
- * @flow
- * @format
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
  */
+
+/* @flow */
 
 // Ported from https://github.com/Microsoft/vscode-debugadapter-node/blob/master/protocol/src/debugProtocol.ts
 

--- a/flow-libs/vscode-debugprotocol.js.flow
+++ b/flow-libs/vscode-debugprotocol.js.flow
@@ -1,0 +1,1439 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+// Ported from https://github.com/Microsoft/vscode-debugadapter-node/blob/master/protocol/src/debugProtocol.ts
+
+declare module 'vscode-debugprotocol' {
+  declare interface base$ProtocolMessage {
+    /** Sequence number. */
+    seq: number,
+    /** One of 'request', 'response', or 'event'. */
+    +type: 'request' | 'response' | 'event',
+  }
+
+  declare type ProtocolMessage = Request | Event | Response;
+
+  declare interface base$Request extends base$ProtocolMessage {
+    type: 'request',
+    /** The command to execute. */
+    +command: string,
+    /** Object containing arguments for the command. */
+    +arguments?: any,
+  }
+
+  /** Server-initiated event. */
+  declare interface base$Event extends base$ProtocolMessage {
+    type: 'event',
+    /** Type of event. */
+    +event: string,
+    /** Event-specific information. */
+    +body?: any,
+  }
+
+  /** Response to a request. */
+  declare interface base$Response extends base$ProtocolMessage {
+    type: 'response',
+    /** Sequence number of the corresponding request. */
+    request_seq: number,
+    /** Outcome of the request. */
+    success: boolean,
+    /** The command requested. */
+    command: string,
+    /** Contains error message if success == false. */
+    message?: string,
+    /** Contains request result if success is true and optional error details if success is false. */
+    +body?: any,
+  }
+
+  declare interface InitializedEvent extends base$Event {
+    event: 'initialized',
+  }
+
+  declare interface StoppedEvent extends base$Event {
+    event: 'stopped',
+    body: {
+      /** The reason for the event (such as: 'step', 'breakpoint', 'exception', 'pause', 'entry').
+        For backward compatibility this string is shown in the UI if the 'description' attribute is missing (but it must not be translated).
+      */
+      reason: string,
+      /** The full reason for the event, e.g. 'Paused on exception'. This string is shown in the UI as is. */
+      description?: string,
+      /** The thread which was stopped. */
+      threadId?: number,
+      /** Additional information. E.g. if reason is 'exception', text contains the exception name. This string is shown in the UI. */
+      text?: string,
+      /** If allThreadsStopped is true, a debug adapter can announce that all threads have stopped.
+        *  The client should use this information to enable that all threads can be expanded to access their stacktraces.
+        *  If the attribute is missing or false, only the thread with the given threadId can be expanded.
+      */
+      allThreadsStopped?: boolean,
+    },
+  }
+
+  declare interface ContinuedEvent extends base$Event {
+    event: 'continued',
+    body: {
+      /** The thread which was continued. */
+      threadId: number,
+      /** If allThreadsContinued is true, a debug adapter can announce that all threads have continued. */
+      allThreadsContinued?: boolean,
+    },
+  }
+
+  /** Event message for 'exited' event type.
+    The event indicates that the debuggee has exited.
+  */
+  declare interface ExitedEvent extends base$Event {
+    event: 'exited',
+    body: {
+      /** The exit code returned from the debuggee. */
+      exitCode: number,
+    },
+  }
+
+  /** Event message for 'terminated' event types.
+    The event indicates that debugging of the debuggee has terminated.
+  */
+  declare interface TerminatedEvent extends base$Event {
+    event: 'terminated',
+    body?: {
+      /** A debug adapter may set 'restart' to true to request that the front end restarts the session. */
+      restart?: boolean,
+    },
+  }
+
+  /** Event message for 'thread' event type.
+    The event indicates that a thread has started or exited.
+  */
+  declare interface ThreadEvent extends base$Event {
+    event: 'thread',
+    body: {
+      /** The reason for the event (such as: 'started', 'exited'). */
+      reason: string,
+      /** The identifier of the thread. */
+      threadId: number,
+    },
+  }
+
+  /** Event message for 'output' event type.
+    The event indicates that the target has produced some output.
+  */
+  declare interface OutputEvent extends base$Event {
+    event: 'output',
+    body: {
+      /** The category of output (such as: 'console', 'stdout', 'stderr', 'telemetry'). If not specified, 'console' is assumed. */
+      category?: string,
+      /** The output to report. */
+      output: string,
+      /** If an attribute 'variablesReference' exists and its value is > 0, the output contains objects which can be retrieved by passing variablesReference to the VariablesRequest. */
+      variablesReference?: number,
+      /** Optional data to report. For the 'telemetry' category the data will be sent to telemetry, for the other categories the data is shown in JSON format. */
+      data?: any,
+    },
+  }
+
+  /** Event message for 'breakpoint' event type.
+    The event indicates that some information about a breakpoint has changed.
+  */
+  declare interface BreakpointEvent extends base$Event {
+    event: 'breakpoint',
+    body: {
+      /** The reason for the event (such as: 'changed', 'new'). */
+      reason: string,
+      /** The breakpoint. */
+      breakpoint: Breakpoint,
+    },
+  }
+
+  /** Event message for 'module' event type.
+    The event indicates that some information about a module has changed.
+  */
+  declare interface ModuleEvent extends base$Event {
+    event: 'module',
+    body: {
+      /** The reason for the event. */
+      reason: 'new' | 'changed' | 'removed',
+      /** The new, changed, or removed module. In case of 'removed' only the module id is used. */
+      module: Module,
+    },
+  }
+
+  /** runInTerminal request; value of command field is 'runInTerminal'.
+    With this request a debug adapter can run a command in a terminal.
+  */
+  declare interface RunInTerminalRequest extends base$Request {
+    command: 'runInTerminal',
+    arguments: RunInTerminalRequestArguments,
+  }
+
+  /** Arguments for 'runInTerminal' request. */
+  declare type RunInTerminalRequestArguments = {
+    /** What kind of terminal to launch. */
+    kind?: 'integrated' | 'external',
+    /** Optional title of the terminal. */
+    title?: string,
+    /** Working directory of the command. */
+    cwd: string,
+    /** List of arguments. The first argument is the command to run. */
+    args: string[],
+    /** Environment key-value pairs that are added to the default environment. */
+    env?: {[key: string]: string},
+  };
+
+  /** Response to Initialize request. */
+  declare interface RunInTerminalResponse extends base$Response {
+    body: {
+      /** The process ID. */
+      processId?: number,
+    },
+  }
+
+  /** On error that is whenever 'success' is false, the body can provide more details. */
+  declare interface ErrorResponse extends base$Response {
+    body: {
+      /** An optional, structured error message. */
+      error?: Message,
+    },
+  }
+
+  /** Initialize request; value of command field is 'initialize'. */
+  declare interface InitializeRequest extends base$Request {
+    command: 'initialize',
+    arguments: InitializeRequestArguments,
+  }
+
+  /** Arguments for 'initialize' request. */
+  declare type InitializeRequestArguments = {
+    /** The ID of the (frontend) client using this adapter. */
+    clientID?: string,
+    /** The ID of the debug adapter. */
+    adapterID: string,
+    /** If true all line numbers are 1-based (default). */
+    linesStartAt1?: boolean,
+    /** If true all column numbers are 1-based (default). */
+    columnsStartAt1?: boolean,
+    /** Determines in what format paths are specified. Possible values are 'path' or 'uri'. The default is 'path', which is the native format. */
+    pathFormat?: string,
+    /** Client supports the optional type attribute for variables. */
+    supportsVariableType?: boolean,
+    /** Client supports the paging of variables. */
+    supportsVariablePaging?: boolean,
+    /** Client supports the runInTerminal request. */
+    supportsRunInTerminalRequest?: boolean,
+  };
+
+  /** Response to 'initialize' request. */
+  declare interface InitializeResponse extends base$Response {
+    /** The capabilities of this debug adapter. */
+    body?: Capabilities,
+  }
+
+  /** ConfigurationDone request; value of command field is 'configurationDone'.
+    The client of the debug protocol must send this request at the end of the sequence of configuration requests (which was started by the InitializedEvent).
+  */
+  declare interface ConfigurationDoneRequest extends base$Request {
+    command: 'configurationDone',
+    arguments?: ConfigurationDoneArguments,
+  }
+
+  /** Arguments for 'configurationDone' request.
+    The configurationDone request has no standardized attributes.
+  */
+  declare type ConfigurationDoneArguments = {};
+
+  /** Response to 'configurationDone' request. This is just an acknowledgement, so no body field is required. */
+  declare interface ConfigurationDoneResponse extends base$Response {}
+
+  /** Launch request; value of command field is 'launch'. */
+  declare interface LaunchRequest extends base$Request {
+    command: 'launch',
+    arguments: LaunchRequestArguments,
+  }
+
+  /** Arguments for 'launch' request. */
+  declare type LaunchRequestArguments = {
+    /** If noDebug is true the launch request should launch the program without enabling debugging. */
+    noDebug?: boolean,
+  };
+
+  /** Response to 'launch' request. This is just an acknowledgement, so no body field is required. */
+  declare interface LaunchResponse extends base$Response {}
+
+  /** Attach request; value of command field is 'attach'. */
+  declare interface AttachRequest extends base$Request {
+    command: 'attach',
+    arguments: AttachRequestArguments,
+  }
+
+  /** Arguments for 'attach' request.
+    The attach request has no standardized attributes.
+  */
+  declare type AttachRequestArguments = {};
+
+  /** Response to 'attach' request. This is just an acknowledgement, so no body field is required. */
+  declare interface AttachResponse extends base$Response {}
+
+  /** Restart request; value of command field is 'restart'.
+    Restarts a debug session. If the capability 'supportsRestartRequest' is missing or has the value false,
+    the client will implement 'restart' by terminating the debug adapter first and then launching it anew.
+    A debug adapter can override this default behaviour by implementing a restart request
+    and setting the capability 'supportsRestartRequest' to true.
+  */
+  declare interface RestartRequest extends base$Request {
+    command: 'restart',
+    arguments?: RestartArguments,
+  }
+
+  /** Arguments for 'restart' request.
+    The restart request has no standardized attributes.
+  */
+  declare type RestartArguments = {};
+
+  /** Response to 'restart' request. This is just an acknowledgement, so no body field is required. */
+  declare interface RestartResponse extends base$Response {}
+
+  /** Disconnect request; value of command field is 'disconnect'. */
+  declare interface DisconnectRequest extends base$Request {
+    command: 'disconnect',
+    arguments?: DisconnectArguments,
+  }
+
+  /** Arguments for 'disconnect' request. */
+  declare type DisconnectArguments = {
+    /** Indicates whether the debuggee should be terminated when the debugger is disconnected.
+      If unspecified, the debug adapter is free to do whatever it thinks is best.
+      A client can only rely on this attribute being properly honored if a debug adapter returns true for the 'supportTerminateDebuggee' capability.
+    */
+    terminateDebuggee?: boolean,
+  };
+
+  /** Response to 'disconnect' request. This is just an acknowledgement, so no body field is required. */
+  declare interface DisconnectResponse extends base$Response {}
+
+  /** SetBreakpoints request; value of command field is 'setBreakpoints'.
+    Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
+    To clear all breakpoint for a source, specify an empty array.
+    When a breakpoint is hit, a StoppedEvent (event type 'breakpoint') is generated.
+  */
+  declare interface SetBreakpointsRequest extends base$Request {
+    command: 'setBreakpoints',
+    arguments: SetBreakpointsArguments,
+  }
+
+  /** Arguments for 'setBreakpoints' request. */
+  declare type SetBreakpointsArguments = {
+    /** The source location of the breakpoints; either source.path or source.reference must be specified. */
+    source: Source,
+    /** The code locations of the breakpoints. */
+    breakpoints?: SourceBreakpoint[],
+    /** Deprecated: The code locations of the breakpoints. */
+    lines?: number[],
+    /** A value of true indicates that the underlying source has been modified which results in new breakpoint locations. */
+    sourceModified?: boolean,
+  };
+
+  /** Response to 'setBreakpoints' request.
+    Returned is information about each breakpoint created by this request.
+    This includes the actual code location and whether the breakpoint could be verified.
+    The breakpoints returned are in the same order as the elements of the 'breakpoints'
+    (or the deprecated 'lines') in the SetBreakpointsArguments.
+  */
+  declare interface SetBreakpointsResponse extends base$Response {
+    body: {
+      /** Information about the breakpoints. The array elements are in the same order as the elements of the 'breakpoints' (or the deprecated 'lines') in the SetBreakpointsArguments. */
+      breakpoints: Breakpoint[],
+    },
+  }
+
+  /** SetFunctionBreakpoints request; value of command field is 'setFunctionBreakpoints'.
+    Sets multiple function breakpoints and clears all previous function breakpoints.
+    To clear all function breakpoint, specify an empty array.
+    When a function breakpoint is hit, a StoppedEvent (event type 'function breakpoint') is generated.
+  */
+  declare interface SetFunctionBreakpointsRequest extends base$Request {
+    command: 'setFunctionBreakpoints',
+    arguments: SetFunctionBreakpointsArguments,
+  }
+
+  /** Arguments for 'setFunctionBreakpoints' request. */
+  declare type SetFunctionBreakpointsArguments = {
+    /** The function names of the breakpoints. */
+    breakpoints: FunctionBreakpoint[],
+  };
+
+  /** Response to 'setFunctionBreakpoints' request.
+    Returned is information about each breakpoint created by this request.
+  */
+  declare interface SetFunctionBreakpointsResponse extends base$Response {
+    body: {
+      /** Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array. */
+      breakpoints: Breakpoint[],
+    },
+  }
+
+  /** SetExceptionBreakpoints request; value of command field is 'setExceptionBreakpoints'.
+    The request configures the debuggers response to thrown exceptions. If an exception is configured to break, a StoppedEvent is fired (event type 'exception').
+  */
+  declare interface SetExceptionBreakpointsRequest extends base$Request {
+    command: 'setExceptionBreakpoints',
+    arguments: SetExceptionBreakpointsArguments,
+  }
+
+  /** Arguments for 'setExceptionBreakpoints' request. */
+  declare type SetExceptionBreakpointsArguments = {
+    /** IDs of checked exception options. The set of IDs is returned via the 'exceptionBreakpointFilters' capability. */
+    filters: string[],
+    /** Configuration options for selected exceptions. */
+    exceptionOptions?: ExceptionOptions[],
+  };
+
+  /** Response to 'setExceptionBreakpoints' request. This is just an acknowledgement, so no body field is required. */
+  declare interface SetExceptionBreakpointsResponse extends base$Response {}
+
+  /** Continue request; value of command field is 'continue'.
+    The request starts the debuggee to run again.
+  */
+  declare interface ContinueRequest extends base$Request {
+    command: 'continue',
+    arguments: ContinueArguments,
+  }
+
+  /** Arguments for 'continue' request. */
+  declare type ContinueArguments = {
+    /** Continue execution for the specified thread (if possible). If the backend cannot continue on a single thread but will continue on all threads, it should set the allThreadsContinued attribute in the response to true. */
+    threadId: number,
+  };
+
+  /** Response to 'continue' request. */
+  declare interface ContinueResponse extends base$Response {
+    body: {
+      /** If true, the continue request has ignored the specified thread and continued all threads instead. If this attribute is missing a value of 'true' is assumed for backward compatibility. */
+      allThreadsContinued?: boolean,
+    },
+  }
+
+  declare interface nuclide_ContinueToLocationRequest extends base$Request {
+    command: 'nuclide_continueToLocation',
+    arguments: nuclide_ContinueToLocationArguments,
+  }
+
+  /** Arguments for 'nuclide_continueToLocation' request. */
+  declare interface nuclide_ContinueToLocationArguments {
+    /** The source location for which the goto targets are determined. */
+    source: Source,
+    /** The line location for which the goto targets are determined. */
+    line: number,
+    /** An optional column location for which the goto targets are determined. */
+    column?: number,
+  }
+
+  /** Response to 'nuclide_continueToLocation' request. */
+  declare interface nuclide_ContinueToLocationResponse extends base$Response {}
+
+  /** Next request; value of command field is 'next'.
+    The request starts the debuggee to run again for one step.
+    The debug adapter first sends the NextResponse and then a StoppedEvent (event type 'step') after the step has completed.
+  */
+  declare interface NextRequest extends base$Request {
+    command: 'next',
+    arguments: NextArguments,
+  }
+
+  /** Arguments for 'next' request. */
+  declare type NextArguments = {
+    /** Execute 'next' for this thread. */
+    threadId: number,
+  };
+
+  /** Response to 'next' request. This is just an acknowledgement, so no body field is required. */
+  declare interface NextResponse extends base$Response {}
+
+  /** StepIn request; value of command field is 'stepIn'.
+    The request starts the debuggee to step into a function/method if possible.
+    If it cannot step into a target, 'stepIn' behaves like 'next'.
+    The debug adapter first sends the StepInResponse and then a StoppedEvent (event type 'step') after the step has completed.
+    If there are multiple function/method calls (or other targets) on the source line,
+    the optional argument 'targetId' can be used to control into which target the 'stepIn' should occur.
+    The list of possible targets for a given source line can be retrieved via the 'stepInTargets' request.
+  */
+  declare interface StepInRequest extends base$Request {
+    command: 'stepIn',
+    arguments: StepInArguments,
+  }
+
+  /** Arguments for 'stepIn' request. */
+  declare type StepInArguments = {
+    /** Execute 'stepIn' for this thread. */
+    threadId: number,
+    /** Optional id of the target to step into. */
+    targetId?: number,
+  };
+
+  /** Response to 'stepIn' request. This is just an acknowledgement, so no body field is required. */
+  declare interface StepInResponse extends base$Response {}
+
+  /** StepOut request; value of command field is 'stepOut'.
+    The request starts the debuggee to run again for one step.
+    The debug adapter first sends the StepOutResponse and then a StoppedEvent (event type 'step') after the step has completed.
+  */
+  declare interface StepOutRequest extends base$Request {
+    command: 'stepOut',
+    arguments: StepOutArguments,
+  }
+
+  /** Arguments for 'stepOut' request. */
+  declare type StepOutArguments = {
+    /** Execute 'stepOut' for this thread. */
+    threadId: number,
+  };
+
+  /** Response to 'stepOut' request. This is just an acknowledgement, so no body field is required. */
+  declare interface StepOutResponse extends base$Response {}
+
+  /** StepBack request; value of command field is 'stepBack'.
+    The request starts the debuggee to run one step backwards.
+    The debug adapter first sends the StepBackResponse and then a StoppedEvent (event type 'step') after the step has completed. Clients should only call this request if the capability supportsStepBack is true.
+  */
+  declare interface StepBackRequest extends base$Request {
+    command: 'stepBack',
+    arguments: StepBackArguments,
+  }
+
+  /** Arguments for 'stepBack' request. */
+  declare type StepBackArguments = {
+    /** Exceute 'stepBack' for this thread. */
+    threadId: number,
+  };
+
+  /** Response to 'stepBack' request. This is just an acknowledgement, so no body field is required. */
+  declare interface StepBackResponse extends base$Response {}
+
+  /** ReverseContinue request; value of command field is 'reverseContinue'.
+    The request starts the debuggee to run backward. Clients should only call this request if the capability supportsStepBack is true.
+  */
+  declare interface ReverseContinueRequest extends base$Request {
+    command: 'reverseContinue',
+    arguments: ReverseContinueArguments,
+  }
+
+  /** Arguments for 'reverseContinue' request. */
+  declare type ReverseContinueArguments = {
+    /** Exceute 'reverseContinue' for this thread. */
+    threadId: number,
+  };
+
+  /** Response to 'reverseContinue' request. This is just an acknowledgement, so no body field is required. */
+  declare interface ReverseContinueResponse extends base$Response {}
+
+  /** RestartFrame request; value of command field is 'restartFrame'.
+    The request restarts execution of the specified stackframe.
+    The debug adapter first sends the RestartFrameResponse and then a StoppedEvent (event type 'restart') after the restart has completed.
+  */
+  declare interface RestartFrameRequest extends base$Request {
+    command: 'restartFrame',
+    arguments: RestartFrameArguments,
+  }
+
+  /** Arguments for 'restartFrame' request. */
+  declare type RestartFrameArguments = {
+    /** Restart this stackframe. */
+    frameId: number,
+  };
+
+  /** Response to 'restartFrame' request. This is just an acknowledgement, so no body field is required. */
+  declare interface RestartFrameResponse extends base$Response {}
+
+  /** Goto request; value of command field is 'goto'.
+    The request sets the location where the debuggee will continue to run.
+    This makes it possible to skip the execution of code or to executed code again.
+    The code between the current location and the goto target is not executed but skipped.
+    The debug adapter first sends the GotoResponse and then a StoppedEvent (event type 'goto').
+  */
+  declare interface GotoRequest extends base$Request {
+    command: 'goto',
+    arguments: GotoArguments,
+  }
+
+  /** Arguments for 'goto' request. */
+  declare type GotoArguments = {
+    /** Set the goto target for this thread. */
+    threadId: number,
+    /** The location where the debuggee will continue to run. */
+    targetId: number,
+  };
+
+  /** Response to 'goto' request. This is just an acknowledgement, so no body field is required. */
+  declare interface GotoResponse extends base$Response {}
+
+  /** Pause request; value of command field is 'pause'.
+    The request suspenses the debuggee.
+    The debug adapter first sends the PauseResponse and then a StoppedEvent (event type 'pause') after the thread has been paused successfully.
+  */
+  declare interface PauseRequest extends base$Request {
+    command: 'pause',
+    arguments: PauseArguments,
+  }
+
+  /** Arguments for 'pause' request. */
+  declare type PauseArguments = {
+    /** Pause execution for this thread. */
+    threadId: number,
+  };
+
+  /** Response to 'pause' request. This is just an acknowledgement, so no body field is required. */
+  declare interface PauseResponse extends base$Response {}
+
+  /** StackTrace request; value of command field is 'stackTrace'. The request returns a stacktrace from the current execution state. */
+  declare interface StackTraceRequest extends base$Request {
+    command: 'stackTrace',
+    arguments: StackTraceArguments,
+  }
+
+  /** Arguments for 'stackTrace' request. */
+  declare type StackTraceArguments = {
+    /** Retrieve the stacktrace for this thread. */
+    threadId: number,
+    /** The index of the first frame to return; if omitted frames start at 0. */
+    startFrame?: number,
+    /** The maximum number of frames to return. If levels is not specified or 0, all frames are returned. */
+    levels?: number,
+    /** Specifies details on how to format the stack frames. */
+    format?: StackFrameFormat,
+  };
+
+  /** Response to 'stackTrace' request. */
+  declare interface StackTraceResponse extends base$Response {
+    body: {
+      /** The frames of the stackframe. If the array has length zero, there are no stackframes available.
+        This means that there is no location information available.
+      */
+      stackFrames: StackFrame[],
+      /** The total number of frames available. */
+      totalFrames?: number,
+    },
+  }
+
+  /** Scopes request; value of command field is 'scopes'.
+    The request returns the variable scopes for a given stackframe ID.
+  */
+  declare interface ScopesRequest extends base$Request {
+    command: 'scopes',
+    arguments: ScopesArguments,
+  }
+
+  /** Arguments for 'scopes' request. */
+  declare type ScopesArguments = {
+    /** Retrieve the scopes for this stackframe. */
+    frameId: number,
+  };
+
+  /** Response to 'scopes' request. */
+  declare interface ScopesResponse extends base$Response {
+    body: {
+      /** The scopes of the stackframe. If the array has length zero, there are no scopes available. */
+      scopes: Scope[],
+    },
+  }
+
+  /** Variables request; value of command field is 'variables'.
+    Retrieves all child variables for the given variable reference.
+    An optional filter can be used to limit the fetched children to either named or indexed children.
+  */
+  declare interface VariablesRequest extends base$Request {
+    command: 'variables',
+    arguments: VariablesArguments,
+  }
+
+  /** Arguments for 'variables' request. */
+  declare type VariablesArguments = {
+    /** The Variable reference. */
+    variablesReference: number,
+    /** Optional filter to limit the child variables to either named or indexed. If omitted, both types are fetched. */
+    filter?: 'indexed' | 'named',
+    /** The index of the first variable to return; if omitted children start at 0. */
+    start?: number,
+    /** The number of variables to return. If count is missing or 0, all variables are returned. */
+    count?: number,
+    /** Specifies details on how to format the Variable values. */
+    format?: ValueFormat,
+  };
+
+  /** Response to 'variables' request. */
+  declare interface VariablesResponse extends base$Response {
+    body: {
+      /** All (or a range) of variables for the given variable reference. */
+      variables: Variable[],
+    },
+  }
+
+  /** setVariable request; value of command field is 'setVariable'.
+    Set the variable with the given name in the variable container to a new value.
+  */
+  declare interface SetVariableRequest extends base$Request {
+    command: 'setVariable',
+    arguments: SetVariableArguments,
+  }
+
+  /** Arguments for 'setVariable' request. */
+  declare type SetVariableArguments = {
+    /** The reference of the variable container. */
+    variablesReference: number,
+    /** The name of the variable. */
+    name: string,
+    /** The value of the variable. */
+    value: string,
+    /** Specifies details on how to format the response value. */
+    format?: ValueFormat,
+  };
+
+  /** Response to 'setVariable' request. */
+  declare interface SetVariableResponse extends base$Response {
+    body: {
+      /** The new value of the variable. */
+      value: string,
+      /** The type of the new value. Typically shown in the UI when hovering over the value. */
+      type?: string,
+      /** If variablesReference is > 0, the new value is structured and its children can be retrieved by passing variablesReference to the VariablesRequest. */
+      variablesReference?: number,
+      /** The number of named child variables.
+        The client can use this optional information to present the variables in a paged UI and fetch them in chunks.
+      */
+      namedVariables?: number,
+      /** The number of indexed child variables.
+        The client can use this optional information to present the variables in a paged UI and fetch them in chunks.
+      */
+      indexedVariables?: number,
+    },
+  }
+
+  /** Source request; value of command field is 'source'.
+    The request retrieves the source code for a given source reference.
+  */
+  declare interface SourceRequest extends base$Request {
+    command: 'source',
+    arguments: SourceArguments,
+  }
+
+  /** Arguments for 'source' request. */
+  declare type SourceArguments = {
+    /** Specifies the source content to load. Either source.path or source.sourceReference must be specified. */
+    source?: Source,
+    /** The reference to the source. This is the same as source.sourceReference. This is provided for backward compatibility since old backends do not understand the 'source' attribute. */
+    sourceReference: number,
+  };
+
+  /** Response to 'source' request. */
+  declare interface SourceResponse extends base$Response {
+    body: {
+      /** Content of the source reference. */
+      content: string,
+      /** Optional content type (mime type) of the source. */
+      mimeType?: string,
+    },
+  }
+
+  /** Thread request; value of command field is 'threads'.
+    The request retrieves a list of all threads.
+  */
+  declare interface ThreadsRequest extends base$Request {
+    command: 'threads',
+  }
+
+  /** Response to 'threads' request. */
+  declare interface ThreadsResponse extends base$Response {
+    body: {
+      /** All threads. */
+      threads: Thread[],
+    },
+  }
+
+  /** Modules can be retrieved from the debug adapter with the ModulesRequest which can either return all modules or a range of modules to support paging. */
+  declare interface ModulesRequest extends base$Request {
+    command: 'modules',
+    arguments: ModulesArguments,
+  }
+
+  /** Arguments for 'modules' request. */
+  declare type ModulesArguments = {
+    /** The index of the first module to return; if omitted modules start at 0. */
+    startModule?: number,
+    /** The number of modules to return. If moduleCount is not specified or 0, all modules are returned. */
+    moduleCount?: number,
+  };
+
+  /** Response to 'modules' request. */
+  declare interface ModulesResponse extends base$Response {
+    body: {
+      /** All modules or range of modules. */
+      modules: Module[],
+      /** The total number of modules available. */
+      totalModules?: number,
+    },
+  }
+
+  /** Evaluate request; value of command field is 'evaluate'.
+    Evaluates the given expression in the context of the top most stack frame.
+    The expression has access to any variables and arguments that are in scope.
+  */
+  declare interface EvaluateRequest extends base$Request {
+    command: 'evaluate',
+    arguments: EvaluateArguments,
+  }
+
+  /** Arguments for 'evaluate' request. */
+  declare type EvaluateArguments = {
+    /** The expression to evaluate. */
+    expression: string,
+    /** Evaluate the expression in the scope of this stack frame. If not specified, the expression is evaluated in the global scope. */
+    frameId?: number,
+    /** The context in which the evaluate request is run. Possible values are 'watch' if evaluate is run in a watch, 'repl' if run from the REPL console, or 'hover' if run from a data hover. */
+    context?: string,
+    /** Specifies details on how to format the Evaluate result. */
+    format?: ValueFormat,
+  };
+
+  /** Response to 'evaluate' request. */
+  declare interface EvaluateResponse extends base$Response {
+    body: {
+      /** The result of the evaluate request. */
+      result: string,
+      /** The optional type of the evaluate result. */
+      type?: string,
+      /** If variablesReference is > 0, the evaluate result is structured and its children can be retrieved by passing variablesReference to the VariablesRequest. */
+      variablesReference: number,
+      /** The number of named child variables.
+        The client can use this optional information to present the variables in a paged UI and fetch them in chunks.
+      */
+      namedVariables?: number,
+      /** The number of indexed child variables.
+        The client can use this optional information to present the variables in a paged UI and fetch them in chunks.
+      */
+      indexedVariables?: number,
+    },
+  }
+
+  /** StepInTargets request; value of command field is 'stepInTargets'.
+    This request retrieves the possible stepIn targets for the specified stack frame.
+    These targets can be used in the 'stepIn' request.
+    The StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.
+  */
+  declare interface StepInTargetsRequest extends base$Request {
+    command: 'stepInTargets',
+    arguments: StepInTargetsArguments,
+  }
+
+  /** Arguments for 'stepInTargets' request. */
+  declare type StepInTargetsArguments = {
+    /** The stack frame for which to retrieve the possible stepIn targets. */
+    frameId: number,
+  };
+
+  /** Response to 'stepInTargets' request. */
+  declare interface StepInTargetsResponse extends base$Response {
+    body: {
+      /** The possible stepIn targets of the specified source location. */
+      targets: StepInTarget[],
+    },
+  }
+
+  /** GotoTargets request; value of command field is 'gotoTargets'.
+    This request retrieves the possible goto targets for the specified source location.
+    These targets can be used in the 'goto' request.
+    The GotoTargets request may only be called if the 'supportsGotoTargetsRequest' capability exists and is true.
+  */
+  declare interface GotoTargetsRequest extends base$Request {
+    command: 'gotoTargets',
+    arguments: GotoTargetsArguments,
+  }
+
+  /** Arguments for 'gotoTargets' request. */
+  declare type GotoTargetsArguments = {
+    /** The source location for which the goto targets are determined. */
+    source: Source,
+    /** The line location for which the goto targets are determined. */
+    line: number,
+    /** An optional column location for which the goto targets are determined. */
+    column?: number,
+  };
+
+  /** Response to 'gotoTargets' request. */
+  declare interface GotoTargetsResponse extends base$Response {
+    body: {
+      /** The possible goto targets of the specified location. */
+      targets: GotoTarget[],
+    },
+  }
+
+  /** CompletionsRequest request; value of command field is 'completions'.
+    Returns a list of possible completions for a given caret position and text.
+    The CompletionsRequest may only be called if the 'supportsCompletionsRequest' capability exists and is true.
+  */
+  declare interface CompletionsRequest extends base$Request {
+    command: 'completions',
+    arguments: CompletionsArguments,
+  }
+
+  /** Arguments for 'completions' request. */
+  declare type CompletionsArguments = {
+    /** Returns completions in the scope of this stack frame. If not specified, the completions are returned for the global scope. */
+    frameId?: number,
+    /** One or more source lines. Typically this is the text a user has typed into the debug console before he asked for completion. */
+    text: string,
+    /** The character position for which to determine the completion proposals. */
+    column: number,
+    /** An optional line for which to determine the completion proposals. If missing the first line of the text is assumed. */
+    line?: number,
+  };
+
+  /** Response to 'completions' request. */
+  declare interface CompletionsResponse extends base$Response {
+    body: {
+      /** The possible completions for . */
+      targets: CompletionItem[],
+    },
+  }
+
+  /** ExceptionInfoRequest request; value of command field is 'exceptionInfo'.
+    Retrieves the details of the exception that caused the StoppedEvent to be raised.
+  */
+  declare interface ExceptionInfoRequest extends base$Request {
+    command: 'exceptionInfo',
+    arguments: ExceptionInfoArguments,
+  }
+
+  /** Arguments for 'exceptionInfo' request. */
+  declare interface ExceptionInfoArguments {
+    /** Thread for which exception information should be retrieved. */
+    threadId: number,
+  }
+
+  /** Response to 'exceptionInfo' request. */
+  declare interface ExceptionInfoResponse extends base$Response {
+    body: {
+      /** ID of the exception that was thrown. */
+      exceptionId: string,
+      /** Descriptive text for the exception provided by the debug adapter. */
+      description?: string,
+      /** Mode that caused the exception notification to be raised. */
+      breakMode: ExceptionBreakMode,
+      /** Detailed information about the exception. */
+      details?: ExceptionDetails,
+    },
+  }
+
+  declare interface CustomRequest extends base$Request {}
+  declare interface CustomResponse extends base$Response {}
+
+  declare type Request =
+    | RunInTerminalRequest
+    | InitializeRequest
+    | ConfigurationDoneRequest
+    | LaunchRequest
+    | AttachRequest
+    | RestartRequest
+    | DisconnectRequest
+    | SetBreakpointsRequest
+    | SetFunctionBreakpointsRequest
+    | SetExceptionBreakpointsRequest
+    | ContinueRequest
+    | NextRequest
+    | StepInRequest
+    | StepOutRequest
+    | StepBackRequest
+    | ReverseContinueRequest
+    | RestartFrameRequest
+    | GotoRequest
+    | PauseRequest
+    | StackTraceRequest
+    | ScopesRequest
+    | VariablesRequest
+    | SetVariableRequest
+    | SourceRequest
+    | ThreadsRequest
+    | ModulesRequest
+    | EvaluateRequest
+    | StepInTargetsRequest
+    | GotoTargetsRequest
+    | CompletionsRequest
+    | ExceptionInfoRequest
+    | nuclide_ContinueToLocationRequest
+    | CustomRequest;
+  declare type Response =
+    | RunInTerminalResponse
+    | InitializeResponse
+    | ConfigurationDoneResponse
+    | LaunchResponse
+    | AttachResponse
+    | RestartResponse
+    | DisconnectResponse
+    | SetBreakpointsResponse
+    | SetFunctionBreakpointsResponse
+    | SetExceptionBreakpointsResponse
+    | ContinueResponse
+    | NextResponse
+    | StepInResponse
+    | StepOutResponse
+    | StepBackResponse
+    | ReverseContinueResponse
+    | RestartFrameResponse
+    | GotoResponse
+    | PauseResponse
+    | StackTraceResponse
+    | ScopesResponse
+    | VariablesResponse
+    | SetVariableResponse
+    | SourceResponse
+    | ThreadsResponse
+    | ModulesResponse
+    | EvaluateResponse
+    | StepInTargetsResponse
+    | GotoTargetsResponse
+    | CompletionsResponse
+    | ExceptionInfoResponse
+    | nuclide_ContinueToLocationResponse
+    | CustomResponse;
+  declare type Event =
+    | InitializedEvent
+    | StoppedEvent
+    | ContinuedEvent
+    | ExitedEvent
+    | TerminatedEvent
+    | ThreadEvent
+    | OutputEvent
+    | BreakpointEvent
+    | ModuleEvent;
+
+  declare type Capabilities = {
+    /** The debug adapter supports the configurationDoneRequest. */
+    supportsConfigurationDoneRequest?: boolean,
+    /** The debug adapter supports function breakpoints. */
+    supportsFunctionBreakpoints?: boolean,
+    /** The debug adapter supports conditional breakpoints. */
+    supportsConditionalBreakpoints?: boolean,
+    /** The debug adapter supports breakpoints that break execution after a specified number of hits. */
+    supportsHitConditionalBreakpoints?: boolean,
+    /** The debug adapter supports a (side effect free) evaluate request for data hovers. */
+    supportsEvaluateForHovers?: boolean,
+    /** Available filters or options for the setExceptionBreakpoints request. */
+    exceptionBreakpointFilters?: ExceptionBreakpointsFilter[],
+    /** The debug adapter supports stepping back via the stepBack and reverseContinue requests. */
+    supportsStepBack?: boolean,
+    /** The debug adapter supports setting a variable to a value. */
+    supportsSetVariable?: boolean,
+    /** The debug adapter supports restarting a frame. */
+    supportsRestartFrame?: boolean,
+    /** The debug adapter supports the gotoTargetsRequest. */
+    supportsGotoTargetsRequest?: boolean,
+    /** The debug adapter supports the stepInTargetsRequest. */
+    supportsStepInTargetsRequest?: boolean,
+    /** The debug adapter supports the completionsRequest. */
+    supportsCompletionsRequest?: boolean,
+    /** The debug adapter supports the modules request. */
+    supportsModulesRequest?: boolean,
+    /** The set of additional module information exposed by the debug adapter. */
+    // additionalModuleColumns?: ColumnDescriptor[];
+    /** Checksum algorithms supported by the debug adapter. */
+    // supportedChecksumAlgorithms?: ChecksumAlgorithm[];
+    /** The debug adapter supports the RestartRequest. In this case a client should not implement 'restart' by terminating and relaunching the adapter but by calling the RestartRequest. */
+    supportsRestartRequest?: boolean,
+    /** The debug adapter supports 'exceptionOptions' on the setExceptionBreakpoints request. */
+    supportsExceptionOptions?: boolean,
+    /** The debug adapter supports a 'format' attribute on the stackTraceRequest, variablesRequest, and evaluateRequest. */
+    supportsValueFormattingOptions?: boolean,
+    /** The debug adapter supports the exceptionInfo request. */
+    supportsExceptionInfoRequest?: boolean,
+    /** The debug adapter supports the 'terminateDebuggee' attribute on the 'disconnect' request. */
+    supportTerminateDebuggee?: boolean,
+  };
+
+  /** An ExceptionBreakpointsFilter is shown in the UI as an option for configuring how exceptions are dealt with. */
+  declare type ExceptionBreakpointsFilter = {
+    /** The internal ID of the filter. This value is passed to the setExceptionBreakpoints request. */
+    filter: string,
+    /** The name of the filter. This will be shown in the UI. */
+    label: string,
+    /** Initial value of the filter. If not specified a value 'false' is assumed. */
+    default?: boolean,
+  };
+
+  /** A structured message object. Used to return errors from requests. */
+  declare type Message = {
+    /** Unique identifier for the message. */
+    id: number,
+    /** A format string for the message. Embedded variables have the form '{name}'.
+      If variable name starts with an underscore character, the variable does not contain user data (PII) and can be safely used for telemetry purposes.
+    */
+    format: string,
+    /** An object used as a dictionary for looking up the variables in the format string. */
+    variables?: {[key: string]: string},
+    /** If true send to telemetry. */
+    sendTelemetry?: boolean,
+    /** If true show user. */
+    showUser?: boolean,
+    /** An optional url where additional information about this message can be found. */
+    url?: string,
+    /** An optional label that is presented to the user as the UI for opening the url. */
+    urlLabel?: string,
+  };
+
+  /** A Module object represents a row in the modules view.
+    Two attributes are mandatory: an id identifies a module in the modules view and is used in a ModuleEvent for identifying a module for adding, updating or deleting.
+    The name is used to minimally render the module in the UI.
+
+    Additional attributes can be added to the module. They will show up in the module View if they have a corresponding ColumnDescriptor.
+
+    To avoid an unnecessary proliferation of additional attributes with similar semantics but different names
+    we recommend to re-use attributes from the 'recommended' list below first, and only introduce new attributes if nothing appropriate could be found.
+  */
+  declare type Module = {
+    /** Unique identifier for the module. */
+    id: number | string,
+    /** A name of the module. */
+    name: string,
+    /** optional but recommended attributes.
+      always try to use these first before introducing additional attributes.
+
+      Logical full path to the module. The exact definition is implementation defined, but usually this would be a full path to the on-disk file for the module.
+    */
+    path?: string,
+    /** True if the module is optimized. */
+    isOptimized?: boolean,
+    /** True if the module is considered 'user code' by a debugger that supports 'Just My Code'. */
+    isUserCode?: boolean,
+    /** Version of Module. */
+    version?: string,
+    /** User understandable description of if symbols were found for the module (ex: 'Symbols Loaded', 'Symbols not found', etc. */
+    symbolStatus?: string,
+    /** Logical full path to the symbol file. The exact definition is implementation defined. */
+    symbolFilePath?: string,
+    /** Module created or modified. */
+    dateTimeStamp?: string,
+    /** Address range covered by this module. */
+    addressRange?: string,
+  };
+
+  /** A ColumnDescriptor specifies what module attribute to show in a column of the ModulesView, how to format it, and what the column's label should be.
+    It is only used if the underlying UI actually supports this level of customization.
+  */
+  declare type ColumnDescriptor = {
+    /** Name of the attribute rendered in this column. */
+    attributeName: string,
+    /** Header UI label of column. */
+    label: string,
+    /** Format to use for the rendered values in this column. TBD how the format strings looks like. */
+    format?: string,
+    /** Datatype of values in this column.  Defaults to 'string' if not specified. */
+    type?: 'string' | 'number' | 'boolean' | 'unixTimestampUTC',
+    /** Width of this column in characters (hint only). */
+    width?: number,
+  };
+
+  /** The ModulesViewDescriptor is the container for all declarative configuration options of a ModuleView.
+    For now it only specifies the columns to be shown in the modules view.
+  */
+  declare type ModulesViewDescriptor = {
+    columns: ColumnDescriptor[],
+  };
+
+  /** A Thread */
+  declare type Thread = {
+    /** Unique identifier for the thread. */
+    id: number,
+    /** A name of the thread. */
+    name: string,
+  };
+
+  /** A Source is a descriptor for source code. It is returned from the debug adapter as part of a StackFrame and it is used by clients when specifying breakpoints. */
+  declare type Source = {
+    /** The short name of the source. Every source returned from the debug adapter has a name. When sending a source to the debug adapter this name is optional. */
+    name?: string,
+    /** The path of the source to be shown in the UI. It is only used to locate and load the content of the source if no sourceReference is specified (or its vaule is 0). */
+    path?: string,
+    /** If sourceReference > 0 the contents of the source must be retrieved through the SourceRequest (even if a path is specified). A sourceReference is only valid for a session, so it must not be used to persist a source. */
+    sourceReference?: number,
+    /** An optional hint for how to present the source in the UI. A value of 'deemphasize' can be used to indicate that the source is not available or that it is skipped on stepping. */
+    presentationHint?: 'emphasize' | 'deemphasize',
+    /** The (optional) origin of this source: possible values 'internal module', 'inlined content from source map', etc. */
+    origin?: string,
+    /** Optional data that a debug adapter might want to loop through the client. The client should leave the data intact and persist it across sessions. The client should not interpret the data. */
+    adapterData?: any,
+    /** The checksums associated with this file. */
+    checksums?: Checksum[],
+  };
+
+  /** A Stackframe contains the source location. */
+  declare type StackFrame = {
+    /** An identifier for the stack frame. It must be unique across all threads. This id can be used to retrieve the scopes of the frame with the 'scopesRequest' or to restart the execution of a stackframe. */
+    id: number,
+    /** The name of the stack frame, typically a method name. */
+    name: string,
+    /** The optional source of the frame. */
+    source?: Source,
+    /** The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored. */
+    line: number,
+    /** The column within the line. If source is null or doesn't exist, column is 0 and must be ignored. */
+    column: number,
+    /** An optional end line of the range covered by the stack frame. */
+    endLine?: number,
+    /** An optional end column of the range covered by the stack frame. */
+    endColumn?: number,
+    /** The module associated with this frame, if any. */
+    moduleId?: number | string,
+    /** An optional hint for how to present this frame in the UI. A value of 'label' can be used to indicate that the frame is an artificial frame that is used as a visual label or separator. */
+    presentationHint?: 'normal' | 'label',
+  };
+
+  /** A Scope is a named container for variables. Optionally a scope can map to a source or a range within a source. */
+  declare type Scope = {
+    /** Name of the scope such as 'Arguments', 'Locals'. */
+    name: string,
+    /** The variables of this scope can be retrieved by passing the value of variablesReference to the VariablesRequest. */
+    variablesReference: number,
+    /** The number of named variables in this scope.
+      The client can use this optional information to present the variables in a paged UI and fetch them in chunks.
+    */
+    namedVariables?: number,
+    /** The number of indexed variables in this scope.
+      The client can use this optional information to present the variables in a paged UI and fetch them in chunks.
+    */
+    indexedVariables?: number,
+    /** If true, the number of variables in this scope is large or expensive to retrieve. */
+    expensive: boolean,
+    /** Optional source for this scope. */
+    source?: Source,
+    /** Optional start line of the range covered by this scope. */
+    line?: number,
+    /** Optional start column of the range covered by this scope. */
+    column?: number,
+    /** Optional end line of the range covered by this scope. */
+    endLine?: number,
+    /** Optional end column of the range covered by this scope. */
+    endColumn?: number,
+  };
+
+  /** A Variable is a name/value pair.
+    Optionally a variable can have a 'type' that is shown if space permits or when hovering over the variable's name.
+    An optional 'kind' is used to render additional properties of the variable, e.g. different icons can be used to indicate that a variable is public or private.
+    If the value is structured (has children), a handle is provided to retrieve the children with the VariablesRequest.
+    If the number of named or indexed children is large, the numbers should be returned via the optional 'namedVariables' and 'indexedVariables' attributes.
+    The client can use this optional information to present the children in a paged UI and fetch them in chunks.
+  */
+  declare type Variable = {
+    /** The variable's name. */
+    name: string,
+    /** The variable's value. This can be a multi-line text, e.g. for a function the body of a function. */
+    value: string,
+    /** The type of the variable's value. Typically shown in the UI when hovering over the value. */
+    type?: string,
+    /** Properties of a variable that can be used to determine how to render the variable in the UI. Format of the string value: TBD. */
+    kind?: string,
+    /** Optional evaluatable name of this variable which can be passed to the 'EvaluateRequest' to fetch the variable's value. */
+    evaluateName?: string,
+    /** If variablesReference is > 0, the variable is structured and its children can be retrieved by passing variablesReference to the VariablesRequest. */
+    variablesReference: number,
+    /** The number of named child variables.
+      The client can use this optional information to present the children in a paged UI and fetch them in chunks.
+    */
+    namedVariables?: number,
+    /** The number of indexed child variables.
+      The client can use this optional information to present the children in a paged UI and fetch them in chunks.
+    */
+    indexedVariables?: number,
+  };
+
+  /** Properties of a breakpoint passed to the setBreakpoints request. */
+  declare type SourceBreakpoint = {
+    /** The source line of the breakpoint. */
+    line: number,
+    /** An optional source column of the breakpoint. */
+    column?: number,
+    /** An optional expression for conditional breakpoints. */
+    condition?: string,
+    /** An optional expression that controls how many hits of the breakpoint are ignored. The backend is expected to interpret the expression as needed. */
+    hitCondition?: string,
+  };
+
+  /** Properties of a breakpoint passed to the setFunctionBreakpoints request. */
+  declare type FunctionBreakpoint = {
+    /** The name of the function. */
+    name: string,
+    /** An optional expression for conditional breakpoints. */
+    condition?: string,
+    /** An optional expression that controls how many hits of the breakpoint are ignored. The backend is expected to interpret the expression as needed. */
+    hitCondition?: string,
+  };
+
+  /** Information about a Breakpoint created in setBreakpoints or setFunctionBreakpoints. */
+  declare type Breakpoint = {
+    /** An optional unique identifier for the breakpoint. */
+    id?: number,
+    /** If true breakpoint could be set (but not necessarily at the desired location). */
+    verified: boolean,
+    /** An optional message about the state of the breakpoint. This is shown to the user and can be used to explain why a breakpoint could not be verified. */
+    message?: string,
+    /** The source where the breakpoint is located. */
+    source?: Source,
+    /** The start line of the actual range covered by the breakpoint. */
+    line?: number,
+    /** An optional start column of the actual range covered by the breakpoint. */
+    column?: number,
+    /** An optional end line of the actual range covered by the breakpoint. */
+    endLine?: number,
+    /** An optional end column of the actual range covered by the breakpoint. If no end line is given, then the end column is assumed to be in the start line. */
+    endColumn?: number,
+
+    /** Nuclide custom extensions **/
+    nuclide_hitCount?: number,
+  };
+
+  /** A StepInTarget can be used in the 'stepIn' request and determines into which single target the stepIn request should step. */
+  declare type StepInTarget = {
+    /** Unique identifier for a stepIn target. */
+    id: number,
+    /** The name of the stepIn target (shown in the UI). */
+    label: string,
+  };
+
+  /** A GotoTarget describes a code location that can be used as a target in the 'goto' request.
+    The possible goto targets can be determined via the 'gotoTargets' request.
+  */
+  declare type GotoTarget = {
+    /** Unique identifier for a goto target. This is used in the goto request. */
+    id: number,
+    /** The name of the goto target (shown in the UI). */
+    label: string,
+    /** The line of the goto target. */
+    line: number,
+    /** An optional column of the goto target. */
+    column?: number,
+    /** An optional end line of the range covered by the goto target. */
+    endLine?: number,
+    /** An optional end column of the range covered by the goto target. */
+    endColumn?: number,
+  };
+
+  /** CompletionItems are the suggestions returned from the CompletionsRequest. */
+  declare type CompletionItem = {
+    /** The label of this completion item. By default this is also the text that is inserted when selecting this completion. */
+    label: string,
+    /** If text is not falsy then it is inserted instead of the label. */
+    text?: string,
+    /** The item's type. Typically the client uses this information to render the item in the UI with an icon. */
+    type?: CompletionItemType,
+    /** This value determines the location (in the CompletionsRequest's 'text' attribute) where the completion text is added.
+      If missing the text is added at the location specified by the CompletionsRequest's 'column' attribute.
+    */
+    start?: number,
+    /** This value determines how many characters are overwritten by the completion text.
+      If missing the value 0 is assumed which results in the completion text being inserted.
+    */
+    length?: number,
+  };
+
+  /** Some predefined types for the CompletionItem. Please note that not all clients have specific icons for all of them. */
+  declare type CompletionItemType =
+    | 'method'
+    | 'function'
+    | 'constructor'
+    | 'field'
+    | 'variable'
+    | 'class'
+    | 'interface'
+    | 'module'
+    | 'property'
+    | 'unit'
+    | 'value'
+    | 'enum'
+    | 'keyword'
+    | 'snippet'
+    | 'text'
+    | 'color'
+    | 'file'
+    | 'reference'
+    | 'customcolor';
+
+  /** Names of checksum algorithms that may be supported by a debug adapter. */
+  declare type ChecksumAlgorithm = 'MD5' | 'SHA1' | 'SHA256' | 'timestamp';
+
+  /** The checksum of an item calculated by the specified algorithm. */
+  declare type Checksum = {
+    /** The algorithm used to calculate this checksum. */
+    algorithm: ChecksumAlgorithm,
+    /** Value of the checksum. */
+    checksum: string,
+  };
+
+  /** Provides formatting information for a value. */
+  declare type ValueFormat = {
+    /** Display the value in hex. */
+    hex?: boolean,
+  };
+
+  /** Provides formatting information for a stack frame. */
+  declare type StackFrameFormat = ValueFormat & {
+    /** Displays parameters for the stack frame. */
+    parameters?: boolean,
+    /** Displays the types of parameters for the stack frame. */
+    parameterTypes?: boolean,
+    /** Displays the names of parameters for the stack frame. */
+    parameterNames?: boolean,
+    /** Displays the values of parameters for the stack frame. */
+    parameterValues?: boolean,
+    /** Displays the line number of the stack frame. */
+    line?: boolean,
+    /** Displays the module of the stack frame. */
+    module?: boolean,
+  };
+
+  /** An ExceptionOptions assigns configuration options to a set of exceptions. */
+  declare type ExceptionOptions = {
+    /** A path that selects a single or multiple exceptions in a tree. If 'path' is missing, the whole tree is selected. By convention the first segment of the path is a category that is used to group exceptions in the UI. */
+    path?: ExceptionPathSegment[],
+    /** Condition when a thrown exception should result in a break. */
+    breakMode: ExceptionBreakMode,
+  };
+
+  /** This enumeration defines all possible conditions when a thrown exception should result in a break.
+    never: never breaks,
+    always: always breaks,
+    unhandled: breaks when excpetion unhandled,
+    userUnhandled: breaks if the exception is not handled by user code.
+  */
+  declare type ExceptionBreakMode =
+    | 'never'
+    | 'always'
+    | 'unhandled'
+    | 'userUnhandled';
+
+  /** An ExceptionPathSegment represents a segment in a path that is used to match leafs or nodes in a tree of exceptions. If a segment consists of more than one name, it matches the names provided if 'negate' is false or missing or it matches anything except the names provided if 'negate' is true. */
+  declare type ExceptionPathSegment = {
+    /** If false or missing this segment matches the names provided, otherwise it matches anything except the names provided. */
+    negate?: boolean,
+    /** Depending on the value of 'negate' the names that should match or not match. */
+    names: string[],
+  };
+
+  /** Detailed information about an exception that has occurred. */
+  declare type ExceptionDetails = {
+    /** Message contained in the exception. */
+    message?: string,
+    /** Short type name of the exception object. */
+    typeName?: string,
+    /** Fully-qualified type name of the exception object. */
+    fullTypeName?: string,
+    /** Optional expression that can be evaluated in the current scope to obtain the exception object. */
+    evaluateName?: string,
+    /** Stack trace at the time the exception was thrown. */
+    stackTrace?: string,
+    /** Details of the exception contained by this exception, if any. */
+    innerException?: ExceptionDetails[],
+  };
+}


### PR DESCRIPTION
Release notes: none
Summary:
- Add defined flow libs
- Starting with vscode-debugadapter and vscode-debugprotocol
    - vscode-debugprotocol obtained from public Nuclide open source
    - vscode-debugadapter generated using https://github.com/joarwilk/flowgen and modified  

 Test Plan:
`yarn flow`