### PR TITLE
Lazy objects v0 for raw objects

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -17,6 +17,7 @@ export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "node-source-ma
 export type RealmOptions = {
   compatibility?: Compatibility,
   debugNames?: boolean,
+  lazyObjectsRuntime?: string,
   errorHandler?: ErrorHandler,
   mathRandomSeed?: string,
   omitInvariants?: boolean,
@@ -31,6 +32,7 @@ export type RealmOptions = {
 
 export type SerializerOptions = {
   additionalFunctions?: Array<string>,
+  lazyObjectsRuntime?: string,
   delayInitializations?: boolean,
   delayUnsupportedRequires?: boolean,
   initializeMoreModules?: boolean,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -44,6 +44,7 @@ function run(
     --maxStackDepth          Specify the maximum call stack depth.
     --timeout                The amount of time in seconds until Prepack should time out.
     --additionalFunctions    Additional functions that should be prepacked (comma separated).
+    --lazyObjectsRuntime     Enable lazy objects feature and specify the JS runtime that support this feature.
     --debugNames             Changes the output of Prepack so that for named functions and variables that get emitted into
                              Prepack's output, the original name is appended as a suffix to Prepack's generated identifier.
     --speculate              Enable speculative initialization of modules (for the module system Prepack has builtin
@@ -70,6 +71,7 @@ function run(
   let maxStackDepth: number;
   let timeout: number;
   let additionalFunctions: Array<string>;
+  let lazyObjectsRuntime: string;
   let debugInFilePath: string;
   let debugOutFilePath: string;
   let flags = {
@@ -146,9 +148,12 @@ function run(
         case "debugOutFilePath":
           debugOutFilePath = args.shift();
           break;
+        case "lazyObjectsRuntime":
+          lazyObjectsRuntime = args.shift();
+          break;
         case "help":
           console.log(
-            "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --maxStackDepth depthValue ] [ --timeout seconds ] [ --additionalFunctions fnc1,fnc2,... ]" +
+            "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --maxStackDepth depthValue ] [ --timeout seconds ] [ --additionalFunctions fnc1,fnc2,... ] [ --lazyObjectsRuntime lazyObjectsRuntimeName]" +
               Object.keys(flags).map(s => "[ --" + s + "]").join(" ") +
               "\n" +
               HELP_STR
@@ -177,12 +182,22 @@ function run(
       maxStackDepth: maxStackDepth,
       timeout: timeout,
       additionalFunctions: additionalFunctions,
+      lazyObjectsRuntime: lazyObjectsRuntime,
       enableDebugger: false, //always turn off debugger until debugger is fully built
       debugInFilePath: debugInFilePath,
       debugOutFilePath: debugOutFilePath,
     },
     flags
   );
+  if (
+    lazyObjectsRuntime &&
+    (resolvedOptions.additionalFunctions || resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)
+  ) {
+    console.error(
+      "lazy objects feature is incompatible with additionalFunctions, delayInitializations and inlineExpressions options"
+    );
+    process.exit(1);
+  }
 
   let errors: Map<BabelNodeSourceLocation, CompilerDiagnostic> = new Map();
   function errorHandler(diagnostic: CompilerDiagnostic): ErrorHandlerResult {

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -17,6 +17,7 @@ import invariant from "./invariant.js";
 export type PrepackOptions = {|
   additionalGlobals?: Realm => void,
   additionalFunctions?: Array<string>,
+  lazyObjectsRuntime?: string,
   compatibility?: Compatibility,
   debugNames?: boolean,
   delayInitializations?: boolean,
@@ -50,6 +51,7 @@ export type PrepackOptions = {|
 export function getRealmOptions({
   compatibility = "browser",
   debugNames = false,
+  lazyObjectsRuntime,
   errorHandler,
   mathRandomSeed,
   omitInvariants = false,
@@ -64,6 +66,7 @@ export function getRealmOptions({
   return {
     compatibility,
     debugNames,
+    lazyObjectsRuntime,
     errorHandler,
     mathRandomSeed,
     omitInvariants,
@@ -79,6 +82,7 @@ export function getRealmOptions({
 
 export function getSerializerOptions({
   additionalFunctions,
+  lazyObjectsRuntime,
   delayInitializations = false,
   delayUnsupportedRequires = false,
   internalDebug = false,
@@ -101,6 +105,9 @@ export function getSerializerOptions({
     trace,
   };
   if (additionalFunctions) result.additionalFunctions = additionalFunctions;
+  if (lazyObjectsRuntime !== undefined) {
+    result.lazyObjectsRuntime = lazyObjectsRuntime;
+  }
   return result;
 }
 

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { Realm } from "../realm.js";
+import { AbstractValue, FunctionValue, Value, ObjectValue } from "../values/index.js";
+import * as t from "babel-types";
+import type {
+  BabelNodeExpression,
+  BabelNodeStatement,
+  BabelNodeIdentifier,
+  BabelNodeBlockStatement,
+  BabelNodeSwitchCase,
+} from "babel-types";
+import type {
+  SerializedBody,
+  FunctionInfo,
+  FunctionInstance,
+  AdditionalFunctionInfo,
+  ReactSerializerState,
+} from "./types.js";
+import type { SerializerOptions } from "../options.js";
+import invariant from "../invariant.js";
+import { SerializerStatistics } from "./types.js";
+import { Logger } from "./logger.js";
+import { Modules } from "./modules.js";
+import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
+import type { Scope } from "./ResidualHeapVisitor.js";
+import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js";
+import type { Effects } from "../realm.js";
+import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
+import { getOrDefault } from "./utils.js";
+
+const LAZY_OBJECTS_SERIALIZER_BODY_TYPE = "LazyObjectInitializer";
+
+/**
+ * Serialize objects in lazy mode by leveraging the JS runtime that support this feature.
+ * Objects are serialized into two parts:
+ * 1. All lazy objects are created via lightweight LazyObjectsRuntime.createLazyObject() call.
+ * 2. Lazy objects' property assignments are delayed in a callback function which is registered with the runtime.
+ *    lazy objects rutnime will execute this callback to hydrate the lazy objects.
+ *
+ * Currently only the raw objects are taking part in the lazy objects feature.
+ * TODO: suppor for other objects, like array, regex etc...
+ */
+export class LazyObjectsSerializer extends ResidualHeapSerializer {
+  constructor(
+    realm: Realm,
+    logger: Logger,
+    modules: Modules,
+    residualHeapValueIdentifiers: ResidualHeapValueIdentifiers,
+    residualHeapInspector: ResidualHeapInspector,
+    residualValues: Map<Value, Set<Scope>>,
+    residualFunctionInstances: Map<FunctionValue, FunctionInstance>,
+    residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>,
+    options: SerializerOptions,
+    referencedDeclaredValues: Set<AbstractValue>,
+    additionalFunctionValuesAndEffects: Map<FunctionValue, Effects> | void,
+    additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
+    statistics: SerializerStatistics,
+    react: ReactSerializerState
+  ) {
+    super(
+      realm,
+      logger,
+      modules,
+      residualHeapValueIdentifiers,
+      residualHeapInspector,
+      residualValues,
+      residualFunctionInstances,
+      residualFunctionInfos,
+      options,
+      referencedDeclaredValues,
+      additionalFunctionValuesAndEffects,
+      additionalFunctionValueInfos,
+      statistics,
+      react
+    );
+    this._lazyObjectIdSeed = 0;
+    this._valueLazyIds = new Map();
+    this._lazyObjectInitializers = new Map();
+    this._callbackLazyObjectParam = t.identifier("obj");
+    invariant(this._options.lazyObjectsRuntime != null);
+    this._lazyObjectJSRuntimeName = t.identifier(this._options.lazyObjectsRuntime);
+    this._initializationCallbackName = t.identifier("__initializerCallback");
+  }
+
+  _lazyObjectIdSeed: number;
+  _valueLazyIds: Map<ObjectValue, number>;
+  // Holds object's lazy initializer bodies.
+  // These bodies will be combined into a well-known callback after generator serialization is done and registered with the runtime.
+  _lazyObjectInitializers: Map<ObjectValue, SerializedBody>;
+  _currentSerializeLazyObject: void | ObjectValue;
+
+  _lazyObjectJSRuntimeName: BabelNodeIdentifier;
+  _callbackLazyObjectParam: BabelNodeIdentifier;
+  _initializationCallbackName: BabelNodeIdentifier;
+
+  _getValueLazyId(obj: ObjectValue): number {
+    return getOrDefault(this._valueLazyIds, obj, () => this._lazyObjectIdSeed++);
+  }
+
+  // TODO: change to use _getTarget() to get the lazy objects initializer body.
+  _serializeLazyObjectInitializer(obj: ObjectValue): SerializedBody {
+    const prevLazyObject = this._currentSerializeLazyObject;
+    this._currentSerializeLazyObject = obj;
+    const initializerBody = { type: LAZY_OBJECTS_SERIALIZER_BODY_TYPE, entries: [] };
+    let oldBody = this.emitter.beginEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, initializerBody);
+    this._emitObjectProperties(obj);
+    this.emitter.endEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, oldBody);
+    this._currentSerializeLazyObject = prevLazyObject;
+    return initializerBody;
+  }
+
+  _serializeLazyObjectInitializerSwitchCase(obj: ObjectValue, initializer: SerializedBody): BabelNodeSwitchCase {
+    // TODO: only serialize this switch case if the initializer(property assignment) is not empty.
+    const caseBody = initializer.entries.concat(t.breakStatement());
+    const lazyId = this._getValueLazyId(obj);
+    return t.switchCase(t.numericLiteral(lazyId), caseBody);
+  }
+
+  _serializeInitializationCallback(): BabelNodeStatement {
+    const body = [];
+
+    const switchCases = [];
+    for (const [obj, initializer] of this._lazyObjectInitializers) {
+      switchCases.push(this._serializeLazyObjectInitializerSwitchCase(obj, initializer));
+    }
+    // Default case.
+    switchCases.push(
+      t.switchCase(null, [
+        t.throwStatement(t.newExpression(t.identifier("Error"), [t.stringLiteral("Unknown lazy id")])),
+      ])
+    );
+
+    const selector = t.identifier("id");
+    body.push(t.switchStatement(selector, switchCases));
+
+    const params = [this._callbackLazyObjectParam, selector];
+    const initializerCallbackFunction = t.functionExpression(null, params, t.blockStatement(body));
+    // TODO: use NameGenerator.
+    return t.variableDeclaration("var", [
+      t.variableDeclarator(this._initializationCallbackName, initializerCallbackFunction),
+    ]);
+  }
+
+  _serializeRegisterInitializationCallback(): BabelNodeStatement {
+    return t.expressionStatement(
+      t.callExpression(t.memberExpression(this._lazyObjectJSRuntimeName, t.identifier("setLazyObjectInitializer")), [
+        this._initializationCallbackName,
+      ])
+    );
+  }
+
+  _serializeCreateLazyObject(obj: ObjectValue): BabelNodeExpression {
+    const lazyId = this._getValueLazyId(obj);
+    return t.callExpression(
+      t.memberExpression(this._lazyObjectJSRuntimeName, t.identifier("createLazyObject"), /*computed*/ false),
+      [t.numericLiteral(lazyId)]
+    );
+  }
+
+  // Override default behavior.
+  // Inside lazy objects callback, the lazy object identifier needs to be replaced with the
+  // parameter passed from the runtime.
+  getSerializeObjectIdentifier(val: Value): BabelNodeIdentifier {
+    return this.emitter.getBody().type === LAZY_OBJECTS_SERIALIZER_BODY_TYPE && this._currentSerializeLazyObject === val
+      ? this._callbackLazyObjectParam
+      : super.getSerializeObjectIdentifier(val);
+  }
+
+  // Override default behavior.
+  // Inside lazy objects callback, the lazy object identifier needs to be replaced with the
+  // parameter passed from the runtime.
+  getSerializeObjectIdentifierOptional(val: Value): void | BabelNodeIdentifier {
+    return this.emitter.getBody().type === LAZY_OBJECTS_SERIALIZER_BODY_TYPE && this._currentSerializeLazyObject === val
+      ? this._callbackLazyObjectParam
+      : super.getSerializeObjectIdentifierOptional(val);
+  }
+
+  // Override default serializer with lazy mode.
+  serializeValueRawObject(obj: ObjectValue): BabelNodeExpression {
+    this._lazyObjectInitializers.set(obj, this._serializeLazyObjectInitializer(obj));
+    return this._serializeCreateLazyObject(obj);
+  }
+
+  // Override.
+  // Serialize the initialization callback and its registration in prelude if there are object being lazied.
+  postGeneratorSerialization(): void {
+    if (this._lazyObjectInitializers.size > 0) {
+      // Insert initialization callback at the end of prelude code.
+      this.prelude.push(this._serializeInitializationCallback());
+      this.prelude.push(this._serializeRegisterInitializationCallback());
+    }
+  }
+}

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -29,6 +29,7 @@ import { LoggingTracer } from "./LoggingTracer.js";
 import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
 import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js";
+import { LazyObjectsSerializer } from "./LazyObjectsSerializer.js";
 import * as t from "babel-types";
 
 export class Serializer {
@@ -156,7 +157,7 @@ export class Serializer {
         residualHeapVisitor.values,
         residualHeapVisitor.functionInstances,
         residualHeapVisitor.functionInfos,
-        !!this.options.delayInitializations,
+        this.options,
         residualHeapVisitor.referencedDeclaredValues,
         additionalFunctionValuesAndEffects,
         residualHeapVisitor.additionalFunctionValueInfos,
@@ -170,7 +171,8 @@ export class Serializer {
 
     // Serialize for a second time, using reference counts to minimize number of generated identifiers
     if (timingStats !== undefined) timingStats.serializePassTime = Date.now();
-    let residualHeapSerializer = new ResidualHeapSerializer(
+    const TargetSerializer = this.options.lazyObjectsRuntime != null ? LazyObjectsSerializer : ResidualHeapSerializer;
+    let residualHeapSerializer = new TargetSerializer(
       this.realm,
       this.logger,
       this.modules,
@@ -179,7 +181,7 @@ export class Serializer {
       residualHeapVisitor.values,
       residualHeapVisitor.functionInstances,
       residualHeapVisitor.functionInfos,
-      !!this.options.delayInitializations,
+      this.options,
       residualHeapVisitor.referencedDeclaredValues,
       additionalFunctionValuesAndEffects,
       residualHeapVisitor.additionalFunctionValueInfos,

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -20,7 +20,12 @@ import invariant from "../invariant.js";
 export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) => T;
 
 // TODO: add type for additional functions.
-export type SerializedBodyType = "MainGenerator" | "Generator" | "DelayInitializations" | "ConditionalAssignmentBranch";
+export type SerializedBodyType =
+  | "MainGenerator"
+  | "Generator"
+  | "DelayInitializations"
+  | "ConditionalAssignmentBranch"
+  | "LazyObjectInitializer";
 
 export type SerializedBody = {
   type: SerializedBodyType,


### PR DESCRIPTION
Release Note: introduce lazy objects feature for raw objects in Prepack.
Introduce lazy objects feature for raw objects in Prepack with supported runtime.
Lazy object is a collaboration feature between the Prepack and new runtime that supports this feature. With this feature, object can be created with a special LazyObjectsRuntime.createLazyObject() API. The object created with this API can be a light-weight placeholder object. Once the lazy object is *touched/used* the first time, runtime is responsible to callback the registered initialization function to hydrate the object into a real object. 
By doing this we will save both memory and object creation speed. 

Currently, Prepack only supports lazy for raw objects.

The APIs that runtime needs to support:
1. LazyObjectsRuntime.createLazyObject(<lazy_object_id>);
2. LazyObjectsRuntime.setLazyObjectInitializer(<well-known-callback>).

Under lazy objects mode, Prepack will serialize all lazy objects into two parts:
 1. All lazy objects are created via lightweight LazyObjectsRuntime.createLazyObject() call.
 2. Lazy objects' property assignments are delayed in a callback function which is registered with the runtime. 
 
TODO:
1. Test-runner support for lazy mode.
2. Support more object types for this feature
3. Remove "reference count === 1" objects' root and directly serialize into callback function.
4. Figure out "reference count > 1" objects that are safe to remove root from global anonymous function and directly serialize into callback function.

Test Plan:
1. "bin/prepack.js <foo.js> --lazyObjectsRuntime LazyObjectRuntime"
2. test-runner introduced a lazy mode(later PR) can successfully run all tests.