### PR TITLE
Store Flow class component parameter annotations

### DIFF
--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -83,6 +83,7 @@ export function ClassDefinitionEvaluation(
 
   let protoParent;
   let constructorParent;
+  let superTypeParameters;
   // 5. If ClassHeritage opt is not present, then
   let ClassHeritage = ast.superClass;
   if (!ClassHeritage) {
@@ -155,6 +156,10 @@ export function ClassDefinitionEvaluation(
   // 7. Let proto be ObjectCreate(protoParent).
   let proto = ObjectCreate(realm, protoParent);
 
+  // react. Check the Flow class paramater annotations, stored in "superTypeParameters"
+  if (realm.react.enabled && ast.superTypeParameters) {
+    proto.$SuperTypeParameters = ast.superTypeParameters;
+  }
   let constructor;
   let ClassBody: Array<BabelNodeClassMethod> = [];
   for (let elem of ast.body.body) {

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -83,7 +83,6 @@ export function ClassDefinitionEvaluation(
 
   let protoParent;
   let constructorParent;
-  let superTypeParameters;
   // 5. If ClassHeritage opt is not present, then
   let ClassHeritage = ast.superClass;
   if (!ClassHeritage) {

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -156,7 +156,7 @@ export function ClassDefinitionEvaluation(
   let proto = ObjectCreate(realm, protoParent);
 
   // react. Check the Flow class paramater annotations, stored in "superTypeParameters"
-  if (realm.react.enabled && ast.superTypeParameters) {
+  if (realm.react.enabled && realm.react.flowRequired && ast.superTypeParameters) {
     proto.$SuperTypeParameters = ast.superTypeParameters;
   }
   let constructor;

--- a/src/realm.js
+++ b/src/realm.js
@@ -184,6 +184,7 @@ export class Realm {
 
     this.react = {
       enabled: opts.reactEnabled || false,
+      flowRequired: true,
       reactElementSymbol: undefined,
     };
 
@@ -220,6 +221,7 @@ export class Realm {
 
   react: {
     enabled: boolean,
+    flowRequired: boolean,
     reactElementSymbol?: SymbolValue,
   };
 

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -188,7 +188,7 @@ export class Serializer {
     );
 
     let ast = residualHeapSerializer.serialize();
-    if (this.realm.react.enabled) {
+    if (this.realm.react.enabled && this.realm.react.flowRequired) {
       stripFlowTypeAnnotations(ast);
     }
     let generated = generate(ast, { sourceMaps: sourceMaps }, (code: any));

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -29,7 +29,10 @@ export default function(
   try {
     let plugins = [];
     if (realm.react.enabled) {
-      plugins.push("jsx", "flow");
+      plugins.push("jsx");
+      if (realm.react.flowRequired) {
+        plugins.push("flow");
+      }
     }
     let ast = parse(code, { filename, sourceType, startLine, plugins });
     traverseFast(ast, node => {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -92,7 +92,6 @@ export default class ObjectValue extends ConcreteValue {
     "$StringIteratorNextIndex",
     "$WeakMapData",
     "$WeakSetData",
-    "$SuperTypeParameters",
   ];
 
   getTrackedPropertyNames(): Array<string> {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -52,6 +52,7 @@ import {
   ThrowIfMightHaveBeenDeleted,
 } from "../methods/index.js";
 import invariant from "../invariant.js";
+import type { typeAnnotation } from "babel-types";
 
 export default class ObjectValue extends ConcreteValue {
   constructor(
@@ -91,6 +92,7 @@ export default class ObjectValue extends ConcreteValue {
     "$StringIteratorNextIndex",
     "$WeakMapData",
     "$WeakSetData",
+    "$SuperTypeParameters",
   ];
 
   getTrackedPropertyNames(): Array<string> {
@@ -171,6 +173,9 @@ export default class ObjectValue extends ConcreteValue {
   $SetNextIndex: void | number;
   $IteratedSet: void | ObjectValue | UndefinedValue;
   $SetData: void | Array<void | Value>;
+
+  // react
+  $SuperTypeParameters: void | typeAnnotation;
 
   // map
   $MapIterationKind: void | IterationKind;


### PR DESCRIPTION
For the React folding optimizations to work on ES2015 class components, we need to get the Flow type annotations for the `Component`. For example:

```jsx
type Props = { ... };
type State = { ... };

class MyComponent extends React.Component<Props, State> {
  render() { ... }
}
```

The type annotations are used in the reconciliation process as hints for the shape of abstract objects.