### PR TITLE
Refactor to consolidate all generator operations into Generator class itself

### DIFF
--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -210,27 +210,8 @@ function emitResidualLoopIfSafe(
           }
         }
         // add loop to generator
-        generator.addEntry({
-          // duplicate args to ensure refcount > 1
-          args: [o, targetObject, sourceObject, targetObject, sourceObject],
-          buildNode: ([obj, tgt, src, obj1, tgt1, src1]) => {
-            invariant(boundName !== undefined);
-            return t.forInStatement(
-              lh,
-              obj,
-              t.blockStatement([
-                t.expressionStatement(
-                  t.assignmentExpression(
-                    "=",
-                    t.memberExpression(tgt, boundName, true),
-                    t.memberExpression(src, boundName, true)
-                  )
-                ),
-              ])
-            );
-          },
-        });
-
+        invariant(boundName != null);
+        generator.emitForInStatement(o, lh, sourceObject, targetObject, boundName);
         return realm.intrinsics.undefined;
       }
     }


### PR DESCRIPTION
There are only three places that use addEntry() directly. This refactoring moves all three cases into the Generator class itself and mark _addEntry() private. By doing this, we can read Generator class itself to see all the generator entry adding logic instead of searching the whole codebase.