### PR TITLE
Let + deal with implicit conversions that result in abstract values

### DIFF
--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -24,7 +24,7 @@ import {
   ToBoolean,
   ToInt32,
   ToNumber,
-  ToPrimitive,
+  ToPrimitiveOrAbstract,
   ToPropertyKey,
   ToString,
   ToUint32,
@@ -112,8 +112,12 @@ export default class ValuesDomain {
   static computeBinary(realm: Realm, op: BabelBinaryOperator, lval: ConcreteValue, rval: ConcreteValue): Value {
     if (op === "+") {
       // ECMA262 12.8.3 The Addition Operator
-      let lprim = ToPrimitive(realm, lval);
-      let rprim = ToPrimitive(realm, rval);
+      let lprim = ToPrimitiveOrAbstract(realm, lval);
+      let rprim = ToPrimitiveOrAbstract(realm, rval);
+
+      if (lprim instanceof AbstractValue || rprim instanceof AbstractValue) {
+        return AbstractValue.createFromBinaryOp(realm, op, lprim, rprim);
+      }
 
       if (lprim instanceof StringValue || rprim instanceof StringValue) {
         let lstr = ToString(realm, lprim);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -324,6 +324,11 @@ export default class AbstractValue extends Value {
     throw new FatalError();
   }
 
+  throwIfNotConcretePrimitive(): PrimitiveValue {
+    AbstractValue.reportIntrospectionError(this);
+    throw new FatalError();
+  }
+
   throwIfNotObject(): AbstractObjectValue {
     invariant(!(this instanceof AbstractObjectValue));
     AbstractValue.reportIntrospectionError(this);

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -15,6 +15,7 @@ import {
   NullValue,
   NumberValue,
   ObjectValue,
+  PrimitiveValue,
   StringValue,
   BooleanValue,
   SymbolValue,
@@ -104,6 +105,10 @@ export default class ConcreteValue extends Value {
 
   throwIfNotConcreteObject(): ObjectValue {
     return this.throwIfNotObject();
+  }
+
+  throwIfNotConcretePrimitive(): PrimitiveValue {
+    invariant(false, "expected this to be a primitive value if concrete");
   }
 
   throwIfNotObject(): ObjectValue {

--- a/src/values/PrimitiveValue.js
+++ b/src/values/PrimitiveValue.js
@@ -18,4 +18,8 @@ export default class PrimitiveValue extends ConcreteValue {
     invariant(realm, "realm required");
     super(realm, intrinsicName);
   }
+
+  throwIfNotConcretePrimitive(): PrimitiveValue {
+    return this;
+  }
 }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -12,17 +12,18 @@
 import type { BabelNodeSourceLocation } from "babel-types";
 import type { Realm } from "../realm.js";
 import {
-  EmptyValue,
-  UndefinedValue,
-  NullValue,
+  AbstractObjectValue,
   BooleanValue,
-  StringValue,
-  SymbolValue,
+  ConcreteValue,
+  EmptyValue,
+  FunctionValue,
+  NullValue,
   NumberValue,
   ObjectValue,
-  ConcreteValue,
-  AbstractObjectValue,
-  FunctionValue,
+  PrimitiveValue,
+  StringValue,
+  SymbolValue,
+  UndefinedValue,
 } from "./index.js";
 import invariant from "../invariant.js";
 
@@ -191,11 +192,11 @@ export default class Value {
     invariant(false, "abstract method; please override");
   }
 
-  throwIfNotObject(): ObjectValue | AbstractObjectValue {
+  throwIfNotConcretePrimitive(): PrimitiveValue {
     invariant(false, "abstract method; please override");
   }
 
-  throwIfNotConcreteString(): StringValue {
+  throwIfNotObject(): ObjectValue | AbstractObjectValue {
     invariant(false, "abstract method; please override");
   }
 

--- a/test/serializer/abstract/ToString2.js
+++ b/test/serializer/abstract/ToString2.js
@@ -1,0 +1,9 @@
+let x = global.__abstract ? __abstract("string", "('xxxx')") : "xxxx";
+let y = global.__abstract ? __abstract("number", "(3)") : 3;
+let ob =  { toString: () => x };
+let ob2 = { toString: () => x, valueOf: () => y}
+str = "aaa" + ob;
+num = 123 + ob2;
+
+
+inspect = function() { return str + num; }


### PR DESCRIPTION
The + operator already checks if its operands are abstract and generates a suitable abstract value as the result in that case. In the case of concrete operands that become abstract after conversion, however, it just gave up. 

This pull request fixes this by introducing a variation of ToPrimitive that can result in an abstract value and then using that in the place of ToPrimitive in computeBinary and dealing with the case where the result is abstract.