### PR TITLE
Use integration api to run Test262 tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,8 @@ test:
     - yarn test-react
     - yarn test-test262 -- --statusFile $CIRCLE_ARTIFACTS/test262-status.txt --timeout 120 --cpuScale 0.25 --verbose:
         timeout: 1800
+    - yarn test-test262-new -- --statusFile $CIRCLE_ARTIFACTS/test262-new-status.txt --timeout 120 --verbose:
+        timeout: 1800
   post:
     - mv coverage/lcov-report $CIRCLE_ARTIFACTS/coverage-report
     - mv coverage-sourcemapped $CIRCLE_ARTIFACTS/coverage-report-sourcemapped

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test-sourcemaps": "babel-node scripts/generate-sourcemaps-test.js && bash < scripts/test-sourcemaps.sh",
     "test-test262": "babel-node scripts/test262-runner.js",
     "test-test262-nightly": "NIGHTLY_BUILD=true babel-node -- scripts/test262-runner.js",
+    "test-test262-new": "babel-node scripts/test262.js",
     "test-internal": "babel-node --stack_size=10000 --stack_trace_limit=200 --max_old_space_size=16384 scripts/test-internal.js",
     "test-error-handler": "babel-node scripts/test-error-handler.js",
     "test-error-handler-with-coverage": "./node_modules/.bin/istanbul cover ./lib/test-error-handler.js --dir coverage.error && ./node_modules/.bin/remap-istanbul -i coverage.error/coverage.json -o coverage-sourcemapped.error -t html",
@@ -100,6 +101,7 @@
     "react-test-renderer": "^16.0.0",
     "remap-istanbul": "^0.9.1",
     "source-map-support": "^0.4.6",
+    "test262-integrator": "^1.2.0",
     "uglify-js": "^2.6.2",
     "webpack": "^2.3.3"
   },

--- a/scripts/test262-filters.yml
+++ b/scripts/test262-filters.yml
@@ -1,0 +1,62 @@
+features:
+  - async-iteration
+  - tail-call-optimization
+  - generators
+  - default-parameters
+  - Function.prototype.toString
+  - SharedArrayBuffer
+  - atomics
+  - cross-realm
+  - u180e
+  - Symbol.isConcatSpreadable
+  - class-fields
+  - destructuring-binding
+  - BigInt
+esid:
+  - pending
+es5id:
+  - 7.8.5_A1.4_T2
+  - 7.8.5_A2.4_T2
+  - 7.8.5_A2.1_T2
+  - 7.8.5_A1.1_T2
+  - 15.1.2.2_A8
+  - 15.1.2.3_A6
+  - 7.4_A5
+  - 7.4_A6
+  - 15.10.2.12_A3_T1
+  - 15.10.2.12_A4_T1
+  - 15.10.2.12_A5_T1
+  - 15.10.2.12_A6_T1
+es6id:
+  - 22.1.3.1_3
+flags:
+  - module
+  - async
+paths:
+  - language/directive-prologue/
+  - harness
+  - intl402
+  - built-ins/Function/prototype/toString/
+  - built-ins/SharedArrayBuffer/
+  - built-ins/Atomics/
+  - annexB/
+  - language/statements/with/
+  - detached-buffer-after-toindex-byteoffset.js
+  - built-ins/ArrayIteratorPrototype/next/detach-typedarray-in-progress.js
+  - built-ins/RegExp/S15.10.2.12_A1_T1.js
+  - built-ins/RegExp/S15.10.2.12_A2_T1.js
+  - built-ins/RegExp/prototype/Symbol.search/lastindex-no-restore.js
+  - built-ins/RegExp/prototype/exec/failure-lastindex-no-access.js
+  - built-ins/RegExp/prototype/exec/success-lastindex-no-access.js
+  - built-ins/RegExp/prototype/Symbol.match/builtin-success-u-return-val-groups.js
+  - built-ins/decodeURI
+  - built-ins/encodeURI
+  - built-ins/decodeURIComponent
+  - built-ins/encodeURIComponent
+  - built-ins/Array/S15.4.5.2_A1_T1.js
+  - built-ins/Array/S15.4.5.2_A1_T1.js
+  - built-ins/Array/S15.4_A1
+  - built-ins/Array/length/S15.4.5.2_A3
+negative:
+  phase:
+    - early

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -936,7 +936,7 @@ function createRealm(timeout: number): { realm: Realm, $: ObjectValue } {
   $.defineNativeProperty("global", realm.$GlobalObject);
 
   let glob = ((realm.$GlobalObject: any): ObjectValue);
-  glob.defineNativeProperty("$", $);
+  glob.defineNativeProperty("$262", $);
   glob.defineNativeMethod("print", 1, (context, [arg]) => {
     return realm.intrinsics.undefined;
   });
@@ -1155,6 +1155,24 @@ function filterFeatures(data: BannerData): boolean {
   if (features.includes("default-parameters")) return false;
   if (features.includes("generators")) return false;
   if (features.includes("generator")) return false;
+  if (features.includes("BigInt")) return false;
+  if (features.includes("class-fields")) return false;
+  if (features.includes("async-iteration")) return false;
+  if (features.includes("Function.prototype.toString")) return false;
+  if (features.includes("SharedArrayBuffer")) return false;
+  if (features.includes("cross-realm")) return false;
+  if (features.includes("atomics")) return false;
+  if (features.includes("u180e")) return false;
+  if (features.includes("Symbol.isConcatSpreadable")) return false;
+  if (features.includes("destructuring-binding")) return false;
+  if (features.includes("IsHTMLDDA")) return false;
+  if (features.includes("regexp-unicode-property-escapes")) return false;
+  if (features.includes("regexp-named-groups")) return false;
+  if (features.includes("regexp-lookbehind")) return false;
+  if (features.includes("regexp-dotall")) return false;
+  if (features.includes("optional-catch-binding")) return false;
+  if (features.includes("Symbol.asyncIterator")) return false;
+  if (features.includes("Promise.prototype.finally")) return false;
   return true;
 }
 

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -636,7 +636,7 @@ function handleFinished(args: MasterProgramArgs, groups: GroupsMap, earlierNumSk
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 11798 || numPassedES6 < 5245 || numTimeouts > 0)) {
+  if (!args.filterString && (numPassedES5 < 11575 || numPassedES6 < 4252 || numTimeouts > 0)) {
     console.log(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {

--- a/scripts/test262.js
+++ b/scripts/test262.js
@@ -1,0 +1,427 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+import path from "path";
+import fs from "fs";
+import yaml from "js-yaml";
+import Integrator from "test262-integrator";
+
+import tty from "tty";
+import minimist from "minimist";
+
+import initializeGlobals from "../lib/globals.js";
+import { AbruptCompletion, ThrowCompletion } from "../lib/completions.js";
+import { DetachArrayBuffer } from "../lib/methods/arraybuffer.js";
+import construct_realm from "../lib/construct_realm.js";
+import { ObjectValue, StringValue } from "../lib/values/index.js";
+import { Realm, ExecutionContext } from "../lib/realm.js";
+import { ToStringPartial } from "../lib/methods/to.js";
+import { Get } from "../lib/methods/get.js";
+
+const filters = yaml.safeLoad(fs.readFileSync(path.join(__dirname, "./test262-filters.yml"), "utf8"));
+
+class TestAttrs {
+  description: string;
+  esid: ?string;
+  es5id: ?string;
+  es6id: ?string;
+  features: ?(string[]);
+  includes: ?(string[]);
+  info: ?string;
+  flags: TestFlags;
+  negative: TestAttrsNegative;
+  skip: boolean;
+}
+
+class TestAttrsNegative {
+  phase: string;
+  type: string;
+}
+
+class TestFlags {
+  generated: boolean;
+  onlyStrict: boolean;
+  noStrict: boolean;
+  async: boolean;
+}
+
+class TestObject {
+  file: string;
+  contents: string;
+  copyright: string;
+  scenario: string; // "default", "strict mode", ...
+  attrs: TestAttrs;
+}
+
+class Result {
+  pass: boolean;
+  error: ?Error;
+  skip: ?boolean;
+  constructor(pass, error, skip): void {
+    this.pass = pass;
+    this.error = error;
+    this.skip = skip;
+  }
+}
+
+class TestResult extends TestObject {
+  result: Result;
+}
+
+function execute(timeout: number, test: TestObject): Result {
+  let { contents, attrs, file, scenario } = test;
+  let { realm } = createRealm(timeout);
+
+  let strict = scenario === "strict mode";
+
+  // Run the test.
+  try {
+    try {
+      let completion = realm.$GlobalEnv.execute(contents, file);
+      if (completion instanceof ThrowCompletion) throw completion;
+      if (completion instanceof AbruptCompletion) {
+        return new Result(false, new Error("Unexpected abrupt completion"));
+      }
+    } catch (err) {
+      if (err.message === "Timed out") return new Result(false, err);
+      if (!attrs.negative) {
+        throw err;
+      }
+    }
+
+    if (attrs.negative && attrs.negative.type) {
+      throw new Error("Was supposed to error with type " + attrs.negative.type + " but passed");
+    }
+
+    // succeeded
+    return new Result(true);
+  } catch (err) {
+    if (err.value && err.value.$Prototype && err.value.$Prototype.intrinsicName === "SyntaxError.prototype") {
+      // Skip test
+      return new Result(false, null, true);
+    }
+
+    let stack = err.stack;
+    if (attrs.negative && attrs.negative.type) {
+      let type = attrs.negative.type;
+      if (err && err instanceof ThrowCompletion && Get(realm, err.value, "name").value === type) {
+        // Expected an error and got one.
+        return new Result(true);
+      } else {
+        // Expected an error, but got something else.
+        if (err && err instanceof ThrowCompletion) {
+          return new Result(false, err);
+        } else {
+          let err2 = new Error(`Expected an error, but got something else: ${err.message}`);
+          return new Result(false, err2);
+        }
+      }
+    } else {
+      // Not expecting an error, but got one.
+      try {
+        if (err && err instanceof ThrowCompletion) {
+          let interpreterStack: void | string;
+
+          if (err.value instanceof ObjectValue) {
+            if (err.value.$HasProperty("stack")) {
+              interpreterStack = ToStringPartial(realm, Get(realm, err.value, "stack"));
+            } else {
+              interpreterStack = ToStringPartial(realm, Get(realm, err.value, "message"));
+            }
+            // filter out if the error stack is due to async
+            if (interpreterStack.includes("async ")) {
+              // Skip test
+              return new Result(false, null, true);
+            }
+          } else if (err.value instanceof StringValue) {
+            interpreterStack = err.value.value;
+            if (interpreterStack === "only plain identifiers are supported in parameter lists") {
+              // Skip test
+              return new Result(false, null, true);
+            }
+          }
+
+          // Many strict-only tests involving eval check if certain SyntaxErrors are thrown.
+          // Some of those would require changes to Babel to support properly, and some we should handle ourselves in Prepack some day.
+          // But for now, ignore.
+          if (contents.includes("eval(") && strict) {
+            // Skip test
+            return new Result(false, null, true);
+          }
+
+          if (interpreterStack) {
+            stack = `Interpreter: ${interpreterStack}\nNative: ${err.nativeStack}`;
+          }
+        }
+      } catch (_err) {
+        stack = _err.stack;
+      }
+
+      return new Result(false, new Error(`Got an error, but was not expecting one:\n${stack}`));
+    }
+  }
+}
+
+function createRealm(timeout: number): { realm: Realm, $: ObjectValue } {
+  // Create a new realm.
+  let realm = construct_realm({
+    strictlyMonotonicDateNow: true,
+    timeout: timeout * 1000,
+  });
+  initializeGlobals(realm);
+  let executionContext = new ExecutionContext();
+  executionContext.realm = realm;
+  realm.pushContext(executionContext);
+
+  // Create the Host-Defined functions.
+  let $ = new ObjectValue(realm);
+
+  $.defineNativeMethod("createRealm", 0, context => {
+    return createRealm(timeout).$;
+  });
+
+  $.defineNativeMethod("detachArrayBuffer", 1, (context, [buffer]) => {
+    return DetachArrayBuffer(realm, buffer);
+  });
+
+  $.defineNativeMethod("evalScript", 1, (context, [sourceText]) => {
+    // TODO: eval
+    return realm.intrinsics.undefined;
+  });
+
+  $.defineNativeProperty("global", realm.$GlobalObject);
+
+  $.defineNativeMethod("destroy", 0, () => realm.intrinsics.undefined);
+
+  let glob = ((realm.$GlobalObject: any): ObjectValue);
+  glob.defineNativeProperty("$262", $);
+  glob.defineNativeMethod("print", 1, (context, [arg]) => {
+    return realm.intrinsics.undefined;
+  });
+
+  return { realm, $ };
+}
+
+class ReportResults {
+  skipped: number;
+  passed: number;
+  total: number;
+  name: string;
+
+  constructor(name: string) {
+    this.skipped = 0;
+    this.passed = 0;
+    this.total = 0;
+    this.name = name;
+  }
+
+  report(pass: boolean, skip: boolean): void {
+    if (skip) {
+      this.skipped += 1;
+    } else if (pass) {
+      this.passed += 1;
+    }
+
+    this.total += 1;
+  }
+
+  percentage(x: number, total: number): string {
+    if (total === 0) {
+      return "100%";
+    }
+    return (x / total * 100).toFixed(2) + "%";
+  }
+
+  info(title: string, x: number, y: number, force: boolean): string {
+    if (!force && x === 0) {
+      return "";
+    }
+
+    return `${title} ${x}/${y} (${this.percentage(x, y)})`;
+  }
+
+  formatResult(): string {
+    const subtotal = this.total - this.skipped;
+    const failed = subtotal - this.passed;
+    return [
+      `${this.name}: `,
+      this.info("Ran", subtotal, this.total, true),
+      this.info(", Passed", this.passed, subtotal, false),
+      this.info(", Failed", failed, subtotal, false),
+      this.info(", Skipped", this.skipped, this.total, false),
+    ].join("");
+  }
+
+  static safeTypeReturn(map: Map<string, ReportResults>, key: string): ReportResults {
+    const result = map.get(key);
+    if (result instanceof ReportResults) {
+      return result;
+    }
+    throw new Error("Wrong type set in a list of ReportResults");
+  }
+}
+
+function processResults(verbose: boolean, statusFile: string, results: TestResult[]): void {
+  let status = "\n";
+  const foldersMap = new Map();
+  const featuresMap = new Map();
+  const allResults = new ReportResults("\nTotal");
+
+  console.log("\n");
+
+  results.forEach(({ file, scenario, attrs: { features }, result: { pass, skip, error } = {} }) => {
+    // Limits the report result in a max depth of 5 folders.
+    // This fits most cases for built-ins prototype methods as e.g.
+    // test/built-ins/Array/prototype/sort
+    const folder = path.dirname(file).split(path.sep).slice(1, 5).join(path.sep);
+    let folderResults: ReportResults;
+
+    if (!foldersMap.has(folder)) {
+      folderResults = new ReportResults(folder);
+      foldersMap.set(folder, folderResults);
+    } else {
+      folderResults = ReportResults.safeTypeReturn(foldersMap, folder);
+    }
+
+    if (folderResults) {
+      folderResults.report(!!pass, !!skip);
+    }
+    allResults.report(!!pass, !!skip);
+
+    if (features) {
+      for (let feature of features) {
+        let featureResults: ReportResults;
+
+        if (!featuresMap.has(feature)) {
+          featureResults = new ReportResults(feature);
+          featuresMap.set(feature, featureResults);
+        } else {
+          featureResults = ReportResults.safeTypeReturn(featuresMap, feature);
+        }
+
+        if (featureResults) {
+          featureResults.report(!!pass, !!skip);
+        }
+      }
+    }
+
+    if (verbose && !skip && !pass) {
+      let message = "";
+      if (error && error.message) {
+        message = error.message;
+      }
+      status += `Failed: ${file} (${scenario})\n${message}\n\n`;
+    }
+  });
+
+  foldersMap.forEach(folderResults => {
+    status += folderResults.formatResult();
+    status += "\n";
+  });
+
+  status += "\nFeatures:\n\n";
+
+  featuresMap.forEach(featureResults => {
+    status += featureResults.formatResult();
+    status += "\n";
+  });
+
+  status += allResults.formatResult();
+
+  console.log(status);
+
+  if (statusFile) {
+    fs.writeFileSync(statusFile, status);
+  }
+}
+
+class MasterProgramArgs {
+  verbose: boolean;
+  timeout: number;
+  statusFile: string;
+  paths: string[];
+  testDir: string;
+
+  constructor(verbose: boolean, timeout: number, statusFile: string, paths: string[], testDir: string) {
+    this.verbose = verbose;
+    this.timeout = timeout;
+    this.statusFile = statusFile;
+    this.paths = paths;
+    this.testDir = testDir;
+  }
+}
+
+function masterArgsParse(): MasterProgramArgs {
+  let { _: _paths, verbose, timeout, statusFile, testDir } = minimist(process.argv.slice(2), {
+    string: ["statusFile", "testDir"],
+    boolean: ["verbose"],
+    default: {
+      testDir: ["..", "test", "test262"].join(path.sep),
+      verbose: process.stdout instanceof tty.WriteStream ? false : true,
+      statusFile: "",
+      timeout: 10,
+    },
+  });
+
+  // Test paths can be provided as "built-ins/Array", "language/statements/class", etc.
+  let paths = _paths.map(p => path.join("test", p));
+  if (typeof verbose !== "boolean") {
+    throw new Error("verbose must be a boolean (either --verbose or not)");
+  }
+  if (typeof timeout !== "number") {
+    throw new Error("timeout must be a number (in seconds) (--timeout 10)");
+  }
+  if (typeof statusFile !== "string") {
+    throw new Error("statusFile must be a string (--statusFile file.txt)");
+  }
+  if (typeof testDir !== "string") {
+    throw new Error("testDir must be a string (--testDir ../test/test262)");
+  }
+
+  return new MasterProgramArgs(verbose, timeout, statusFile, paths, testDir);
+}
+
+function usage(message: string): void {
+  console.error(
+    [
+      `Illegal argument: ${message}`,
+      `Usage: ${process.argv[0]} ${process.argv[1]}`,
+      "[--verbose] (defaults to false)",
+      "[--timeout <number>] (defaults to 10)",
+      "[--statusFile <string>]",
+      "[--testDir <string>] (defaults to ../test/test262)",
+    ].join("\n")
+  );
+}
+
+function main(): void {
+  try {
+    let { testDir, verbose, paths, statusFile, timeout } = masterArgsParse();
+
+    // Execution
+    Integrator({
+      filters,
+      execute: execute.bind(null, timeout),
+      testDir: path.join(__dirname, testDir),
+      verbose,
+      paths: paths.length ? paths : null,
+    })
+      .then(processResults.bind(null, verbose, statusFile), err => {
+        console.error(`Error running the tests: ${err}`);
+        process.exit(1);
+      })
+      .then(() => process.exit(0));
+  } catch (e) {
+    usage(e.message);
+    process.exit(2);
+  }
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,6 +14,13 @@ abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
+accepts@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.3.tgz#c3ca7434938648c3e0d9c1e328dd68b622c284ca"
+  dependencies:
+    mime-types "~2.1.11"
+    negotiator "0.6.1"
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -47,6 +54,10 @@ acorn@^4.0.3, acorn@^4.0.4:
 acorn@^5.0.0, acorn@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
+
+after@0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
 ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
@@ -183,6 +194,10 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+arraybuffer.slice@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
+
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -249,9 +264,15 @@ async@1.x, async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4:
+async@^2.1.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  dependencies:
+    lodash "^4.14.0"
+
+async@^2.1.4:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
 
@@ -1106,6 +1127,10 @@ babylon@^6.17.0, babylon@^6.17.2, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
+backo2@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1114,9 +1139,17 @@ base62@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/base62/-/base62-1.2.0.tgz#31e7e560dc846c9f44c1a531df6514da35474157"
 
+base64-arraybuffer@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
+
 base64-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+
+base64id@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base64id/-/base64id-1.0.0.tgz#47688cb99bb6804f0e06d3e763b1c32e57d8e6b6"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
@@ -1127,6 +1160,12 @@ bcrypt-pbkdf@^1.0.0:
 beeper@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
+
+better-assert@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
+  dependencies:
+    callsite "1.0.0"
 
 big.js@^3.1.3:
   version "3.1.3"
@@ -1173,6 +1212,10 @@ bl@^1.0.0:
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.1.tgz#cac328f7bee45730d404b692203fcb590e172d5e"
   dependencies:
     readable-stream "^2.0.5"
+
+blob@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
 
 block-stream@*:
   version "0.0.9"
@@ -1325,6 +1368,10 @@ caller-path@^0.1.0:
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
   dependencies:
     callsites "^0.2.0"
+
+callsite@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
 
 callsites@^0.2.0:
   version "0.2.0"
@@ -1494,8 +1541,8 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 color-convert@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
   dependencies:
     color-name "^1.1.1"
 
@@ -1541,6 +1588,22 @@ commoner@~0.10.3:
     q "^1.1.2"
     recast "^0.11.17"
 
+component-bind@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/component-bind/-/component-bind-1.0.0.tgz#00c608ab7dcd93897c0009651b1d3a8e1e73bbd1"
+
+component-emitter@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
+
+component-emitter@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
+component-inherit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1579,6 +1642,10 @@ convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.4.0,
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -1590,6 +1657,10 @@ core-js@^2.4.0:
 core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+
+core-js@~2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.3.0.tgz#fab83fbb0b2d8dc85fa636c4b9d34c75420c6d65"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1706,6 +1777,18 @@ dbly-linked-list@0.1.10:
   dependencies:
     lodash "4.6.1"
 
+debug@2.2.0, debug@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  dependencies:
+    ms "0.7.1"
+
+debug@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
+  dependencies:
+    ms "0.7.2"
+
 debug@^2.1.1, debug@^2.2.0:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
@@ -1723,12 +1806,6 @@ debug@^3.1.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
-
-debug@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  dependencies:
-    ms "0.7.1"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -2056,6 +2133,45 @@ end-of-stream@^1.0.0:
   dependencies:
     once "^1.4.0"
 
+engine.io-client@~1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-1.8.4.tgz#9fe85dee25853ca6babe25bd2ad68710863e91c2"
+  dependencies:
+    component-emitter "1.2.1"
+    component-inherit "0.0.3"
+    debug "2.3.3"
+    engine.io-parser "1.3.2"
+    has-cors "1.1.0"
+    indexof "0.0.1"
+    parsejson "0.0.3"
+    parseqs "0.0.5"
+    parseuri "0.0.5"
+    ws "1.1.2"
+    xmlhttprequest-ssl "1.5.3"
+    yeast "0.1.2"
+
+engine.io-parser@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-1.3.2.tgz#937b079f0007d0893ec56d46cb220b8cb435220a"
+  dependencies:
+    after "0.8.2"
+    arraybuffer.slice "0.0.6"
+    base64-arraybuffer "0.1.5"
+    blob "0.0.4"
+    has-binary "0.1.7"
+    wtf-8 "1.0.0"
+
+engine.io@~1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-1.8.4.tgz#77bce12b80e5d60429337fec3b0daf691ebc9003"
+  dependencies:
+    accepts "1.3.3"
+    base64id "1.0.0"
+    cookie "0.3.1"
+    debug "2.3.3"
+    engine.io-parser "1.3.2"
+    ws "1.1.4"
+
 enhanced-resolve@^3.3.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
@@ -2086,6 +2202,12 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+error-stack-parser@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
+  dependencies:
+    stackframe "^0.3.1"
+
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.24"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.24.tgz#a55877c9924bc0c8d9bd3c2cbe17495ac1709b14"
@@ -2111,6 +2233,10 @@ es6-map@^0.1.3:
     es6-set "~0.1.5"
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
+
+es6-promise@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
 
 es6-set@~0.1.5:
   version "0.1.5"
@@ -2161,6 +2287,16 @@ escope@^3.4.0, escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eshost@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eshost/-/eshost-3.6.0.tgz#66d7bd1ff881837a8f9fedfeb4c12adeba4e72ec"
+  dependencies:
+    error-stack-parser "^1.3.3"
+    selenium-webdriver "^3.4.0"
+    server-destroy "^1.0.1"
+    socket.io "^1.3.7"
+    temp "^0.8.3"
 
 eslint-config-kittens@^1.0.3:
   version "1.0.5"
@@ -2833,7 +2969,7 @@ got@^5.0.0:
     unzip-response "^1.0.2"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.0.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -2963,6 +3099,16 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-binary@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-binary/-/has-binary-0.1.7.tgz#68e61eb16210c9545a0a5cce06a873912fe1e68c"
+  dependencies:
+    isarray "0.0.1"
+
+has-cors@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
@@ -3074,6 +3220,10 @@ ignore@^2.2.19:
 ignore@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
+
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -3698,7 +3848,7 @@ js-yaml@3.x, js-yaml@^3.5.1, js-yaml@^3.6.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-js-yaml@^3.7.0:
+js-yaml@^3.10.0, js-yaml@^3.2.1, js-yaml@^3.7.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3759,6 +3909,10 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json3@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+
 json5@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
@@ -3788,6 +3942,16 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+jszip@^3.1.3:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.1.5.tgz#e3c2a6c6d706ac6e603314036d43cd40beefdf37"
+  dependencies:
+    core-js "~2.3.0"
+    es6-promise "~3.0.2"
+    lie "~3.1.0"
+    pako "~1.0.2"
+    readable-stream "~2.0.6"
+
 kcheck@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/kcheck/-/kcheck-2.0.3.tgz#e8574eb2af413dab4a18c9db98113663b52fa9d9"
@@ -3811,6 +3975,12 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+klaw@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.1.0.tgz#694a269019f4321d9233fb1b9abdae21e38259fb"
+  dependencies:
+    graceful-fs "^4.1.9"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -3846,6 +4016,12 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lie@~3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  dependencies:
+    immediate "~3.0.5"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -3970,6 +4146,10 @@ lodash.assign@^3.2.0:
     lodash._baseassign "^3.0.0"
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
+
+lodash.assign@^4.0.3, lodash.assign@^4.0.6:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
 
 lodash.escape@^3.0.0:
   version "3.2.0"
@@ -4195,11 +4375,21 @@ mime-db@~1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
 
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
 mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
   dependencies:
     mime-db "~1.29.0"
+
+mime-types@~2.1.11:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  dependencies:
+    mime-db "~1.30.0"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -4273,6 +4463,10 @@ ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
+ms@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4306,6 +4500,10 @@ natural-compare@^1.4.0:
 ncp@~0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/ncp/-/ncp-0.4.2.tgz#abcc6cbd3ec2ed2a729ff6e7c1fa8f01784a8574"
+
+negotiator@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
 node-fetch@^1.0.1:
   version "1.7.3"
@@ -4434,6 +4632,10 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
+object-assign@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
 object-assign@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
@@ -4449,6 +4651,10 @@ object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@
 object-assign@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.0.1.tgz#99504456c3598b5cad4fc59c26e8a9bb107fe0bd"
+
+object-component@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -4497,6 +4703,10 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+options@>=0.0.5:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
+
 ora@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-1.1.0.tgz#69aaa4a209630e43b142c5f7ff41820da87e2faf"
@@ -4539,7 +4749,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -4580,6 +4790,10 @@ pako@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
 
+pako@~1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
+
 parse-asn1@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.0.tgz#37c4f9b7ed3ab65c74817b5f2480937fbf97c712"
@@ -4612,6 +4826,24 @@ parse-ms@^1.0.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+parsejson@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/parsejson/-/parsejson-0.0.3.tgz#ab7e3759f209ece99437973f7d0f1f64ae0e64ab"
+  dependencies:
+    better-assert "~1.0.0"
+
+parseqs@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseqs/-/parseqs-0.0.5.tgz#d5208a3738e46766e291ba2ea173684921a8b89d"
+  dependencies:
+    better-assert "~1.0.0"
+
+parseuri@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/parseuri/-/parseuri-0.0.5.tgz#80204a50d4dbb779bfdc6ebe2778d90e4bce320a"
+  dependencies:
+    better-assert "~1.0.0"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -4861,15 +5093,16 @@ rc@^1.1.2, rc@^1.1.6, rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-test-renderer@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.1.0.tgz#33a1d3ce896311e0dd1547649b1456ffa7fda415"
   dependencies:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.1.0.tgz#1c2bdac3c17fe7ee9282fa35aca6cc36387903e1"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -4943,7 +5176,7 @@ readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@~2.0.0:
+readable-stream@~2.0.0, readable-stream@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
@@ -5218,7 +5451,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rimraf@~2.2.0:
+rimraf@^2.5.4:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
+  dependencies:
+    glob "^7.0.5"
+
+rimraf@~2.2.0, rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
@@ -5264,7 +5503,7 @@ sass-lookup@^1.0.2:
     commander "~2.8.1"
     is-relative-path "~1.0.0"
 
-sax@^1.2.1:
+sax@>=0.6.0, sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -5277,6 +5516,15 @@ seek-bzip@^1.0.3:
   resolved "https://registry.yarnpkg.com/seek-bzip/-/seek-bzip-1.0.5.tgz#cfe917cb3d274bcffac792758af53173eb1fabdc"
   dependencies:
     commander "~2.8.1"
+
+selenium-webdriver@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz#2ba87a1662c020b8988c981ae62cb2a01298eafc"
+  dependencies:
+    jszip "^3.1.3"
+    rimraf "^2.5.4"
+    tmp "0.0.30"
+    xml2js "^0.4.17"
 
 semver-regex@^1.0.0:
   version "1.0.0"
@@ -5295,6 +5543,10 @@ semver-truncate@^1.0.0:
 semver@^4.0.3:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+server-destroy@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/server-destroy/-/server-destroy-1.0.1.tgz#f13bf928e42b9c3e79383e61cc3998b5d14e6cdd"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -5365,6 +5617,50 @@ sntp@1.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   dependencies:
     hoek "2.x.x"
+
+socket.io-adapter@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz#cb6d4bb8bec81e1078b99677f9ced0046066bb8b"
+  dependencies:
+    debug "2.3.3"
+    socket.io-parser "2.3.1"
+
+socket.io-client@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-1.7.4.tgz#ec9f820356ed99ef6d357f0756d648717bdd4281"
+  dependencies:
+    backo2 "1.0.2"
+    component-bind "1.0.0"
+    component-emitter "1.2.1"
+    debug "2.3.3"
+    engine.io-client "~1.8.4"
+    has-binary "0.1.7"
+    indexof "0.0.1"
+    object-component "0.0.3"
+    parseuri "0.0.5"
+    socket.io-parser "2.3.1"
+    to-array "0.1.4"
+
+socket.io-parser@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-2.3.1.tgz#dd532025103ce429697326befd64005fcfe5b4a0"
+  dependencies:
+    component-emitter "1.1.2"
+    debug "2.2.0"
+    isarray "0.0.1"
+    json3 "3.3.2"
+
+socket.io@^1.3.7:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-1.7.4.tgz#2f7ecedc3391bf2d5c73e291fe233e6e34d4dd00"
+  dependencies:
+    debug "2.3.3"
+    engine.io "~1.8.4"
+    has-binary "0.1.7"
+    object-assign "4.1.0"
+    socket.io-adapter "0.5.0"
+    socket.io-client "1.7.4"
+    socket.io-parser "2.3.1"
 
 source-list-map@^2.0.0:
   version "2.0.0"
@@ -5457,6 +5753,10 @@ sshpk@^1.7.0:
 stable@~0.1.3:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.6.tgz#910f5d2aed7b520c6e777499c1f32e139fdecb10"
+
+stackframe@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
 
 stat-mode@^0.2.0:
   version "0.2.2"
@@ -5681,6 +5981,13 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
+
 temp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/temp/-/temp-0.4.0.tgz#671ad63d57be0fe9d7294664b3fc400636678a60"
@@ -5694,6 +6001,35 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+test262-compiler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/test262-compiler/-/test262-compiler-3.0.0.tgz#fb811c1fd5d62cf872b6d5b33aab96ff4f4ed723"
+  dependencies:
+    test262-parser "^2.0.7"
+    yargs "^4.7.1"
+
+test262-integrator@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/test262-integrator/-/test262-integrator-1.2.0.tgz#65b8c513aa4efd69b1c90d32a27e9ad21498d6ac"
+  dependencies:
+    eshost "^3.5.1"
+    js-yaml "^3.10.0"
+    test262-stream "git://github.com/bocoup/test262-stream.git"
+
+test262-parser@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/test262-parser/-/test262-parser-2.0.7.tgz#733b46bf7759e747eae34b5b14d6a3c8d2082add"
+  dependencies:
+    js-yaml "^3.2.1"
+    through "^2.3.4"
+
+"test262-stream@git://github.com/bocoup/test262-stream.git":
+  version "1.0.0"
+  resolved "git://github.com/bocoup/test262-stream.git#5435de672d20cd66789a5f57e5bb8bd60d001b44"
+  dependencies:
+    klaw "^2.1.0"
+    test262-compiler "^3.0.0"
 
 text-table@~0.2.0:
   version "0.2.0"
@@ -5743,7 +6079,7 @@ through2@^2.0.0, through2@~2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@^2.3.6, through@~2.3.8:
+through@^2.3.4, through@^2.3.6, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -5761,6 +6097,12 @@ timers-browserify@^2.0.2:
   dependencies:
     setimmediate "^1.0.4"
 
+tmp@0.0.30:
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.30.tgz#72419d4a8be7d6ce75148fd8b324e593a711c2ed"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
@@ -5770,6 +6112,10 @@ to-absolute-glob@^0.1.1:
   resolved "https://registry.yarnpkg.com/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz#1cdfa472a9ef50c239ee66999b662ca0eb39937f"
   dependencies:
     extend-shallow "^2.0.1"
+
+to-array@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -5867,6 +6213,10 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+ultron@1.0.x:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
 unique-stream@^2.0.2:
   version "2.2.1"
@@ -6134,6 +6484,10 @@ window-size@^0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.4.tgz#f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876"
 
+window-size@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
+
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
@@ -6184,9 +6538,42 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.2.tgz#8a244fa052401e08c9886cf44a85189e1fd4067f"
+  dependencies:
+    options ">=0.0.5"
+    ultron "1.0.x"
+
+ws@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.4.tgz#57f40d036832e5f5055662a397c4de76ed66bf61"
+  dependencies:
+    options ">=0.0.5"
+    ultron "1.0.x"
+
+wtf-8@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
+
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xml2js@^0.4.17:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.4.tgz#519cb4ca686d005a8420d3496f3f0caeecca580f"
+
+xmlhttprequest-ssl@1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
 "xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
@@ -6200,6 +6587,13 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
+yargs-parser@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-2.4.1.tgz#85568de3cf150ff49fa51825f03a8c880ddcc5c4"
+  dependencies:
+    camelcase "^3.0.0"
+    lodash.assign "^4.0.6"
+
 yargs-parser@^4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
@@ -6211,6 +6605,25 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs@^4.7.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-4.8.1.tgz#c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
+  dependencies:
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    lodash.assign "^4.0.3"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^1.0.1"
+    which-module "^1.0.0"
+    window-size "^0.2.0"
+    y18n "^3.2.1"
+    yargs-parser "^2.4.1"
 
 yargs@^6.0.0:
   version "6.6.0"
@@ -6274,3 +6687,7 @@ yauzl@^2.2.1:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.0.1"
+
+yeast@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"


### PR DESCRIPTION
This method provides an alternative way to run Test262 through a
stream of compiled test contents for each scenario (default, strict
mode), including all the necessary harness contents.

The logic to capture an execution success or failure is similar to
the original one - from scripts/test262-runner.js - and improvements
should be done as follow ups.

The filtering system is now done through a configuration yaml file,
using tests metadata and path locations. This filter is used as an
object that can be extended with further logic, but still offers a
single point to check for filtering.

The report system requires some improvements and these should also
be done as follow-ups. For now they provide a report for each
folder and the total results. Although, the results data contain
enough information to highly expand the report.

Some further improvements are expected and planned, this work
should be at least ready for an initial round for feedback review.