### PR TITLE
Introduce an abstract value that is a kind of union.

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -159,11 +159,6 @@ export function computeBinary(
       (!lval.mightNotBeObject() && (rval instanceof NullValue || rval instanceof UndefinedValue)) ||
       ((lval instanceof NullValue || lval instanceof UndefinedValue) && !rval.mightNotBeObject())
     ) {
-      //TODO #1001: We can only get here if lval or rval is known to be an object. In general, we require that such values
-      //can never be null or undefined, so the next line makes no sense. It is in fact a short term hack to deal
-      //with the need for some intrinsic objects to be optionally null or undefined. It is still an open question
-      //how best to model such objects. When that question is resolved, the next line should go away.
-      if (lval.isIntrinsic() || rval.isIntrinsic()) return AbstractValue.createFromBinaryOp(realm, op, lval, rval, loc);
       return new BooleanValue(realm, op[0] !== "=");
     }
   }

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -46,10 +46,8 @@ export default function(
   }
   invariant(lval instanceof AbstractValue);
 
-  if (!lval.isIntrinsic()) {
-    if (!lval.mightNotBeFalse()) return ast.operator === "||" ? env.evaluate(ast.right, strictCode) : lval;
-    if (!lval.mightNotBeTrue()) return ast.operator === "&&" ? env.evaluate(ast.right, strictCode) : lval;
-  }
+  if (!lval.mightNotBeFalse()) return ast.operator === "||" ? env.evaluate(ast.right, strictCode) : lval;
+  if (!lval.mightNotBeTrue()) return ast.operator === "&&" ? env.evaluate(ast.right, strictCode) : lval;
 
   // Create empty effects for the case where ast.right is not evaluated
   let [compl1, gen1, bindings1, properties1, createdObj1] = construct_empty_effects(realm);

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -9,14 +9,7 @@
 
 /* @flow */
 
-import {
-  AbstractObjectValue,
-  AbstractValue,
-  ConcreteValue,
-  NullValue,
-  UndefinedValue,
-  Value,
-} from "../values/index.js";
+import { AbstractValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
 import invariant from "../invariant.js";
 
 export function withPathCondition<T>(condition: AbstractValue, evaluate: () => T): T {
@@ -80,8 +73,7 @@ function pushPathCondition(condition: Value) {
 
 // An inverse path condition is an abstract value that is known to be false in a particular code path
 function pushInversePathCondition(condition: Value) {
-  // it is mistake to assert that true is false (but special case intrinsic objects until there is a better story)
-  if (condition instanceof AbstractObjectValue && condition.isIntrinsic()) return;
+  // it is mistake to assert that true is false.
   invariant(condition.mightNotBeTrue());
   if (condition instanceof ConcreteValue) return;
   invariant(condition instanceof AbstractValue);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -177,6 +177,12 @@ export default class AbstractValue extends Value {
     // Neither this nor val is a known value, so we need to some reasoning based on the structure
     if (this.equals(val)) return true; // x => x regardless of its value
     if (!val.mightNotBeTrue()) return true; // x => true regardless of the value of x
+    // x => x !== null && x !== undefined
+    if (val instanceof AbstractValue && val.kind === "!==") {
+      let [x, y] = val.args;
+      if (this.equals(x)) return y instanceof NullValue || y instanceof UndefinedValue;
+      if (this.equals(y)) return x instanceof NullValue || x instanceof UndefinedValue;
+    }
     return false;
   }
 
@@ -536,6 +542,31 @@ export default class AbstractValue extends Value {
     } else {
       return realm.generator.derive(types, values, args, buildFunction);
     }
+  }
+
+  // Creates a union of an abstract value with one or more concrete values.
+  // The build node for the abstract values becomes the build node for the union.
+  // Use this only to allow instrinsic abstract objects to be null and/or undefined.
+  static createAbstractConcreteUnion(realm: Realm, ...elements: Array<Value>) {
+    let concreteValues: Array<ConcreteValue> = (elements.filter(e => e instanceof ConcreteValue): any);
+    invariant(concreteValues.length > 0 && concreteValues.length === elements.length - 1);
+    let concreteSet = new Set(concreteValues);
+    let abstractValue = elements.find(e => e instanceof AbstractValue);
+    invariant(abstractValue instanceof AbstractValue);
+    let values;
+    if (!abstractValue.values.isTop()) {
+      abstractValue.values.getElements().forEach(v => concreteSet.add(v));
+      values = new ValuesDomain(concreteSet);
+    } else {
+      values = ValuesDomain.topVal;
+    }
+    let types = TypesDomain.topVal;
+    let [hash, operands] = hashCall("union", ...elements);
+    let result = new AbstractValue(realm, types, values, hash, operands, abstractValue._buildNode, {
+      kind: "abstractConcreteUnion",
+    });
+    result.expressionLocation = realm.currentLocation;
+    return result;
   }
 
   static generateErrorInformationForAbstractVal(val: AbstractValue): string {

--- a/test/serializer/abstract/NegateObject.js
+++ b/test/serializer/abstract/NegateObject.js
@@ -1,6 +1,5 @@
 y = global.__abstract ? __abstract("object", "({})") : {};
 let z = !y;
-// Once intrinsic objects can be designated not null/undefined, invert the condition below: see issue #1001
-if (global.__isAbstract && !__isAbstract(z)) throw new Error("bug!");
+if (global.__isAbstract && __isAbstract(z)) throw new Error("bug!");
 x = z;
 inspect = function() { return x; }

--- a/test/serializer/abstract/Optional.js
+++ b/test/serializer/abstract/Optional.js
@@ -1,5 +1,5 @@
 function f() { return 123; }
-var g = global.__abstract ? __abstract("function", "null") : null;
+var g = global.__abstractOrNull ? __abstractOrNull("function", "null") : null;
 z = undefined;
 if (g !== null)
   z = g();

--- a/test/serializer/abstract/Optional2.js
+++ b/test/serializer/abstract/Optional2.js
@@ -1,5 +1,5 @@
 function f() { return 123; }
-var g = global.__abstract ? __abstract("function", "f") : f;
+var g = global.__abstractOrUndefined ? __abstractOrUndefined("function", "f") : f;
 if (g != null)
   z = g();
 

--- a/test/serializer/abstract/Optional3.js
+++ b/test/serializer/abstract/Optional3.js
@@ -1,5 +1,5 @@
 function f() { return 123; }
-var g = global.__abstract ? __abstract("function", "f") : f;
+var g = global.__abstractOrNullOrUndefined ? __abstractOrNullOrUndefined("function", "f") : f;
 z = g && g();
 
 inspect = function() { return "" + z }

--- a/test/serializer/abstract/Optional4.js
+++ b/test/serializer/abstract/Optional4.js
@@ -1,4 +1,4 @@
-var g = global.__abstract ? __abstract("function", "null") : null;
+var g = global.__abstractOrNull ? __abstractOrNull("function", "null") : null;
 z = g && g();
 
 inspect = function() { return "" + z }

--- a/test/serializer/abstract/Optional5.js
+++ b/test/serializer/abstract/Optional5.js
@@ -1,6 +1,6 @@
 // add at runtime: let x = { items: "abc" };
 let x = { items: "abc" };
-let y = global.__abstract ? __abstract(x, "x") : x;
+let y = global.__abstractOrUndefined ? __abstractOrUndefined(x, "x") : x;
 
 function getCollectionData(collection) {
   return {


### PR DESCRIPTION
Release note: Introduce model functions for environment properties that may result in optional values.

Rather than special case intrinsic abstract objects, revert to treating them as not null and not undefined. Instead, there is now an abstract value kind "abstractConcreteUnion" which is the union of an abstract value with one or more concrete values. There are also new helper functions: __abstractOrNull, __abstractOrNullOrUndefined and __abstractOrUndefined that can be used to construct such unions.

The serializer need not know anything about these new kind of values, since their build nodes just defer to the build nodes of the single embedded abstract value that must always form part of the union.

The simplifier has been extended to simplify unions into their constituents if the path conditions allow it.

The rest of this request is just removing all of the places where special logic was needed to allow intrinsic abstract objects to behave like they might be null or undefined.

Issue #1001.