### PR TITLE
Join properties with get/set

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -26,7 +26,7 @@ import {
   ThrowCompletion,
 } from "../completions.js";
 import { Reference } from "../environment.js";
-import { cloneDescriptor, IsDataDescriptor, StrictEqualityComparison } from "../methods/index.js";
+import { cloneDescriptor, equalDescriptors, IsDataDescriptor, StrictEqualityComparison } from "../methods/index.js";
 import { construct_empty_effects } from "../realm.js";
 import { Generator } from "../utils/generator.js";
 import { AbstractValue, ObjectValue, Value } from "../values/index.js";
@@ -682,9 +682,6 @@ export function joinPropertyBindings(
   c1: CreatedObjects,
   c2: CreatedObjects
 ): PropertyBindings {
-  function getAbstractValue(v1: void | Value, v2: void | Value): Value {
-    return joinValuesAsConditional(realm, joinCondition, v1, v2);
-  }
   function join(b: PropertyBinding, d1: void | Descriptor, d2: void | Descriptor) {
     // If the PropertyBinding object has been freshly allocated do not join
     if (d1 === undefined) {
@@ -711,7 +708,7 @@ export function joinPropertyBindings(
         d2 = b.descriptor; //Get value of property before the split
       }
     }
-    return joinDescriptors(realm, d1, d2, getAbstractValue);
+    return joinDescriptors(realm, joinCondition, d1, d2);
   }
   return joinMaps(m1, m2, join);
 }
@@ -720,12 +717,19 @@ export function joinPropertyBindings(
 // Descriptors with get/set are not yet supported.
 export function joinDescriptors(
   realm: Realm,
+  joinCondition: AbstractValue,
   d1: void | Descriptor,
-  d2: void | Descriptor,
-  getAbstractValue: (void | Value, void | Value) => Value
+  d2: void | Descriptor
 ): void | Descriptor {
+  function getAbstractValue(v1: void | Value, v2: void | Value): Value {
+    return joinValuesAsConditional(realm, joinCondition, v1, v2);
+  }
   function clone_with_abstract_value(d: Descriptor) {
-    if (!IsDataDescriptor(realm, d)) throw new FatalError("TODO #1015: join computed properties");
+    if (!IsDataDescriptor(realm, d)) {
+      let d3: Descriptor = {};
+      d3.joinCondition = joinCondition;
+      return d3;
+    }
     let dc = cloneDescriptor(d);
     invariant(dc !== undefined);
     let dcValue = dc.value;
@@ -751,37 +755,26 @@ export function joinDescriptors(
   if (d1 === undefined) {
     if (d2 === undefined) return undefined;
     // d2 is a new property created in only one branch, join with empty
-    return clone_with_abstract_value(d2);
-  } else if (d2 === undefined) {
-    // d1 is a new property created in only one branch, join with empty
-    return clone_with_abstract_value(d1);
-  } else {
-    let d3: Descriptor = {};
-    let writable = joinBooleans(d1.writable, d2.writable);
-    if (writable !== undefined) d3.writable = writable;
-    let enumerable = joinBooleans(d1.enumerable, d2.enumerable);
-    if (enumerable !== undefined) d3.enumerable = enumerable;
-    let configurable = joinBooleans(d1.configurable, d2.configurable);
-    if (configurable !== undefined) d3.configurable = configurable;
-    //TODO #1015: do not join the values if one the descriptors is a getter/setters
-    if (IsDataDescriptor(realm, d1) || IsDataDescriptor(realm, d2))
-      d3.value = joinValues(realm, d1.value, d2.value, getAbstractValue);
-    if (d1.hasOwnProperty("get") || d2.hasOwnProperty("get"))
-      d3.get = (joinValues(realm, d1.get, d2.get, getAbstractValue): any);
-    if (d1.hasOwnProperty("set") || d2.hasOwnProperty("set"))
-      d3.set = (joinValues(realm, d1.set, d2.set, getAbstractValue): any);
+    let d3 = clone_with_abstract_value(d2);
+    if (!IsDataDescriptor(realm, d2)) d3.descriptor2 = d2;
     return d3;
-  }
-}
-
-// Returns v1 || v2, treating undefined as false,
-// but returns undefined if both v1 and v2 are undefined.
-export function joinBooleans(v1: void | boolean, v2: void | boolean): void | boolean {
-  if (v1 === undefined) {
-    return v2;
-  } else if (v2 === undefined) {
-    return v1;
+  } else if (d2 === undefined) {
+    invariant(d1 !== undefined);
+    // d1 is a new property created in only one branch, join with empty
+    let d3 = clone_with_abstract_value(d1);
+    if (!IsDataDescriptor(realm, d1)) d3.descriptor1 = d1;
+    return d3;
   } else {
-    return v1 || v2;
+    if (equalDescriptors(d1, d2) && IsDataDescriptor(realm, d1)) {
+      let dc = cloneDescriptor(d1);
+      invariant(dc !== undefined);
+      dc.value = joinValues(realm, d1.value, d2.value, getAbstractValue);
+      return dc;
+    }
+    let d3: Descriptor = {};
+    d3.joinCondition = joinCondition;
+    d3.descriptor1 = d1;
+    d3.descriptor2 = d2;
+    return d3;
   }
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -33,6 +33,7 @@ import {
   composePossiblyNormalCompletions,
   Construct,
   incorporateSavedCompletion,
+  GetValue,
   ToString,
   updatePossiblyNormalCompletionWithSubsequentEffects,
 } from "./methods/index.js";
@@ -404,8 +405,14 @@ export class Realm {
 
       let c;
       try {
-        c = f();
-        // This is join point for the normal branch of a PossiblyNormalCompletion.
+        try {
+          c = f();
+          if (c instanceof Reference) c = GetValue(this, c);
+        } catch (e) {
+          if (e instanceof AbruptCompletion) c = e;
+          else throw e;
+        }
+        // This is a join point for the normal branch of a PossiblyNormalCompletion.
         if (c instanceof Value || c instanceof AbruptCompletion) c = incorporateSavedCompletion(this, c);
         invariant(c !== undefined);
         if (c instanceof PossiblyNormalCompletion) {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -379,13 +379,51 @@ export class ResidualHeapSerializer {
     };
     if (desc === undefined) {
       this._deleteProperty(locationFunction());
-    } else if (this._canEmbedProperty(val, key, desc)) {
+    } else {
+      this.emitter.emit(this.emitDefinePropertyBody(deleteIfMightHaveBeenDeleted, locationFunction, val, key, desc));
+    }
+  }
+
+  emitDefinePropertyBody(
+    deleteIfMightHaveBeenDeleted: boolean,
+    locationFunction: void | (() => BabelNodeLVal),
+    val: ObjectValue,
+    key: string | SymbolValue,
+    desc: Descriptor
+  ): BabelNodeStatement {
+    if (desc.joinCondition) {
+      let cond = this.serializeValue(desc.joinCondition);
+      invariant(cond !== undefined);
+      let trueBody;
+      let falseBody;
+      if (desc.descriptor1)
+        trueBody = this.emitDefinePropertyBody(
+          deleteIfMightHaveBeenDeleted,
+          locationFunction,
+          val,
+          key,
+          desc.descriptor1
+        );
+      if (desc.descriptor2)
+        falseBody = this.emitDefinePropertyBody(
+          deleteIfMightHaveBeenDeleted,
+          locationFunction,
+          val,
+          key,
+          desc.descriptor2
+        );
+      if (trueBody && falseBody) return t.ifStatement(cond, trueBody, falseBody);
+      if (trueBody) return t.ifStatement(cond, trueBody);
+      if (falseBody) return t.ifStatement(t.unaryExpression("!", cond), falseBody);
+      invariant(false);
+    }
+    if (locationFunction !== undefined && this._canEmbedProperty(val, key, desc)) {
       let descValue = desc.value;
       invariant(descValue instanceof Value);
       invariant(!this.emitter.getReasonToWaitForDependencies([descValue, val]), "precondition of _emitProperty");
       let mightHaveBeenDeleted = descValue.mightHaveBeenDeleted();
       // The only case we do not need to remove the dummy property is array index property.
-      this._assignProperty(
+      return this._getPropertyAssignment(
         locationFunction,
         () => {
           invariant(descValue instanceof Value);
@@ -394,12 +432,7 @@ export class ResidualHeapSerializer {
         mightHaveBeenDeleted,
         deleteIfMightHaveBeenDeleted
       );
-    } else {
-      this.emitter.emit(this.emitDefinePropertyBody(val, key, desc));
     }
-  }
-
-  emitDefinePropertyBody(val: ObjectValue, key: string | SymbolValue, desc: Descriptor): BabelNodeStatement {
     let body = [];
     let descProps = [];
     let boolKeys = ["enumerable", "configurable"];
@@ -437,6 +470,10 @@ export class ResidualHeapSerializer {
       if (descKey in desc) {
         let descValue = desc[descKey];
         invariant(descValue instanceof Value);
+        if (descValue instanceof UndefinedValue) {
+          this.serializeValue(descValue);
+          continue;
+        }
         invariant(!this.emitter.getReasonToWaitForDependencies([descValue]), "precondition of _emitProperty");
         body.push(
           t.assignmentExpression(
@@ -622,6 +659,7 @@ export class ResidualHeapSerializer {
   }
 
   _getDescriptorValues(desc: Descriptor): Array<Value> {
+    if (desc.joinCondition !== undefined) return [desc.joinCondition];
     invariant(desc.value === undefined || desc.value instanceof Value);
     if (desc.value !== undefined) return [desc.value];
     invariant(desc.get !== undefined);
@@ -642,6 +680,17 @@ export class ResidualHeapSerializer {
     mightHaveBeenDeleted: boolean,
     deleteIfMightHaveBeenDeleted: boolean = false
   ) {
+    this.emitter.emit(
+      this._getPropertyAssignment(locationFn, valueFn, mightHaveBeenDeleted, deleteIfMightHaveBeenDeleted)
+    );
+  }
+
+  _getPropertyAssignment(
+    locationFn: () => BabelNodeLVal,
+    valueFn: () => BabelNodeExpression,
+    mightHaveBeenDeleted: boolean,
+    deleteIfMightHaveBeenDeleted: boolean = false
+  ) {
     let location = locationFn();
     let value = valueFn();
     let assignment = t.expressionStatement(t.assignmentExpression("=", location, value));
@@ -654,9 +703,9 @@ export class ResidualHeapSerializer {
           t.unaryExpression("delete", ((location: any): BabelNodeMemberExpression), true)
         );
       }
-      this.emitter.emit(t.ifStatement(condition, assignment, deletion));
+      return t.ifStatement(condition, assignment, deletion);
     } else {
-      this.emitter.emit(assignment);
+      return assignment;
     }
   }
 
@@ -1033,6 +1082,7 @@ export class ResidualHeapSerializer {
 
   // Checks whether a property can be defined via simple assignment, or using object literal syntax.
   _canEmbedProperty(obj: ObjectValue, key: string | SymbolValue, prop: Descriptor): boolean {
+    if (prop.joinCondition !== undefined) return false;
     if ((obj instanceof FunctionValue && key === "prototype") || (obj.getKind() === "RegExp" && key === "lastIndex"))
       return !!prop.writable && !prop.configurable && !prop.enumerable && !prop.set && !prop.get;
     else return !!prop.writable && !!prop.configurable && !!prop.enumerable && !prop.set && !prop.get;
@@ -1087,6 +1137,10 @@ export class ResidualHeapSerializer {
           serializedValue = this.serializeValue(propValue);
         }
         props.push(t.objectProperty(serializedKey, serializedValue));
+      } else if (descriptor.value instanceof Value && descriptor.value.mightHaveBeenDeleted()) {
+        dummyProperties.add(key);
+        let serializedKey = this.generator.getAsPropertyNameExpression(key);
+        props.push(t.objectProperty(serializedKey, voidExpression));
       }
     }
     this._emitObjectProperties(val, remainingProperties, createViaAuxiliaryConstructor, dummyProperties);
@@ -1308,7 +1362,7 @@ export class ResidualHeapSerializer {
       emit: (statement: BabelNodeStatement) => {
         this.emitter.emit(statement);
       },
-      emitDefinePropertyBody: this.emitDefinePropertyBody.bind(this),
+      emitDefinePropertyBody: this.emitDefinePropertyBody.bind(this, false, undefined),
       canOmit: (value: AbstractValue) => {
         return !this.referencedDeclaredValues.has(value);
       },
@@ -1548,6 +1602,7 @@ export class ResidualHeapSerializer {
       }
     }
 
+    // Make sure that the visitor visited as many values as the serializer
     invariant(
       this.serializedValues.size === this.residualValues.size,
       "serialized " + this.serializedValues.size + " of " + this.residualValues.size

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -208,6 +208,12 @@ export class ResidualHeapVisitor {
 
   visitDescriptor(desc: Descriptor): void {
     invariant(desc.value === undefined || desc.value instanceof Value);
+    if (desc.joinCondition !== undefined) {
+      desc.joinCondition = this.visitEquivalentValue(desc.joinCondition);
+      if (desc.descriptor1 !== undefined) this.visitDescriptor(desc.descriptor1);
+      if (desc.descriptor2 !== undefined) this.visitDescriptor(desc.descriptor2);
+      return;
+    }
     if (desc.value !== undefined) desc.value = this.visitEquivalentValue(desc.value);
     if (desc.get !== undefined) this.visitValue(desc.get);
     if (desc.set !== undefined) this.visitValue(desc.set);

--- a/src/types.js
+++ b/src/types.js
@@ -96,6 +96,13 @@ export type Descriptor = {
 
   get?: UndefinedValue | CallableObjectValue | AbstractValue,
   set?: UndefinedValue | CallableObjectValue | AbstractValue,
+
+  // Only used if the result of a join of two descriptors is not a data descriptor with identical attribute values.
+  // When present, any update to the property must produce effects that are the join of updating both desriptors,
+  // using joinCondition as the condition of the join.
+  joinCondition?: AbstractValue,
+  descriptor1?: Descriptor,
+  descriptor2?: Descriptor,
 };
 
 export type FunctionBodyAstNode = {
@@ -295,6 +302,7 @@ export type DebugServerType = {
 
 export type PathType = {
   implies(condition: AbstractValue): boolean,
+  impliesNot(condition: AbstractValue): boolean,
   withCondition<T>(condition: AbstractValue, evaluate: () => T): T,
   withInverseCondition<T>(condition: AbstractValue, evaluate: () => T): T,
 };

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -22,6 +22,15 @@ export class PathImplementation {
     return false;
   }
 
+  impliesNot(condition: AbstractValue): boolean {
+    let path = condition.$Realm.pathConditions;
+    for (let i = path.length - 1; i >= 0; i--) {
+      let pathCondition = path[i];
+      if (pathCondition.impliesNot(condition)) return true;
+    }
+    return false;
+  }
+
   withCondition<T>(condition: AbstractValue, evaluate: () => T): T {
     let realm = condition.$Realm;
     let savedPath = realm.pathConditions;

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -42,6 +42,10 @@ export default function simplifyAndRefineAbstractValue(
 function simplify(realm, value: Value, isCondition: boolean = false): Value {
   if (value instanceof ConcreteValue) return value;
   invariant(value instanceof AbstractValue);
+  if (isCondition || value.getType() === BooleanValue) {
+    if (Path.implies(value)) return realm.intrinsics.true;
+    if (Path.impliesNot(value)) return realm.intrinsics.false;
+  }
   let loc = value.expressionLocation;
   let op = value.kind;
   switch (op) {
@@ -206,7 +210,7 @@ function negate(
   invariant(value instanceof AbstractValue);
   if (value.kind === "!") {
     let [x] = value.args;
-    if (x.getType() === BooleanValue) return x;
+    if (x.getType() === BooleanValue) return simplify(realm, x, true);
     if (unsimplifiedNegation !== undefined) return unsimplifiedNegation;
     return makeBoolean(realm, x, loc);
   }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -173,15 +173,40 @@ export default class AbstractValue extends Value {
     return this._buildNode && this._buildNode.type === "Identifier";
   }
 
+  // this => val. A false value does not imply that !(this => val).
   implies(val: Value): boolean {
-    // Neither this nor val is a known value, so we need to some reasoning based on the structure
     if (this.equals(val)) return true; // x => x regardless of its value
+    if (!this.mightNotBeFalse()) return true; // false => val
     if (!val.mightNotBeTrue()) return true; // x => true regardless of the value of x
-    // x => x !== null && x !== undefined
-    if (val instanceof AbstractValue && val.kind === "!==") {
-      let [x, y] = val.args;
-      if (this.equals(x)) return y instanceof NullValue || y instanceof UndefinedValue;
-      if (this.equals(y)) return x instanceof NullValue || x instanceof UndefinedValue;
+    if (val instanceof AbstractValue) {
+      // Neither this (x) nor val (y) is a known value, so we need to some reasoning based on the structure
+      // x => !y if y => !x
+      if (val.kind === "!") {
+        let [y] = val.args;
+        invariant(y instanceof AbstractValue);
+        return y.impliesNot(this);
+      }
+      // x => x !== null && x !== undefined
+      if (val.kind === "!==") {
+        let [x, y] = val.args;
+        if (this.equals(x)) return y instanceof NullValue || y instanceof UndefinedValue;
+        if (this.equals(y)) return x instanceof NullValue || x instanceof UndefinedValue;
+      }
+    }
+    return false;
+  }
+
+  // this => !val. A false value does not imply that !(this => !val).
+  impliesNot(val: Value): boolean {
+    if (this.equals(val)) return false; // x => x regardless of its value, hence x => !val is false
+    if (!this.mightNotBeFalse()) return true; // false => !val
+    if (!val.mightNotBeFalse()) return true; // x => !false regardless of the value of x
+    if (val instanceof AbstractValue) {
+      // !x => !y if y => x
+      if (this.kind === "!") {
+        let [x] = this.args;
+        return val.implies(x);
+      }
     }
     return false;
   }

--- a/test/serializer/abstract/Property.js
+++ b/test/serializer/abstract/Property.js
@@ -1,0 +1,22 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+let ob = { };
+if (x) {
+  Object.defineProperty(ob, "x",
+    { configurable: true, get: () => 2 });
+  ob.x = 123;
+}
+if (x) {
+} else {
+  Object.defineProperty(ob, "y",
+    { configurable: true, set: () => {} });
+}
+
+let ob2 = { y: 2 };
+if (!x) {
+  Object.defineProperty(ob2, "x",
+    { configurable: true, get: () => this._x, set: (v) => { this._x = v; } } );
+  ob2.x = 123;
+}
+
+inspect = function() { return ob.x + " " + ob.y + " " + ob2.x; }

--- a/test/serializer/abstract/Property2.js
+++ b/test/serializer/abstract/Property2.js
@@ -1,0 +1,55 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+let ob = { };
+if (x) {
+  Object.defineProperty(ob, "x", { configurable: true, get: () => 2 });
+} else {
+  ob.x = 123;
+}
+if (!x) {
+} else {
+  Object.defineProperty(ob, "y", { configurable: true, get: () => 3 });
+}
+
+let ob2 = { y: 2 };
+if (!x) {
+  Object.defineProperty(ob2, "x",
+    { configurable: true, get: () => this._x, set: (v) => { this._x = v; } } );
+} else {
+  ob2.x = 123;
+}
+ob2.x = 456;
+
+let ob3 = {  };
+if (x) {
+  Object.defineProperty(ob3, "x",
+    { configurable: true, get: () => this._x, set: (v) => { throw v; } } );
+} else {
+  ob3.x = 123;
+}
+try {
+  ob3.x = 789;
+} catch(e) {
+  ob3.e = e;
+}
+
+let ob4 = {};
+if (x) {
+  Object.defineProperty(ob4, "x", { configurable: true, get: () => 4 });
+} else {
+  Object.defineProperty(ob4, "x", { configurable: false, get: () => 5 });
+}
+
+let ob5 = {};
+if (x) {
+  Object.defineProperty(ob5, "x", { configurable: true, get: () => { throw 4; } });
+} else {
+  Object.defineProperty(ob5, "x", { configurable: false, get: () => 5 });
+}
+try {
+  z = ob5.x;
+} catch (e) {
+  z = "caught " + e;
+}
+
+inspect = function() { return ob.x + " " + ob.y + " " + ob2.x + " " + ob3.x + " " + ob3.e + " " + z; }


### PR DESCRIPTION
Release notes: Provides support for joining properties that have get and set methods. Also now fully support properties that are only defined in one branch of an unknown conditional.

The main thing that happens here is that descriptors that result from joins now track the join condition and the original descriptors, so that the serializer can emit conditional code for defining the entire property, which allows it to also conditionally omit properties altogether.

Issue #1015 