### PR TITLE
Distinguish Serialized Body from Generator Body

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -45,14 +45,13 @@ import { ResidualFunctions } from "./ResidualFunctions.js";
 //    the lower body entry is finished.
 //    To this end, the emitter maintains the `_activeBodies` and `_waitingForBodies` datastructures.
 export class Emitter {
-  constructor(residualFunctions: ResidualFunctions, delayInitializations: boolean) {
+  constructor(residualFunctions: ResidualFunctions) {
     let mainBody = { type: "MainGenerator", entries: [] };
     this._waitingForValues = new Map();
     this._waitingForBodies = new Map();
     this._body = mainBody;
     this._declaredAbstractValues = new Map();
     this._residualFunctions = residualFunctions;
-    this._delayInitializations = delayInitializations;
     this._activeStack = [];
     this._activeValues = new Set();
     this._activeBodies = [mainBody];
@@ -64,7 +63,6 @@ export class Emitter {
   _activeValues: Set<Value>;
   _activeBodies: Array<EmitBody>;
   _residualFunctions: ResidualFunctions;
-  _delayInitializations: boolean;
   _waitingForValues: Map<Value, Array<{ body: EmitBody, dependencies: Array<Value>, func: () => void }>>;
   _waitingForBodies: Map<EmitBody, Array<{ dependencies: Array<Value>, func: () => void }>>;
   _declaredAbstractValues: Map<AbstractValue, Array<EmitBody>>;

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -541,7 +541,7 @@ export class ResidualFunctions {
         // v8 seems to do something clever with array splicing, so this potentially
         // expensive operations seems to be actually cheap.
         Array.prototype.splice.apply(
-          insertionPoint.body,
+          insertionPoint.body.entries,
           ([insertionPoint.index, 0]: Array<any>).concat((functionBody: Array<any>))
         );
       }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1429,11 +1429,6 @@ export class ResidualHeapSerializer {
     return rewrittenAdditionalFunctions;
   }
 
-  // For overriding.
-  beforeFinalizeEmitter(): void {
-    // todo:
-  }
-
   serialize(): BabelNodeFile {
     this.generator.serialize(this._getContext());
     invariant(this.emitter._declaredAbstractValues.size <= this.preludeGenerator.derivedIds.size);
@@ -1452,7 +1447,6 @@ export class ResidualHeapSerializer {
 
     this.modules.resolveInitializedModules();
 
-    this.beforeFinalizeEmitter();
     this.emitter.finalize();
 
     this.residualFunctions.residualFunctionInitializers.factorifyInitializers(this.factoryNameGenerator);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -135,7 +135,7 @@ export class ResidualHeapSerializer {
       additionalFunctionValueInfos,
       this.additionalFunctionValueNestedFunctions
     );
-    this.emitter = new Emitter(this.residualFunctions, delayInitializations);
+    this.emitter = new Emitter(this.residualFunctions);
     this.mainBody = this.emitter.getBody();
     this.currentFunctionBody = this.mainBody;
     this.residualHeapInspector = residualHeapInspector;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -56,6 +56,7 @@ import type {
   FunctionInstance,
   AdditionalFunctionInfo,
   ReactSerializerState,
+  EmitBody,
 } from "./types.js";
 import { TimingStatistics, SerializerStatistics } from "./types.js";
 import { Logger } from "./logger.js";
@@ -121,7 +122,7 @@ export class ResidualHeapSerializer {
         getLocation: value => this.residualHeapValueIdentifiers.getIdentifierAndIncrementReferenceCountOptional(value),
         createLocation: () => {
           let location = t.identifier(this.valueNameGenerator.generate("initialized"));
-          this.currentFunctionBody.push(t.variableDeclaration("var", [t.variableDeclarator(location)]));
+          this.currentFunctionBody.entries.push(t.variableDeclaration("var", [t.variableDeclarator(location)]));
           return location;
         },
       },
@@ -153,10 +154,10 @@ export class ResidualHeapSerializer {
   functionInstances: Array<FunctionInstance>;
   prelude: Array<BabelNodeStatement>;
   body: Array<BabelNodeStatement>;
-  mainBody: Array<BabelNodeStatement>;
+  mainBody: EmitBody;
   // if we're in an additional function we need to access both mainBody and the
   // additional function's body which will be currentFunctionBody.
-  currentFunctionBody: Array<BabelNodeStatement>;
+  currentFunctionBody: EmitBody;
   realm: Realm;
   preludeGenerator: PreludeGenerator;
   generator: Generator;
@@ -181,7 +182,7 @@ export class ResidualHeapSerializer {
   residualFunctions: ResidualFunctions;
   delayInitializations: boolean;
   referencedDeclaredValues: Set<AbstractValue>;
-  activeGeneratorBodies: Map<Generator, Array<BabelNodeStatement>>;
+  activeGeneratorBodies: Map<Generator, EmitBody>;
   additionalFunctionValuesAndEffects: Map<FunctionValue, Effects> | void;
   additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>;
   react: ReactSerializerState;
@@ -345,14 +346,14 @@ export class ResidualHeapSerializer {
       invariant(consequent instanceof AbstractValue);
       let alternate = absVal.args[2];
       invariant(alternate instanceof AbstractValue);
-      let oldBody = this.emitter.beginEmitting("consequent", []);
+      let oldBody = this.emitter.beginEmitting("consequent", { type: "Other", entries: [] });
       this._emitPropertiesWithComputedNames(obj, consequent);
       let consequentBody = this.emitter.endEmitting("consequent", oldBody);
-      let consequentStatement = t.blockStatement(consequentBody);
-      oldBody = this.emitter.beginEmitting("alternate", []);
+      let consequentStatement = t.blockStatement(consequentBody.entries);
+      oldBody = this.emitter.beginEmitting("alternate", { type: "Other", entries: [] });
       this._emitPropertiesWithComputedNames(obj, alternate);
       let alternateBody = this.emitter.endEmitting("alternate", oldBody);
-      let alternateStatement = t.blockStatement(alternateBody);
+      let alternateStatement = t.blockStatement(alternateBody.entries);
       this.emitter.emit(t.ifStatement(serializedCond, consequentStatement, alternateStatement));
     }
   }
@@ -481,7 +482,7 @@ export class ResidualHeapSerializer {
   _getTarget(
     val: Value,
     scopes: Set<Scope>
-  ): { body: Array<BabelNodeStatement>, usedOnlyByResidualFunctions?: true, usedOnlyByAdditionalFunctions?: boolean } {
+  ): { body: EmitBody, usedOnlyByResidualFunctions?: true, usedOnlyByAdditionalFunctions?: boolean } {
     // All relevant values were visited in at least one scope.
     invariant(scopes.size >= 1);
 
@@ -528,7 +529,7 @@ export class ResidualHeapSerializer {
           functionValues,
           val
         );
-        return { body, usedOnlyByResidualFunctions: true };
+        return { body: { type: "DelayInitialization", entries: body }, usedOnlyByResidualFunctions: true };
       }
     }
 
@@ -538,14 +539,17 @@ export class ResidualHeapSerializer {
     invariant(commonAncestor instanceof Generator); // every scope is either the root, or a descendant
     let body;
     while (true) {
-      if (commonAncestor === this.generator) body = this.currentFunctionBody;
-      else body = this.activeGeneratorBodies.get(commonAncestor);
+      if (commonAncestor === this.generator) {
+        body = this.currentFunctionBody;
+      } else {
+        body = this.activeGeneratorBodies.get(commonAncestor);
+      }
       if (body !== undefined) break;
       commonAncestor = commonAncestor.parent;
       invariant(commonAncestor !== undefined);
     }
     invariant(body !== undefined);
-    return { body: body };
+    return { body };
   }
 
   serializeValue(val: Value, referenceOnly?: boolean, bindingType?: BabelVariableKind): BabelNodeExpression {
@@ -580,7 +584,7 @@ export class ResidualHeapSerializer {
         if (init !== id) {
           if (target.usedOnlyByResidualFunctions) {
             let declar = t.variableDeclaration(bindingType ? bindingType : "var", [t.variableDeclarator(id)]);
-            this.mainBody.push(declar);
+            this.mainBody.entries.push(declar);
             let assignment = t.expressionStatement(t.assignmentExpression("=", id, init));
             this.emitter.emit(assignment);
           } else {
@@ -1274,13 +1278,13 @@ export class ResidualHeapSerializer {
     }
   }
 
-  _withGeneratorScope(generator: Generator, callback: (Array<BabelNodeStatement>) => void): Array<BabelNodeStatement> {
-    let newBody = [];
+  _withGeneratorScope(generator: Generator, callback: EmitBody => void): Array<BabelNodeStatement> {
+    let newBody = { type: "Generator", entries: [] };
     let oldBody = this.emitter.beginEmitting(generator, newBody);
     this.activeGeneratorBodies.set(generator, newBody);
     callback(newBody);
     this.activeGeneratorBodies.delete(generator);
-    return this.emitter.endEmitting(generator, oldBody);
+    return this.emitter.endEmitting(generator, oldBody).entries;
   }
 
   _getContext(): SerializationContext {
@@ -1425,6 +1429,11 @@ export class ResidualHeapSerializer {
     return rewrittenAdditionalFunctions;
   }
 
+  // For overriding.
+  beforeFinalizeEmitter(): void {
+    // todo:
+  }
+
   serialize(): BabelNodeFile {
     this.generator.serialize(this._getContext());
     invariant(this.emitter._declaredAbstractValues.size <= this.preludeGenerator.derivedIds.size);
@@ -1443,6 +1452,7 @@ export class ResidualHeapSerializer {
 
     this.modules.resolveInitializedModules();
 
+    this.beforeFinalizeEmitter();
     this.emitter.finalize();
 
     this.residualFunctions.residualFunctionInitializers.factorifyInitializers(this.factoryNameGenerator);
@@ -1489,7 +1499,7 @@ export class ResidualHeapSerializer {
         ])
       );
     }
-    let body = this.prelude.concat(this.emitter.getBody());
+    let body = this.prelude.concat(this.emitter.getBody().entries);
     factorifyObjects(body, this.factoryNameGenerator);
 
     let ast_body = [];

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -20,10 +20,10 @@ import invariant from "../invariant.js";
 export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) => T;
 
 // TODO: add type for additional functions.
-export type EmitBodyType = "MainGenerator" | "Generator" | "DelayInitialization" | "Other";
+export type SerializedBodyType = "MainGenerator" | "Generator" | "DelayInitializations" | "ConditionalAssignmentBranch";
 
-export type EmitBody = {
-  type: string,
+export type SerializedBody = {
+  type: SerializedBodyType,
   entries: Array<BabelNodeStatement>,
 };
 
@@ -91,7 +91,7 @@ export function AreSameResidualBinding(realm: Realm, x: ResidualFunctionBinding,
 }
 
 export class BodyReference {
-  constructor(body: EmitBody, index: number) {
+  constructor(body: SerializedBody, index: number) {
     invariant(index >= 0);
     this.body = body;
     this.index = index;
@@ -99,7 +99,7 @@ export class BodyReference {
   isNotEarlierThan(other: BodyReference): boolean {
     return this.body === other.body && this.index >= other.index;
   }
-  body: EmitBody;
+  body: SerializedBody;
   index: number;
 }
 

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -19,6 +19,14 @@ import invariant from "../invariant.js";
 
 export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) => T;
 
+// TODO: add type for additional functions.
+export type EmitBodyType = "MainGenerator" | "Generator" | "DelayInitialization" | "Other";
+
+export type EmitBody = {
+  type: string,
+  entries: Array<BabelNodeStatement>,
+};
+
 export type AdditionalFunctionInfo = {
   functionValue: FunctionValue,
   captures: Set<string>,
@@ -73,8 +81,6 @@ export type ScopeBinding = {
   containingAdditionalFunction: void | FunctionValue,
 };
 
-export type GeneratorBody = Array<BabelNodeStatement>;
-
 export function AreSameResidualBinding(realm: Realm, x: ResidualFunctionBinding, y: ResidualFunctionBinding) {
   if (x.serializedValue === y.serializedValue) return true;
   if (x.value && x.value === y.value) return true;
@@ -85,7 +91,7 @@ export function AreSameResidualBinding(realm: Realm, x: ResidualFunctionBinding,
 }
 
 export class BodyReference {
-  constructor(body: Array<BabelNodeStatement>, index: number) {
+  constructor(body: EmitBody, index: number) {
     invariant(index >= 0);
     this.body = body;
     this.index = index;
@@ -93,7 +99,7 @@ export class BodyReference {
   isNotEarlierThan(other: BodyReference): boolean {
     return this.body === other.body && this.index >= other.index;
   }
-  body: Array<BabelNodeStatement>;
+  body: EmitBody;
   index: number;
 }
 


### PR DESCRIPTION
Release Note: no
We used to only serialize all code into generator body(either main generator or child generator). But with recently changes, there are additional other emit bodies: delay initializations body, additional function body, and lazy objects body(coming). 
Without a type field to categorize these bodies, it is very hard to reason/debug in the emitter.
This is the first refactoring to add strong type to emit body and improve emitter reasoning.
It also fixed a TODO item in Emitter.