### PR TITLE
Add threads request to debugger

### DIFF
--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -197,6 +197,18 @@ class PrepackDebugSession extends LoggingDebugSession {
       this.sendResponse(response);
     });
   }
+
+  threadsRequest(response: DebugProtocol.ThreadsResponse): void {
+    // There will only be 1 thread, so respond immediately
+    let thread: DebugProtocol.Thread = {
+      id: DebuggerConstants.PREPACK_THREAD_ID,
+      name: "main",
+    }
+    response.body = {
+      threads: [thread],
+    };
+    this.sendResponse(response);
+  }
 }
 
 DebugSession.run(PrepackDebugSession);

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -203,7 +203,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     let thread: DebugProtocol.Thread = {
       id: DebuggerConstants.PREPACK_THREAD_ID,
       name: "main",
-    }
+    };
     response.body = {
       threads: [thread],
     };

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -129,8 +129,15 @@ export class UISession {
   }
 
   _processResponse(response: DebugProtocol.Response) {
-    // to be implemented
-    console.log(response);
+    if (response.command === "threads") {
+      this._processThreadsResponse(((response: any): DebugProtocol.ThreadsResponse));
+    }
+  }
+
+  _processThreadsResponse(response: DebugProtocol.ThreadsResponse) {
+    for (const thread of response.body.threads) {
+      this._uiOutput(`${thread.id}: ${thread.name}`);
+    }
   }
 
   // execute a command if it is valid
@@ -166,6 +173,10 @@ export class UISession {
           }
           this._sendBreakpointRequest(filePath, line, column);
         }
+        break;
+      case "threads":
+        if (parts.length !== 1) return false;
+        this._sendThreadsRequest();
         break;
       default:
         // invalid command
@@ -251,6 +262,16 @@ export class UISession {
       seq: this._sequenceNum,
       command: "setBreakpoints",
       arguments: args,
+    };
+    let json = JSON.stringify(message);
+    this._packageAndSend(json);
+  }
+
+  _sendThreadsRequest() {
+    let message = {
+      type: "request",
+      seq: this._sequenceNum,
+      command: "threads",
     };
     let json = JSON.stringify(message);
     this._packageAndSend(json);


### PR DESCRIPTION
Release note: none
Summary:
- let UI send threads request
- adapter returns information about the one thread

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path_to_adapter> --prepack <command_to_run_prepack> --inFilePath <debug_input_file_path> --outFilePath <debug_output_file_path>`
e.g. `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepack "lib/prepack-cli.js test/serializer/basic/Date.js" --inFilePath src/debugger/.sessionlogs/engine2adapter.txt --outFilePath src/debugger/.sessionlogs/adapter2engine.txt`

- `threads`: display the thread information on the CLI