### PR TITLE
Compose effect tracking

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -105,7 +105,8 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     consequent: Completion | Value,
     consequentEffects: Effects,
     alternate: Completion | Value,
-    alternateEffects: Effects
+    alternateEffects: Effects,
+    savedEffects: void | Effects = undefined
   ) {
     invariant(
       consequent instanceof NormalCompletion ||
@@ -134,6 +135,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     this.consequentEffects = consequentEffects;
     this.alternate = alternate;
     this.alternateEffects = alternateEffects;
+    this.savedEffects = savedEffects;
   }
 
   joinCondition: AbstractValue;
@@ -141,6 +143,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   consequentEffects: Effects;
   alternate: Completion | Value;
   alternateEffects: Effects;
+  savedEffects: void | Effects;
 
   containsBreakOrContinue(): boolean {
     if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -90,8 +90,7 @@ function callBothFunctionsAndJoinTheirEffects(
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    completion = realm.getRunningContext().composeWithSavedCompletion(completion);
-    realm.captureEffects();
+    completion = realm.composeWithSavedCompletion(completion);
   }
 
   // Note that the effects of (non joining) abrupt branches are not included

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -109,8 +109,7 @@ export function evaluateWithAbstractConditional(
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    completion = realm.getRunningContext().composeWithSavedCompletion(completion);
-    realm.captureEffects();
+    completion = realm.composeWithSavedCompletion(completion);
   }
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -85,8 +85,7 @@ export default function(
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    completion = realm.getRunningContext().composeWithSavedCompletion(completion);
-    realm.captureEffects();
+    completion = realm.composeWithSavedCompletion(completion);
   }
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.

--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -23,11 +23,9 @@ import { AbstractValue, Value, EmptyValue } from "../values/index.js";
 import { GlobalEnvironmentRecord } from "../environment.js";
 import {
   BoundNames,
-  composePossiblyNormalCompletions,
   FindVarScopedDeclarations,
   incorporateSavedCompletion,
   stopEffectCaptureJoinApplyAndReturnCompletion,
-  updatePossiblyNormalCompletionWithValue,
 } from "../methods/index.js";
 import IsStrict from "../utils/strict.js";
 import invariant from "../invariant.js";
@@ -241,35 +239,26 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
 
   for (let node of ast.body) {
     if (node.type !== "FunctionDeclaration") {
-      let potentialVal = env.evaluateCompletionDeref(node, strictCode);
-      potentialVal = incorporateSavedCompletion(realm, potentialVal);
-      if (potentialVal instanceof AbruptCompletion) {
-        if (!realm.useAbstractInterpretation) throw potentialVal;
+      let res = env.evaluateCompletionDeref(node, strictCode);
+      if (res instanceof AbruptCompletion) {
+        if (!realm.useAbstractInterpretation) throw res;
         // We are about the leave this program and this presents a join point where all non exeptional control flows
         // converge into a single flow using the joined effects as the new state.
-        // The call to incorporateSavedCompletion above, has already taken care of the join.
+        res = incorporateSavedCompletion(realm, res);
+        // The call to incorporateSavedCompletion above, has taken care of the join because res is abrupt.
         // What remains to be done is to emit throw statements to the generator.
-        if (potentialVal instanceof JoinedAbruptCompletions) {
-          emitConditionalThrow(potentialVal.joinCondition, potentialVal.consequent, potentialVal.alternate);
-          potentialVal = potentialVal.value;
-        } else if (potentialVal instanceof ThrowCompletion) {
-          emitThrow(potentialVal.value);
-          potentialVal = realm.intrinsics.undefined;
+        if (res instanceof JoinedAbruptCompletions) {
+          emitConditionalThrow(res.joinCondition, res.consequent, res.alternate);
+          res = res.value;
+        } else if (res instanceof ThrowCompletion) {
+          emitThrow(res.value);
+          res = realm.intrinsics.undefined;
         } else {
           invariant(false); // other kinds of abrupt completions should not get this far
         }
       }
-      if (potentialVal !== undefined && !(potentialVal instanceof EmptyValue)) {
-        if (val instanceof PossiblyNormalCompletion) {
-          if (potentialVal instanceof PossiblyNormalCompletion) {
-            val = composePossiblyNormalCompletions(realm, val, potentialVal);
-          } else {
-            invariant(potentialVal instanceof Value);
-            updatePossiblyNormalCompletionWithValue(realm, val, potentialVal);
-          }
-        } else {
-          val = potentialVal;
-        }
+      if (!(res instanceof EmptyValue)) {
+        val = res;
       }
     }
   }
@@ -277,13 +266,22 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
   if (!val && directives && directives.length) {
     let directive = directives[directives.length - 1];
     val = env.evaluate(directive, strictCode);
+    invariant(val instanceof Value);
   }
 
-  if (val instanceof PossiblyNormalCompletion) {
-    // There are still some conditional throws to emit and state still has to be joined in.
-    stopEffectCaptureJoinApplyAndReturnCompletion(val, new ReturnCompletion(realm.intrinsics.undefined), realm);
-    emitConditionalThrow(val.joinCondition, val.consequent, val.alternate);
-    val = val.value;
+  // We are about to leave this program and this presents a join point where all control flows
+  // converge into a single flow and the joined effects become the final state.
+  if (val instanceof Value) {
+    val = incorporateSavedCompletion(realm, val);
+    if (val instanceof PossiblyNormalCompletion) {
+      // There are still some conditional throws to emit and state still has to be joined in.
+      stopEffectCaptureJoinApplyAndReturnCompletion(val, new ReturnCompletion(realm.intrinsics.undefined), realm);
+      // The global state has now been updated to the join of all the flows reaching this join point
+      emitConditionalThrow(val.joinCondition, val.consequent, val.alternate);
+      val = val.value;
+    }
+  } else {
+    // program was empty. Nothing to do.
   }
 
   invariant(val === undefined || val instanceof Value);

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -96,7 +96,7 @@ export default function(
   invariant(completion === undefined || completion instanceof PossiblyNormalCompletion);
   completion = composeNormalCompletions(completion, callCompletion, callResult, realm);
   if (completion instanceof PossiblyNormalCompletion) {
-    realm.captureEffects();
+    realm.captureEffects(completion);
   }
   return [completion, t.callExpression((calleeAst: any), partialArgs), io];
 }
@@ -134,7 +134,7 @@ function callBothFunctionsAndJoinTheirEffects(
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    joinedCompletion = realm.getRunningContext().composeWithSavedCompletion(joinedCompletion);
+    joinedCompletion = realm.composeWithSavedCompletion(joinedCompletion);
   }
 
   // Note that the effects of (non joining) abrupt branches are not included

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -13,7 +13,7 @@ import type { BabelNodeIfStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 
-import { AbruptCompletion, Completion, NormalCompletion } from "../completions.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
 import { Reference } from "../environment.js";
 import { joinEffects, UpdateEmpty } from "../methods/index.js";
 import { AbstractValue, Value } from "../values/index.js";
@@ -31,7 +31,7 @@ export default function(
   let [exprValue, exprAst, exprIO] = env.partiallyEvaluateCompletionDeref(ast.test, strictCode);
   if (exprValue instanceof AbruptCompletion) return [exprValue, t.expressionStatement((exprAst: any)), exprIO];
   let completion;
-  if (exprValue instanceof NormalCompletion) {
+  if (exprValue instanceof PossiblyNormalCompletion) {
     completion = exprValue;
     exprValue = completion.value;
   }
@@ -83,12 +83,12 @@ export default function(
     [altCompl, gen2, bindings2, properties2, createdObj2]
   );
   completion = joinedEffects[0];
-  if (completion instanceof NormalCompletion) {
+  if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.
     // Consequently we have to continue tracking changes until the point where
     // all the branches come together into one.
-    realm.captureEffects();
+    realm.captureEffects(completion);
   }
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.


### PR DESCRIPTION
There are two different ways to track, capture and undo effects. They need to compose with each other. The second way, needed for PossiblyNormalCompletions, was done with matching calls that updated a field on the current context object. While such completions were not allowed to propagate very far, things seemed to work. But once things got more aggressive strange failures started appearing in large internal test cases.

Thinking about things some more, it became pretty clear to me that the current way does not compose and is thus fundamentally broken. This pull request is a biggish refactor that moves the saved effects for PossiblyNormalCompletions out of the context object and into the completion itself. There is also now logic in evaluateForEffects to make sure that the saved effects of a nested possibly normal completion can never escape from the protected scope protected by evaluateForEffects.

Along the way it also become clear that try-catch-finally did not quite do the right thing by PossiblyNormalCompletions and JoinedAbruptCompletions, so this pull request does yet another rewrite.

Things now really do seem better and I feel more more confident that the design itself is not fundamentally broken.