### PR TITLE
Fix wait generator body for delay initializations

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -144,13 +144,14 @@ export class Emitter {
   _processValue(value: Value) {
     let a = this._waitingForValues.get(value);
     if (a === undefined) return;
-    let oldBody = this._body;
+    let currentBody = this._body;
     while (a.length > 0) {
       let { body, dependencies, func } = a.shift();
-      if (body !== oldBody) {
+      // If body is not generator body no need to wait for it.
+      if (this._isGeneratorBody(body) && body !== currentBody) {
         this._emitAfterWaitingForGeneratorBody(body, dependencies, func);
       } else {
-        this.emitNowOrAfterWaitingForDependencies(dependencies, func);
+        this.emitNowOrAfterWaitingForDependencies(dependencies, func, body);
       }
     }
     this._waitingForValues.delete(value);
@@ -268,9 +269,22 @@ export class Emitter {
     invariant(this._activeValues.has(value));
     return condition ? value : undefined;
   }
-  emitAfterWaiting(delayReason: void | Value | SerializedBody, dependencies: Array<Value>, func: () => void) {
+  emitAfterWaiting(
+    delayReason: void | Value | SerializedBody,
+    dependencies: Array<Value>,
+    func: () => void,
+    targetBody: ?SerializedBody
+  ) {
     if (!delayReason) {
-      func();
+      if (targetBody == null || targetBody === this._body) {
+        // Emit into current body.
+        func();
+      } else {
+        invariant(!this._isGeneratorBody(targetBody));
+        const oldBody = this.beginEmitting(targetBody.type, targetBody);
+        func();
+        this.endEmitting(targetBody.type, oldBody);
+      }
     } else if (delayReason instanceof Value) {
       this._emitAfterWaitingForValue(delayReason, dependencies, func);
     } else if (this._isGeneratorBody(delayReason)) {
@@ -298,9 +312,9 @@ export class Emitter {
     if (b === undefined) this._waitingForBodies.set(reason, (b = []));
     b.push({ dependencies, func });
   }
-  emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void) {
+  emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void, targetBody: ?SerializedBody) {
     invariant(!this._finalized);
-    this.emitAfterWaiting(this.getReasonToWaitForDependencies(dependencies), dependencies, func);
+    this.emitAfterWaiting(this.getReasonToWaitForDependencies(dependencies), dependencies, func, targetBody);
   }
   _cloneGeneratorStack() {
     return this._activeBodies.slice();

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -273,10 +273,10 @@ export class Emitter {
     delayReason: void | Value | SerializedBody,
     dependencies: Array<Value>,
     func: () => void,
-    targetBody: ?SerializedBody
+    targetBody?: SerializedBody
   ) {
     if (!delayReason) {
-      if (targetBody == null || targetBody === this._body) {
+      if (targetBody === undefined || targetBody === this._body) {
         // Emit into current body.
         func();
       } else {
@@ -285,14 +285,17 @@ export class Emitter {
         func();
         this.endEmitting(targetBody.type, oldBody);
       }
-    } else if (delayReason instanceof Value) {
-      this._emitAfterWaitingForValue(delayReason, dependencies, func);
-    } else if (this._isGeneratorBody(delayReason)) {
-      // delayReason is a generator body.
-      this._emitAfterWaitingForGeneratorBody(delayReason, dependencies, func);
     } else {
-      // Unknown delay reason.
-      invariant(false);
+      invariant(targetBody === undefined || targetBody === this._body);
+      if (delayReason instanceof Value) {
+        this._emitAfterWaitingForValue(delayReason, dependencies, func);
+      } else if (this._isGeneratorBody(delayReason)) {
+        // delayReason is a generator body.
+        this._emitAfterWaitingForGeneratorBody(delayReason, dependencies, func);
+      } else {
+        // Unknown delay reason.
+        invariant(false);
+      }
     }
   }
   _emitAfterWaitingForValue(reason: Value, dependencies: Array<Value>, func: () => void) {
@@ -312,7 +315,7 @@ export class Emitter {
     if (b === undefined) this._waitingForBodies.set(reason, (b = []));
     b.push({ dependencies, func });
   }
-  emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void, targetBody: ?SerializedBody) {
+  emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void, targetBody?: SerializedBody) {
     invariant(!this._finalized);
     this.emitAfterWaiting(this.getReasonToWaitForDependencies(dependencies), dependencies, func, targetBody);
   }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1218,7 +1218,7 @@ export class ResidualHeapSerializer {
     ]);
   }
 
-  _serializeAbstractValue(val: AbstractValue): BabelNodeExpression {
+  _serializeAbstractValueHelper(val: AbstractValue): BabelNodeExpression {
     invariant(val.kind !== "sentinel member expression", "invariant established by visitor");
     let serializedArgs = val.args.map((abstractArg, i) => this.serializeValue(abstractArg));
     let serializedValue = val.buildNode(serializedArgs);
@@ -1227,6 +1227,22 @@ export class ResidualHeapSerializer {
       invariant(!this.preludeGenerator.derivedIds.has(id.name) || this.emitter.hasBeenDeclared(val));
     }
     return serializedValue;
+  }
+
+  _serializeAbstractValue(val: AbstractValue): void | BabelNodeExpression {
+    invariant(val.kind !== "sentinel member expression", "invariant established by visitor");
+    if (val.hasIdentifier()) {
+      return this._serializeAbstractValueHelper(val);
+    } else {
+      // This abstract value's dependencies may have been declared
+      // but still need to check it again in case their serialized bodies are in different generator scope.
+      this.emitter.emitNowOrAfterWaitingForDependencies(val.args, () => {
+        const serializedValue = this._serializeAbstractValueHelper(val);
+        let uid = this.residualHeapValueIdentifiers.getIdentifierAndIncrementReferenceCount(val);
+        let declar = t.variableDeclaration("var", [t.variableDeclarator(uid, serializedValue)]);
+        this.emitter.emit(declar);
+      });
+    }
   }
 
   _serializeValue(val: Value): void | BabelNodeExpression {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1238,6 +1238,8 @@ export class ResidualHeapSerializer {
       // but still need to check it again in case their serialized bodies are in different generator scope.
       this.emitter.emitNowOrAfterWaitingForDependencies(val.args, () => {
         const serializedValue = this._serializeAbstractValueHelper(val);
+        // Fetch the previous assigned identifier by residualHeapValueIdentifiers.setIdentifier()
+        // before _serializeAbstractValue() is called.
         let uid = this.residualHeapValueIdentifiers.getIdentifierAndIncrementReferenceCount(val);
         let declar = t.variableDeclaration("var", [t.variableDeclarator(uid, serializedValue)]);
         this.emitter.emit(declar);

--- a/test/serializer/abstract/WaitGenerator5.js
+++ b/test/serializer/abstract/WaitGenerator5.js
@@ -1,0 +1,17 @@
+// The conditional abstract value "obj.time" is referenced both from residual function and global scope.
+(function() {
+    let x = global.__abstract ? __abstract("boolean", "(true)") : true;
+    // Reference "obj.time" before its dependency abstract value "scope" to trigger wait generator body ordering.
+    residual = function() { return obj.time > 0; };
+    var obj = {};
+    if (x) {
+        var scope = Date.now();
+        obj.time = scope;
+    } else {
+        obj.time = -33;
+    }
+    global.obj = obj.time;
+    inspect = function() {
+      return obj.time > 0;
+    }
+})();


### PR DESCRIPTION
Release Note: Fix wait generator body for delay initializations.
Fix #1106
There are three issues need to be fixed here:
1. _processValue() should only call _emitAfterWaitingForGeneratorBody() for generator body.
2. emitAfterWaiting() needs to handle emitting into non-generator body
3. _serializeAbstractValue() needs to wait for all its own generator body to be available.