### PR TITLE
Add scope requests to debugger

### DIFF
--- a/flow-libs/vscode-debugadapter.js.flow
+++ b/flow-libs/vscode-debugadapter.js.flow
@@ -216,10 +216,4 @@ declare module 'vscode-debugadapter' {
       sendResponse(response: DebugProtocol.Response): void;
       dispatchRequest(request: DebugProtocol.Request): void
   }
-  declare export class Handles<T>{
-      constructor(startHandle?: number): this;
-      reset(): void;
-      create(value: T): number;
-      get(handle: number, dflt?: T): T
-  }
 }

--- a/flow-libs/vscode-debugadapter.js.flow
+++ b/flow-libs/vscode-debugadapter.js.flow
@@ -216,4 +216,10 @@ declare module 'vscode-debugadapter' {
       sendResponse(response: DebugProtocol.Response): void;
       dispatchRequest(request: DebugProtocol.Request): void
   }
+  declare export class Handles<T>{
+      constructor(startHandle?: number): this;
+      reset(): void;
+      create(value: T): number;
+      get(handle: number, dflt?: T): T
+  }
 }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -26,7 +26,7 @@ import type {
 } from "./types.js";
 import type { Realm } from "./../realm.js";
 import { ExecutionContext } from "./../realm.js";
-import { Handles } from "vscode-debugadapter";
+import { ReferenceMap } from "./ReferenceMap.js";
 
 export class DebugServer {
   constructor(channel: DebugChannel, realm: Realm) {
@@ -36,7 +36,7 @@ export class DebugServer {
     this._lastRunRequestID = 0;
     this._channel = channel;
     this._realm = realm;
-    this._variableMapping = new Handles();
+    this._variableMapping = new ReferenceMap(0);
     this.waitForRun();
   }
   // the collection of breakpoints
@@ -48,7 +48,7 @@ export class DebugServer {
   _channel: DebugChannel;
   _lastRunRequestID: number;
   _realm: Realm;
-  _variableMapping: Handles<VariableContainer>;
+  _variableMapping: ReferenceMap<VariableContainer>;
   /* Block until adapter says to run
   /* runCondition: a function that determines whether the adapter has told
   /* Prepack to continue running
@@ -210,7 +210,7 @@ export class DebugServer {
     let scopes = [];
     if (context.variableEnvironment) {
       // get a new mapping for this collection of variables
-      let variableRef = this._variableMapping.create(context.variableEnvironment);
+      let variableRef = this._variableMapping.add(context.variableEnvironment);
       let scope: Scope = {
         name: "Locals",
         variablesReference: variableRef,
@@ -220,7 +220,7 @@ export class DebugServer {
     }
     if (context.lexicalEnvironment) {
       // get a new mapping for this collection of variables
-      let variableRef = this._variableMapping.create(context.variableEnvironment);
+      let variableRef = this._variableMapping.add(context.variableEnvironment);
       let scope: Scope = {
         name: "Globals",
         variablesReference: variableRef,

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -16,7 +16,14 @@ import invariant from "../invariant.js";
 import type { DebugChannel } from "./channel/DebugChannel.js";
 import { DebugMessage } from "./channel/DebugMessage.js";
 import { DebuggerError } from "./DebuggerError.js";
-import type { DebuggerRequest, StackframeArguments, ScopesArguments, Stackframe, VariableContainer } from "./types.js";
+import type {
+  DebuggerRequest,
+  StackframeArguments,
+  ScopesArguments,
+  Stackframe,
+  VariableContainer,
+  Scope,
+} from "./types.js";
 import type { Realm } from "./../realm.js";
 import { ExecutionContext } from "./../realm.js";
 import { Handles } from "vscode-debugadapter";
@@ -204,8 +211,24 @@ export class DebugServer {
     if (context.variableEnvironment) {
       // get a new mapping for this collection of variables
       let variableRef = this._variableMapping.create(context.variableEnvironment);
-      scopes.push()
+      let scope: Scope = {
+        name: "Locals",
+        variablesReference: variableRef,
+        expensive: false,
+      };
+      scopes.push(scope);
     }
+    if (context.lexicalEnvironment) {
+      // get a new mapping for this collection of variables
+      let variableRef = this._variableMapping.create(context.variableEnvironment);
+      let scope: Scope = {
+        name: "Globals",
+        variablesReference: variableRef,
+        expensive: false,
+      };
+      scopes.push(scope);
+    }
+    this._channel.sendScopesResponse(requestID, scopes);
   }
 
   shutdown() {

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -36,7 +36,7 @@ export class DebugServer {
     this._lastRunRequestID = 0;
     this._channel = channel;
     this._realm = realm;
-    this._variableMapping = new ReferenceMap(0);
+    this._variableMapping = new ReferenceMap();
     this.waitForRun();
   }
   // the collection of breakpoints

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -16,8 +16,10 @@ import invariant from "../invariant.js";
 import type { DebugChannel } from "./channel/DebugChannel.js";
 import { DebugMessage } from "./channel/DebugMessage.js";
 import { DebuggerError } from "./DebuggerError.js";
-import type { DebuggerRequest, StackframeArguments, Stackframe } from "./types.js";
+import type { DebuggerRequest, StackframeArguments, ScopesArguments, Stackframe, VariableContainer } from "./types.js";
 import type { Realm } from "./../realm.js";
+import { ExecutionContext } from "./../realm.js";
+import { Handles } from "vscode-debugadapter";
 
 export class DebugServer {
   constructor(channel: DebugChannel, realm: Realm) {
@@ -27,6 +29,7 @@ export class DebugServer {
     this._lastRunRequestID = 0;
     this._channel = channel;
     this._realm = realm;
+    this._variableMapping = new Handles();
     this.waitForRun();
   }
   // the collection of breakpoints
@@ -38,7 +41,7 @@ export class DebugServer {
   _channel: DebugChannel;
   _lastRunRequestID: number;
   _realm: Realm;
-
+  _variableMapping: Handles<VariableContainer>;
   /* Block until adapter says to run
   /* runCondition: a function that determines whether the adapter has told
   /* Prepack to continue running
@@ -144,6 +147,10 @@ export class DebugServer {
         invariant(args.kind === "stackframe");
         this.processStackframesCommand(requestID, args);
         break;
+      case DebugMessage.SCOPES_COMMAND:
+        invariant(args.kind === "scopes");
+        this.processScopesCommand(requestID, args);
+        break;
       default:
         throw new DebuggerError("Invalid command", "Invalid command from adapter: " + command);
     }
@@ -181,6 +188,24 @@ export class DebugServer {
       loc = frame.loc;
     }
     this._channel.sendStackframeResponse(requestID, frameInfos);
+  }
+
+  processScopesCommand(requestID: number, args: ScopesArguments) {
+    // first check that frameId is in the valid range
+    if (args.frameId < 0 || args.frameId >= this._realm.contextStack.length) {
+      throw new DebuggerError("Invalid command", "Invalid frame id for scopes request: " + args.frameId);
+    }
+    // here the frameId is in reverse order of the contextStack, ie frameId 0
+    // refers to last element of contextStack
+    let stackIndex = this._realm.contextStack.length - 1 - args.frameId;
+    let context = this._realm.contextStack[stackIndex];
+    invariant(context instanceof ExecutionContext);
+    let scopes = [];
+    if (context.variableEnvironment) {
+      // get a new mapping for this collection of variables
+      let variableRef = this._variableMapping.create(context.variableEnvironment);
+      scopes.push()
+    }
   }
 
   shutdown() {

--- a/src/debugger/ReferenceMap.js
+++ b/src/debugger/ReferenceMap.js
@@ -14,7 +14,7 @@
 // specifies fetching variable collections via unique IDs
 export class ReferenceMap<T> {
   constructor() {
-    this._mapping = []
+    this._mapping = [];
   }
   _mapping: Array<T>;
 

--- a/src/debugger/ReferenceMap.js
+++ b/src/debugger/ReferenceMap.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+// A map with an incrementing counter as the keys
+// Used to store references to variable collections since DebugProtocol
+// specifies fetching variable collections via unique IDs
+export class ReferenceMap<T> {
+  constructor(start: number) {
+    this._start = start;
+    this._counter = start;
+    this._mapping = new Map();
+  }
+  _start: number;
+  _counter: number;
+  _mapping: { [number]: T };
+
+  add(value: T): number {
+    this._counter += 1;
+    this._mapping[this._counter] = value;
+    return this._counter;
+  }
+
+  get(reference: number): void | T {
+    if (reference in this._mapping) {
+      return this._mapping[reference];
+    }
+    return undefined;
+  }
+}

--- a/src/debugger/ReferenceMap.js
+++ b/src/debugger/ReferenceMap.js
@@ -13,25 +13,17 @@
 // Used to store references to variable collections since DebugProtocol
 // specifies fetching variable collections via unique IDs
 export class ReferenceMap<T> {
-  constructor(start: number) {
-    this._start = start;
-    this._counter = start;
-    this._mapping = new Map();
+  constructor() {
+    this._mapping = []
   }
-  _start: number;
-  _counter: number;
-  _mapping: { [number]: T };
+  _mapping: Array<T>;
 
   add(value: T): number {
-    this._counter += 1;
-    this._mapping[this._counter] = value;
-    return this._counter;
+    this._mapping.push(value);
+    return this._mapping.length - 1;
   }
 
   get(reference: number): void | T {
-    if (reference in this._mapping) {
-      return this._mapping[reference];
-    }
-    return undefined;
+    return this._mapping[reference];
   }
 }

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -247,8 +247,22 @@ class PrepackDebugSession extends LoggingDebugSession {
   }
 
   scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments): void {
-    //console.error(args.frameId);
     this._adapterChannel.getScopes(response.request_seq, args.frameId, (dbgResponse: DebuggerResponse) => {
+      let result = dbgResponse.result;
+      invariant(result.kind === "scopes");
+      let scopeInfos = result.scopes;
+      let scopes: Array<DebugProtocol.Scope> = [];
+      for (const scopeInfo of scopeInfos) {
+        let scope: DebugProtocol.Scope = {
+          name: scopeInfo.name,
+          variablesReference: scopeInfo.variablesReference,
+          expensive: scopeInfo.expensive,
+        };
+        scopes.push(scope);
+      }
+      response.body = {
+        scopes: scopes,
+      };
       this.sendResponse(response);
     });
   }

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -245,6 +245,13 @@ class PrepackDebugSession extends LoggingDebugSession {
     };
     this.sendResponse(response);
   }
+
+  scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments): void {
+    //console.error(args.frameId);
+    this._adapterChannel.getScopes(response.request_seq, args.frameId, (dbgResponse: DebuggerResponse) => {
+      this.sendResponse(response);
+    });
+  }
 }
 
 DebugSession.run(PrepackDebugSession);

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -125,6 +125,12 @@ export class AdapterChannel {
     this._addRequestCallback(requestID, callback);
   }
 
+  getScopes(requestID: number, frameId: number, callback: DebuggerResponse => void) {
+    this._queue.enqueue(this._marshaller.marshallScopesRequest(requestID, frameId));
+    this.trySendNextRequest();
+    this._addRequestCallback(requestID, callback);
+  }
+
   writeOut(contents: string) {
     this._ioWrapper.writeOutSync(contents);
   }

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -71,6 +71,11 @@ export class AdapterChannel {
       this._prepackWaiting = true;
       this._processRequestCallback(requestID, dbgResponse);
       this.trySendNextRequest();
+    } else if (messageType === DebugMessage.SCOPES_RESPONSE) {
+      let dbgResponse = this._marshaller.unmarshallScopesResponse(requestID, parts.slice(2).join(" "));
+      this._prepackWaiting = true;
+      this._processRequestCallback(requestID, dbgResponse);
+      this.trySendNextRequest();
     }
   }
 

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -20,6 +20,7 @@ import type {
   RunArguments,
   StackframeArguments,
   Stackframe,
+  Scope,
 } from "./../types.js";
 
 //Channel used by the DebugServer in Prepack to communicate with the debug adapter
@@ -129,6 +130,10 @@ export class DebugChannel {
 
   sendStackframeResponse(requestID: number, stackframes: Array<Stackframe>): void {
     this.writeOut(this._marshaller.marshallStackFramesResponse(requestID, stackframes));
+  }
+
+  sendScopesResponse(requestID: number, scopes: Array<Scope>): void {
+    this.writeOut(this._marshaller.marshallScopesResponse(requestID, scopes));
   }
 
   sendPrepackFinish(): void {

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -88,6 +88,9 @@ export class DebugChannel {
         };
         args = stackFrameArgs;
         break;
+      case DebugMessage.SCOPES_COMMAND:
+        args = this._marshaller.unmarshallScopesArguments(requestID, parts[2]);
+        break;
       default:
         throw new DebuggerError("Invalid command", "Invalid command from adapter: " + command);
     }

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -38,6 +38,8 @@ export class DebugMessage {
   static BREAKPOINT_STOPPED_RESPONSE: string = "Breakpoint-stopped-response";
   // Respond to the adapter with the request stackframes
   static STACKFRAMES_RESPONSE: string = "Stackframes-response";
+  // Respond to the adapter with the requested scopes
+  static SCOPES_RESPONSE: string = "Scopes-response";
 
   /* Messages from Prepack to adapter to acknowledge having received the request */
   // Acknowledgement for setting a breakpoint

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -26,6 +26,8 @@ export class DebugMessage {
   static BREAKPOINT_DISABLE_COMMAND: string = "Breakpoint-disable-command";
   // Command to fetch stack frames
   static STACKFRAMES_COMMAND: string = "Stackframes-command";
+  // Command to fetch scopes
+  static SCOPES_COMMAND: string = "Scopes-command";
 
   /* Messages from Prepack to adapter with requested information */
   // Respond to the adapter that Prepack is ready

--- a/src/debugger/channel/MessageMarshaller.js
+++ b/src/debugger/channel/MessageMarshaller.js
@@ -11,6 +11,7 @@
 import { DebugMessage } from "./DebugMessage.js";
 import type {
   BreakpointArguments,
+  ScopesArguments,
   Stackframe,
   DebuggerResponse,
   StackframeResult,
@@ -56,8 +57,12 @@ export class MessageMarshaller {
     return `${requestID} ${DebugMessage.STACKFRAMES_COMMAND}`;
   }
 
-  marshallStackFramesResponse(requestID: number, stackframes: Array<Stackframe>) {
+  marshallStackFramesResponse(requestID: number, stackframes: Array<Stackframe>): string {
     return `${requestID} ${DebugMessage.STACKFRAMES_RESPONSE} ${JSON.stringify(stackframes)}`;
+  }
+
+  marshallScopesRequest(requestID: number, frameId: number): string {
+    return `${requestID} ${DebugMessage.SCOPES_COMMAND} ${frameId}`;
   }
 
   unmarshallBreakpointArguments(requestID: number, parts: Array<string>): BreakpointArguments {
@@ -76,6 +81,16 @@ export class MessageMarshaller {
       filePath: filePath,
       line: lineNum,
       column: columnNum,
+    };
+    return result;
+  }
+
+  unmarshallScopesArguments(requestID: number, frameIdString: string): ScopesArguments {
+    let frameId = parseInt(frameIdString, 10);
+    invariant(!isNaN(frameId));
+    let result: ScopesArguments = {
+      kind: "scopes",
+      frameId: frameId,
     };
     return result;
   }

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -201,6 +201,15 @@ export class UISession {
         if (parts.length !== 1) return false;
         this._sendThreadsRequest();
         break;
+      case "scopes":
+        if (parts.length !== 2) return false;
+        let frameId = parseInt(parts[1], 10);
+        if (isNaN(frameId)) return false;
+        let scopesArgs: DebugProtocol.ScopesArguments = {
+          frameId: frameId,
+        }
+        this._sendScopesRequest(scopesArgs);
+        break;
       default:
         // invalid command
         return false;
@@ -306,6 +315,17 @@ export class UISession {
       type: "request",
       seq: this._sequenceNum,
       command: "threads",
+    };
+    let json = JSON.stringify(message);
+    this._packageAndSend(json);
+  }
+
+  _sendScopesRequest(args: DebugProtocol.ScopesArguments) {
+    let message = {
+      type: "request",
+      seq: this._sequenceNum,
+      command: "scopes",
+      arguments: args,
     };
     let json = JSON.stringify(message);
     this._packageAndSend(json);

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -135,6 +135,15 @@ export class UISession {
     } else if (response.command === "stackTrace") {
       //flow doesn't have type refinement for interfaces, so must do a cast here
       this._processStackTraceResponse(((response: any): DebugProtocol.StackTraceResponse));
+    } else if (response.command === "scopes") {
+      this._processScopesResponse(((response: any): DebugProtocol.ScopesResponse));
+    }
+  }
+
+  _processScopesResponse(response: DebugProtocol.ScopesResponse) {
+    let scopes = response.body.scopes;
+    for (const scope of scopes) {
+      this._uiOutput(`${scope.name} ${scope.variablesReference}`);
     }
   }
 
@@ -207,7 +216,7 @@ export class UISession {
         if (isNaN(frameId)) return false;
         let scopesArgs: DebugProtocol.ScopesArguments = {
           frameId: frameId,
-        }
+        };
         this._sendScopesRequest(scopesArgs);
         break;
       default:

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -43,14 +43,19 @@ export type Stackframe = {
 export type ScopesArguments = {
   kind: "scopes",
   frameId: number,
-}
+};
 
 export type DebuggerResponse = {
   id: number,
   result: DebuggerResponseResult,
 };
 
-export type DebuggerResponseResult = ReadyResult | StackframeResult | BreakpointAddResult | BreakpointStoppedResult;
+export type DebuggerResponseResult =
+  | ReadyResult
+  | StackframeResult
+  | BreakpointAddResult
+  | BreakpointStoppedResult
+  | ScopesResult;
 
 export type ReadyResult = {
   kind: "ready",
@@ -70,6 +75,17 @@ export type BreakpointStoppedResult = {
   filePath: string,
   line: number,
   column: number,
+};
+
+export type Scope = {
+  name: string,
+  variablesReference: number,
+  expensive: boolean,
+};
+
+export type ScopesResult = {
+  kind: "scopes",
+  scopes: Array<Scope>,
 };
 
 // any object that can contain a collection of variables

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -8,14 +8,14 @@
  */
 
 /* @flow */
-
+import type { LexicalEnvironment } from "./../environment.js";
 export type DebuggerRequest = {
   id: number,
   command: string,
   arguments: DebuggerRequestArguments,
 };
 
-export type DebuggerRequestArguments = BreakpointArguments | RunArguments | StackframeArguments;
+export type DebuggerRequestArguments = BreakpointArguments | RunArguments | StackframeArguments | ScopesArguments;
 
 export type BreakpointArguments = {
   kind: "breakpoint",
@@ -39,6 +39,11 @@ export type Stackframe = {
   column: number,
   functionName: string,
 };
+
+export type ScopesArguments = {
+  kind: "scopes",
+  frameId: number,
+}
 
 export type DebuggerResponse = {
   id: number,
@@ -66,3 +71,6 @@ export type BreakpointStoppedResult = {
   line: number,
   column: number,
 };
+
+// any object that can contain a collection of variables
+export type VariableContainer = LexicalEnvironment;


### PR DESCRIPTION
Release note: none
Summary:
- send scopes requests from the CLI
- debugger engine responds with the scopes for a given frame id
- set up variable mapping so variables can be retrieved for scopes

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path_to_adapter> --prepack <command_to_run_prepack> --inFilePath <debug_input_file_path> --outFilePath <debug_output_file_path>`
e.g. `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepack "lib/prepack-cli.js test/serializer/basic/Date.js" --inFilePath src/debugger/.sessionlogs/engine2adapter.txt --outFilePath src/debugger/.sessionlogs/adapter2engine.txt`

Supported commands so far:
-`breakpoint add <filePath> <line> ?<column>`: sets a breakpoint at the specified location. If `column` is specified, it is a column breakpoint, otherwise it is a line breakpoint.
-`threads`: display the threads (only 1 in Prepack)
-`stackframes`: fetch the current stack frames when stopped at a breakpoint
-`scopes <frameId>`: fetch the scopes for the given frameId
-`run`: tell Prepack to continue executing, either upon entry or when stopped at a breakpoint
-`exit`: quit the debugger.