### PR TITLE
Adapter respond to UI through callbacks

### DIFF
--- a/src/debugger/DebuggerConstants.js
+++ b/src/debugger/DebuggerConstants.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+export class DebuggerConstants {
+  // request ID used between the debug adapter and Prepack when there is no
+  // corresponding command from the UI. Currently, this is only used on starting
+  // up Prepack
+  static DEFAULT_REQUEST_ID: number = 0;
+}

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -164,7 +164,10 @@ class PrepackDebugSession extends LoggingDebugSession {
   }
 
   _processRequestCallback(requestID: number, message: string) {
-    invariant(requestID in this._pendingRequestCallbacks, "Request ID does not exist in pending requests: " + requestID);
+    invariant(
+      requestID in this._pendingRequestCallbacks,
+      "Request ID does not exist in pending requests: " + requestID
+    );
     let callback = this._pendingRequestCallbacks[requestID];
     callback(message);
   }

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -41,6 +41,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     this.setDebuggerColumnsStartAt1(true);
 
     this._prepackWaiting = false;
+    this._pendingRequestCallbacks = new Map();
     this._readCLIParameters();
     this._startPrepack();
   }
@@ -53,6 +54,7 @@ class PrepackDebugSession extends LoggingDebugSession {
   _adapterChannel: AdapterChannel;
   _debuggerOptions: DebuggerOptions;
   _prepackWaiting: boolean;
+  _pendingRequestCallbacks: { [number]: (string) => void };
 
   _readCLIParameters() {
     let args = Array.from(process.argv);
@@ -146,10 +148,12 @@ class PrepackDebugSession extends LoggingDebugSession {
       this.sendEvent(new StoppedEvent("entry", 1));
       this._trySendNextRequest();
     } else if (prefix === DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE) {
+      this._processRequestCallback(requestID, message);
       // Prepack acknowledged adding a breakpoint
       this._prepackWaiting = true;
       this._trySendNextRequest();
     } else if (prefix === DebugMessage.BREAKPOINT_STOPPED_RESPONSE) {
+      this._processRequestCallback(requestID, message);
       // Prepack stopped on a breakpoint
       this._prepackWaiting = true;
       // the second argument is the threadID required by the protocol, since
@@ -157,6 +161,17 @@ class PrepackDebugSession extends LoggingDebugSession {
       this.sendEvent(new StoppedEvent("breakpoint " + parts.slice(2).join(" "), 1));
       this._trySendNextRequest();
     }
+  }
+
+  _processRequestCallback(requestID: number, message: string) {
+    invariant(requestID in this._pendingRequestCallbacks, "Request ID does not exist in pending requests: " + requestID);
+    let callback = this._pendingRequestCallbacks[requestID];
+    callback(message);
+  }
+
+  _addRequestCallback(requestID: number, callback: string => void) {
+    invariant(!(requestID in this._pendingRequestCallbacks), "Request ID already exists in pending requests");
+    this._pendingRequestCallbacks[requestID] = callback;
   }
 
   // Error handler for errors in files from the adapter channel
@@ -190,6 +205,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     response.body = response.body || {};
     response.body.supportsConfigurationDoneRequest = true;
     // Respond back to the UI with the configurations. Will add more configurations gradually as needed.
+    // Adapter can respond immediately here because no message is sent to Prepack
     this.sendResponse(response);
   }
 
@@ -200,7 +216,10 @@ class PrepackDebugSession extends LoggingDebugSession {
     // queue a Run request to Prepack and try to send the next request in the queue
     this._messageQueue.enqueue(`${response.request_seq} ${DebugMessage.PREPACK_RUN_COMMAND}`);
     this._trySendNextRequest();
-    this.sendResponse(response);
+
+    this._addRequestCallback(response.request_seq, (message: string) => {
+      this.sendResponse(response);
+    });
   }
 
   setBreakPointsRequest(
@@ -221,7 +240,9 @@ class PrepackDebugSession extends LoggingDebugSession {
       );
     }
     this._trySendNextRequest();
-    this.sendResponse(response);
+    this._addRequestCallback(response.request_seq, (message: string) => {
+      this.sendResponse(response);
+    });
   }
 }
 

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -32,6 +32,9 @@ export class DebugMessage {
   static PREPACK_FINISH_RESPONSE: string = "PrepackFinish";
   // Respond to the adapter that Prepack has stopped on a breakpoint
   static BREAKPOINT_STOPPED_RESPONSE: string = "Breakpoint-stopped";
+
+  // Acknowledgement for running
+  static PREPACK_RUN_ACKNOWLEDGE: string = "PrepackRun-Acknowledge";
   // Acknowledgement for setting a breakpoint
   static BREAKPOINT_ADD_ACKNOWLEDGE: string = "Breakpoint-add-acknowledge";
   // Acknowledgement for removing a breakpoint

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -32,9 +32,6 @@ export class DebugMessage {
   static PREPACK_FINISH_RESPONSE: string = "PrepackFinish";
   // Respond to the adapter that Prepack has stopped on a breakpoint
   static BREAKPOINT_STOPPED_RESPONSE: string = "Breakpoint-stopped";
-
-  // Acknowledgement for running
-  static PREPACK_RUN_ACKNOWLEDGE: string = "PrepackRun-Acknowledge";
   // Acknowledgement for setting a breakpoint
   static BREAKPOINT_ADD_ACKNOWLEDGE: string = "Breakpoint-add-acknowledge";
   // Acknowledgement for removing a breakpoint


### PR DESCRIPTION
Release note: none
Summary:
- add in unique request IDs for requests between debug adapter and Prepack
- use request IDs to register callbacks for adapter to respond to UI.

Prevsiouly, the responses from the adapter to the UI to already implemented requests (continue and set breakpoints) do not need any information from Prepack, they only needed an acknowledgement. To handle other requests such as stackframe, variable, etc, the adapter requires information from Prepack before being able to respond to the UI. This PR makes the responses for all requests into callbacks so they can be sent when Prepack has sent back any needed information.

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path_to_adapter> --prepack <command_to_run_prepack> --inFilePath <debug_input_file_path> --outFilePath <debug_output_file_path>`
e.g. `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepack "lib/prepack-cli.js test/serializer/basic/Date.js" --inFilePath src/debugger/.sessionlogs/engine2adapter.txt --outFilePath src/debugger/.sessionlogs/adapter2engine.txt`

Supported commands so far:
-`breakpoint add <filePath> <line> ?<column>`: sets a breakpoint at the specified location. If `column` is specified, it is a column breakpoint, otherwise it is a line breakpoint.
-`run`: tell Prepack to continue executing, either upon entry or when stopped at a breakpoint
-`exit`: quit the debugger.