### PR TITLE
Support running tests in inferior JavaScript repl.

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -372,9 +372,9 @@ function runTest(name, code, options, args) {
   }
 }
 
-function testInferiorRepl(replPath) {
-  if (!fs.existsSync(replPath)) {
-    throw new ArgsParseError(`repl ${replPath} does not exist`);
+function prepareReplExternalSepc(procPath) {
+  if (!fs.existsSync(procPath)) {
+    throw new ArgsParseError(`runtime ${procPath} does not exist`);
   }
   // find out how to print
   let script = `
@@ -384,12 +384,12 @@ function testInferiorRepl(replPath) {
     else if (typeof('print') !== 'undefined') {
       print('print')
     }`;
-  let out = child_process.spawnSync(replPath, { input: script });
+  let out = child_process.spawnSync(procPath, { input: script });
   let output = String(out.stdout);
   if (output.trim() === "") {
-    throw new ArgsParseError(`could not figure out how to print in inferior repl ${replPath}`);
+    throw new ArgsParseError(`could not figure out how to print in inferior repl ${procPath}`);
   }
-  return { printName: output.trim(), cmd: replPath.trim() };
+  return { printName: output.trim(), cmd: procPath.trim() };
 }
 
 function run(args) {
@@ -397,7 +397,7 @@ function run(args) {
   let passed = 0;
   let total = 0;
   if (args.outOfProcessRuntime !== "") {
-    execSpec = testInferiorRepl(args.outOfProcessRuntime);
+    execSpec = prepareReplExternalSepc(args.outOfProcessRuntime);
   }
 
   for (let test of tests) {
@@ -460,7 +460,9 @@ function main(): number {
 // Helper function to provide correct usage information to the user
 function usage(): string {
   return (
-    `Usage: ${process.argv[0]} ${process.argv[1]} ` + EOL + `[--verbose] [--filter <string>] [--repl <path>] [--es5]`
+    `Usage: ${process.argv[0]} ${process.argv[1]} ` +
+    EOL +
+    `[--verbose] [--filter <string>] [--outOfProcessRuntime <path>] [--es5]`
   );
 }
 

--- a/test/serializer/abstract/SymbolAbstractValueDescription.js
+++ b/test/serializer/abstract/SymbolAbstractValueDescription.js
@@ -1,3 +1,4 @@
+// es6
 var someNumber = 5
 var someString = "hello"
 var abstractNumber = global.__abstract ? __abstract("number", "someNumber") : 5;

--- a/test/serializer/abstract/Symbols.js
+++ b/test/serializer/abstract/Symbols.js
@@ -1,3 +1,4 @@
+// es6
 (function() {
   var myObj = {};
   var fooSym = Symbol('foo');

--- a/test/serializer/abstract/Symbols2.js
+++ b/test/serializer/abstract/Symbols2.js
@@ -1,3 +1,4 @@
+// es6
 (function() {
   var myObj = {};
   var otherSym = Symbol('bar');

--- a/test/serializer/abstract/Symbols3.js
+++ b/test/serializer/abstract/Symbols3.js
@@ -1,3 +1,4 @@
+// es6
 (function() {
     let x = global.__abstract ? __abstract("boolean", "(true)") : true;
     let obj = {};

--- a/test/serializer/abstract/Symbols4.js
+++ b/test/serializer/abstract/Symbols4.js
@@ -1,3 +1,4 @@
+// es6
 (function() {
     //let x = global.__abstract ? __abstract("boolean", "(true)") : true;
     let obj = {};

--- a/test/serializer/abstract/WeakMap.js
+++ b/test/serializer/abstract/WeakMap.js
@@ -1,3 +1,4 @@
+// es6
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 let foo = { x: "yz" };
 let bar1 = { y: 1 };

--- a/test/serializer/abstract/WeakSet.js
+++ b/test/serializer/abstract/WeakSet.js
@@ -1,3 +1,4 @@
+// es6
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 let bar0 = { y: 0 };
 let bar1 = { y: 1 };

--- a/test/serializer/abstract/getOwnPropertyDescriptor7.js
+++ b/test/serializer/abstract/getOwnPropertyDescriptor7.js
@@ -1,3 +1,4 @@
+// es6
 let nondet = global.__abstract ? __abstract("boolean", "true") : true;
 global.a = undefined;
 let descriptor;

--- a/test/serializer/abstract/require_tracking.js
+++ b/test/serializer/abstract/require_tracking.js
@@ -1,3 +1,4 @@
+// es6
 // delay unsupported requires
 
 var modules = Object.create(null);

--- a/test/serializer/abstract/require_tracking2.js
+++ b/test/serializer/abstract/require_tracking2.js
@@ -1,3 +1,4 @@
+// es6
 // delay unsupported requires
 
 var modules = Object.create(null);

--- a/test/serializer/additional-functions/require_opt.js
+++ b/test/serializer/additional-functions/require_opt.js
@@ -1,3 +1,4 @@
+// es6
 // additional functions
 // does not contain:var y = 5;
 // does not contain:var y = 10;

--- a/test/serializer/basic/GlobalPropertyGetter.js
+++ b/test/serializer/basic/GlobalPropertyGetter.js
@@ -1,3 +1,4 @@
+// es6
 // We use the name "console" because it already exists.
 // Adding a non-existing property will break our test-runner in Node 7.x.x.
 Object.defineProperty(global, "console", {

--- a/test/serializer/basic/IteratorPrototype.js
+++ b/test/serializer/basic/IteratorPrototype.js
@@ -1,3 +1,4 @@
+// es6
 let IteratorPrototype = [][Symbol.iterator]().__proto__.__proto__;
 
 inspect = function() {

--- a/test/serializer/basic/MapIteratorPrototype.js
+++ b/test/serializer/basic/MapIteratorPrototype.js
@@ -1,3 +1,4 @@
+// es6
 let MapIteratorPrototype = new Map()[Symbol.iterator]().__proto__;
 
 inspect = function() {

--- a/test/serializer/basic/Prototypes.js
+++ b/test/serializer/basic/Prototypes.js
@@ -1,3 +1,4 @@
+// es6
 (function() {
   var a = [
     "Object", "Array", "Function", "Symbol", "String", 

--- a/test/serializer/basic/SetTimeout.js
+++ b/test/serializer/basic/SetTimeout.js
@@ -1,3 +1,4 @@
+// es6
 var st = global.setTimeout;
 global.setTimeout = function(x) {
   return st(x, y);

--- a/test/serializer/basic/Symbols.js
+++ b/test/serializer/basic/Symbols.js
@@ -1,3 +1,4 @@
+// es6
 it = Symbol.iterator;
 
 inspect = function() { return it === Symbol.iterator; }

--- a/test/serializer/basic/Symbols2.js
+++ b/test/serializer/basic/Symbols2.js
@@ -1,3 +1,4 @@
+// es6
 (function() {
     let a = Symbol.for("test");
     let b = Symbol.for("test");

--- a/test/serializer/basic/WeakMap.js
+++ b/test/serializer/basic/WeakMap.js
@@ -1,3 +1,4 @@
+// es6
 let a = {a:1};
 let b = {b:3};
 let c = {c:5};

--- a/test/serializer/basic/WeakSet.js
+++ b/test/serializer/basic/WeakSet.js
@@ -1,3 +1,4 @@
+// es6
 let a = {a:1};
 let b = {b:2};
 var m = new WeakSet([a, b]);

--- a/test/serializer/basic/setTimeoutAndInterval.js
+++ b/test/serializer/basic/setTimeoutAndInterval.js
@@ -1,3 +1,4 @@
+// es6
 // does contain:keep me
 (function() {
     let f = function() { /* keep me */ };

--- a/test/serializer/optimizations/require_accelerate.js
+++ b/test/serializer/optimizations/require_accelerate.js
@@ -1,3 +1,4 @@
+// es6
 // delay unsupported requires
 
 var modules = Object.create(null);

--- a/test/serializer/optimizations/require_delay.js
+++ b/test/serializer/optimizations/require_delay.js
@@ -1,3 +1,4 @@
+// es6
 // delay unsupported requires
 
 var modules = Object.create(null);

--- a/test/serializer/optimizations/require_hoist.js
+++ b/test/serializer/optimizations/require_hoist.js
@@ -1,3 +1,4 @@
+// es6
 var modules = Object.create(null);
 
 __d = define;

--- a/test/serializer/optimizations/require_opt.js
+++ b/test/serializer/optimizations/require_opt.js
@@ -1,3 +1,4 @@
+// es6
 // does not contain:(0)
 var modules = Object.create(null);
 

--- a/test/serializer/optimizations/require_spec_accelerate_delay.js
+++ b/test/serializer/optimizations/require_spec_accelerate_delay.js
@@ -1,3 +1,4 @@
+// es6
 // delay unsupported requires
 // initialize more modules
 

--- a/test/serializer/optimizations/require_speculatively.js
+++ b/test/serializer/optimizations/require_speculatively.js
@@ -1,3 +1,4 @@
+// es6
 // does not contain:r(0)
 // initialize more modules
 

--- a/test/serializer/react/default-props.js
+++ b/test/serializer/react/default-props.js
@@ -1,3 +1,4 @@
+// es6
 // react
 // babel:jsx
 

--- a/test/serializer/react/element-simple.js
+++ b/test/serializer/react/element-simple.js
@@ -1,3 +1,4 @@
+// es6
 // react
 // babel:jsx
 

--- a/test/serializer/react/jsx-simple.js
+++ b/test/serializer/react/jsx-simple.js
@@ -1,3 +1,4 @@
+// es6
 // react
 // babel:jsx
 

--- a/test/serializer/react/jsx-spread.js
+++ b/test/serializer/react/jsx-spread.js
@@ -1,3 +1,4 @@
+// es6
 // react
 // babel:jsx
 

--- a/test/serializer/react/key-children.js
+++ b/test/serializer/react/key-children.js
@@ -1,3 +1,4 @@
+// es6
 // react
 // babel:jsx
 


### PR DESCRIPTION
Define two new flags for test-runner.js:
 --repl <path> : If present the, the prepack sources of test are evaluated
using by piping to the process instead of in a new node context.
--es5 : run babel on tests, used if the repl does not support es6.

To further deal with es6 a new test header flag is introduced, es6. If a test is
not relevant in a non es6 world, the test is skipped if the es5 flag is also set.
This flag has been added to some tests.

Running subprocess for each test is obviously more expensive so the default
behavior is unchanged and still uses a new context.