### PR TITLE
Change debugger launching arguments

### DIFF
--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -81,13 +81,15 @@ class PrepackDebugSession extends LoggingDebugSession {
 
   launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
     // set up the communication channel
-    this._adapterChannel = new AdapterChannel(args.inFilePath, args.outFilePath);
+    this._adapterChannel = new AdapterChannel(args.debugInFilePath, args.debugOutFilePath);
     this._registerMessageCallbacks();
     let launchArgs: PrepackLaunchArguments = {
       kind: "launch",
-      prepackCommand: args.prepackCommand,
-      inFilePath: args.inFilePath,
-      outFilePath: args.outFilePath,
+      prepackRuntime: args.prepackRuntime,
+      sourceFile: args.sourceFile,
+      prepackArguments: args.prepackArguments,
+      inFilePath: args.debugInFilePath,
+      outFilePath: args.debugOutFilePath,
       outputCallback: (data: Buffer) => {
         let outputEvent = new OutputEvent(data.toString(), "stdout");
         this.sendEvent(outputEvent);

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -85,11 +85,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     this._registerMessageCallbacks();
     let launchArgs: PrepackLaunchArguments = {
       kind: "launch",
-      prepackRuntime: args.prepackRuntime,
-      sourceFile: args.sourceFile,
-      prepackArguments: args.prepackArguments,
-      inFilePath: args.debugInFilePath,
-      outFilePath: args.debugOutFilePath,
+      ...args,
       outputCallback: (data: Buffer) => {
         let outputEvent = new OutputEvent(data.toString(), "stdout");
         this.sendEvent(outputEvent);

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -116,9 +116,9 @@ export class AdapterChannel {
     // Note: here the input file for the adapter is the output file for Prepack, and vice versa.
     prepackCommand = prepackCommand.concat([
       "--debugInFilePath",
-      args.outFilePath,
+      args.debugOutFilePath,
       "--debugOutFilePath",
-      args.inFilePath,
+      args.debugInFilePath,
     ]);
     // the runtime can be `prepack` or `node <script>`
     let runtime = "prepack";

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -120,12 +120,12 @@ export class AdapterChannel {
       "--debugOutFilePath",
       args.debugInFilePath,
     ]);
-    // the runtime can be `prepack` or `node <script>`
+
     let runtime = "prepack";
-    if (args.prepackRuntime.startsWith("node")) {
-      let parts = args.prepackRuntime.split(" ");
+    if (args.prepackRuntime.length > 0) {
+      // user specified a Prepack path
       runtime = "node";
-      prepackCommand = parts.slice(1).concat(prepackCommand);
+      prepackCommand = [args.prepackRuntime].concat(prepackCommand);
     }
     this._prepackProcess = child_process.spawn(runtime, prepackCommand);
 

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -16,6 +16,15 @@ import { DataHandler } from "./DataHandler.js";
 import { DebuggerConstants } from "./../DebuggerConstants";
 import { LaunchRequestArguments } from "./../types.js";
 
+export type DebuggerCLIArguments = {
+  adapterPath: string,
+  prepackRuntime: string,
+  sourceFile: string,
+  prepackArguments: Array<string>,
+  debugInFilePath: string,
+  debugOutFilePath: string,
+};
+
 //separator for messages according to the protocol
 const TWO_CRLF = "\r\n\r\n";
 
@@ -24,12 +33,14 @@ const TWO_CRLF = "\r\n\r\n";
  * sends the commands to the adapter and process any responses
 */
 export class UISession {
-  constructor(proc: Process, adapterPath: string, prepackCommand: string, inFilePath: string, outFilePath: string) {
+  constructor(proc: Process, args: DebuggerCLIArguments) {
     this._proc = proc;
-    this._adapterPath = adapterPath;
-    this._prepackCommand = prepackCommand;
-    this._inFilePath = inFilePath;
-    this._outFilePath = outFilePath;
+    this._adapterPath = args.adapterPath;
+    this._prepackRuntime = args.prepackRuntime;
+    this._sourceFile = args.sourceFile;
+    this._prepackArguments = args.prepackArguments;
+    this._inFilePath = args.debugInFilePath;
+    this._outFilePath = args.debugOutFilePath;
     this._sequenceNum = 1;
     this._invalidCount = 0;
     this._dataHandler = new DataHandler();
@@ -53,8 +64,12 @@ export class UISession {
   _reader: readline.Interface;
   // number of invalid commands
   _invalidCount: number;
-  // command to start Prepack with
-  _prepackCommand: string;
+  // Prepack runtime command (e.g. lib/prepack-cli.js)
+  _prepackRuntime: string;
+  // input source file to Prepack
+  _sourceFile: string;
+  // arguments to start Prepack with
+  _prepackArguments: Array<string>;
   // handler for any received messages
   _dataHandler: DataHandler;
   // flag whether Prepack is waiting for a command
@@ -153,9 +168,11 @@ export class UISession {
 
   _processInitializeResponse(response: DebugProtocol.InitializeResponse) {
     let launchArgs: LaunchRequestArguments = {
-      prepackCommand: this._prepackCommand,
-      inFilePath: this._inFilePath,
-      outFilePath: this._outFilePath,
+      prepackRuntime: this._prepackRuntime,
+      sourceFile: this._sourceFile,
+      prepackArguments: this._prepackArguments,
+      debugInFilePath: this._inFilePath,
+      debugOutFilePath: this._outFilePath,
     };
     this._sendLaunchRequest(launchArgs);
   }

--- a/src/debugger/mock-ui/debugger-cli.js
+++ b/src/debugger/mock-ui/debugger-cli.js
@@ -10,21 +10,14 @@
 /* @flow */
 
 import { UISession } from "./UISession.js";
-
-type DebuggerCLIArguments = {
-  adapterPath: string,
-  prepackCommand: string,
-  inFilePath: string,
-  outFilePath: string,
-};
-
+import type { DebuggerCLIArguments } from "./UISession.js";
 /* The entry point to start up the debugger CLI
  * Reads in command line arguments and starts up a UISession
 */
 
 function run(process, console) {
   let args = readCLIArguments(process, console);
-  let session = new UISession(process, args.adapterPath, args.prepackCommand, args.inFilePath, args.outFilePath);
+  let session = new UISession(process, args);
   try {
     session.serve();
   } catch (e) {
@@ -35,9 +28,11 @@ function run(process, console) {
 
 function readCLIArguments(process, console): DebuggerCLIArguments {
   let adapterPath = "";
-  let prepackCommand = "";
-  let inFilePath = "";
-  let outFilePath = "";
+  let prepackRuntime = "";
+  let prepackArguments = [];
+  let sourceFile = "";
+  let debugInFilePath = "";
+  let debugOutFilePath = "";
 
   let args = Array.from(process.argv);
   args.splice(0, 2);
@@ -51,38 +46,47 @@ function readCLIArguments(process, console): DebuggerCLIArguments {
     arg = arg.slice(2);
     if (arg === "adapterPath") {
       adapterPath = args.shift();
-    } else if (arg === "prepack") {
-      prepackCommand = args.shift();
-    } else if (arg === "inFilePath") {
-      inFilePath = args.shift();
-    } else if (arg === "outFilePath") {
-      outFilePath = args.shift();
+    } else if (arg === "prepackRuntime") {
+      prepackRuntime = args.shift();
+    } else if (arg === "prepackArguments") {
+      prepackArguments = args.shift().split(" ");
+    } else if (arg === "sourceFile") {
+      sourceFile = args.shift();
+    } else if (arg === "debugInFilePath") {
+      debugInFilePath = args.shift();
+    } else if (arg === "debugOutFilePath") {
+      debugOutFilePath = args.shift();
     } else {
       console.error("Unknown argument: " + arg);
       process.exit(1);
     }
   }
-  if (inFilePath === 0) {
-    console.error("No input file path provided!");
+  if (debugInFilePath === 0) {
+    console.error("No debugger input file path provided!");
     process.exit(1);
   }
-  if (outFilePath === 0) {
-    console.error("No output file path provided!");
+  if (debugOutFilePath === 0) {
+    console.error("No debugger output file path provided!");
     process.exit(1);
   }
   if (adapterPath.length === 0) {
     console.error("No path to the debug adapter provided!");
     process.exit(1);
   }
-  if (prepackCommand.length === 0) {
-    console.error("No command given to start Prepack");
+  if (prepackRuntime.length === 0) {
+    console.error("No Prepack runtime given to start Prepack");
     process.exit(1);
+  }
+  if (sourceFile.length === 0) {
+    console.error("No source code input file provided");
   }
   let result: DebuggerCLIArguments = {
     adapterPath: adapterPath,
-    prepackCommand: prepackCommand,
-    inFilePath: inFilePath,
-    outFilePath: outFilePath,
+    prepackRuntime: prepackRuntime,
+    prepackArguments: prepackArguments,
+    sourceFile: sourceFile,
+    debugInFilePath: debugInFilePath,
+    debugOutFilePath: debugOutFilePath,
   };
   return result;
 }

--- a/src/debugger/mock-ui/debugger-cli.js
+++ b/src/debugger/mock-ui/debugger-cli.js
@@ -61,11 +61,11 @@ function readCLIArguments(process, console): DebuggerCLIArguments {
       process.exit(1);
     }
   }
-  if (debugInFilePath === 0) {
+  if (debugInFilePath.length === 0) {
     console.error("No debugger input file path provided!");
     process.exit(1);
   }
-  if (debugOutFilePath === 0) {
+  if (debugOutFilePath.length === 0) {
     console.error("No debugger output file path provided!");
     process.exit(1);
   }

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -24,8 +24,8 @@ export type PrepackLaunchArguments = {
   prepackRuntime: string,
   prepackArguments: Array<string>,
   sourceFile: string,
-  inFilePath: string,
-  outFilePath: string,
+  debugInFilePath: string,
+  debugOutFilePath: string,
   outputCallback: Buffer => void,
   exitCallback: () => void,
 };

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -21,7 +21,9 @@ export type DebuggerRequestArguments = BreakpointArguments | RunArguments | Stac
 
 export type PrepackLaunchArguments = {
   kind: "launch",
-  prepackCommand: string,
+  prepackRuntime: string,
+  prepackArguments: Array<string>,
+  sourceFile: string,
   inFilePath: string,
   outFilePath: string,
   outputCallback: Buffer => void,
@@ -102,7 +104,9 @@ export type ScopesResult = {
 export type VariableContainer = LexicalEnvironment;
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   noDebug?: boolean,
-  prepackCommand: string,
-  inFilePath: string,
-  outFilePath: string,
+  sourceFile: string,
+  prepackRuntime: string,
+  prepackArguments: Array<string>,
+  debugInFilePath: string,
+  debugOutFilePath: string,
 }


### PR DESCRIPTION
Release note: none
Summary:
-restructure debugger launching arguments to align with what would be inputted from IDE
-update CLI to read in and pass the new arguments

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path-to-adapter> --prepackRuntime <prepack runtime command> --sourceFile <file to prepack> --debugInFilePath <input file for debugger> --debugOutFilePath <output file for debugger>`
e.g.: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepackRuntime "node lib/prepack-cli.js" --sourceFile test/serializer/basic/Date.js --debugInFilePath src/debugger/.sessionlogs/engine2adapter.txt --debugOutFilePath src/debugger/.sessionlogs/adapter2engine.txt`