### PR TITLE
Debugger launch Prepack via request

### DIFF
--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -39,7 +39,6 @@ class PrepackDebugSession extends LoggingDebugSession {
     super("prepack");
     this.setDebuggerLinesStartAt1(true);
     this.setDebuggerColumnsStartAt1(true);
-    this._pendingRequestCallbacks = new Map();
   }
 
   _prepackCommand: string;
@@ -49,7 +48,6 @@ class PrepackDebugSession extends LoggingDebugSession {
   _adapterChannel: AdapterChannel;
   _debuggerOptions: DebuggerOptions;
   _prepackWaiting: boolean;
-  _pendingRequestCallbacks: { [number]: (string) => void };
 
   // Start Prepack in a child process
   _startPrepack() {
@@ -111,11 +109,6 @@ class PrepackDebugSession extends LoggingDebugSession {
         );
       }
     );
-  }
-
-  _addRequestCallback(requestID: number, callback: string => void) {
-    invariant(!(requestID in this._pendingRequestCallbacks), "Request ID already exists in pending requests");
-    this._pendingRequestCallbacks[requestID] = callback;
   }
 
   /**

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -18,13 +18,15 @@ import {
   StoppedEvent,
 } from "vscode-debugadapter";
 import * as DebugProtocol from "vscode-debugprotocol";
-import child_process from "child_process";
 import { AdapterChannel } from "./../channel/AdapterChannel.js";
-import type { DebuggerOptions } from "./../../options.js";
-import { getDebuggerOptions } from "./../../prepack-options.js";
 import invariant from "./../../invariant.js";
 import { DebugMessage } from "./../channel/DebugMessage.js";
-import type { BreakpointArguments, DebuggerResponse, LaunchRequestArguments, PrepackLaunchArguments } from "./../types.js";
+import type {
+  BreakpointArguments,
+  DebuggerResponse,
+  LaunchRequestArguments,
+  PrepackLaunchArguments,
+} from "./../types.js";
 import { DebuggerConstants } from "./../DebuggerConstants.js";
 
 /* An implementation of an debugger adapter adhering to the VSCode Debug protocol
@@ -40,14 +42,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     this.setDebuggerLinesStartAt1(true);
     this.setDebuggerColumnsStartAt1(true);
   }
-
-  _prepackCommand: string;
-  _inFilePath: string;
-  _outFilePath: string;
-  _prepackProcess: child_process.ChildProcess;
   _adapterChannel: AdapterChannel;
-  _debuggerOptions: DebuggerOptions;
-  _prepackWaiting: boolean;
 
   _registerMessageCallbacks() {
     this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_READY_RESPONSE, (response: DebuggerResponse) => {
@@ -85,11 +80,8 @@ class PrepackDebugSession extends LoggingDebugSession {
   }
 
   launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-    this._prepackCommand = args.prepackCommand;
-    this._inFilePath = args.inFilePath;
-    this._outFilePath = args.outFilePath;
     // set up the communication channel
-    this._adapterChannel = new AdapterChannel(this._inFilePath, this._outFilePath);
+    this._adapterChannel = new AdapterChannel(args.inFilePath, args.outFilePath);
     this._registerMessageCallbacks();
     let launchArgs: PrepackLaunchArguments = {
       kind: "launch",

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -8,14 +8,12 @@
  */
 
 /* @flow */
-import type { DebuggerOptions } from "./../../options.js";
 import { FileIOWrapper } from "./FileIOWrapper.js";
 import { MessageMarshaller } from "./MessageMarshaller.js";
 import Queue from "queue-fifo";
 import EventEmitter from "events";
 import invariant from "./../../invariant.js";
 import { DebugMessage } from "./DebugMessage.js";
-import { DebuggerConstants } from "./../DebuggerConstants.js";
 import child_process from "child_process";
 import type { BreakpointArguments, DebuggerResponse, PrepackLaunchArguments } from "./../types.js";
 
@@ -116,12 +114,7 @@ export class AdapterChannel {
 
     let prepackArgs = args.prepackCommand.split(" ");
     // Note: here the input file for the adapter is the output file for Prepack, and vice versa.
-    prepackArgs = prepackArgs.concat([
-      "--debugInFilePath",
-      args.outFilePath,
-      "--debugOutFilePath",
-      args.inFilePath,
-    ]);
+    prepackArgs = prepackArgs.concat(["--debugInFilePath", args.outFilePath, "--debugOutFilePath", args.inFilePath]);
     this._prepackProcess = child_process.spawn("node", prepackArgs);
 
     process.on("exit", () => {

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -20,8 +20,8 @@ import type { BreakpointArguments, DebuggerResponse } from "./../types.js";
 
 //Channel used by the debug adapter to communicate with Prepack
 export class AdapterChannel {
-  constructor(dbgOptions: DebuggerOptions) {
-    this._ioWrapper = new FileIOWrapper(true, dbgOptions.inFilePath, dbgOptions.outFilePath);
+  constructor(inFilePath: string, outFilePath: string) {
+    this._ioWrapper = new FileIOWrapper(true, inFilePath, outFilePath);
     this._marshaller = new MessageMarshaller();
     this._queue = new Queue();
     this._pendingRequestCallbacks = new Map();

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -105,7 +105,6 @@ export class AdapterChannel {
 
   launch(requestID: number, args: PrepackLaunchArguments, callback: DebuggerResponse => void) {
     if (!args.prepackCommand || args.prepackCommand.length === 0) {
-      console.error("No command given to start Prepack in adapter");
       process.exit(1);
     }
 

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -59,15 +59,7 @@ export class UISession {
   _prepackWaiting: boolean;
 
   _startAdapter() {
-    let adapterArgs = [
-      this._adapterPath,
-      "--prepack",
-      this._prepackCommand,
-      "--inFilePath",
-      this._inFilePath,
-      "--outFilePath",
-      this._outFilePath,
-    ];
+    let adapterArgs = [this._adapterPath];
     this._adapterProcess = child_process.spawn("node", adapterArgs);
     this._proc.on("exit", () => {
       this.shutdown();

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -18,6 +18,15 @@ export type DebuggerRequest = {
 
 export type DebuggerRequestArguments = BreakpointArguments | RunArguments | StackframeArguments;
 
+export type PrepackLaunchArguments = {
+  kind: "launch",
+  prepackCommand: string,
+  inFilePath: string,
+  outFilePath: string,
+  outputCallback: Buffer => void,
+  exitCallback: () => void,
+};
+
 export type BreakpointArguments = {
   kind: "breakpoint",
   filePath: string,

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -78,7 +78,8 @@ export type BreakpointStoppedResult = {
 };
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+  noDebug?: boolean,
   prepackCommand: string,
   inFilePath: string,
   outFilePath: string,
-};
+}

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -8,6 +8,7 @@
  */
 
 /* @flow */
+import * as DebugProtocol from "vscode-debugprotocol";
 
 export type DebuggerRequest = {
   id: number,
@@ -65,4 +66,10 @@ export type BreakpointStoppedResult = {
   filePath: string,
   line: number,
   column: number,
+};
+
+export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+  prepackCommand: string,
+  inFilePath: string,
+  outFilePath: string,
 };


### PR DESCRIPTION
Release note: none

Summary:
Previously, when a debugger is started, it would launch Prepack immediately. This PR makes the debugger launch Prepack upon a `launch` request from the UI.
Reasons for doing so:
- more closely aligns with how an IDE debugger would start Prepack, making integration easier
- helps to support `restart` requests in the future.
- makes DebugAdapter code cleaner

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path_to_adapter> --prepack <command_to_run_prepack> --inFilePath <debug_input_file_path> --outFilePath <debug_output_file_path>`
e.g. `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepack "lib/prepack-cli.js test/serializer/basic/Date.js" --inFilePath src/debugger/.sessionlogs/engine2adapter.txt --outFilePath src/debugger/.sessionlogs/adapter2engine.txt`

Supported commands so far:
-`breakpoint add <filePath> <line> ?<column>`: sets a breakpoint at the specified location. If `column` is specified, it is a column breakpoint, otherwise it is a line breakpoint.
-`threads`: display the threads (only 1 in Prepack)
-`stackframes`: fetch the current stack frames when stopped at a breakpoint
-`run`: tell Prepack to continue executing, either upon entry or when stopped at a breakpoint
-`exit`: quit the debugger.