### PR TITLE
Strips Flow types if React is enabled

### DIFF
--- a/src/flow/utils.js
+++ b/src/flow/utils.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import traverse from "babel-traverse";
+import { BabelNode } from "babel-types";
+import * as t from "babel-types";
+
+// taken directly from Babel:
+// https://github.com/babel/babel/blob/master/packages/babel-plugin-transform-flow-strip-types/src/index.js
+export function stripFlowTypeAnnotations(ast: BabelNode): void {
+  traverse(
+    ast,
+    {
+      ImportDeclaration(path) {
+        if (!path.node.specifiers.length) return;
+        let typeCount = 0;
+        path.node.specifiers.forEach(({ importKind }) => {
+          if (importKind === "type" || importKind === "typeof") {
+            typeCount++;
+          }
+        });
+        if (typeCount === path.node.specifiers.length) {
+          path.remove();
+        }
+      },
+      Flow(path) {
+        path.remove();
+      },
+      ClassProperty(path) {
+        path.node.variance = null;
+        path.node.typeAnnotation = null;
+        if (!path.node.value) path.remove();
+      },
+      Class(path) {
+        path.node.implements = null;
+        path.get("body.body").forEach(child => {
+          if (child.isClassProperty()) {
+            child.node.typeAnnotation = null;
+            if (!child.node.value) child.remove();
+          }
+        });
+      },
+      AssignmentPattern({ node }) {
+        node.left.optional = false;
+      },
+      Function({ node }) {
+        for (let i = 0; i < node.params.length; i++) {
+          const param = node.params[i];
+          param.optional = false;
+          if (param.type === "AssignmentPattern") {
+            param.left.optional = false;
+          }
+        }
+        node.predicate = null;
+      },
+      TypeCastExpression(path) {
+        let { node } = path;
+        do {
+          node = node.expression;
+        } while (t.isTypeCastExpression(node));
+        path.replaceWith(node);
+      },
+    },
+    undefined,
+    (undefined: any),
+    undefined
+  );
+}

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -17,6 +17,7 @@ import { Generator } from "../utils/generator.js";
 import generate from "babel-generator";
 import type SourceMap from "babel-generator";
 import traverseFast from "../utils/traverse-fast.js";
+import { stripFlowTypeAnnotations } from "../flow/utils.js";
 import invariant from "../invariant.js";
 import type { SerializerOptions } from "../options.js";
 import { TimingStatistics, SerializerStatistics } from "./types.js";
@@ -182,6 +183,9 @@ export class Serializer {
     );
 
     let ast = residualHeapSerializer.serialize();
+    if (this.realm.react.enabled) {
+      stripFlowTypeAnnotations(ast);
+    }
     let generated = generate(ast, { sourceMaps: sourceMaps }, (code: any));
     if (timingStats !== undefined) {
       timingStats.serializePassTime = Date.now() - timingStats.serializePassTime;


### PR DESCRIPTION
Release note: none

With the `reactEnabled` option turned on, Flow now get parsed by Babylon, which can break the output. So this PR traverses the AST after serialization and strips all Flow types using the same method from the core Babel strip Flow types plugin to ensure the Flow types aren't in the final output.