### PR TITLE
Remove modules with static functions from the big Flow cycle, part 1

### DIFF
--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { Realm } from "./realm.js";
+import initializeSingletons from "./initialize-singletons.js";
 import { initialize as initializeIntrinsics } from "./intrinsics/index.js";
 import initializeGlobal from "./intrinsics/ecma262/global.js";
 import type { RealmOptions } from "./options.js";
@@ -22,6 +23,7 @@ import type { DebugChannel } from "./debugger/channel/DebugChannel.js";
 import simplifyAndRefineAbstractValue from "./utils/simplifier.js";
 
 export default function(opts: RealmOptions = {}, debugChannel: void | DebugChannel = undefined): Realm {
+  initializeSingletons();
   let r = new Realm(opts);
   if (debugChannel) {
     if (debugChannel.debuggerIsAttached()) {

--- a/src/environment.js
+++ b/src/environment.js
@@ -54,14 +54,11 @@ import {
   HasProperty,
   Get,
   GetValue,
-  PutValue,
-  DefinePropertyOrThrow,
-  Set,
   IsExtensible,
   HasOwnProperty,
   IsDataDescriptor,
-  ThrowIfMightHaveBeenDeleted,
 } from "./methods/index.js";
+import { Properties } from "./singletons.js";
 import * as t from "babel-types";
 
 const sourceMap = require("source-map");
@@ -366,7 +363,7 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
     // 4. Return ? DefinePropertyOrThrow(bindings, N, PropertyDescriptor{[[Value]]: undefined, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: configValue}).
     return new BooleanValue(
       realm,
-      DefinePropertyOrThrow(realm, bindings, N, {
+      Properties.DefinePropertyOrThrow(realm, bindings, N, {
         value: realm.intrinsics.undefined,
         writable: true,
         enumerable: true,
@@ -404,7 +401,7 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
     let bindings = envRec.object;
 
     // 3. Return ? Set(bindings, N, V, S).
-    return new BooleanValue(realm, Set(realm, bindings, N, V, S));
+    return new BooleanValue(realm, Properties.Set(realm, bindings, N, V, S));
   }
 
   // ECMA262 8.1.1.2.6
@@ -816,7 +813,7 @@ export class GlobalEnvironmentRecord extends EnvironmentRecord {
 
     // 5. If existingProp is undefined, return false.
     if (!existingProp) return false;
-    ThrowIfMightHaveBeenDeleted(existingProp.value);
+    Properties.ThrowIfMightHaveBeenDeleted(existingProp.value);
 
     // 6. If existingProp.[[Configurable]] is true, return false.
     if (existingProp.configurable) return false;
@@ -866,7 +863,7 @@ export class GlobalEnvironmentRecord extends EnvironmentRecord {
 
     // 5. If existingProp is undefined, return ? IsExtensible(globalObject).
     if (!existingProp) return IsExtensible(realm, globalObject);
-    ThrowIfMightHaveBeenDeleted(existingProp.value);
+    Properties.ThrowIfMightHaveBeenDeleted(existingProp.value);
 
     // 6. If existingProp.[[Configurable]] is true, return true.
     if (existingProp.configurable) return true;
@@ -941,18 +938,18 @@ export class GlobalEnvironmentRecord extends EnvironmentRecord {
       desc = { value: V, writable: true, enumerable: true, configurable: D };
     } else {
       // 6. Else,
-      ThrowIfMightHaveBeenDeleted(existingProp.value);
+      Properties.ThrowIfMightHaveBeenDeleted(existingProp.value);
       // a. Let desc be the PropertyDescriptor{[[Value]]: V }.
       desc = { value: V };
     }
 
     // 7. Perform ? DefinePropertyOrThrow(globalObject, N, desc).
-    DefinePropertyOrThrow(this.realm, globalObject, N, desc);
+    Properties.DefinePropertyOrThrow(this.realm, globalObject, N, desc);
 
     // 8. Record that the binding for N in ObjRec has been initialized.
 
     // 9. Perform ? Set(globalObject, N, V, false).
-    Set(this.realm, globalObject, N, V, false);
+    Properties.Set(this.realm, globalObject, N, V, false);
 
     // 10. Let varDeclaredNames be envRec.[[VarNames]].
     let varDeclaredNames = envRec.$VarNames;
@@ -980,7 +977,7 @@ export class LexicalEnvironment {
 
   assignToGlobal(globalAst: BabelNodeLVal, rvalue: Value) {
     let globalValue = this.evaluate(globalAst, false);
-    PutValue(this.realm, globalValue, rvalue);
+    Properties.PutValue(this.realm, globalValue, rvalue);
   }
 
   partiallyEvaluateCompletionDeref(

--- a/src/evaluators/ArrayExpression.js
+++ b/src/evaluators/ArrayExpression.js
@@ -14,10 +14,10 @@ import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { StringValue, NumberValue } from "../values/index.js";
 import { GetIterator, GetValue } from "../methods/index.js";
-import { Set } from "../methods/index.js";
 import { ArrayCreate, CreateDataProperty } from "../methods/index.js";
 import invariant from "../invariant.js";
 import { IteratorStep, IteratorValue } from "../methods/iterator.js";
+import { Properties } from "../singletons.js";
 import type { BabelNodeArrayExpression } from "babel-types";
 
 // ECMA262 2.2.5.3
@@ -95,7 +95,7 @@ export default function(
   // 3. ReturnIfAbrupt(len).
 
   // 4. Perform Set(array, "length", ToUint32(len), false).
-  Set(realm, array, "length", new NumberValue(realm, nextIndex), false);
+  Properties.Set(realm, array, "length", new NumberValue(realm, nextIndex), false);
 
   // 5. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
 

--- a/src/evaluators/AssignmentExpression.js
+++ b/src/evaluators/AssignmentExpression.js
@@ -20,9 +20,9 @@ import {
   HasOwnProperty,
   IsAnonymousFunctionDefinition,
   IsIdentifierRef,
-  PutValue,
   SetFunctionName,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeAssignmentExpression, BabelBinaryOperator } from "babel-types";
 import { computeBinary } from "./BinaryExpression.js";
@@ -70,7 +70,7 @@ export default function(
         }
       }
       // f. Perform ? PutValue(lref, rval).
-      PutValue(realm, lref, rval);
+      Properties.PutValue(realm, lref, rval);
       // g. Return rval.
       return rval;
     }
@@ -108,7 +108,7 @@ export default function(
   // 6. Let r be the result of applying op to lval and rval as if evaluating the expression lval op rval.
   let r = GetValue(realm, computeBinary(realm, op, lval, rval, ast.left.loc, ast.right.loc));
   // 7. Perform ? PutValue(lref, r).
-  PutValue(realm, lref, r);
+  Properties.PutValue(realm, lref, r);
   // 8. Return r.
   return r;
 }

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -35,10 +35,10 @@ import {
   ConstructorMethod,
   GetValue,
   IsStatic,
-  PropertyDefinitionEvaluation,
   InitializeBoundName,
   NonConstructorMethodDefinitions,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 function EvaluateClassHeritage(
@@ -239,11 +239,11 @@ export function ClassDefinitionEvaluation(
       // a. If IsStatic of m is false, then
       if (!IsStatic(m)) {
         // Let status be the result of performing PropertyDefinitionEvaluation for m with arguments proto and false.
-        PropertyDefinitionEvaluation(realm, m, proto, env, strictCode, false);
+        Properties.PropertyDefinitionEvaluation(realm, m, proto, (env: any), strictCode, false);
       } else {
         // Else,
         // Let status be the result of performing PropertyDefinitionEvaluation for m with arguments F and false.
-        PropertyDefinitionEvaluation(realm, m, F, env, strictCode, false);
+        Properties.PropertyDefinitionEvaluation(realm, m, F, (env: any), strictCode, false);
       }
       // c. If status is an abrupt completion, then
       // i. Set the running execution context's LexicalEnvironment to lex.

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -28,14 +28,12 @@ import invariant from "../invariant.js";
 import {
   InitializeReferencedBinding,
   GetValue,
-  PutValue,
   IteratorStep,
   IteratorValue,
   NewDeclarativeEnvironment,
   ResolveBinding,
   IteratorClose,
   ToObjectPartial,
-  EnumerateObjectProperties,
   UpdateEmpty,
   BoundNames,
   BindingInitialization,
@@ -43,6 +41,7 @@ import {
   GetIterator,
   IsDestructuring,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 import type {
   BabelNode,
   BabelNodeForOfStatement,
@@ -113,7 +112,7 @@ export function ForInOfHeadEvaluation(
   expr: BabelNode,
   iterationKind: IterationKind,
   strictCode: boolean
-) {
+): ObjectValue | AbstractObjectValue {
   // 1. Let oldEnv be the running execution context's LexicalEnvironment.
   let oldEnv = realm.getRunningContext().lexicalEnvironment;
 
@@ -166,7 +165,7 @@ export function ForInOfHeadEvaluation(
     if (obj.isPartialObject() || obj instanceof AbstractObjectValue) {
       return obj;
     } else {
-      return EnumerateObjectProperties(realm, obj);
+      return Properties.EnumerateObjectProperties(realm, obj);
     }
   } else {
     // 8. Else,
@@ -287,7 +286,7 @@ export function ForInOfBodyEvaluation(
           // iii. Else,
           // 1. Let status be PutValue(lhsRef, nextValue).
           invariant(lhsRef !== undefined);
-          status = PutValue(realm, lhsRef, nextValue);
+          status = Properties.PutValue(realm, lhsRef, nextValue);
         }
       } else {
         // g. Else,

--- a/src/evaluators/FunctionDeclaration.js
+++ b/src/evaluators/FunctionDeclaration.js
@@ -15,7 +15,7 @@ import type { Value } from "../values/index.js";
 import { SetFunctionName, FunctionCreate, GeneratorFunctionCreate } from "../methods/function.js";
 import { MakeConstructor } from "../methods/construct.js";
 import { ObjectCreate } from "../methods/create.js";
-import { DefinePropertyOrThrow } from "../methods/properties.js";
+import { Properties } from "../singletons.js";
 import { StringValue } from "../values/index.js";
 import IsStrict from "../utils/strict.js";
 import type { BabelNodeFunctionDeclaration } from "babel-types";
@@ -46,7 +46,7 @@ export default function(
     let prototype = ObjectCreate(realm, realm.intrinsics.GeneratorPrototype);
 
     // 5. Perform DefinePropertyOrThrow(F, "prototype", PropertyDescriptor{[[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false}).
-    DefinePropertyOrThrow(realm, F, "prototype", {
+    Properties.DefinePropertyOrThrow(realm, F, "prototype", {
       value: prototype,
       writable: true,
       configurable: false,

--- a/src/evaluators/FunctionExpression.js
+++ b/src/evaluators/FunctionExpression.js
@@ -15,7 +15,7 @@ import type { Value } from "../values/index.js";
 import { NewDeclarativeEnvironment, SetFunctionName, FunctionCreate, MakeConstructor } from "../methods/index.js";
 import { ObjectCreate } from "../methods/create.js";
 import { GeneratorFunctionCreate } from "../methods/function.js";
-import { DefinePropertyOrThrow } from "../methods/properties.js";
+import { Properties } from "../singletons.js";
 import { StringValue } from "../values/index.js";
 import IsStrict from "../utils/strict.js";
 import type { BabelNodeFunctionExpression } from "babel-types";
@@ -59,7 +59,7 @@ export default function(
       prototype.originalConstructor = closure;
 
       // 9. Perform DefinePropertyOrThrow(closure, "prototype", PropertyDescriptor{[[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false}).
-      DefinePropertyOrThrow(realm, closure, "prototype", {
+      Properties.DefinePropertyOrThrow(realm, closure, "prototype", {
         value: prototype,
         writable: true,
         enumerable: false,
@@ -126,7 +126,7 @@ export default function(
       prototype.originalConstructor = closure;
 
       // 5. Perform DefinePropertyOrThrow(closure, "prototype", PropertyDescriptor{[[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false}).
-      DefinePropertyOrThrow(realm, closure, "prototype", {
+      Properties.DefinePropertyOrThrow(realm, closure, "prototype", {
         value: prototype,
         writable: true,
         enumerable: false,

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -18,7 +18,7 @@ import { Reference } from "../environment.js";
 import { GetValue, joinEffects, ToBoolean, UpdateEmpty } from "../methods/index.js";
 import type { BabelNode, BabelNodeIfStatement } from "babel-types";
 import invariant from "../invariant.js";
-import { withPathCondition, withInversePathCondition } from "../utils/paths.js";
+import { Path } from "../singletons.js";
 
 export function evaluate(ast: BabelNodeIfStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value {
   // 1. Let exprRef be the result of evaluating Expression
@@ -87,11 +87,11 @@ export function evaluateWithAbstractConditional(
   realm: Realm
 ): Value {
   // Evaluate consequent and alternate in sandboxes and get their effects.
-  let [compl1, gen1, bindings1, properties1, createdObj1] = withPathCondition(condValue, () => {
+  let [compl1, gen1, bindings1, properties1, createdObj1] = Path.withCondition(condValue, () => {
     return realm.evaluateNodeForEffects(consequent, strictCode, env);
   });
 
-  let [compl2, gen2, bindings2, properties2, createdObj2] = withInversePathCondition(condValue, () => {
+  let [compl2, gen2, bindings2, properties2, createdObj2] = Path.withInverseCondition(condValue, () => {
     return alternate ? realm.evaluateNodeForEffects(alternate, strictCode, env) : construct_empty_effects(realm);
   });
 

--- a/src/evaluators/JSXElement.js
+++ b/src/evaluators/JSXElement.js
@@ -33,8 +33,8 @@ import {
   ArrayCreate,
   CreateDataPropertyOrThrow,
   ObjectCreate,
-  Set,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import { computeBinary } from "./BinaryExpression.js";
 
@@ -212,7 +212,7 @@ function evaluateJSXChildren(
     return lastChildValue;
   }
 
-  Set(realm, array, "length", new NumberValue(realm, dynamicChildrenLength), false);
+  Properties.Set(realm, array, "length", new NumberValue(realm, dynamicChildrenLength), false);
   return array;
 }
 

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -18,7 +18,7 @@ import { Reference } from "../environment.js";
 import { GetValue, joinEffects, ToBoolean } from "../methods/index.js";
 import type { BabelNodeLogicalExpression } from "babel-types";
 import invariant from "../invariant.js";
-import { withPathCondition, withInversePathCondition } from "../utils/paths.js";
+import { Path } from "../singletons.js";
 
 export default function(
   ast: BabelNodeLogicalExpression,
@@ -54,7 +54,7 @@ export default function(
   compl1; // ignore
 
   // Evaluate ast.right in a sandbox to get its effects
-  let wrapper = ast.operator === "&&" ? withPathCondition : withInversePathCondition;
+  let wrapper = ast.operator === "&&" ? Path.withCondition : Path.withInverseCondition;
   let [compl2, gen2, bindings2, properties2, createdObj2] = wrapper(lval, () =>
     realm.evaluateNodeForEffects(ast.right, strictCode, env)
   );

--- a/src/evaluators/ObjectExpression.js
+++ b/src/evaluators/ObjectExpression.js
@@ -21,10 +21,10 @@ import {
   CreateDataPropertyOrThrow,
   IsAnonymousFunctionDefinition,
   HasOwnProperty,
-  PropertyDefinitionEvaluation,
   ToPropertyKey,
   ToString,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type {
   BabelNodeObjectExpression,
@@ -124,7 +124,7 @@ export default function(
       }
     } else {
       invariant(prop.type === "ObjectMethod");
-      PropertyDefinitionEvaluation(realm, prop, obj, env, strictCode, true);
+      Properties.PropertyDefinitionEvaluation(realm, prop, obj, (env: any), strictCode, true);
     }
   }
 

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -13,9 +13,10 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
-import { Add, GetValue, ToNumber, PutValue, IsToNumberPure } from "../methods/index.js";
+import { Add, GetValue, ToNumber, IsToNumberPure } from "../methods/index.js";
 import { AbstractValue, NumberValue } from "../values/index.js";
 import type { BabelNodeUpdateExpression } from "babel-types";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 export default function(
@@ -44,7 +45,7 @@ export default function(
     invariant(ast.operator === "++" || ast.operator === "--"); // As per BabelNodeUpdateExpression
     let op = ast.operator === "++" ? "+" : "-";
     let newAbstractValue = AbstractValue.createFromBinaryOp(realm, op, oldExpr, new NumberValue(realm, 1), ast.loc);
-    PutValue(realm, expr, newAbstractValue);
+    Properties.PutValue(realm, expr, newAbstractValue);
     if (ast.prefix) {
       return newAbstractValue;
     } else {
@@ -61,7 +62,7 @@ export default function(
       let newValue = Add(realm, oldValue, 1);
 
       // 4. Perform ? PutValue(expr, newValue).
-      PutValue(realm, expr, newValue);
+      Properties.PutValue(realm, expr, newValue);
 
       // 5. Return newValue.
       return newValue;
@@ -72,7 +73,7 @@ export default function(
       let newValue = Add(realm, oldValue, -1);
 
       // 4. Perform ? PutValue(expr, newValue).
-      PutValue(realm, expr, newValue);
+      Properties.PutValue(realm, expr, newValue);
 
       // 5. Return newValue.
       return newValue;
@@ -86,7 +87,7 @@ export default function(
       let newValue = Add(realm, oldValue, 1);
 
       // 4. Perform ? PutValue(lhs, newValue).
-      PutValue(realm, expr, newValue);
+      Properties.PutValue(realm, expr, newValue);
 
       // 5. Return oldValue.
       return new NumberValue(realm, oldValue);
@@ -97,7 +98,7 @@ export default function(
       let newValue = Add(realm, oldValue, -1);
 
       // 4. Perform ? PutValue(lhs, newValue).
-      PutValue(realm, expr, newValue);
+      Properties.PutValue(realm, expr, newValue);
 
       // 5. Return oldValue.
       return new NumberValue(realm, oldValue);

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -15,7 +15,6 @@ import { FatalError } from "../errors.js";
 import type { Value } from "../values/index.js";
 import { ObjectValue, StringValue } from "../values/index.js";
 import {
-  PutValue,
   GetValue,
   ResolveBinding,
   InitializeReferencedBinding,
@@ -24,6 +23,7 @@ import {
   SetFunctionName,
   BindingInitialization,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeVariableDeclaration } from "babel-types";
 
@@ -129,7 +129,7 @@ export default function(
       }
 
       // 6. Return ? PutValue(lhs, value).
-      PutValue(realm, lhs, value);
+      Properties.PutValue(realm, lhs, value);
     } else if ((declar.id.type === "ObjectPattern" || declar.id.type === "ArrayPattern") && Initializer) {
       // 1. Let rhs be the result of evaluating Initializer.
       let rhs = env.evaluate(Initializer, strictCode);

--- a/src/globals.js
+++ b/src/globals.js
@@ -14,6 +14,7 @@ import initializePrepackGlobals from "./intrinsics/prepack/global.js";
 import initializeDOMGlobals from "./intrinsics/dom/global.js";
 import initializeReactNativeGlobals from "./intrinsics/react-native/global.js";
 import initializeReactMocks from "./intrinsics/react-mocks/global.js";
+import initializeSingletons from "./initialize-singletons.js";
 
 export default function(realm: Realm): Realm {
   initializePrepackGlobals(realm);
@@ -27,5 +28,6 @@ export default function(realm: Realm): Realm {
   if (realm.isCompatibleWith(realm.MOBILE_JSC_VERSION)) {
     initializeReactNativeGlobals(realm);
   }
+  initializeSingletons();
   return realm;
 }

--- a/src/globals.js
+++ b/src/globals.js
@@ -14,7 +14,6 @@ import initializePrepackGlobals from "./intrinsics/prepack/global.js";
 import initializeDOMGlobals from "./intrinsics/dom/global.js";
 import initializeReactNativeGlobals from "./intrinsics/react-native/global.js";
 import initializeReactMocks from "./intrinsics/react-mocks/global.js";
-import initializeSingletons from "./initialize-singletons.js";
 
 export default function(realm: Realm): Realm {
   initializePrepackGlobals(realm);
@@ -28,6 +27,5 @@ export default function(realm: Realm): Realm {
   if (realm.isCompatibleWith(realm.MOBILE_JSC_VERSION)) {
     initializeReactNativeGlobals(realm);
   }
-  initializeSingletons();
   return realm;
 }

--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -11,7 +11,9 @@
 
 import * as Singletons from "./singletons.js";
 import { PathImplementation } from "./utils/paths.js";
+import { PropertiesImplementation } from "./methods/properties.js";
 
 export default function() {
   Singletons.setPath(new PathImplementation());
+  Singletons.setProperties((new PropertiesImplementation(): any));
 }

--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import * as Singletons from "./singletons.js";
+import { PathImplementation } from "./utils/paths.js";
+
+export default function() {
+  Singletons.setPath(new PathImplementation());
+}

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -32,10 +32,10 @@ import {
   IsArray,
   IsConstructor,
   IsCallable,
-  Set,
 } from "../../methods/index.js";
 import { ToString, ToUint32, ToObject, ToLength } from "../../methods/to.js";
 import { GetIterator, IteratorClose, IteratorStep, IteratorValue } from "../../methods/iterator.js";
+import { Properties } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -97,7 +97,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // 8. Perform ! Set(array, "length", intLen, true).
-      Set(realm, array, "length", new NumberValue(realm, intLen), true);
+      Properties.Set(realm, array, "length", new NumberValue(realm, intLen), true);
 
       // 9. Return array.
       return array;
@@ -201,7 +201,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // 8. Perform ? Set(A, "length", len, true).
-      Set(realm, A, "length", new NumberValue(realm, len), true);
+      Properties.Set(realm, A, "length", new NumberValue(realm, len), true);
 
       // 9. Return A.
       return A;
@@ -278,7 +278,7 @@ export default function(realm: Realm): NativeFunctionValue {
           // iv. If next is false, then
           if (next === false) {
             // 1. Perform ? Set(A, "length", k, true).
-            Set(realm, A, "length", new NumberValue(realm, k), true);
+            Properties.Set(realm, A, "length", new NumberValue(realm, k), true);
 
             // 2. Return A.
             return A;
@@ -377,7 +377,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // 13. Perform ? Set(A, "length", len, true).
-      Set(realm, A, "length", new NumberValue(realm, len), true);
+      Properties.Set(realm, A, "length", new NumberValue(realm, len), true);
 
       // 14. Return A.
       return A;

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -34,11 +34,9 @@ import {
   ToNumber,
   ToBooleanPartial,
   Get,
-  DeletePropertyOrThrow,
-  Set,
   HasSomeCompatibleType,
-  ThrowIfMightHaveBeenDeleted,
 } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.31
@@ -123,7 +121,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 6. Perform ? Set(A, "length", n, true).
-    Set(realm, A, "length", new NumberValue(realm, n), true);
+    Properties.Set(realm, A, "length", new NumberValue(realm, n), true);
 
     // 7. Return A.
     return A;
@@ -192,11 +190,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
           // i. Let fromVal be ? Get(O, fromKey).
           let fromVal = Get(realm, O, fromKey);
           // ii. Perform ? Set(O, toKey, fromVal, true).
-          Set(realm, O, toKey, fromVal, true);
+          Properties.Set(realm, O, toKey, fromVal, true);
         } else {
           // e. Else fromPresent is false,
           // i. Perform ? DeletePropertyOrThrow(O, toKey).
-          DeletePropertyOrThrow(realm, O, toKey);
+          Properties.DeletePropertyOrThrow(realm, O, toKey);
         }
 
         // f. Let from be from + direction.
@@ -295,7 +293,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let Pk = new StringValue(realm, k + "");
 
       // b. Perform ? Set(O, Pk, value, true).
-      Set(realm, O, Pk, value, true);
+      Properties.Set(realm, O, Pk, value, true);
 
       // c. Increase k by 1.
       k++;
@@ -768,7 +766,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 3. If len is zero, then
     if (len === 0) {
       // a. Perform ? Set(O, "length", 0, true).
-      Set(realm, O, "length", realm.intrinsics.zero, true);
+      Properties.Set(realm, O, "length", realm.intrinsics.zero, true);
 
       // b. Return undefined.
       return realm.intrinsics.undefined;
@@ -784,10 +782,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let element = Get(realm, O, indx);
 
       // d. Perform ? DeletePropertyOrThrow(O, indx).
-      DeletePropertyOrThrow(realm, O, indx);
+      Properties.DeletePropertyOrThrow(realm, O, indx);
 
       // e. Perform ? Set(O, "length", newLen, true).
-      Set(realm, O, "length", new NumberValue(realm, newLen), true);
+      Properties.Set(realm, O, "length", new NumberValue(realm, newLen), true);
 
       // f. Return element.
       return element;
@@ -819,14 +817,14 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let E = items.shift();
 
       // b. Perform ? Set(O, ! ToString(len), E, true).
-      Set(realm, O, new StringValue(realm, len + ""), E, true);
+      Properties.Set(realm, O, new StringValue(realm, len + ""), E, true);
 
       // c. Let len be len+1.
       len++;
     }
 
     // 7. Perform ? Set(O, "length", len, true).
-    Set(realm, O, new StringValue(realm, "length"), new NumberValue(realm, len), true);
+    Properties.Set(realm, O, new StringValue(realm, "length"), new NumberValue(realm, len), true);
 
     // 8. Return len.
     return new NumberValue(realm, len);
@@ -1055,28 +1053,28 @@ export default function(realm: Realm, obj: ObjectValue): void {
         invariant(upperValue, "expected upper value to exist");
 
         // i. Perform ? Set(O, lowerP, upperValue, true).
-        Set(realm, O, lowerP, upperValue, true);
+        Properties.Set(realm, O, lowerP, upperValue, true);
 
         // ii. Perform ? Set(O, upperP, lowerValue, true).
-        Set(realm, O, upperP, lowerValue, true);
+        Properties.Set(realm, O, upperP, lowerValue, true);
       } else if (!lowerExists && upperExists) {
         // i. Else if lowerExists is false and upperExists is true, then
         invariant(upperValue, "expected upper value to exist");
 
         // i. Perform ? Set(O, lowerP, upperValue, true).
-        Set(realm, O, lowerP, upperValue, true);
+        Properties.Set(realm, O, lowerP, upperValue, true);
 
         // ii. Perform ? DeletePropertyOrThrow(O, upperP).
-        DeletePropertyOrThrow(realm, O, upperP);
+        Properties.DeletePropertyOrThrow(realm, O, upperP);
       } else if (lowerExists && !upperExists) {
         // j. Else if lowerExists is true and upperExists is false, then
         invariant(lowerValue, "expected lower value to exist");
 
         // i. Perform ? DeletePropertyOrThrow(O, lowerP).
-        DeletePropertyOrThrow(realm, O, lowerP);
+        Properties.DeletePropertyOrThrow(realm, O, lowerP);
 
         // ii. Perform ? Set(O, upperP, lowerValue, true).
-        Set(realm, O, upperP, lowerValue, true);
+        Properties.Set(realm, O, upperP, lowerValue, true);
       } else {
         // k. Else both lowerExists and upperExists are false,
         // i. No action is required.
@@ -1101,7 +1099,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 3. If len is zero, then
     if (len === 0) {
       // a. Perform ? Set(O, "length", 0, true).
-      Set(realm, O, "length", realm.intrinsics.zero, true);
+      Properties.Set(realm, O, "length", realm.intrinsics.zero, true);
 
       // b. Return undefined.
       return realm.intrinsics.undefined;
@@ -1130,11 +1128,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let fromVal = Get(realm, O, frm);
 
         // ii. Perform ? Set(O, to, fromVal, true).
-        Set(realm, O, to, fromVal, true);
+        Properties.Set(realm, O, to, fromVal, true);
       } else {
         // d. Else fromPresent is false,
         // i. Perform ? DeletePropertyOrThrow(O, to).
-        DeletePropertyOrThrow(realm, O, to);
+        Properties.DeletePropertyOrThrow(realm, O, to);
       }
 
       // e. Increase k by 1.
@@ -1142,10 +1140,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 7. Perform ? DeletePropertyOrThrow(O, ! ToString(len-1)).
-    DeletePropertyOrThrow(realm, O, new StringValue(realm, len - 1 + ""));
+    Properties.DeletePropertyOrThrow(realm, O, new StringValue(realm, len - 1 + ""));
 
     // 8. Perform ? Set(O, "length", len-1, true).
-    Set(realm, O, "length", new NumberValue(realm, len - 1), true);
+    Properties.Set(realm, O, "length", new NumberValue(realm, len - 1), true);
 
     // 9. Return first.
     return first;
@@ -1205,7 +1203,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 11. Perform ? Set(A, "length", n, true).
-    Set(realm, A, "length", new NumberValue(realm, n), true);
+    Properties.Set(realm, A, "length", new NumberValue(realm, n), true);
 
     // 12. Return A.
     return A;
@@ -1277,7 +1275,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let elem = O.$GetOwnProperty(i.toString());
         // b.If elem is undefined, return true.
         if (elem === undefined) return true;
-        ThrowIfMightHaveBeenDeleted(elem.value);
+        Properties.ThrowIfMightHaveBeenDeleted(elem.value);
       }
       // 2.Return false.
       return false;
@@ -1311,7 +1309,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         // is a data property whose [[Configurable]] attribute is false.
         let prop = O.$GetOwnProperty(j.toString());
         if (prop !== undefined && !prop.configurable) {
-          ThrowIfMightHaveBeenDeleted(prop.value);
+          Properties.ThrowIfMightHaveBeenDeleted(prop.value);
           throw Error(
             "Implementation defined behavior :  Array is sparse and it's prototype has some numbered properties"
           );
@@ -1324,7 +1322,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       //is a data property whose [[writable]] attribute is false.
       let prop = O.$GetOwnProperty(j.toString());
       if (prop !== undefined && !prop.writable) {
-        ThrowIfMightHaveBeenDeleted(prop.value);
+        Properties.ThrowIfMightHaveBeenDeleted(prop.value);
         throw Error("Implementation defined behavior : property " + j.toString() + "is non writable : ");
       }
     }
@@ -1418,7 +1416,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       } else {
         // If obj is not sparse then DeletePropertyOrThrow must not be called.
         invariant(sparse);
-        DeletePropertyOrThrow(realm, O, j.toString());
+        Properties.DeletePropertyOrThrow(realm, O, j.toString());
       }
     }
     // If an abrupt completion is returned from any of these operations, it is immediately returned as the value of this function.
@@ -1503,7 +1501,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 12. Perform ? Set(A, "length", actualDeleteCount, true).
-    Set(realm, A, "length", new NumberValue(realm, actualDeleteCount), true);
+    Properties.Set(realm, A, "length", new NumberValue(realm, actualDeleteCount), true);
 
     // 13. Let items be a List whose elements are, in left to right order, the portion of the actual argument
     //     list starting with the third argument. The list is empty if fewer than three arguments were passed.
@@ -1534,11 +1532,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
           let fromValue = Get(realm, O, frm);
 
           // 2. Perform ? Set(O, to, fromValue, true).
-          Set(realm, O, to, fromValue, true);
+          Properties.Set(realm, O, to, fromValue, true);
         } else {
           // v. Else fromPresent is false,
           // 1. Perform ? DeletePropertyOrThrow(O, to).
-          DeletePropertyOrThrow(realm, O, to);
+          Properties.DeletePropertyOrThrow(realm, O, to);
         }
 
         // vi. Increase k by 1.
@@ -1551,7 +1549,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // d. Repeat, while k > (len - actualDeleteCount + itemCount)
       while (k > len - actualDeleteCount + itemCount) {
         // i. Perform ? DeletePropertyOrThrow(O, ! ToString(k-1)).
-        DeletePropertyOrThrow(realm, O, new StringValue(realm, k - 1 + ""));
+        Properties.DeletePropertyOrThrow(realm, O, new StringValue(realm, k - 1 + ""));
 
         // ii. Decrease k by 1.
         k--;
@@ -1578,11 +1576,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
           let fromValue = Get(realm, O, frm);
 
           // 2. Perform ? Set(O, to, fromValue, true).
-          Set(realm, O, to, fromValue, true);
+          Properties.Set(realm, O, to, fromValue, true);
         } else {
           // v. Else fromPresent is false,
           // 1. Perform ? DeletePropertyOrThrow(O, to).
-          DeletePropertyOrThrow(realm, O, to);
+          Properties.DeletePropertyOrThrow(realm, O, to);
         }
 
         // vi. Decrease k by 1.
@@ -1599,14 +1597,14 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let E = items.shift();
 
       // b. Perform ? Set(O, ! ToString(k), E, true).
-      Set(realm, O, new StringValue(realm, k + ""), E, true);
+      Properties.Set(realm, O, new StringValue(realm, k + ""), E, true);
 
       // c. Increase k by 1.
       k++;
     }
 
     // 19. Perform ? Set(O, "length", len - actualDeleteCount + itemCount, true).
-    Set(realm, O, "length", new NumberValue(realm, len - actualDeleteCount + itemCount), true);
+    Properties.Set(realm, O, "length", new NumberValue(realm, len - actualDeleteCount + itemCount), true);
 
     // 20. Return A.
     return A;
@@ -1714,11 +1712,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
           let fromValue = Get(realm, O, frm);
 
           // 2. Perform ? Set(O, to, fromValue, true).
-          Set(realm, O, to, fromValue, true);
+          Properties.Set(realm, O, to, fromValue, true);
         } else {
           // vi. Else fromPresent is false,
           // 1. Perform ? DeletePropertyOrThrow(O, to).
-          DeletePropertyOrThrow(realm, O, to);
+          Properties.DeletePropertyOrThrow(realm, O, to);
         }
 
         // vii. Decrease k by 1.
@@ -1738,7 +1736,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let E = items.shift();
 
         // ii. Perform ? Set(O, ! ToString(j), E, true).
-        Set(realm, O, new StringValue(realm, j + ""), E, true);
+        Properties.Set(realm, O, new StringValue(realm, j + ""), E, true);
 
         // iii. Increase j by 1.
         j++;
@@ -1746,7 +1744,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 5. Perform ? Set(O, "length", len+argCount, true).
-    Set(realm, O, "length", new NumberValue(realm, len + argCount), true);
+    Properties.Set(realm, O, "length", new NumberValue(realm, len + argCount), true);
 
     // 6. Return len+argCount.
     return new NumberValue(realm, len + argCount);

--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -12,13 +12,8 @@
 import type { Realm } from "../../realm.js";
 import type { LexicalEnvironment } from "../../environment.js";
 import { ObjectValue, FunctionValue, NativeFunctionValue, StringValue } from "../../values/index.js";
-import {
-  DefinePropertyOrThrow,
-  Get,
-  OrdinaryCreateFromConstructor,
-  ToStringPartial,
-  ToStringValue,
-} from "../../methods/index.js";
+import { Get, OrdinaryCreateFromConstructor, ToStringPartial, ToStringValue } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 import invariant from "../../invariant.js";
 import type { BabelNodeSourceLocation } from "babel-types";
 
@@ -116,7 +111,7 @@ export function build(name: string, realm: Realm, inheritError?: boolean = true)
       configurable: true,
       writable: true,
     };
-    DefinePropertyOrThrow(realm, O, "stack", stackDesc);
+    Properties.DefinePropertyOrThrow(realm, O, "stack", stackDesc);
 
     // 3. If message is not undefined, then
     if (!message.mightBeUndefined()) {
@@ -132,7 +127,7 @@ export function build(name: string, realm: Realm, inheritError?: boolean = true)
       };
 
       // c. Perform ! DefinePropertyOrThrow(O, "message", msgDesc).
-      DefinePropertyOrThrow(realm, O, "message", msgDesc);
+      Properties.DefinePropertyOrThrow(realm, O, "message", msgDesc);
     } else {
       message.throwIfNotConcrete();
     }

--- a/src/intrinsics/ecma262/FunctionPrototype.js
+++ b/src/intrinsics/ecma262/FunctionPrototype.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { BoundFunctionCreate, SetFunctionName } from "../../methods/function.js";
-import { DefinePropertyOrThrow } from "../../methods/properties.js";
+import { Properties } from "../../singletons.js";
 import {
   AbstractValue,
   BooleanValue,
@@ -131,7 +131,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 8. Perform ! DefinePropertyOrThrow(F, "length", PropertyDescriptor {[[Value]]: L, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true}).
-    DefinePropertyOrThrow(realm, F, "length", {
+    Properties.DefinePropertyOrThrow(realm, F, "length", {
       value: new NumberValue(realm, L),
       writable: false,
       enumerable: false,

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -32,7 +32,6 @@ import {
   IsArray,
   IsCallable,
   ObjectCreate,
-  ThrowIfMightHaveBeenDeleted,
   ToInteger,
   ToLength,
   ToNumber,
@@ -42,6 +41,7 @@ import {
 import { InternalizeJSONProperty } from "../../methods/json.js";
 import { ValuesDomain } from "../../domains/index.js";
 import { FatalError } from "../../errors.js";
+import { Properties } from "../../singletons.js";
 import nativeToInterp from "../../utils/native-to-interp.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
@@ -309,7 +309,7 @@ function InternalCloneObject(realm: Realm, val: ObjectValue): ObjectValue {
     if (binding === undefined || binding.descriptor === undefined) continue; // deleted
     invariant(binding.descriptor !== undefined);
     let value = binding.descriptor.value;
-    ThrowIfMightHaveBeenDeleted(value);
+    Properties.ThrowIfMightHaveBeenDeleted(value);
     if (value === undefined) {
       AbstractValue.reportIntrospectionError(val, key); // cannot handle accessors
       throw new FatalError();

--- a/src/intrinsics/ecma262/MapPrototype.js
+++ b/src/intrinsics/ecma262/MapPrototype.js
@@ -11,13 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { NumberValue, StringValue, NativeFunctionValue, ObjectValue } from "../../values/index.js";
-import {
-  Call,
-  CreateMapIterator,
-  IsCallable,
-  SameValueZeroPartial,
-  ThrowIfMightHaveBeenDeleted,
-} from "../../methods/index.js";
+import { Call, CreateMapIterator, IsCallable, SameValueZeroPartial } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -308,7 +303,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 23.1.3.12
   let entriesPropertyDescriptor = obj.$GetOwnProperty("entries");
   invariant(entriesPropertyDescriptor);
-  ThrowIfMightHaveBeenDeleted(entriesPropertyDescriptor.value);
+  Properties.ThrowIfMightHaveBeenDeleted(entriesPropertyDescriptor.value);
   obj.defineNativeProperty(realm.intrinsics.SymbolIterator, undefined, entriesPropertyDescriptor);
 
   // ECMA262 23.1.3.13

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -36,15 +36,11 @@ import {
   OrdinaryCreateFromConstructor,
   RequireObjectCoercible,
   SameValuePartial,
-  Set,
-  ObjectDefineProperties,
-  DefinePropertyOrThrow,
-  FromPropertyDescriptor,
   TestIntegrityLevel,
   SetIntegrityLevel,
   HasSomeCompatibleType,
-  ThrowIfMightHaveBeenDeleted,
 } from "../../methods/index.js";
+import { Properties as Props } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -119,13 +115,13 @@ export default function(realm: Realm): NativeFunctionValue {
 
         // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
         if (desc && desc.enumerable) {
-          ThrowIfMightHaveBeenDeleted(desc.value);
+          Props.ThrowIfMightHaveBeenDeleted(desc.value);
 
           // 1. Let propValue be ? Get(from, nextKey).
           let propValue = Get(realm, frm, nextKey);
 
           // 2. Perform ? Set(to, nextKey, propValue, true).
-          Set(realm, to, nextKey, propValue, true);
+          Props.Set(realm, to, nextKey, propValue, true);
         }
       }
     }
@@ -148,7 +144,7 @@ export default function(realm: Realm): NativeFunctionValue {
     // 3. If Properties is not undefined, then
     if (!Properties.mightBeUndefined()) {
       // a. Return ? ObjectDefineProperties(obj, Properties).
-      return ObjectDefineProperties(realm, obj, Properties);
+      return Props.ObjectDefineProperties(realm, obj, Properties);
     }
     Properties.throwIfNotConcrete();
 
@@ -159,7 +155,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.1.2.3
   func.defineNativeMethod("defineProperties", 2, (context, [O, Properties]) => {
     // 1. Return ? ObjectDefineProperties(O, Properties).
-    return ObjectDefineProperties(realm, O, Properties);
+    return Props.ObjectDefineProperties(realm, O, Properties);
   });
 
   // ECMA262 19.1.2.4
@@ -177,7 +173,7 @@ export default function(realm: Realm): NativeFunctionValue {
     let desc = ToPropertyDescriptor(realm, Attributes);
 
     // 4. Perform ? DefinePropertyOrThrow(O, key, desc).
-    DefinePropertyOrThrow(realm, (O: any), key, desc);
+    Props.DefinePropertyOrThrow(realm, (O: any), key, desc);
 
     // 4. Return O.
     return O;
@@ -213,7 +209,7 @@ export default function(realm: Realm): NativeFunctionValue {
     let desc = obj.$GetOwnProperty(key);
 
     // 4. Return FromPropertyDescriptor(desc).
-    return FromPropertyDescriptor(realm, desc);
+    return Props.FromPropertyDescriptor(realm, desc);
   });
 
   // ECMA262 19.1.2.7
@@ -237,10 +233,10 @@ export default function(realm: Realm): NativeFunctionValue {
     for (let key of ownKeys) {
       // a. Let desc be ? obj.[[GetOwnProperty]](key).
       let desc = obj.$GetOwnProperty(key);
-      if (desc !== undefined) ThrowIfMightHaveBeenDeleted(desc.value);
+      if (desc !== undefined) Props.ThrowIfMightHaveBeenDeleted(desc.value);
 
       // b. Let descriptor be ! FromPropertyDescriptor(desc).
-      let descriptor = FromPropertyDescriptor(realm, desc);
+      let descriptor = Props.FromPropertyDescriptor(realm, desc);
 
       // c. If descriptor is not undefined, perform ! CreateDataProperty(descriptors, key, descriptor).
       if (!(descriptor instanceof UndefinedValue)) CreateDataProperty(realm, descriptors, key, descriptor);

--- a/src/intrinsics/ecma262/ObjectPrototype.js
+++ b/src/intrinsics/ecma262/ObjectPrototype.js
@@ -15,7 +15,7 @@ import { ToPropertyKey, ToObject, ToObjectPartial } from "../../methods/to.js";
 import { SameValuePartial, RequireObjectCoercible } from "../../methods/abstract.js";
 import { HasOwnProperty, HasSomeCompatibleType } from "../../methods/has.js";
 import { Invoke } from "../../methods/call.js";
-import { ThrowIfMightHaveBeenDeleted } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -68,7 +68,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
     // 4. If desc is undefined, return false.
     if (!desc) return realm.intrinsics.false;
-    ThrowIfMightHaveBeenDeleted(desc.value);
+    Properties.ThrowIfMightHaveBeenDeleted(desc.value);
 
     // 5. Return the value of desc.[[Enumerable]].
     return desc.enumerable === undefined ? realm.intrinsics.undefined : new BooleanValue(realm, desc.enumerable);

--- a/src/intrinsics/ecma262/Reflect.js
+++ b/src/intrinsics/ecma262/Reflect.js
@@ -13,7 +13,6 @@ import type { Realm } from "../../realm.js";
 import { BooleanValue, ObjectValue, NullValue } from "../../values/index.js";
 import {
   CreateArrayFromList,
-  FromPropertyDescriptor,
   ToPropertyDescriptor,
   Construct,
   ToPropertyKey,
@@ -22,6 +21,7 @@ import {
   Call,
   IsConstructor,
 } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 
 export default function(realm: Realm): ObjectValue {
   let obj = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "Reflect");
@@ -137,7 +137,7 @@ export default function(realm: Realm): ObjectValue {
     let desc = target.$GetOwnProperty(key);
 
     // 4. Return FromPropertyDescriptor(desc).
-    return FromPropertyDescriptor(realm, desc);
+    return Properties.FromPropertyDescriptor(realm, desc);
   });
 
   // ECMA262 26.1.7

--- a/src/intrinsics/ecma262/RegExpPrototype.js
+++ b/src/intrinsics/ecma262/RegExpPrototype.js
@@ -25,7 +25,7 @@ import { SameValue } from "../../methods/abstract.js";
 import { Call } from "../../methods/call.js";
 import { Construct, SpeciesConstructor } from "../../methods/construct.js";
 import { Get, GetSubstitution } from "../../methods/get.js";
-import { Set } from "../../methods/properties.js";
+import { Properties } from "../../singletons.js";
 import { IsCallable } from "../../methods/is.js";
 import { ToString, ToStringPartial, ToBooleanPartial, ToLength, ToInteger, ToUint32 } from "../../methods/to.js";
 import { RegExpBuiltinExec, RegExpExec, EscapeRegExpPattern, AdvanceStringIndex } from "../../methods/regexp.js";
@@ -174,7 +174,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let fullUnicode = ToBooleanPartial(realm, Get(realm, rx, "unicode"));
 
       // b. Perform ? Set(rx, "lastIndex", 0, true).
-      Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
+      Properties.Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
 
       // c. Let A be ArrayCreate(0).
       let A = ArrayCreate(realm, 0);
@@ -221,7 +221,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
             let nextIndex = AdvanceStringIndex(realm, S, thisIndex, fullUnicode);
 
             // c .Perform ? Set(rx, "lastIndex", nextIndex, true).
-            Set(realm, rx, "lastIndex", new NumberValue(realm, nextIndex), true);
+            Properties.Set(realm, rx, "lastIndex", new NumberValue(realm, nextIndex), true);
           }
 
           // 5. Increment n.
@@ -273,7 +273,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       fullUnicode = ToBooleanPartial(realm, Get(realm, rx, "unicode"));
 
       // b. Perform ? Set(rx, "lastIndex", 0, true).
-      Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
+      Properties.Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
     }
 
     // 9. Let results be a new empty List.
@@ -314,7 +314,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
             let nextIndex = AdvanceStringIndex(realm, S, thisIndex, fullUnicode);
 
             // c. Perform ? Set(rx, "lastIndex", nextIndex, true).
-            Set(realm, rx, "lastIndex", new NumberValue(realm, nextIndex), true);
+            Properties.Set(realm, rx, "lastIndex", new NumberValue(realm, nextIndex), true);
           }
         }
       }
@@ -434,13 +434,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let previousLastIndex = Get(realm, rx, "lastIndex");
 
     // 5. Perform ? Set(rx, "lastIndex", 0, true).
-    Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
+    Properties.Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
 
     // 6. Let result be ? RegExpExec(rx, S).
     let result = RegExpExec(realm, rx, S);
 
     // 7. Perform ? Set(rx, "lastIndex", previousLastIndex, true).
-    Set(realm, rx, "lastIndex", previousLastIndex, true);
+    Properties.Set(realm, rx, "lastIndex", previousLastIndex, true);
 
     // 8. If result is null, return -1.
     if (result instanceof NullValue) return new NumberValue(realm, -1);
@@ -567,7 +567,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 19. Repeat, while q < size
     while (q < size) {
       // a. Perform ? Set(splitter, "lastIndex", q, true).
-      Set(realm, splitter, "lastIndex", new NumberValue(realm, q), true);
+      Properties.Set(realm, splitter, "lastIndex", new NumberValue(realm, q), true);
 
       // b. Let z be ? RegExpExec(splitter, S).
       let z = RegExpExec(realm, splitter, S);

--- a/src/intrinsics/ecma262/SetPrototype.js
+++ b/src/intrinsics/ecma262/SetPrototype.js
@@ -11,13 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, ObjectValue, StringValue, NumberValue } from "../../values/index.js";
-import {
-  Call,
-  CreateSetIterator,
-  IsCallable,
-  SameValueZeroPartial,
-  ThrowIfMightHaveBeenDeleted,
-} from "../../methods/index.js";
+import { Call, CreateSetIterator, IsCallable, SameValueZeroPartial } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -250,7 +245,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 23.2.3.8
   let valuesPropertyDescriptor = obj.$GetOwnProperty("values");
   invariant(valuesPropertyDescriptor);
-  ThrowIfMightHaveBeenDeleted(valuesPropertyDescriptor.value);
+  Properties.ThrowIfMightHaveBeenDeleted(valuesPropertyDescriptor.value);
   obj.defineNativeProperty("keys", undefined, valuesPropertyDescriptor);
 
   // ECMA262 23.2.3.11

--- a/src/intrinsics/ecma262/TypedArray.js
+++ b/src/intrinsics/ecma262/TypedArray.js
@@ -23,7 +23,7 @@ import {
 import { SpeciesConstructor } from "../../methods/construct.js";
 import { ToIndexPartial, ToLength, ToString, ToObjectPartial } from "../../methods/to.js";
 import { Get, GetMethod } from "../../methods/get.js";
-import { Set } from "../../methods/properties.js";
+import { Properties } from "../../singletons.js";
 import { IterableToList } from "../../methods/iterator.js";
 import { IsDetachedBuffer, IsConstructor, IsCallable } from "../../methods/is.js";
 import { Call } from "../../methods/call.js";
@@ -107,7 +107,7 @@ export default function(realm: Realm): NativeFunctionValue {
         }
 
         // v. Perform ? Set(targetObj, Pk, mappedValue, true).
-        Set(realm, targetObj, Pk, mappedValue, true);
+        Properties.Set(realm, targetObj, Pk, mappedValue, true);
 
         // vi. Increase k by 1.
         k = k + 1;
@@ -153,7 +153,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // e. Perform ? Set(targetObj, Pk, mappedValue, true).
-      Set(realm, targetObj, Pk, mappedValue, true);
+      Properties.Set(realm, targetObj, Pk, mappedValue, true);
 
       // f. Increase k by 1.
       k = k + 1;
@@ -195,7 +195,7 @@ export default function(realm: Realm): NativeFunctionValue {
       let Pk = ToString(realm, new NumberValue(realm, k));
 
       // c. Perform ? Set(newObj, Pk, kValue, true).
-      Set(realm, newObj, Pk, kValue, true);
+      Properties.Set(realm, newObj, Pk, kValue, true);
 
       // d. Increase k by 1.
       k = k + 1;
@@ -440,7 +440,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
           let kValue = values.shift();
 
           // iii. Perform ? Set(O, Pk, kValue, true).
-          Set(realm, O, Pk, kValue, true);
+          Properties.Set(realm, O, Pk, kValue, true);
 
           // iv. Increase k by 1.
           k = k + 1;
@@ -476,7 +476,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
         let kValue = Get(realm, arrayLike, Pk);
 
         // c. Perform ? Set(O, Pk, kValue, true).
-        Set(realm, O, Pk, kValue, true);
+        Properties.Set(realm, O, Pk, kValue, true);
 
         // d. Increase k by 1.
         k += 1;

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -25,7 +25,6 @@ import {
 } from "../../methods/to.js";
 import { Call, Invoke } from "../../methods/call.js";
 import { Get } from "../../methods/get.js";
-import { Set, DeletePropertyOrThrow } from "../../methods/properties.js";
 import { HasProperty, HasSomeCompatibleType } from "../../methods/has.js";
 import { IsDetachedBuffer, IsCallable } from "../../methods/is.js";
 import {
@@ -39,6 +38,7 @@ import {
 import { CreateArrayIterator } from "../../methods/create.js";
 import { SetValueInBuffer, GetValueFromBuffer, CloneArrayBuffer } from "../../methods/arraybuffer.js";
 import { SameValue, SameValueZeroPartial, StrictEqualityComparisonPartial } from "../../methods/abstract.js";
+import { Properties } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -208,11 +208,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
         // i. Let fromVal be ? Get(O, fromKey).
         let fromVal = Get(realm, O, fromKey);
         // ii. Perform ? Set(O, toKey, fromVal, true).
-        Set(realm, O, toKey, fromVal, true);
+        Properties.Set(realm, O, toKey, fromVal, true);
       } else {
         // e. Else fromPresent is false,
         // i. Perform ? DeletePropertyOrThrow(O, toKey).
-        DeletePropertyOrThrow(realm, O, toKey);
+        Properties.DeletePropertyOrThrow(realm, O, toKey);
       }
 
       // f. Let from be from + direction.
@@ -323,7 +323,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let Pk = new StringValue(realm, k + "");
 
       // b. Perform ? Set(O, Pk, value, true).
-      Set(realm, O, Pk, value, true);
+      Properties.Set(realm, O, Pk, value, true);
 
       // c. Increase k by 1.
       k++;
@@ -396,7 +396,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 12. For each element e of kept
     for (let e of kept) {
       // a. Perform ! Set(A, ! ToString(n), e, true).
-      Set(realm, A, new StringValue(realm, ToString(realm, new NumberValue(realm, n))), e, true);
+      Properties.Set(realm, A, new StringValue(realm, ToString(realm, new NumberValue(realm, n))), e, true);
 
       // b. Increment n by 1.
       n = n + 1;
@@ -855,7 +855,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let mappedValue = Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]);
 
       // d. Perform ? Set(A, Pk, mappedValue, true).
-      Set(realm, A, Pk, mappedValue, true);
+      Properties.Set(realm, A, Pk, mappedValue, true);
 
       // e. Increase k by 1.
       k = k + 1;
@@ -1100,28 +1100,28 @@ export default function(realm: Realm, obj: ObjectValue): void {
         invariant(upperValue, "expected upper value to exist");
 
         // i. Perform ? Set(O, lowerP, upperValue, true).
-        Set(realm, O, lowerP, upperValue, true);
+        Properties.Set(realm, O, lowerP, upperValue, true);
 
         // ii. Perform ? Set(O, upperP, lowerValue, true).
-        Set(realm, O, upperP, lowerValue, true);
+        Properties.Set(realm, O, upperP, lowerValue, true);
       } else if (!lowerExists && upperExists) {
         // i. Else if lowerExists is false and upperExists is true, then
         invariant(upperValue, "expected upper value to exist");
 
         // i. Perform ? Set(O, lowerP, upperValue, true).
-        Set(realm, O, lowerP, upperValue, true);
+        Properties.Set(realm, O, lowerP, upperValue, true);
 
         // ii. Perform ? DeletePropertyOrThrow(O, upperP).
-        DeletePropertyOrThrow(realm, O, upperP);
+        Properties.DeletePropertyOrThrow(realm, O, upperP);
       } else if (lowerExists && !upperExists) {
         // j. Else if lowerExists is true and upperExists is false, then
         invariant(lowerValue, "expected lower value to exist");
 
         // i. Perform ? DeletePropertyOrThrow(O, lowerP).
-        DeletePropertyOrThrow(realm, O, lowerP);
+        Properties.DeletePropertyOrThrow(realm, O, lowerP);
 
         // ii. Perform ? Set(O, upperP, lowerValue, true).
-        Set(realm, O, upperP, lowerValue, true);
+        Properties.Set(realm, O, upperP, lowerValue, true);
       } else {
         // k. Else both lowerExists and upperExists are false,
         // i. No action is required.
@@ -1455,7 +1455,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let kValue = Get(realm, O, Pk);
 
         // iii. Perform ! Set(A, ! ToString(n), kValue).
-        Set(realm, A, ToString(realm, new NumberValue(realm, n)), kValue, true);
+        Properties.Set(realm, A, ToString(realm, new NumberValue(realm, n)), kValue, true);
 
         // iv. Increase k by 1.
         k += 1;

--- a/src/intrinsics/node/buffer.js
+++ b/src/intrinsics/node/buffer.js
@@ -13,8 +13,9 @@ import invariant from "../../invariant.js";
 import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NumberValue, NativeFunctionValue, ObjectValue, StringValue } from "../../values/index.js";
-import { Set, ToInteger } from "../../methods/index.js";
+import { ToInteger } from "../../methods/index.js";
 import { getNodeBufferFromTypedArray } from "./utils.js";
+import { Properties } from "../../singletons.js";
 
 declare var process: any;
 
@@ -58,7 +59,7 @@ export default function(realm: Realm): ObjectValue {
         let wrapper = new NativeFunctionValue(realm, "Buffer.prototype." + name, name, 0, (context, args) => {
           throw new FatalError("TODO: " + name);
         });
-        Set(realm, proto, name, wrapper, true);
+        Properties.Set(realm, proto, name, wrapper, true);
       }
 
       // utf8Slice is used to read source code.
@@ -69,7 +70,7 @@ export default function(realm: Realm): ObjectValue {
         let utf8String = nativeBufferPrototype.utf8Slice.apply(self, decodedArgs);
         return new StringValue(realm, utf8String);
       });
-      Set(realm, proto, "utf8Slice", utf8Slice, true);
+      Properties.Set(realm, proto, "utf8Slice", utf8Slice, true);
 
       // copy has recently moved from the prototype to the instance upstream.
       let copy = new NativeFunctionValue(realm, "Buffer.prototype.copy", "copy", 0, (context, args) => {
@@ -86,13 +87,13 @@ export default function(realm: Realm): ObjectValue {
         let bytesCopied = nativeBufferPrototype.copy.apply(self, decodedArgs);
         return new NumberValue(realm, bytesCopied);
       });
-      Set(realm, proto, "copy", copy, true);
+      Properties.Set(realm, proto, "copy", copy, true);
 
       // TODO: Set up more methods on the prototype and bindingObject
       return realm.intrinsics.undefined;
     }
   );
-  Set(realm, obj, "setupBufferJS", setupBufferJS, true);
+  Properties.Set(realm, obj, "setupBufferJS", setupBufferJS, true);
 
   let createFromString = new NativeFunctionValue(
     realm,
@@ -103,7 +104,7 @@ export default function(realm: Realm): ObjectValue {
       throw new FatalError("TODO");
     }
   );
-  Set(realm, obj, "createFromString", createFromString, true);
+  Properties.Set(realm, obj, "createFromString", createFromString, true);
 
   let simpleWrapperNames = [
     "byteLengthUtf8",
@@ -134,11 +135,11 @@ export default function(realm: Realm): ObjectValue {
     let wrapper = new NativeFunctionValue(realm, intrinsicName + "." + name, name, 0, (context, args) => {
       throw new FatalError("TODO");
     });
-    Set(realm, obj, name, wrapper, true);
+    Properties.Set(realm, obj, name, wrapper, true);
   }
 
-  Set(realm, obj, "kMaxLength", new NumberValue(realm, nativeBuffer.kMaxLength), true);
-  Set(realm, obj, "kStringMaxLength", new NumberValue(realm, nativeBuffer.kStringMaxLength), true);
+  Properties.Set(realm, obj, "kMaxLength", new NumberValue(realm, nativeBuffer.kMaxLength), true);
+  Properties.Set(realm, obj, "kStringMaxLength", new NumberValue(realm, nativeBuffer.kStringMaxLength), true);
 
   return obj;
 }

--- a/src/intrinsics/node/contextify.js
+++ b/src/intrinsics/node/contextify.js
@@ -22,15 +22,8 @@ import {
   StringValue,
   UndefinedValue,
 } from "../../values/index.js";
-import {
-  DefinePropertyOrThrow,
-  Set,
-  Get,
-  GetFunctionRealm,
-  ToBoolean,
-  ToInteger,
-  ToString,
-} from "../../methods/index.js";
+import { Get, GetFunctionRealm, ToBoolean, ToInteger, ToString } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 import parse from "../../utils/parse.js";
 import type { BabelNodeFile } from "babel-types";
 
@@ -132,11 +125,11 @@ export default function(realm: Realm): ObjectValue {
     let self = new ObjectValue(realm, proto, intrinsicConstructor);
 
     if (cachedDataBuf.length) {
-      Set(realm, obj, "cachedDataRejected", realm.intrinsics.true, true);
+      Properties.Set(realm, obj, "cachedDataRejected", realm.intrinsics.true, true);
     }
 
     if (produceCachedData) {
-      Set(realm, obj, "cachedDataProduced", realm.intrinsics.false, true);
+      Properties.Set(realm, obj, "cachedDataProduced", realm.intrinsics.false, true);
     }
 
     let ast;
@@ -163,13 +156,13 @@ export default function(realm: Realm): ObjectValue {
     0,
     runInDebugContextImpl
   );
-  Set(realm, obj, "runInDebugContext", runInDebugContext, true);
+  Properties.Set(realm, obj, "runInDebugContext", runInDebugContext, true);
 
   let makeContext = new NativeFunctionValue(realm, `${intrinsicName}.makeContext`, "makeContext", 0, makeContextImpl);
-  Set(realm, obj, "makeContext", makeContext, true);
+  Properties.Set(realm, obj, "makeContext", makeContext, true);
 
   let isContext = new NativeFunctionValue(realm, `${intrinsicName}.isContext`, "isContext", 0, isContextImpl);
-  Set(realm, obj, "isContext", isContext, true);
+  Properties.Set(realm, obj, "isContext", isContext, true);
 
   let ContextifyScript = new NativeFunctionValue(
     realm,
@@ -179,7 +172,7 @@ export default function(realm: Realm): ObjectValue {
     ContextifyScriptConstructor,
     true
   );
-  Set(realm, obj, "ContextifyScript", ContextifyScript, true);
+  Properties.Set(realm, obj, "ContextifyScript", ContextifyScript, true);
 
   // ContextifyScript.prototype
 
@@ -221,7 +214,7 @@ export default function(realm: Realm): ObjectValue {
     let line = lines[errorLocation.loc.line - 1] || "";
     let arrow = " ".repeat(errorLocation.loc.column) + "^";
     let decoratedStack = `${errorLocation.filename}:${errorLocation.loc.line}\n${line}\n${arrow}\n${stack.value}`;
-    Set(realm, error, "stack", new StringValue(realm, decoratedStack), false);
+    Properties.Set(realm, error, "stack", new StringValue(realm, decoratedStack), false);
 
     errorLocation.stackDecorated = true;
   }
@@ -401,14 +394,14 @@ export default function(realm: Realm): ObjectValue {
   ContextifyScriptPrototype.defineNativeMethod("runInContext", 2, runInContext);
   ContextifyScriptPrototype.defineNativeMethod("runInThisContext", 1, runInThisContext);
 
-  DefinePropertyOrThrow(realm, ContextifyScript, "prototype", {
+  Properties.DefinePropertyOrThrow(realm, ContextifyScript, "prototype", {
     value: ContextifyScriptPrototype,
     writable: true,
     enumerable: false,
     configurable: false,
   });
 
-  DefinePropertyOrThrow(realm, ContextifyScriptPrototype, "constructor", {
+  Properties.DefinePropertyOrThrow(realm, ContextifyScriptPrototype, "constructor", {
     value: ContextifyScript,
     writable: true,
     enumerable: false,

--- a/src/intrinsics/node/fs.js
+++ b/src/intrinsics/node/fs.js
@@ -12,10 +12,11 @@
 import invariant from "../../invariant.js";
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NumberValue, ObjectValue, StringValue } from "../../values/index.js";
-import { DefinePropertyOrThrow, ToString, ToNumber } from "../../methods/index.js";
+import { ToString, ToNumber } from "../../methods/index.js";
 import { ValuesDomain } from "../../domains/index.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import { getNodeBufferFromTypedArray } from "./utils.js";
+import { Properties } from "../../singletons.js";
 
 declare var process: any;
 
@@ -85,7 +86,7 @@ export default function(realm: Realm): ObjectValue {
   let val = AbstractValue.createFromTemplate(realm, FSReqWrapTemplate, ObjectValue, [], FSReqWrapTemplateSrc);
   val.values = new ValuesDomain(new Set([new ObjectValue(realm)]));
   val.intrinsicName = FSReqWrapTemplateSrc;
-  DefinePropertyOrThrow(realm, obj, "FSReqWrap", {
+  Properties.DefinePropertyOrThrow(realm, obj, "FSReqWrap", {
     value: val,
     writable: true,
     configurable: true,

--- a/src/intrinsics/node/process.js
+++ b/src/intrinsics/node/process.js
@@ -23,16 +23,9 @@ import {
   ObjectValue,
   StringValue,
 } from "../../values/index.js";
-import {
-  Get,
-  DefinePropertyOrThrow,
-  OrdinaryDelete,
-  OrdinaryDefineOwnProperty,
-  ToString,
-  ToInteger,
-  ToBoolean,
-} from "../../methods/index.js";
+import { Get, ToString, ToInteger, ToBoolean } from "../../methods/index.js";
 import { ValuesDomain } from "../../domains/index.js";
+import { Properties } from "../../singletons.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import initializeBuffer from "./buffer.js";
 import initializeContextify from "./contextify.js";
@@ -52,7 +45,7 @@ function initializeTimerWrap(realm) {
       return realm.intrinsics.undefined;
     }
   );
-  OrdinaryDefineOwnProperty(realm, obj, "Timer", {
+  Properties.OrdinaryDefineOwnProperty(realm, obj, "Timer", {
     value: constructor,
     writable: true,
     enumerable: true,
@@ -91,7 +84,7 @@ function initializeTTYWrap(realm) {
       return new ObjectValue(realm, proto, `new (process.binding('tty_wrap').TTY)(${fd}, ${value.toString()})`);
     }
   );
-  OrdinaryDefineOwnProperty(realm, obj, "TTY", {
+  Properties.OrdinaryDefineOwnProperty(realm, obj, "TTY", {
     value: constructor,
     writable: true,
     enumerable: true,
@@ -119,7 +112,7 @@ function initializeTTYWrap(realm) {
     return realm.intrinsics.undefined;
   });
 
-  DefinePropertyOrThrow(realm, constructor, "prototype", {
+  Properties.DefinePropertyOrThrow(realm, constructor, "prototype", {
     value: TTYPrototype,
     writable: true,
     enumerable: false,
@@ -174,7 +167,7 @@ function initializeSignalWrap(realm) {
       return realm.intrinsics.undefined;
     }
   );
-  OrdinaryDefineOwnProperty(realm, obj, "Signal", {
+  Properties.OrdinaryDefineOwnProperty(realm, obj, "Signal", {
     value: constructor,
     writable: true,
     enumerable: true,
@@ -199,7 +192,7 @@ function initializeSignalWrap(realm) {
     return realm.intrinsics.undefined;
   });
 
-  DefinePropertyOrThrow(realm, constructor, "prototype", {
+  Properties.DefinePropertyOrThrow(realm, constructor, "prototype", {
     value: SignalPrototype,
     writable: true,
     enumerable: false,
@@ -223,7 +216,7 @@ function initializeStreamWrap(realm) {
       return realm.intrinsics.undefined;
     }
   );
-  OrdinaryDefineOwnProperty(realm, obj, "WriteWrap", {
+  Properties.OrdinaryDefineOwnProperty(realm, obj, "WriteWrap", {
     value: constructor,
     writable: true,
     enumerable: true,
@@ -240,7 +233,7 @@ function initializeStreamWrap(realm) {
     return realm.intrinsics.undefined;
   });
 
-  DefinePropertyOrThrow(realm, constructor, "prototype", {
+  Properties.DefinePropertyOrThrow(realm, constructor, "prototype", {
     value: WriteWrapPrototype,
     writable: true,
     enumerable: false,
@@ -248,7 +241,7 @@ function initializeStreamWrap(realm) {
   });
 
   let ShutdownWrap = createAbstractValue(realm, FunctionValue, "process.binding('stream_wrap').ShutdownWrap");
-  DefinePropertyOrThrow(realm, obj, "ShutdownWrap", {
+  Properties.DefinePropertyOrThrow(realm, obj, "ShutdownWrap", {
     value: ShutdownWrap,
     writable: true,
     configurable: true,
@@ -262,7 +255,7 @@ function initializeStreamWrap(realm) {
 function initializeFSEvent(realm) {
   let obj = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "process.binding('fs_event_wrap')");
   let FSEvent = createAbstractValue(realm, FunctionValue, "process.binding('fs_event_wrap').FSEvent");
-  DefinePropertyOrThrow(realm, obj, "FSEvent", {
+  Properties.DefinePropertyOrThrow(realm, obj, "FSEvent", {
     value: FSEvent,
     writable: true,
     configurable: true,
@@ -311,7 +304,7 @@ function createIntrinsicArrayValue(realm, intrinsicName) {
   // Like ArrayCreate but accepts an intrinsic name.
   let obj = new ArrayValue(realm, intrinsicName);
   obj.setExtensible(true);
-  OrdinaryDefineOwnProperty(realm, obj, "length", {
+  Properties.OrdinaryDefineOwnProperty(realm, obj, "length", {
     value: realm.intrinsics.zero,
     writable: true,
     enumerable: false,
@@ -537,7 +530,7 @@ export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
   }
 
   let argv0 = new StringValue(realm, process.argv0, "process.argv0");
-  DefinePropertyOrThrow(realm, obj, "argv0", {
+  Properties.DefinePropertyOrThrow(realm, obj, "argv0", {
     value: argv0,
     writable: false,
     configurable: true,
@@ -546,21 +539,21 @@ export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
 
   let argv = createAbstractValue(realm, ObjectValue, "process.argv");
 
-  DefinePropertyOrThrow(realm, argv, "0", {
+  Properties.DefinePropertyOrThrow(realm, argv, "0", {
     value: argv0,
     writable: true,
     configurable: true,
     enumerable: true,
   });
 
-  DefinePropertyOrThrow(realm, argv, "1", {
+  Properties.DefinePropertyOrThrow(realm, argv, "1", {
     value: new StringValue(realm, processArgv[1]),
     writable: true,
     configurable: true,
     enumerable: true,
   });
 
-  DefinePropertyOrThrow(realm, argv, "indexOf", {
+  Properties.DefinePropertyOrThrow(realm, argv, "indexOf", {
     value: new NativeFunctionValue(realm, "process.argv.indexOf", "indexOf", 0, (context, args) => {
       return realm.intrinsics.false;
     }),
@@ -577,7 +570,7 @@ export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
 
   let env = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "process.env");
   // TODO: This abstract value doesn't work with a conditional for some reason.
-  DefinePropertyOrThrow(realm, env, "NODE_NO_WARNINGS", {
+  Properties.DefinePropertyOrThrow(realm, env, "NODE_NO_WARNINGS", {
     value: new StringValue(realm, "0", "process.env.NODE_NO_WARNINGS"),
     writable: true,
     configurable: true,
@@ -601,21 +594,21 @@ export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
   // TODO: The generated code needs to either always invoke this (make it
   // abstract) or, if we assume it has been done, it doesn't need to delete it.
   obj.defineNativeMethod("_setupProcessObject", 1, (self, [pushValueToArray]) => {
-    OrdinaryDelete(realm, obj, "_setupProcessObject");
+    Properties.OrdinaryDelete(realm, obj, "_setupProcessObject");
     return realm.intrinsics.undefined;
   });
 
   // This method injects a generic global promise reject callback. In real
   // environment we'd want to call this at rejections but we can safely skip it.
   obj.defineNativeMethod("_setupPromises", 1, (self, [promiseRejectCallback]) => {
-    OrdinaryDelete(realm, obj, "_setupPromises");
+    Properties.OrdinaryDelete(realm, obj, "_setupPromises");
     return realm.intrinsics.undefined;
   });
 
   // TODO: Support Promises. Set up a micro task runner and invoke the
   // tickCallback as needed.
   obj.defineNativeMethod("_setupNextTick", 1, (self, [tickCallback, runMicrotasks]) => {
-    OrdinaryDelete(realm, obj, "_setupNextTick");
+    Properties.OrdinaryDelete(realm, obj, "_setupNextTick");
     let runMicrotasksCallback = new NativeFunctionValue(
       realm,
       "(function() { throw new Error('TODO runMicrotasks not reachable') })",
@@ -626,7 +619,7 @@ export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
         return realm.intrinsics.undefined;
       }
     );
-    OrdinaryDefineOwnProperty(realm, runMicrotasks, "runMicrotasks", {
+    Properties.OrdinaryDefineOwnProperty(realm, runMicrotasks, "runMicrotasks", {
       value: runMicrotasksCallback,
       writable: true,
       enumerable: true,
@@ -637,13 +630,13 @@ export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
       realm.intrinsics.ObjectPrototype,
       "(function() { throw new Error('TODO tickInfo is not reachable in the host environment') })"
     );
-    OrdinaryDefineOwnProperty(realm, tickInfo, "0", {
+    Properties.OrdinaryDefineOwnProperty(realm, tickInfo, "0", {
       value: realm.intrinsics.zero,
       writable: true,
       enumerable: true,
       configurable: true,
     });
-    OrdinaryDefineOwnProperty(realm, tickInfo, "1", {
+    Properties.OrdinaryDefineOwnProperty(realm, tickInfo, "1", {
       value: realm.intrinsics.zero,
       writable: true,
       enumerable: true,

--- a/src/intrinsics/node/utils.js
+++ b/src/intrinsics/node/utils.js
@@ -13,7 +13,7 @@ import invariant from "../../invariant.js";
 import { FatalError } from "../../errors.js";
 import type { Realm } from "../../realm.js";
 import { type Value, BooleanValue, ObjectValue, NumberValue, StringValue } from "../../values/index.js";
-import { DefinePropertyOrThrow } from "../../methods/index.js";
+import { Properties } from "../../singletons.js";
 
 export function getNodeBufferFromTypedArray(realm: Realm, value: ObjectValue): Uint8Array {
   let buffer = value.$ViewedArrayBuffer;
@@ -88,5 +88,5 @@ export function copyProperty(realm: Realm, originalObject: {}, realmObject: Obje
     configurable: !!desc.configurable,
     enumerable: !!desc.enumerable,
   };
-  DefinePropertyOrThrow(realm, realmObject, name, newDesc);
+  Properties.DefinePropertyOrThrow(realm, realmObject, name, newDesc);
 }

--- a/src/methods/arraybuffer.js
+++ b/src/methods/arraybuffer.js
@@ -17,7 +17,7 @@ import { SpeciesConstructor } from "../methods/construct.js";
 import { IsConstructor } from "../methods/index.js";
 import { ToIndexPartial, ToBooleanPartial, ToNumber, ElementConv } from "./to.js";
 import { IsDetachedBuffer } from "../methods/is.js";
-import { ThrowIfInternalSlotNotWritable } from "../methods/properties.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import { ElementSize } from "../types.js";
 
@@ -123,10 +123,10 @@ export function DetachArrayBuffer(realm: Realm, arrayBuffer: ObjectValue): NullV
   );
 
   // 2. Set arrayBuffer.[[ArrayBufferData]] to null.
-  ThrowIfInternalSlotNotWritable(realm, arrayBuffer, "$ArrayBufferData").$ArrayBufferData = null;
+  Properties.ThrowIfInternalSlotNotWritable(realm, arrayBuffer, "$ArrayBufferData").$ArrayBufferData = null;
 
   // 3. Set arrayBuffer.[[ArrayBufferByteLength]] to 0.
-  ThrowIfInternalSlotNotWritable(realm, arrayBuffer, "$ArrayBufferByteLength").$ArrayBufferByteLength = 0;
+  Properties.ThrowIfInternalSlotNotWritable(realm, arrayBuffer, "$ArrayBufferByteLength").$ArrayBufferByteLength = 0;
 
   // 4. Return NormalCompletion(null).
   return realm.intrinsics.null;
@@ -424,7 +424,7 @@ export function SetValueInBuffer(
   invariant(typeof value === "number");
 
   // 5. Let block be arrayBuffer.[[ArrayBufferData]].
-  let block = ThrowIfInternalSlotNotWritable(realm, arrayBuffer, "$ArrayBufferData").$ArrayBufferData;
+  let block = Properties.ThrowIfInternalSlotNotWritable(realm, arrayBuffer, "$ArrayBufferData").$ArrayBufferData;
 
   // 6. Assert: block is not undefined.
   invariant(block instanceof Uint8Array);

--- a/src/methods/construct.js
+++ b/src/methods/construct.js
@@ -21,9 +21,9 @@ import {
 } from "../values/index.js";
 import { IsConstructor, IsStatic } from "./is.js";
 import { ObjectCreate } from "./create.js";
-import { DefinePropertyOrThrow } from "./properties.js";
 import { Get } from "./get.js";
 import { HasSomeCompatibleType } from "./has.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeClassMethod } from "babel-types";
 
@@ -55,7 +55,7 @@ export function MakeConstructor(
     prototype.originalConstructor = F;
 
     // b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor{[[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
-    DefinePropertyOrThrow(realm, prototype, "constructor", {
+    Properties.DefinePropertyOrThrow(realm, prototype, "constructor", {
       value: F,
       writable: writablePrototype,
       enumerable: false,
@@ -64,7 +64,7 @@ export function MakeConstructor(
   }
 
   // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor{[[Value]]: prototype, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: false}).
-  DefinePropertyOrThrow(realm, F, "prototype", {
+  Properties.DefinePropertyOrThrow(realm, F, "prototype", {
     value: prototype,
     writable: writablePrototype,
     enumerable: false,

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -28,13 +28,13 @@ import {
   ArgumentsExotic,
 } from "../values/index.js";
 import { GetPrototypeFromConstructor } from "./get.js";
-import { DefinePropertyOrThrow, OrdinaryDefineOwnProperty } from "./properties.js";
 import { IsConstructor, IsPropertyKey, IsArray } from "./is.js";
 import { Type, SameValue, RequireObjectCoercible } from "./abstract.js";
 import { ToStringPartial, ToLength } from "./to.js";
 import { Get, GetFunctionRealm } from "./get.js";
 import { Construct, MakeConstructor } from "./construct.js";
 import { FunctionAllocate, FunctionInitialize, SetFunctionName } from "./function.js";
+import { Properties } from "../singletons.js";
 import IsStrict from "../utils/strict.js";
 import invariant from "../invariant.js";
 import parse from "../utils/parse.js";
@@ -68,7 +68,7 @@ export function StringCreate(realm: Realm, value: StringValue, prototype: Object
   let length = value.value.length;
 
   // 10. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor{[[Value]]: length, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).
-  DefinePropertyOrThrow(realm, S, "length", {
+  Properties.DefinePropertyOrThrow(realm, S, "length", {
     value: new NumberValue(realm, length),
     writable: false,
     enumerable: false,
@@ -312,7 +312,7 @@ export function ArrayCreate(realm: Realm, length: number, proto?: ObjectValue): 
   A.setExtensible(true);
 
   // 10. Perform ! OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor{[[Value]]: length, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false}).
-  OrdinaryDefineOwnProperty(realm, A, "length", {
+  Properties.OrdinaryDefineOwnProperty(realm, A, "length", {
     value: new NumberValue(realm, length),
     writable: true,
     enumerable: false,
@@ -363,7 +363,7 @@ export function CreateUnmappedArgumentsObject(realm: Realm, argumentsList: Array
 
   // 4. Perform DefinePropertyOrThrow(obj, "length", PropertyDescriptor{[[Value]]: len,
   //    [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}).
-  DefinePropertyOrThrow(realm, obj, "length", {
+  Properties.DefinePropertyOrThrow(realm, obj, "length", {
     value: new NumberValue(realm, len),
     writable: true,
     enumerable: false,
@@ -387,7 +387,7 @@ export function CreateUnmappedArgumentsObject(realm: Realm, argumentsList: Array
 
   // 7. Perform ! DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor {[[Value]]:
   //    %ArrayProto_values%, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}).
-  DefinePropertyOrThrow(realm, obj, realm.intrinsics.SymbolIterator, {
+  Properties.DefinePropertyOrThrow(realm, obj, realm.intrinsics.SymbolIterator, {
     value: realm.intrinsics.ArrayProto_values,
     writable: true,
     enumerable: false,
@@ -396,7 +396,7 @@ export function CreateUnmappedArgumentsObject(realm: Realm, argumentsList: Array
 
   // 8. Perform ! DefinePropertyOrThrow(obj, "callee", PropertyDescriptor {[[Get]]:
   // %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: false, [[Configurable]]: false}).
-  DefinePropertyOrThrow(realm, obj, "callee", {
+  Properties.DefinePropertyOrThrow(realm, obj, "callee", {
     get: realm.intrinsics.ThrowTypeError,
     set: realm.intrinsics.ThrowTypeError,
     enumerable: false,
@@ -478,7 +478,7 @@ export function CreateMappedArgumentsObject(
 
   // 18. Perform DefinePropertyOrThrow(obj, "length", PropertyDescriptor{[[Value]]: len,
   //     [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}).
-  DefinePropertyOrThrow(realm, obj, "length", {
+  Properties.DefinePropertyOrThrow(realm, obj, "length", {
     value: new NumberValue(realm, len),
     writable: true,
     enumerable: false,
@@ -526,7 +526,7 @@ export function CreateMappedArgumentsObject(
 
   // 22. Perform ! DefinePropertyOrThrow(obj, @@iterator, PropertyDescriptor {[[Value]]:
   //     %ArrayProto_values%, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}).
-  DefinePropertyOrThrow(realm, obj, realm.intrinsics.SymbolIterator, {
+  Properties.DefinePropertyOrThrow(realm, obj, realm.intrinsics.SymbolIterator, {
     value: realm.intrinsics.ArrayProto_values,
     writable: true,
     enumerable: false,
@@ -535,7 +535,7 @@ export function CreateMappedArgumentsObject(
 
   // 23. Perform ! DefinePropertyOrThrow(obj, "callee", PropertyDescriptor {[[Value]]:
   //     func, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}).
-  DefinePropertyOrThrow(realm, obj, "callee", {
+  Properties.DefinePropertyOrThrow(realm, obj, "callee", {
     value: func,
     writable: true,
     enumerable: false,
@@ -850,7 +850,7 @@ export function CreateDynamicFunction(
     prototype.originalConstructor = F;
 
     // b. Perform DefinePropertyOrThrow(F, "prototype", PropertyDescriptor{[[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false}).
-    DefinePropertyOrThrow(realm, F, "prototype", {
+    Properties.DefinePropertyOrThrow(realm, F, "prototype", {
       value: prototype,
       writable: true,
       enumerable: false,

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -29,11 +29,11 @@ import {
   HasOwnProperty,
   SetFunctionName,
   GetReferencedName,
-  PutValue,
   ArrayCreate,
   CreateDataProperty,
   GetV,
 } from "./index.js";
+import { Properties } from "../singletons.js";
 import type { BabelNodeLVal, BabelNodeArrayPattern, BabelNodeObjectPattern } from "babel-types";
 
 // ECMA262 12.15.5.2
@@ -271,7 +271,7 @@ export function IteratorDestructuringAssignmentEvaluation(
     }
 
     // 8. Return ? PutValue(lref, v).
-    PutValue(realm, lref, v);
+    Properties.PutValue(realm, lref, v);
     continue;
   }
 
@@ -357,7 +357,7 @@ export function IteratorDestructuringAssignmentEvaluation(
       invariant(lref);
 
       // a. Return ? PutValue(lref, A).
-      PutValue(realm, lref, A);
+      Properties.PutValue(realm, lref, A);
     } else {
       // 6. Let nestedAssignmentPattern be the parse of the source text corresponding to DestructuringAssignmentTarget using either AssignmentPattern or AssignmentPattern[Yield] as the goal symbol depending upon whether this AssignmentElement has the [Yield] parameter.
       let nestedAssignmentPattern = DestructuringAssignmentTarget;
@@ -458,5 +458,5 @@ export function KeyedDestructuringAssignmentEvaluation(
   }
 
   // 7. Return ? PutValue(lref, rhsValue).
-  return PutValue(realm, lref, rhsValue);
+  return Properties.PutValue(realm, lref, rhsValue);
 }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -42,7 +42,6 @@ import {
   GetV,
   GetThisValue,
   ToObjectPartial,
-  PutValue,
   RequireObjectCoercible,
   HasSomeCompatibleType,
   GetIterator,
@@ -55,6 +54,7 @@ import {
   HasOwnProperty,
   SetFunctionName,
 } from "./index.js";
+import { Properties } from "../singletons.js";
 import type {
   BabelNode,
   BabelNodeVariableDeclaration,
@@ -735,7 +735,7 @@ export function IteratorBindingInitialization(
 
       // 6. If environment is undefined, return ? PutValue(lhs, v).
       if (!environment) {
-        PutValue(realm, lhs, v);
+        Properties.PutValue(realm, lhs, v);
         continue;
       }
 
@@ -845,7 +845,7 @@ export function IteratorBindingInitialization(
       if (iteratorRecord.$Done === true) {
         // i. If environment is undefined, return ? PutValue(lhs, A).
         if (!environment) {
-          PutValue(realm, lhs, A);
+          Properties.PutValue(realm, lhs, A);
           break;
         }
 
@@ -972,7 +972,7 @@ export function InitializeBoundName(realm: Realm, name: string, value: Value, en
     let lhs = ResolveBinding(realm, name, false);
 
     // b. Return ? PutValue(lhs, value).
-    return PutValue(realm, lhs, value);
+    return Properties.PutValue(realm, lhs, value);
   }
 }
 
@@ -1058,7 +1058,7 @@ export function KeyedBindingInitialization(
     }
 
     // 5. If environment is undefined, return ? PutValue(lhs, v).
-    if (!environment) return PutValue(realm, lhs, v);
+    if (!environment) return Properties.PutValue(realm, lhs, v);
 
     // 6. Return InitializeReferencedBinding(lhs, v).
     return InitializeReferencedBinding(realm, lhs, v);

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -35,7 +35,7 @@ import {
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import { DefinePropertyOrThrow, NewDeclarativeEnvironment } from "./index.js";
+import { NewDeclarativeEnvironment } from "./index.js";
 import { OrdinaryCreateFromConstructor, CreateUnmappedArgumentsObject, CreateMappedArgumentsObject } from "./create.js";
 import { OrdinaryCallEvaluateBody, OrdinaryCallBindThis, PrepareForOrdinaryCall, Call } from "./call.js";
 import { SameValue } from "../methods/abstract.js";
@@ -52,6 +52,7 @@ import {
 } from "../methods/index.js";
 import { CreateListIterator } from "../methods/iterator.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
+import { Properties } from "../singletons.js";
 import traverseFast from "../utils/traverse-fast.js";
 import invariant from "../invariant.js";
 import parse from "../utils/parse.js";
@@ -523,7 +524,7 @@ export function SetFunctionName(
   }
 
   // 6. Return ! DefinePropertyOrThrow(F, "name", PropertyDescriptor{[[Value]]: name, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true}).
-  return DefinePropertyOrThrow(realm, F, "name", {
+  return Properties.DefinePropertyOrThrow(realm, F, "name", {
     value: name,
     enumerable: false,
     writable: false,
@@ -556,7 +557,7 @@ export function FunctionInitialize(
   }
 
   // 3. Perform ! DefinePropertyOrThrow(F, "length", PropertyDescriptor{[[Value]]: len, [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: true}).
-  DefinePropertyOrThrow(realm, F, "length", {
+  Properties.DefinePropertyOrThrow(realm, F, "length", {
     value: new NumberValue(realm, len),
     writable: false,
     enumerable: false,
@@ -566,7 +567,7 @@ export function FunctionInitialize(
   // 4. Let Strict be the value of the [[Strict]] internal slot of F.
   let Strict = F.$Strict;
   if (!Strict) {
-    DefinePropertyOrThrow(realm, F, "caller", {
+    Properties.DefinePropertyOrThrow(realm, F, "caller", {
       value: new UndefinedValue(realm),
       writable: true,
       enumerable: false,
@@ -635,9 +636,9 @@ export function AddRestrictedFunctionProperties(F: FunctionValue, realm: Realm) 
     configurable: true,
   };
   // 3. Perform ! DefinePropertyOrThrow(F, "caller", PropertyDescriptor {[[Get]]: thrower, [[Set]]: thrower, [[Enumerable]]: false, [[Configurable]]: true}).
-  DefinePropertyOrThrow(realm, F, "caller", desc);
+  Properties.DefinePropertyOrThrow(realm, F, "caller", desc);
   // 4. Return ! DefinePropertyOrThrow(F, "arguments", PropertyDescriptor {[[Get]]: thrower, [[Set]]: thrower, [[Enumerable]]: false, [[Configurable]]: true}).
-  return DefinePropertyOrThrow(realm, F, "arguments", desc);
+  return Properties.DefinePropertyOrThrow(realm, F, "arguments", desc);
 }
 
 // ECMA262 9.2.1
@@ -1235,7 +1236,7 @@ export function FunctionCreate(
   // Note: "arguments" ***MUST NOT*** be set if the function is in strict mode or is an arrow, method, constructor, or generator function.
   //   See 16.2 "Forbidden Extensions"
   if (!Strict && kind === "normal") {
-    DefinePropertyOrThrow(realm, F, "arguments", {
+    Properties.DefinePropertyOrThrow(realm, F, "arguments", {
       value: realm.intrinsics.undefined,
       enumerable: false,
       writable: true,

--- a/src/methods/generator.js
+++ b/src/methods/generator.js
@@ -13,7 +13,7 @@ import type { Realm } from "../realm.js";
 import { AbruptCompletion } from "../completions.js";
 import { Value, ObjectValue, UndefinedValue } from "../values/index.js";
 import { CreateIterResultObject } from "../methods/create.js";
-import { ThrowIfInternalSlotNotWritable } from "../methods/properties.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeBlockStatement } from "babel-types";
 
@@ -112,7 +112,7 @@ export function GeneratorResume(realm: Realm, generator: Value, value: Value): V
   methodContext.suspend();
 
   // 7. Set generator.[[GeneratorState]] to "executing".
-  ThrowIfInternalSlotNotWritable(realm, generator, "$GeneratorState").$GeneratorState = "executing";
+  Properties.ThrowIfInternalSlotNotWritable(realm, generator, "$GeneratorState").$GeneratorState = "executing";
 
   // 8. Push genContext onto the execution context stack; genContext is now the running execution context.
   realm.pushContext(genContext);

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -12,8 +12,9 @@
 import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
-import { ThrowIfMightHaveBeenDeleted, IsPropertyKey } from "./index.js";
+import { IsPropertyKey } from "./index.js";
 import { Value, AbstractValue, ObjectValue, NullValue, AbstractObjectValue } from "../values/index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeExpression } from "babel-types";
 
@@ -81,7 +82,7 @@ export function HasOwnProperty(realm: Realm, O: ObjectValue | AbstractObjectValu
 
   // 4. If desc is undefined, return false.
   if (desc === undefined) return false;
-  ThrowIfMightHaveBeenDeleted(desc.value);
+  Properties.ThrowIfMightHaveBeenDeleted(desc.value);
 
   // 5. Return true.
   return true;
@@ -97,7 +98,7 @@ export function OrdinaryHasProperty(realm: Realm, O: ObjectValue, P: PropertyKey
 
   // 3. If hasOwn is not undefined, return true.
   if (hasOwn !== undefined) {
-    ThrowIfMightHaveBeenDeleted(hasOwn.value);
+    Properties.ThrowIfMightHaveBeenDeleted(hasOwn.value);
     return true;
   }
 

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -26,7 +26,6 @@ export * from "./is.js";
 export * from "./iterator.js";
 export * from "./join.js";
 export * from "./own.js";
-export * from "./properties.js";
 export * from "./destructuring.js";
 export * from "./regexp.js";
 export * from "./promise.js";

--- a/src/methods/integrity.js
+++ b/src/methods/integrity.js
@@ -11,8 +11,8 @@
 
 import type { Realm } from "../realm.js";
 import { ObjectValue } from "../values/index.js";
-import { IsExtensible, IsDataDescriptor, IsAccessorDescriptor, ThrowIfMightHaveBeenDeleted } from "./index.js";
-import { DefinePropertyOrThrow } from "./properties.js";
+import { IsExtensible, IsDataDescriptor, IsAccessorDescriptor } from "./index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 type IntegrityLevels = "sealed" | "frozen";
@@ -48,7 +48,7 @@ export function SetIntegrityLevel(realm: Realm, O: ObjectValue, level: Integrity
     // a. Repeat for each element k of keys,
     for (let k of keys) {
       // i. Perform ? DefinePropertyOrThrow(O, k, PropertyDescriptor{[[Configurable]]: false}).
-      DefinePropertyOrThrow(realm, O, k, {
+      Properties.DefinePropertyOrThrow(realm, O, k, {
         configurable: false,
       });
     }
@@ -61,7 +61,7 @@ export function SetIntegrityLevel(realm: Realm, O: ObjectValue, level: Integrity
 
       // ii. If currentDesc is not undefined, then
       if (currentDesc) {
-        ThrowIfMightHaveBeenDeleted(currentDesc.value);
+        Properties.ThrowIfMightHaveBeenDeleted(currentDesc.value);
         let desc;
 
         // 1. If IsAccessorDescriptor(currentDesc) is true, then
@@ -75,7 +75,7 @@ export function SetIntegrityLevel(realm: Realm, O: ObjectValue, level: Integrity
         }
 
         // 3. Perform ? DefinePropertyOrThrow(O, k, desc).
-        DefinePropertyOrThrow(realm, O, k, desc);
+        Properties.DefinePropertyOrThrow(realm, O, k, desc);
       }
     }
   }
@@ -110,7 +110,7 @@ export function TestIntegrityLevel(realm: Realm, O: ObjectValue, level: Integrit
 
     // b. If currentDesc is not undefined, then
     if (currentDesc) {
-      ThrowIfMightHaveBeenDeleted(currentDesc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(currentDesc.value);
 
       // i. If currentDesc.[[Configurable]] is true, return false.
       if (currentDesc.configurable === true) return false;

--- a/src/methods/own.js
+++ b/src/methods/own.js
@@ -11,8 +11,9 @@
 
 import type { PropertyKeyValue } from "../types.js";
 import type { Realm } from "../realm.js";
-import { Get, ToObject, CreateArrayFromList, IsArrayIndex, ThrowIfMightHaveBeenDeleted } from "./index.js";
+import { Get, ToObject, CreateArrayFromList, IsArrayIndex } from "./index.js";
 import { StringValue, ObjectValue, Value, ArrayValue } from "../values/index.js";
+import { Properties } from "../singletons.js";
 
 import invariant from "../invariant.js";
 
@@ -88,7 +89,7 @@ export function EnumerableOwnProperties(realm: Realm, O: ObjectValue, kind: stri
 
       // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
       if (desc && desc.enumerable) {
-        ThrowIfMightHaveBeenDeleted(desc.value);
+        Properties.ThrowIfMightHaveBeenDeleted(desc.value);
 
         // 1. If kind is "key", append key to properties.
         if (kind === "key") {

--- a/src/methods/promise.js
+++ b/src/methods/promise.js
@@ -20,7 +20,7 @@ import { Invoke, Call } from "../methods/call.js";
 import { CreateArrayFromList } from "../methods/create.js";
 import { IsCallable, IsConstructor, IsPromise } from "../methods/is.js";
 import { IteratorStep, IteratorValue } from "../methods/iterator.js";
-import { ThrowIfInternalSlotNotWritable } from "../methods/properties.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 // ECMA262 8.4.1
@@ -383,11 +383,11 @@ export function PerformPromiseThen(
   // 7. If the value of promise's [[PromiseState]] internal slot is "pending", then
   if (promise.$PromiseState === "pending") {
     // a. Append fulfillReaction as the last element of the List that is the value of promise's [[PromiseFulfillReactions]] internal slot.
-    ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseFulfillReactions");
+    Properties.ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseFulfillReactions");
     invariant(promise.$PromiseFulfillReactions);
     promise.$PromiseFulfillReactions.push(fulfillReaction);
     // b. Append rejectReaction as the last element of the List that is the value of promise's [[PromiseRejectReactions]] internal slot.
-    ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseRejectReactions");
+    Properties.ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseRejectReactions");
     invariant(promise.$PromiseRejectReactions);
     promise.$PromiseRejectReactions.push(rejectReaction);
   } else if (promise.$PromiseState === "fulfilled") {
@@ -412,7 +412,7 @@ export function PerformPromiseThen(
   }
 
   // 10. Set promise's [[PromiseIsHandled]] internal slot to true.
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseIsHandled").$PromiseIsHandled = true;
+  Properties.ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseIsHandled").$PromiseIsHandled = true;
 
   // 11. Return resultCapability.[[Promise]].
   invariant(resultCapability.promise instanceof ObjectValue);
@@ -565,16 +565,24 @@ export function FulfillPromise(realm: Realm, promise: ObjectValue, value: Value)
   invariant(reactions);
 
   // 3. Set promise.[[PromiseResult]] to value.
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseResult").$PromiseResult = value;
+  Properties.ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseResult").$PromiseResult = value;
 
   // 4. Set promise.[[PromiseFulfillReactions]] to undefined.
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseFulfillReactions").$PromiseFulfillReactions = undefined;
+  Properties.ThrowIfInternalSlotNotWritable(
+    realm,
+    promise,
+    "$PromiseFulfillReactions"
+  ).$PromiseFulfillReactions = undefined;
 
   // 5. Set promise.[[PromiseRejectReactions]] to undefined.
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseRejectReactions").$PromiseRejectReactions = undefined;
+  Properties.ThrowIfInternalSlotNotWritable(
+    realm,
+    promise,
+    "$PromiseRejectReactions"
+  ).$PromiseRejectReactions = undefined;
 
   // 6. Set promise.[[PromiseState]] to "fulfilled".
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseState").$PromiseState = "fulfilled";
+  Properties.ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseState").$PromiseState = "fulfilled";
 
   // 7. Return TriggerPromiseReactions(reactions, value).
   return TriggerPromiseReactions(realm, reactions, value);
@@ -590,16 +598,24 @@ export function RejectPromise(realm: Realm, promise: ObjectValue, reason: Value)
   invariant(reactions);
 
   // 3. Set promise.[[PromiseResult]] to reason.
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseResult").$PromiseResult = reason;
+  Properties.ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseResult").$PromiseResult = reason;
 
   // 4. Set promise.[[PromiseFulfillReactions]] to undefined.
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseFulfillReactions").$PromiseFulfillReactions = undefined;
+  Properties.ThrowIfInternalSlotNotWritable(
+    realm,
+    promise,
+    "$PromiseFulfillReactions"
+  ).$PromiseFulfillReactions = undefined;
 
   // 5. Set promise.[[PromiseRejectReactions]] to undefined.
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseRejectReactions").$PromiseRejectReactions = undefined;
+  Properties.ThrowIfInternalSlotNotWritable(
+    realm,
+    promise,
+    "$PromiseRejectReactions"
+  ).$PromiseRejectReactions = undefined;
 
   // 6. Set promise.[[PromiseState]] to "rejected".
-  ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseState").$PromiseState = "rejected";
+  Properties.ThrowIfInternalSlotNotWritable(realm, promise, "$PromiseState").$PromiseState = "rejected";
 
   // 7. If promise.[[PromiseIsHandled]] is false, perform HostPromiseRejectionTracker(promise, "reject").
   if (promise.$PromiseIsHandled === false) HostPromiseRejectionTracker(realm, promise, "reject");

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -201,1139 +201,1128 @@ function parentPermitsChildPropertyCreation(realm: Realm, O: ObjectValue, P: Pro
   return false;
 }
 
-// ECMA262 9.1.9.1
-export function OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value, Receiver: Value): boolean {
-  let weakDeletion = V.mightHaveBeenDeleted();
+export class PropertiesImplementation {
+  // ECMA262 9.1.9.1
+  OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value, Receiver: Value): boolean {
+    let weakDeletion = V.mightHaveBeenDeleted();
 
-  // 1. Assert: IsPropertyKey(P) is true.
-  invariant(IsPropertyKey(realm, P), "expected property key");
+    // 1. Assert: IsPropertyKey(P) is true.
+    invariant(IsPropertyKey(realm, P), "expected property key");
 
-  // 2. Let ownDesc be ? O.[[GetOwnProperty]](P).
-  let ownDesc = O.$GetOwnProperty(P);
-  let ownDescValue = !ownDesc
-    ? realm.intrinsics.undefined
-    : ownDesc.value === undefined ? realm.intrinsics.undefined : ownDesc.value;
-  invariant(ownDescValue instanceof Value);
-
-  // 3. If ownDesc is undefined (or might be), then
-  if (!ownDesc || ownDescValue.mightHaveBeenDeleted()) {
-    // a. Let parent be ? O.[[GetPrototypeOf]]().
-    let parent = O.$GetPrototypeOf();
-    parent.throwIfNotConcrete(); //TODO #1016: deal with abstract parents
-
-    // b. If parent is not null, then
-    if (!(parent instanceof NullValue)) {
-      if (!ownDesc) {
-        // i. Return ? parent.[[Set]](P, V, Receiver).
-        return parent.$Set(P, V, Receiver);
-      }
-      // But since we don't know if O has its own property P, the parent might
-      // actually have a say. Give up, unless the parent would be OK with it.
-      if (!parentPermitsChildPropertyCreation(realm, parent, P)) {
-        invariant(ownDescValue instanceof AbstractValue);
-        AbstractValue.reportIntrospectionError(ownDescValue);
-        throw new FatalError();
-      }
-      // Since the parent is OK with us creating a local property for O
-      // we can carry on as if there were no parent.
-    }
-
-    // i. Let ownDesc be the PropertyDescriptor{[[Value]]: undefined, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}.
-    if (!ownDesc)
-      ownDesc = {
-        value: realm.intrinsics.undefined,
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      };
-  }
-
-  // 4. If IsDataDescriptor(ownDesc) is true, then
-  if (IsDataDescriptor(realm, ownDesc)) {
-    // a. If ownDesc.[[Writable]] is false, return false.
-    if (!ownDesc.writable && !weakDeletion) {
-      // The write will fail if the property actually exists
-      if (ownDescValue.mightHaveBeenDeleted()) {
-        // But maybe it does not and thus would succeed.
-        // Since we don't know what will happen, give up for now.
-        invariant(ownDescValue instanceof AbstractValue);
-        AbstractValue.reportIntrospectionError(ownDescValue);
-        throw new FatalError();
-      }
-      return false;
-    }
-
-    // b. If Type(Receiver) is not Object, return false.
-    Receiver = Receiver.throwIfNotConcrete();
-    if (!(Receiver instanceof ObjectValue)) return false;
-
-    // c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
-    let existingDescriptor = Receiver.$GetOwnProperty(P);
-    let existingDescValue = !existingDescriptor
+    // 2. Let ownDesc be ? O.[[GetOwnProperty]](P).
+    let ownDesc = O.$GetOwnProperty(P);
+    let ownDescValue = !ownDesc
       ? realm.intrinsics.undefined
-      : existingDescriptor.value === undefined ? realm.intrinsics.undefined : existingDescriptor.value;
-    invariant(existingDescValue instanceof Value);
+      : ownDesc.value === undefined ? realm.intrinsics.undefined : ownDesc.value;
+    invariant(ownDescValue instanceof Value);
 
-    // d. If existingDescriptor is not undefined, then
-    if (existingDescriptor !== undefined) {
-      // i. If IsAccessorDescriptor(existingDescriptor) is true, return false.
-      if (IsAccessorDescriptor(realm, existingDescriptor)) {
-        invariant(
-          !existingDescValue.mightHaveBeenDeleted(),
-          "should not fail until weak deletes of accessors are suppported"
-        );
-        return false;
+    // 3. If ownDesc is undefined (or might be), then
+    if (!ownDesc || ownDescValue.mightHaveBeenDeleted()) {
+      // a. Let parent be ? O.[[GetPrototypeOf]]().
+      let parent = O.$GetPrototypeOf();
+      parent.throwIfNotConcrete(); //TODO #1016: deal with abstract parents
+
+      // b. If parent is not null, then
+      if (!(parent instanceof NullValue)) {
+        if (!ownDesc) {
+          // i. Return ? parent.[[Set]](P, V, Receiver).
+          return parent.$Set(P, V, Receiver);
+        }
+        // But since we don't know if O has its own property P, the parent might
+        // actually have a say. Give up, unless the parent would be OK with it.
+        if (!parentPermitsChildPropertyCreation(realm, parent, P)) {
+          invariant(ownDescValue instanceof AbstractValue);
+          AbstractValue.reportIntrospectionError(ownDescValue);
+          throw new FatalError();
+        }
+        // Since the parent is OK with us creating a local property for O
+        // we can carry on as if there were no parent.
       }
 
-      // ii. If existingDescriptor.[[Writable]] is false, return false.
-      if (!existingDescriptor.writable && !(weakDeletion && existingDescriptor.configurable)) {
-        // If we are not sure the receiver actually has a property P we can't just return false here.
-        if (existingDescValue.mightHaveBeenDeleted()) {
-          invariant(existingDescValue instanceof AbstractValue);
-          AbstractValue.reportIntrospectionError(existingDescValue);
+      // i. Let ownDesc be the PropertyDescriptor{[[Value]]: undefined, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true}.
+      if (!ownDesc)
+        ownDesc = {
+          value: realm.intrinsics.undefined,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        };
+    }
+
+    // 4. If IsDataDescriptor(ownDesc) is true, then
+    if (IsDataDescriptor(realm, ownDesc)) {
+      // a. If ownDesc.[[Writable]] is false, return false.
+      if (!ownDesc.writable && !weakDeletion) {
+        // The write will fail if the property actually exists
+        if (ownDescValue.mightHaveBeenDeleted()) {
+          // But maybe it does not and thus would succeed.
+          // Since we don't know what will happen, give up for now.
+          invariant(ownDescValue instanceof AbstractValue);
+          AbstractValue.reportIntrospectionError(ownDescValue);
           throw new FatalError();
         }
         return false;
       }
 
-      // iii. Let valueDesc be the PropertyDescriptor{[[Value]]: V}.
-      let valueDesc = { value: V };
-      if (weakDeletion) {
-        valueDesc = existingDescriptor;
-        valueDesc.value = V;
-      }
+      // b. If Type(Receiver) is not Object, return false.
+      Receiver = Receiver.throwIfNotConcrete();
+      if (!(Receiver instanceof ObjectValue)) return false;
 
-      // iv. Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
-      if (weakDeletion || existingDescValue.mightHaveBeenDeleted()) {
-        // At this point we are not actually sure that Receiver actually has
-        // a property P, however, if it has, we are sure that its a data property,
-        // and that redefining the property with valueDesc will not change the
-        // attributes of the property, so we delete it to make things nice for $DefineOwnProperty.
-        Receiver.$Delete(P);
-      }
-      return Receiver.$DefineOwnProperty(P, valueDesc);
-    } else {
-      // e. Else Receiver does not currently have a property P,
+      // c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+      let existingDescriptor = Receiver.$GetOwnProperty(P);
+      let existingDescValue = !existingDescriptor
+        ? realm.intrinsics.undefined
+        : existingDescriptor.value === undefined ? realm.intrinsics.undefined : existingDescriptor.value;
+      invariant(existingDescValue instanceof Value);
 
-      // i. Return ? CreateDataProperty(Receiver, P, V).
-      return CreateDataProperty(realm, Receiver, P, V);
-    }
-  }
-
-  // 5. Assert: IsAccessorDescriptor(ownDesc) is true.
-  invariant(IsAccessorDescriptor(realm, ownDesc), "expected accessor");
-
-  // 6. Let setter be ownDesc.[[Set]].
-  let setter = "set" in ownDesc ? ownDesc.set : undefined;
-
-  // 7. If setter is undefined, return false.
-  if (!setter || setter instanceof UndefinedValue) return false;
-
-  // 8. Perform ? Call(setter, Receiver, « V »).
-  Call(realm, setter.throwIfNotConcrete(), Receiver, [V]);
-
-  // 9. Return true.
-  return true;
-}
-
-// ECMA262 6.2.4.4
-export function FromPropertyDescriptor(realm: Realm, Desc: ?Descriptor): Value {
-  // 1. If Desc is undefined, return undefined.
-  if (!Desc) return realm.intrinsics.undefined;
-
-  // 2. Let obj be ObjectCreate(%ObjectPrototype%).
-  let obj = ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
-
-  // 3. Assert: obj is an extensible ordinary object with no own properties.
-  invariant(obj.getExtensible(), "expected an extensible object");
-  invariant(!obj.properties.size, "expected an object with no own properties");
-
-  // 4. If Desc has a [[Value]] field, then
-  let success = true;
-  if ("value" in Desc) {
-    invariant(Desc.value instanceof Value);
-    // a. Perform CreateDataProperty(obj, "value", Desc.[[Value]]).
-    success = CreateDataProperty(realm, obj, "value", Desc.value) && success;
-  }
-
-  // 5. If Desc has a [[Writable]] field, then
-  if ("writable" in Desc) {
-    invariant(Desc.writable !== undefined);
-    // a. Perform CreateDataProperty(obj, "writable", Desc.[[Writable]]).
-    success = CreateDataProperty(realm, obj, "writable", new BooleanValue(realm, Desc.writable)) && success;
-  }
-
-  // 6. If Desc has a [[Get]] field, then
-  if ("get" in Desc) {
-    invariant(Desc.get !== undefined);
-    // a. Perform CreateDataProperty(obj, "get", Desc.[[Get]]).
-    success = CreateDataProperty(realm, obj, "get", Desc.get) && success;
-  }
-
-  // 7. If Desc has a [[Set]] field, then
-  if ("set" in Desc) {
-    invariant(Desc.set !== undefined);
-    // a. Perform CreateDataProperty(obj, "set", Desc.[[Set]]).
-    success = CreateDataProperty(realm, obj, "set", Desc.set) && success;
-  }
-
-  // 8. If Desc has an [[Enumerable]] field, then
-  if ("enumerable" in Desc) {
-    invariant(Desc.enumerable !== undefined);
-    // a. Perform CreateDataProperty(obj, "enumerable", Desc.[[Enumerable]]).
-    success = CreateDataProperty(realm, obj, "enumerable", new BooleanValue(realm, Desc.enumerable)) && success;
-  }
-
-  // 9. If Desc has a [[Configurable]] field, then
-  if ("configurable" in Desc) {
-    invariant(Desc.configurable !== undefined);
-    // a. Perform CreateDataProperty(obj, "configurable", Desc.[[Configurable]]).
-    success = CreateDataProperty(realm, obj, "configurable", new BooleanValue(realm, Desc.configurable)) && success;
-  }
-
-  // 10. Assert: all of the above CreateDataProperty operations return true.
-  invariant(success, "fails to create data property");
-
-  // 11. Return obj.
-  return obj;
-}
-
-//
-export function OrdinaryDelete(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean {
-  // 1. Assert: IsPropertyKey(P) is true.
-  invariant(IsPropertyKey(realm, P), "expected a property key");
-
-  // 2. Let desc be ? O.[[GetOwnProperty]](P).
-  let desc = O.$GetOwnProperty(P);
-
-  // 3. If desc is undefined, return true.
-  if (!desc) return true;
-
-  // 4. If desc.[[Configurable]] is true, then
-  if (desc.configurable) {
-    // a. Remove the own property with name P from O.
-    let key = InternalGetPropertiesKey(P);
-    let map = InternalGetPropertiesMap(O, P);
-    let propertyBinding = map.get(key);
-    invariant(propertyBinding !== undefined);
-    realm.recordModifiedProperty(propertyBinding);
-    propertyBinding.descriptor = undefined;
-    InternalUpdatedProperty(realm, O, P, desc);
-
-    // b. Return true.
-    return true;
-  }
-
-  // 5. Return false.
-  return false;
-}
-
-// ECMA262 7.3.8
-export function DeletePropertyOrThrow(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean {
-  // 1. Assert: Type(O) is Object.
-  invariant(O instanceof ObjectValue, "expected an object");
-
-  // 2. Assert: IsPropertyKey(P) is true.
-  invariant(IsPropertyKey(realm, P), "expected a property key");
-
-  // 3. Let success be ? O.[[Delete]](P).
-  let success = O.$Delete(P);
-
-  // 4. If success is false, throw a TypeError exception.
-  if (!success) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "couldn't delete property");
-  }
-
-  // 5. Return success.
-  return success;
-}
-
-// ECMA262 6.2.4.6
-export function CompletePropertyDescriptor(realm: Realm, Desc: Descriptor): Descriptor {
-  // 1. Assert: Desc is a Property Descriptor.
-
-  // 2. Let like be Record{[[Value]]: undefined, [[Writable]]: false, [[Get]]: undefined, [[Set]]: undefined, [[Enumerable]]: false, [[Configurable]]: false}.
-  let like = {
-    value: realm.intrinsics.undefined,
-    get: realm.intrinsics.undefined,
-    set: realm.intrinsics.undefined,
-    writable: false,
-    enumerable: false,
-    configurable: false,
-  };
-
-  // 3. If either IsGenericDescriptor(Desc) or IsDataDescriptor(Desc) is true, then
-  if (IsGenericDescriptor(realm, Desc) || IsDataDescriptor(realm, Desc)) {
-    // a. If Desc does not have a [[Value]] field, set Desc.[[Value]] to like.[[Value]].
-    if (!("value" in Desc)) Desc.value = like.value;
-    // b. If Desc does not have a [[Writable]] field, set Desc.[[Writable]] to like.[[Writable]].
-    if (!("writable" in Desc)) Desc.writable = like.writable;
-  } else {
-    // 4. Else,
-    // a. If Desc does not have a [[Get]] field, set Desc.[[Get]] to like.[[Get]].
-    if (!("get" in Desc)) Desc.get = like.get;
-    // b. If Desc does not have a [[Set]] field, set Desc.[[Set]] to like.[[Set]].
-    if (!("set" in Desc)) Desc.set = like.set;
-  }
-
-  // 5. If Desc does not have an [[Enumerable]] field, set Desc.[[Enumerable]] to like.[[Enumerable]].
-  if (!("enumerable" in Desc)) Desc.enumerable = like.enumerable;
-
-  // 6. If Desc does not have a [[Configurable]] field, set Desc.[[Configurable]] to like.[[Configurable]].
-  if (!("configurable" in Desc)) Desc.configurable = like.configurable;
-
-  // 7. Return Desc.
-  return Desc;
-}
-
-// ECMA262 9.1.6.2
-export function IsCompatiblePropertyDescriptor(
-  realm: Realm,
-  extensible: boolean,
-  Desc: Descriptor,
-  current: ?Descriptor
-): boolean {
-  // 1. Return ValidateAndApplyPropertyDescriptor(undefined, undefined, Extensible, Desc, Current).
-  return ValidateAndApplyPropertyDescriptor(realm, undefined, undefined, extensible, Desc, current);
-}
-
-// ECMA262 9.1.6.3
-export function ValidateAndApplyPropertyDescriptor(
-  realm: Realm,
-  O: void | ObjectValue,
-  P: void | PropertyKeyValue,
-  extensible: boolean,
-  Desc: Descriptor,
-  current: ?Descriptor
-): boolean {
-  // 1. Assert: If O is not undefined, then IsPropertyKey(P) is true.
-  if (O !== undefined) {
-    invariant(P !== undefined);
-    invariant(IsPropertyKey(realm, P));
-  }
-
-  // 2. If current is undefined, then
-  if (!current) {
-    // a. If extensible is false, return false.
-    if (!extensible) return false;
-
-    // b. Assert: extensible is true.
-    invariant(extensible === true, "expected extensible to be true");
-
-    // c. If IsGenericDescriptor(Desc) is true or IsDataDescriptor(Desc) is true, then
-    if (IsGenericDescriptor(realm, Desc) || IsDataDescriptor(realm, Desc)) {
-      // i. If O is not undefined, create an own data property named P of object O whose [[Value]],
-      //    [[Writable]], [[Enumerable]] and [[Configurable]] attribute values are described by Desc. If the
-      //    value of an attribute field of Desc is absent, the attribute of the newly created property is set
-      //    to its default value.
-      if (O !== undefined) {
-        invariant(P !== undefined);
-        InternalSetProperty(realm, O, P, {
-          value: "value" in Desc ? Desc.value : realm.intrinsics.undefined,
-          writable: "writable" in Desc ? Desc.writable : false,
-          enumerable: "enumerable" in Desc ? Desc.enumerable : false,
-          configurable: "configurable" in Desc ? Desc.configurable : false,
-        });
-        InternalUpdatedProperty(realm, O, P, undefined);
-      }
-    } else {
-      // d. Else Desc must be an accessor Property Descriptor,
-      // i. If O is not undefined, create an own accessor property named P of object O whose [[Get]],
-      //    [[Set]], [[Enumerable]] and [[Configurable]] attribute values are described by Desc. If the value
-      //    of an attribute field of Desc is absent, the attribute of the newly created property is set to its
-      //    default value.
-      if (O !== undefined) {
-        invariant(P !== undefined);
-        InternalSetProperty(realm, O, P, {
-          get: "get" in Desc ? Desc.get : realm.intrinsics.undefined,
-          set: "set" in Desc ? Desc.set : realm.intrinsics.undefined,
-          enumerable: "enumerable" in Desc ? Desc.enumerable : false,
-          configurable: "configurable" in Desc ? Desc.configurable : false,
-        });
-        InternalUpdatedProperty(realm, O, P, undefined);
-      }
-    }
-
-    // e. Return true.
-    return true;
-  }
-  ThrowIfMightHaveBeenDeleted(current.value);
-
-  // 3. Return true, if every field in Desc is absent.
-  if (!Object.keys(Desc).length) return true;
-
-  // 4. Return true, if every field in Desc also occurs in current and the value of every field in Desc is the
-  // same value as the corresponding field in current when compared using the SameValue algorithm.
-  let identical = true;
-  for (let field in Desc) {
-    if (!(field in current)) {
-      identical = false;
-    } else {
-      let dval = InternalDescriptorPropertyToValue(realm, Desc[field]);
-      let cval = InternalDescriptorPropertyToValue(realm, current[field]);
-      if (dval instanceof ConcreteValue && cval instanceof ConcreteValue) identical = SameValue(realm, dval, cval);
-      else {
-        identical = dval === cval;
-        // This might be false now but true at runtime. This does not
-        // matter because the logic for non identical values will still
-        // do the right thing in the cases below that does not blow up
-        // when dealing with an abstract value.
-      }
-    }
-    if (!identical) break;
-  }
-  if (identical) {
-    return true;
-  }
-
-  // 5. If the [[Configurable]] field of current is false, then
-  if (!current.configurable) {
-    // a. Return false, if the [[Configurable]] field of Desc is true.
-    if (Desc.configurable) return false;
-
-    // b. Return false, if the [[Enumerable]] field of Desc is present and the [[Enumerable]] fields of current and Desc are the Boolean negation of each other.
-    if ("enumerable" in Desc && Desc.enumerable !== current.enumerable) {
-      return false;
-    }
-  }
-
-  let oldDesc = current;
-  current = cloneDescriptor(current);
-  invariant(current !== undefined);
-
-  // 6. If IsGenericDescriptor(Desc) is true, no further validation is required.
-  if (IsGenericDescriptor(realm, Desc)) {
-  } else if (IsDataDescriptor(realm, current) !== IsDataDescriptor(realm, Desc)) {
-    // 7. Else if IsDataDescriptor(current) and IsDataDescriptor(Desc) have different results, then
-    // a. Return false, if the [[Configurable]] field of current is false.
-    if (!current.configurable) return false;
-
-    // b. If IsDataDescriptor(current) is true, then
-    if (IsDataDescriptor(realm, current)) {
-      // i. If O is not undefined, convert the property named P of object O from a data property to an accessor property.
-      // Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes and set the rest of the property's attributes to their default values.
-      if (O !== undefined) {
-        invariant(P !== undefined);
-        let key = InternalGetPropertiesKey(P);
-        let propertyBinding = InternalGetPropertiesMap(O, P).get(key);
-        invariant(propertyBinding !== undefined);
-        delete current.writable;
-        delete current.value;
-        current.get = realm.intrinsics.undefined;
-        current.set = realm.intrinsics.undefined;
-      }
-    } else {
-      // c. Else,
-      // i. If O is not undefined, convert the property named P of object O from an accessor property to a data property. Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes and set the rest of the property's attributes to their default values.
-      if (O !== undefined) {
-        invariant(P !== undefined);
-        let key = InternalGetPropertiesKey(P);
-        let propertyBinding = InternalGetPropertiesMap(O, P).get(key);
-        invariant(propertyBinding !== undefined);
-        delete current.get;
-        delete current.set;
-        current.writable = false;
-        current.value = realm.intrinsics.undefined;
-      }
-    }
-  } else if (IsDataDescriptor(realm, current) && IsDataDescriptor(realm, Desc)) {
-    // 8. Else if IsDataDescriptor(current) and IsDataDescriptor(Desc) are both true, then
-    // a. If the [[Configurable]] field of current is false, then
-    if (!current.configurable) {
-      // i. Return false, if the [[Writable]] field of current is false and the [[Writable]] field of Desc is true.
-      if (!current.writable && Desc.writable) return false;
-
-      // ii. If the [[Writable]] field of current is false, then
-      if (!current.writable) {
-        // 1. Return false, if the [[Value]] field of Desc is present and SameValue(Desc.[[Value]], current.[[Value]]) is false.
-        let descValue = Desc.value || realm.intrinsics.undefined;
-        invariant(descValue instanceof Value);
-        let currentValue = current.value || realm.intrinsics.undefined;
-        invariant(currentValue instanceof Value);
-        if (Desc.value && !SameValuePartial(realm, descValue, currentValue)) {
+      // d. If existingDescriptor is not undefined, then
+      if (existingDescriptor !== undefined) {
+        // i. If IsAccessorDescriptor(existingDescriptor) is true, return false.
+        if (IsAccessorDescriptor(realm, existingDescriptor)) {
+          invariant(
+            !existingDescValue.mightHaveBeenDeleted(),
+            "should not fail until weak deletes of accessors are suppported"
+          );
           return false;
         }
+
+        // ii. If existingDescriptor.[[Writable]] is false, return false.
+        if (!existingDescriptor.writable && !(weakDeletion && existingDescriptor.configurable)) {
+          // If we are not sure the receiver actually has a property P we can't just return false here.
+          if (existingDescValue.mightHaveBeenDeleted()) {
+            invariant(existingDescValue instanceof AbstractValue);
+            AbstractValue.reportIntrospectionError(existingDescValue);
+            throw new FatalError();
+          }
+          return false;
+        }
+
+        // iii. Let valueDesc be the PropertyDescriptor{[[Value]]: V}.
+        let valueDesc = { value: V };
+        if (weakDeletion) {
+          valueDesc = existingDescriptor;
+          valueDesc.value = V;
+        }
+
+        // iv. Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
+        if (weakDeletion || existingDescValue.mightHaveBeenDeleted()) {
+          // At this point we are not actually sure that Receiver actually has
+          // a property P, however, if it has, we are sure that its a data property,
+          // and that redefining the property with valueDesc will not change the
+          // attributes of the property, so we delete it to make things nice for $DefineOwnProperty.
+          Receiver.$Delete(P);
+        }
+        return Receiver.$DefineOwnProperty(P, valueDesc);
+      } else {
+        // e. Else Receiver does not currently have a property P,
+
+        // i. Return ? CreateDataProperty(Receiver, P, V).
+        return CreateDataProperty(realm, Receiver, P, V);
+      }
+    }
+
+    // 5. Assert: IsAccessorDescriptor(ownDesc) is true.
+    invariant(IsAccessorDescriptor(realm, ownDesc), "expected accessor");
+
+    // 6. Let setter be ownDesc.[[Set]].
+    let setter = "set" in ownDesc ? ownDesc.set : undefined;
+
+    // 7. If setter is undefined, return false.
+    if (!setter || setter instanceof UndefinedValue) return false;
+
+    // 8. Perform ? Call(setter, Receiver, « V »).
+    Call(realm, setter.throwIfNotConcrete(), Receiver, [V]);
+
+    // 9. Return true.
+    return true;
+  }
+
+  // ECMA262 6.2.4.4
+  FromPropertyDescriptor(realm: Realm, Desc: ?Descriptor): Value {
+    // 1. If Desc is undefined, return undefined.
+    if (!Desc) return realm.intrinsics.undefined;
+
+    // 2. Let obj be ObjectCreate(%ObjectPrototype%).
+    let obj = ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
+
+    // 3. Assert: obj is an extensible ordinary object with no own properties.
+    invariant(obj.getExtensible(), "expected an extensible object");
+    invariant(!obj.properties.size, "expected an object with no own properties");
+
+    // 4. If Desc has a [[Value]] field, then
+    let success = true;
+    if ("value" in Desc) {
+      invariant(Desc.value instanceof Value);
+      // a. Perform CreateDataProperty(obj, "value", Desc.[[Value]]).
+      success = CreateDataProperty(realm, obj, "value", Desc.value) && success;
+    }
+
+    // 5. If Desc has a [[Writable]] field, then
+    if ("writable" in Desc) {
+      invariant(Desc.writable !== undefined);
+      // a. Perform CreateDataProperty(obj, "writable", Desc.[[Writable]]).
+      success = CreateDataProperty(realm, obj, "writable", new BooleanValue(realm, Desc.writable)) && success;
+    }
+
+    // 6. If Desc has a [[Get]] field, then
+    if ("get" in Desc) {
+      invariant(Desc.get !== undefined);
+      // a. Perform CreateDataProperty(obj, "get", Desc.[[Get]]).
+      success = CreateDataProperty(realm, obj, "get", Desc.get) && success;
+    }
+
+    // 7. If Desc has a [[Set]] field, then
+    if ("set" in Desc) {
+      invariant(Desc.set !== undefined);
+      // a. Perform CreateDataProperty(obj, "set", Desc.[[Set]]).
+      success = CreateDataProperty(realm, obj, "set", Desc.set) && success;
+    }
+
+    // 8. If Desc has an [[Enumerable]] field, then
+    if ("enumerable" in Desc) {
+      invariant(Desc.enumerable !== undefined);
+      // a. Perform CreateDataProperty(obj, "enumerable", Desc.[[Enumerable]]).
+      success = CreateDataProperty(realm, obj, "enumerable", new BooleanValue(realm, Desc.enumerable)) && success;
+    }
+
+    // 9. If Desc has a [[Configurable]] field, then
+    if ("configurable" in Desc) {
+      invariant(Desc.configurable !== undefined);
+      // a. Perform CreateDataProperty(obj, "configurable", Desc.[[Configurable]]).
+      success = CreateDataProperty(realm, obj, "configurable", new BooleanValue(realm, Desc.configurable)) && success;
+    }
+
+    // 10. Assert: all of the above CreateDataProperty operations return true.
+    invariant(success, "fails to create data property");
+
+    // 11. Return obj.
+    return obj;
+  }
+
+  //
+  OrdinaryDelete(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean {
+    // 1. Assert: IsPropertyKey(P) is true.
+    invariant(IsPropertyKey(realm, P), "expected a property key");
+
+    // 2. Let desc be ? O.[[GetOwnProperty]](P).
+    let desc = O.$GetOwnProperty(P);
+
+    // 3. If desc is undefined, return true.
+    if (!desc) return true;
+
+    // 4. If desc.[[Configurable]] is true, then
+    if (desc.configurable) {
+      // a. Remove the own property with name P from O.
+      let key = InternalGetPropertiesKey(P);
+      let map = InternalGetPropertiesMap(O, P);
+      let propertyBinding = map.get(key);
+      invariant(propertyBinding !== undefined);
+      realm.recordModifiedProperty(propertyBinding);
+      propertyBinding.descriptor = undefined;
+      InternalUpdatedProperty(realm, O, P, desc);
+
+      // b. Return true.
+      return true;
+    }
+
+    // 5. Return false.
+    return false;
+  }
+
+  // ECMA262 7.3.8
+  DeletePropertyOrThrow(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean {
+    // 1. Assert: Type(O) is Object.
+    invariant(O instanceof ObjectValue, "expected an object");
+
+    // 2. Assert: IsPropertyKey(P) is true.
+    invariant(IsPropertyKey(realm, P), "expected a property key");
+
+    // 3. Let success be ? O.[[Delete]](P).
+    let success = O.$Delete(P);
+
+    // 4. If success is false, throw a TypeError exception.
+    if (!success) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "couldn't delete property");
+    }
+
+    // 5. Return success.
+    return success;
+  }
+
+  // ECMA262 6.2.4.6
+  CompletePropertyDescriptor(realm: Realm, Desc: Descriptor): Descriptor {
+    // 1. Assert: Desc is a Property Descriptor.
+
+    // 2. Let like be Record{[[Value]]: undefined, [[Writable]]: false, [[Get]]: undefined, [[Set]]: undefined, [[Enumerable]]: false, [[Configurable]]: false}.
+    let like = {
+      value: realm.intrinsics.undefined,
+      get: realm.intrinsics.undefined,
+      set: realm.intrinsics.undefined,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    };
+
+    // 3. If either IsGenericDescriptor(Desc) or IsDataDescriptor(Desc) is true, then
+    if (IsGenericDescriptor(realm, Desc) || IsDataDescriptor(realm, Desc)) {
+      // a. If Desc does not have a [[Value]] field, set Desc.[[Value]] to like.[[Value]].
+      if (!("value" in Desc)) Desc.value = like.value;
+      // b. If Desc does not have a [[Writable]] field, set Desc.[[Writable]] to like.[[Writable]].
+      if (!("writable" in Desc)) Desc.writable = like.writable;
+    } else {
+      // 4. Else,
+      // a. If Desc does not have a [[Get]] field, set Desc.[[Get]] to like.[[Get]].
+      if (!("get" in Desc)) Desc.get = like.get;
+      // b. If Desc does not have a [[Set]] field, set Desc.[[Set]] to like.[[Set]].
+      if (!("set" in Desc)) Desc.set = like.set;
+    }
+
+    // 5. If Desc does not have an [[Enumerable]] field, set Desc.[[Enumerable]] to like.[[Enumerable]].
+    if (!("enumerable" in Desc)) Desc.enumerable = like.enumerable;
+
+    // 6. If Desc does not have a [[Configurable]] field, set Desc.[[Configurable]] to like.[[Configurable]].
+    if (!("configurable" in Desc)) Desc.configurable = like.configurable;
+
+    // 7. Return Desc.
+    return Desc;
+  }
+
+  // ECMA262 9.1.6.2
+  IsCompatiblePropertyDescriptor(realm: Realm, extensible: boolean, Desc: Descriptor, current: ?Descriptor): boolean {
+    // 1. Return ValidateAndApplyPropertyDescriptor(undefined, undefined, Extensible, Desc, Current).
+    return this.ValidateAndApplyPropertyDescriptor(realm, undefined, undefined, extensible, Desc, current);
+  }
+
+  // ECMA262 9.1.6.3
+  ValidateAndApplyPropertyDescriptor(
+    realm: Realm,
+    O: void | ObjectValue,
+    P: void | PropertyKeyValue,
+    extensible: boolean,
+    Desc: Descriptor,
+    current: ?Descriptor
+  ): boolean {
+    // 1. Assert: If O is not undefined, then IsPropertyKey(P) is true.
+    if (O !== undefined) {
+      invariant(P !== undefined);
+      invariant(IsPropertyKey(realm, P));
+    }
+
+    // 2. If current is undefined, then
+    if (!current) {
+      // a. If extensible is false, return false.
+      if (!extensible) return false;
+
+      // b. Assert: extensible is true.
+      invariant(extensible === true, "expected extensible to be true");
+
+      // c. If IsGenericDescriptor(Desc) is true or IsDataDescriptor(Desc) is true, then
+      if (IsGenericDescriptor(realm, Desc) || IsDataDescriptor(realm, Desc)) {
+        // i. If O is not undefined, create an own data property named P of object O whose [[Value]],
+        //    [[Writable]], [[Enumerable]] and [[Configurable]] attribute values are described by Desc. If the
+        //    value of an attribute field of Desc is absent, the attribute of the newly created property is set
+        //    to its default value.
+        if (O !== undefined) {
+          invariant(P !== undefined);
+          InternalSetProperty(realm, O, P, {
+            value: "value" in Desc ? Desc.value : realm.intrinsics.undefined,
+            writable: "writable" in Desc ? Desc.writable : false,
+            enumerable: "enumerable" in Desc ? Desc.enumerable : false,
+            configurable: "configurable" in Desc ? Desc.configurable : false,
+          });
+          InternalUpdatedProperty(realm, O, P, undefined);
+        }
+      } else {
+        // d. Else Desc must be an accessor Property Descriptor,
+        // i. If O is not undefined, create an own accessor property named P of object O whose [[Get]],
+        //    [[Set]], [[Enumerable]] and [[Configurable]] attribute values are described by Desc. If the value
+        //    of an attribute field of Desc is absent, the attribute of the newly created property is set to its
+        //    default value.
+        if (O !== undefined) {
+          invariant(P !== undefined);
+          InternalSetProperty(realm, O, P, {
+            get: "get" in Desc ? Desc.get : realm.intrinsics.undefined,
+            set: "set" in Desc ? Desc.set : realm.intrinsics.undefined,
+            enumerable: "enumerable" in Desc ? Desc.enumerable : false,
+            configurable: "configurable" in Desc ? Desc.configurable : false,
+          });
+          InternalUpdatedProperty(realm, O, P, undefined);
+        }
+      }
+
+      // e. Return true.
+      return true;
+    }
+    this.ThrowIfMightHaveBeenDeleted(current.value);
+
+    // 3. Return true, if every field in Desc is absent.
+    if (!Object.keys(Desc).length) return true;
+
+    // 4. Return true, if every field in Desc also occurs in current and the value of every field in Desc is the
+    // same value as the corresponding field in current when compared using the SameValue algorithm.
+    let identical = true;
+    for (let field in Desc) {
+      if (!(field in current)) {
+        identical = false;
+      } else {
+        let dval = InternalDescriptorPropertyToValue(realm, Desc[field]);
+        let cval = InternalDescriptorPropertyToValue(realm, current[field]);
+        if (dval instanceof ConcreteValue && cval instanceof ConcreteValue) identical = SameValue(realm, dval, cval);
+        else {
+          identical = dval === cval;
+          // This might be false now but true at runtime. This does not
+          // matter because the logic for non identical values will still
+          // do the right thing in the cases below that does not blow up
+          // when dealing with an abstract value.
+        }
+      }
+      if (!identical) break;
+    }
+    if (identical) {
+      return true;
+    }
+
+    // 5. If the [[Configurable]] field of current is false, then
+    if (!current.configurable) {
+      // a. Return false, if the [[Configurable]] field of Desc is true.
+      if (Desc.configurable) return false;
+
+      // b. Return false, if the [[Enumerable]] field of Desc is present and the [[Enumerable]] fields of current and Desc are the Boolean negation of each other.
+      if ("enumerable" in Desc && Desc.enumerable !== current.enumerable) {
+        return false;
+      }
+    }
+
+    let oldDesc = current;
+    current = cloneDescriptor(current);
+    invariant(current !== undefined);
+
+    // 6. If IsGenericDescriptor(Desc) is true, no further validation is required.
+    if (IsGenericDescriptor(realm, Desc)) {
+    } else if (IsDataDescriptor(realm, current) !== IsDataDescriptor(realm, Desc)) {
+      // 7. Else if IsDataDescriptor(current) and IsDataDescriptor(Desc) have different results, then
+      // a. Return false, if the [[Configurable]] field of current is false.
+      if (!current.configurable) return false;
+
+      // b. If IsDataDescriptor(current) is true, then
+      if (IsDataDescriptor(realm, current)) {
+        // i. If O is not undefined, convert the property named P of object O from a data property to an accessor property.
+        // Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes and set the rest of the property's attributes to their default values.
+        if (O !== undefined) {
+          invariant(P !== undefined);
+          let key = InternalGetPropertiesKey(P);
+          let propertyBinding = InternalGetPropertiesMap(O, P).get(key);
+          invariant(propertyBinding !== undefined);
+          delete current.writable;
+          delete current.value;
+          current.get = realm.intrinsics.undefined;
+          current.set = realm.intrinsics.undefined;
+        }
+      } else {
+        // c. Else,
+        // i. If O is not undefined, convert the property named P of object O from an accessor property to a data property. Preserve the existing values of the converted property's [[Configurable]] and [[Enumerable]] attributes and set the rest of the property's attributes to their default values.
+        if (O !== undefined) {
+          invariant(P !== undefined);
+          let key = InternalGetPropertiesKey(P);
+          let propertyBinding = InternalGetPropertiesMap(O, P).get(key);
+          invariant(propertyBinding !== undefined);
+          delete current.get;
+          delete current.set;
+          current.writable = false;
+          current.value = realm.intrinsics.undefined;
+        }
+      }
+    } else if (IsDataDescriptor(realm, current) && IsDataDescriptor(realm, Desc)) {
+      // 8. Else if IsDataDescriptor(current) and IsDataDescriptor(Desc) are both true, then
+      // a. If the [[Configurable]] field of current is false, then
+      if (!current.configurable) {
+        // i. Return false, if the [[Writable]] field of current is false and the [[Writable]] field of Desc is true.
+        if (!current.writable && Desc.writable) return false;
+
+        // ii. If the [[Writable]] field of current is false, then
+        if (!current.writable) {
+          // 1. Return false, if the [[Value]] field of Desc is present and SameValue(Desc.[[Value]], current.[[Value]]) is false.
+          let descValue = Desc.value || realm.intrinsics.undefined;
+          invariant(descValue instanceof Value);
+          let currentValue = current.value || realm.intrinsics.undefined;
+          invariant(currentValue instanceof Value);
+          if (Desc.value && !SameValuePartial(realm, descValue, currentValue)) {
+            return false;
+          }
+        }
+      } else {
+        // b. Else the [[Configurable]] field of current is true, so any change is acceptable.
       }
     } else {
-      // b. Else the [[Configurable]] field of current is true, so any change is acceptable.
-    }
-  } else {
-    // 9. Else IsAccessorDescriptor(current) and IsAccessorDescriptor(Desc) are both true,
-    // a. If the [[Configurable]] field of current is false, then
-    if (!current.configurable) {
-      // i. Return false, if the [[Set]] field of Desc is present and SameValue(Desc.[[Set]], current.[[Set]]) is false.
-      if (Desc.set && !SameValuePartial(realm, Desc.set, current.set || realm.intrinsics.undefined)) return false;
+      // 9. Else IsAccessorDescriptor(current) and IsAccessorDescriptor(Desc) are both true,
+      // a. If the [[Configurable]] field of current is false, then
+      if (!current.configurable) {
+        // i. Return false, if the [[Set]] field of Desc is present and SameValue(Desc.[[Set]], current.[[Set]]) is false.
+        if (Desc.set && !SameValuePartial(realm, Desc.set, current.set || realm.intrinsics.undefined)) return false;
 
-      // ii. Return false, if the [[Get]] field of Desc is present and SameValue(Desc.[[Get]], current.[[Get]]) is false.
-      if (Desc.get && !SameValuePartial(realm, Desc.get, current.get || realm.intrinsics.undefined)) return false;
-    }
-  }
-
-  // 10. If O is not undefined, then
-  if (O !== undefined) {
-    invariant(P !== undefined);
-    let key = InternalGetPropertiesKey(P);
-    let map = InternalGetPropertiesMap(O, P);
-    let propertyBinding = map.get(key);
-    if (propertyBinding === undefined) {
-      propertyBinding = { descriptor: undefined, object: O, key: key };
-      realm.recordModifiedProperty(propertyBinding);
-      propertyBinding.descriptor = current;
-      map.set(key, propertyBinding);
-    } else if (propertyBinding.descriptor === undefined) {
-      realm.recordModifiedProperty(propertyBinding);
-      propertyBinding.descriptor = current;
-    } else {
-      realm.recordModifiedProperty(propertyBinding);
-      propertyBinding.descriptor = current;
+        // ii. Return false, if the [[Get]] field of Desc is present and SameValue(Desc.[[Get]], current.[[Get]]) is false.
+        if (Desc.get && !SameValuePartial(realm, Desc.get, current.get || realm.intrinsics.undefined)) return false;
+      }
     }
 
-    // a. For each field of Desc that is present, set the corresponding attribute of the property named P of
-    //    object O to the value of the field.
-    for (let field in Desc) current[field] = Desc[field];
-    InternalUpdatedProperty(realm, O, P, oldDesc);
-  }
+    // 10. If O is not undefined, then
+    if (O !== undefined) {
+      invariant(P !== undefined);
+      let key = InternalGetPropertiesKey(P);
+      let map = InternalGetPropertiesMap(O, P);
+      let propertyBinding = map.get(key);
+      if (propertyBinding === undefined) {
+        propertyBinding = { descriptor: undefined, object: O, key: key };
+        realm.recordModifiedProperty(propertyBinding);
+        propertyBinding.descriptor = current;
+        map.set(key, propertyBinding);
+      } else if (propertyBinding.descriptor === undefined) {
+        realm.recordModifiedProperty(propertyBinding);
+        propertyBinding.descriptor = current;
+      } else {
+        realm.recordModifiedProperty(propertyBinding);
+        propertyBinding.descriptor = current;
+      }
 
-  // 11. Return true.
-  return true;
-}
-
-// ECMA262 9.1.6.1
-export function OrdinaryDefineOwnProperty(
-  realm: Realm,
-  O: ObjectValue,
-  P: PropertyKeyValue,
-  Desc: Descriptor
-): boolean {
-  invariant(O instanceof ObjectValue);
-
-  // 1. Let current be ? O.[[GetOwnProperty]](P).
-  let current = O.$GetOwnProperty(P);
-
-  // 2. Let extensible be the value of the [[Extensible]] internal slot of O.
-  let extensible = O.getExtensible();
-
-  // 3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
-  return ValidateAndApplyPropertyDescriptor(realm, O, P, extensible, Desc, current);
-}
-
-// ECMA262 19.1.2.3.1
-export function ObjectDefineProperties(realm: Realm, O: Value, Properties: Value): ObjectValue | AbstractObjectValue {
-  // 1. If Type(O) is not Object, throw a TypeError exception.
-  if (O.mightNotBeObject()) {
-    if (O.mightBeObject()) O.throwIfNotConcrete();
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  }
-  invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue);
-
-  // 2. Let props be ? ToObject(Properties).
-  let props = ToObject(realm, Properties.throwIfNotConcrete());
-
-  // 3. Let keys be ? props.[[OwnPropertyKeys]]().
-  let keys = props.$OwnPropertyKeys();
-
-  // 4. Let descriptors be a new empty List.
-  let descriptors = [];
-
-  // 5. Repeat for each element nextKey of keys in List order,
-  for (let nextKey of keys) {
-    // a. Let propDesc be ? props.[[GetOwnProperty]](nextKey).
-    let propDesc = props.$GetOwnProperty(nextKey);
-
-    // b. If propDesc is not undefined and propDesc.[[Enumerable]] is true, then
-    if (propDesc && propDesc.enumerable) {
-      ThrowIfMightHaveBeenDeleted(propDesc.value);
-
-      // i. Let descObj be ? Get(props, nextKey).
-      let descObj = Get(realm, props, nextKey);
-
-      // ii. Let desc be ? ToPropertyDescriptor(descObj).
-      let desc = ToPropertyDescriptor(realm, descObj);
-
-      // iii. Append the pair (a two element List) consisting of nextKey and desc to the end of descriptors.
-      descriptors.push([nextKey, desc]);
-    }
-  }
-
-  // 6. For each pair from descriptors in list order,
-  for (let pair of descriptors) {
-    // a. Let P be the first element of pair.
-    let P = pair[0];
-
-    // b. Let desc be the second element of pair.
-    let desc = pair[1];
-
-    // c. Perform ? DefinePropertyOrThrow(O, P, desc).
-    DefinePropertyOrThrow(realm, O, P, desc);
-  }
-
-  // 7. Return O.
-  return O;
-}
-
-// ECMA262 7.3.3
-export function Set(
-  realm: Realm,
-  O: ObjectValue | AbstractObjectValue,
-  P: PropertyKeyValue,
-  V: Value,
-  Throw: boolean
-): boolean {
-  // 1. Assert: Type(O) is Object.
-
-  // 2. Assert: IsPropertyKey(P) is true.
-  invariant(IsPropertyKey(realm, P), "expected property key");
-
-  // 3. Assert: Type(Throw) is Boolean.
-  invariant(typeof Throw === "boolean", "expected boolean");
-
-  // 4. Let success be ? O.[[Set]](P, V, O).
-  let success = O.$Set(P, V, O);
-
-  // 5. If success is false and Throw is true, throw a TypeError exception.
-  if (success === false && Throw === true) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  }
-
-  // 6. Return success.
-  return success;
-}
-
-// ECMA262 7.3.7
-export function DefinePropertyOrThrow(
-  realm: Realm,
-  O: ObjectValue | AbstractObjectValue,
-  P: PropertyKeyValue,
-  desc: Descriptor
-): boolean {
-  // 1. Assert: Type(O) is Object.
-
-  // 2. Assert: IsPropertyKey(P) is true.
-  invariant(typeof P === "string" || IsPropertyKey(realm, P), "expected property key");
-
-  // 3. Let success be ? O.[[DefineOwnProperty]](P, desc).
-  let success = O.$DefineOwnProperty(P, desc);
-
-  // 4. If success is false, throw a TypeError exception.
-  if (success === false) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  }
-
-  // 5. Return success.
-  return success;
-}
-
-// ECMA262 6.2.3.2
-export function PutValue(realm: Realm, V: Value | Reference, W: Value) {
-  W = W.promoteEmptyToUndefined();
-  // The following two steps are not necessary as we propagate completions with exceptions.
-  // 1. ReturnIfAbrupt(V).
-  // 2. ReturnIfAbrupt(W).
-
-  // 3. If Type(V) is not Reference, throw a ReferenceError exception.
-  if (!(V instanceof Reference)) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, "can't put a value to a non-reference");
-  }
-
-  // 4. Let base be GetBase(V).
-  let base = GetBase(realm, V);
-
-  // 5. If IsUnresolvableReference(V) is true, then
-  if (IsUnresolvableReference(realm, V)) {
-    // a. If IsStrictReference(V) is true, then
-    if (IsStrictReference(realm, V)) {
-      // i. Throw a ReferenceError exception.
-      throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError);
+      // a. For each field of Desc that is present, set the corresponding attribute of the property named P of
+      //    object O to the value of the field.
+      for (let field in Desc) current[field] = Desc[field];
+      InternalUpdatedProperty(realm, O, P, oldDesc);
     }
 
-    // b. Let globalObj be GetGlobalObject().
-    let globalObj = GetGlobalObject(realm);
-
-    // c. Return ? Set(globalObj, GetReferencedName(V), W, false).
-    return Set(realm, globalObj, GetReferencedName(realm, V), W, false);
+    // 11. Return true.
+    return true;
   }
 
-  // 6. Else if IsPropertyReference(V) is true, then
-  if (IsPropertyReference(realm, V)) {
-    // a. If HasPrimitiveBase(V) is true, then
-    if (HasPrimitiveBase(realm, V)) {
-      // i. Assert: In realm case, base will never be null or undefined.
-      invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
+  // ECMA262 9.1.6.1
+  OrdinaryDefineOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, Desc: Descriptor): boolean {
+    invariant(O instanceof ObjectValue);
 
-      // ii. Set base to ToObject(base).
-      base = ToObjectPartial(realm, base);
+    // 1. Let current be ? O.[[GetOwnProperty]](P).
+    let current = O.$GetOwnProperty(P);
+
+    // 2. Let extensible be the value of the [[Extensible]] internal slot of O.
+    let extensible = O.getExtensible();
+
+    // 3. Return ValidateAndApplyPropertyDescriptor(O, P, extensible, Desc, current).
+    return this.ValidateAndApplyPropertyDescriptor(realm, O, P, extensible, Desc, current);
+  }
+
+  // ECMA262 19.1.2.3.1
+  ObjectDefineProperties(realm: Realm, O: Value, Properties: Value): ObjectValue | AbstractObjectValue {
+    // 1. If Type(O) is not Object, throw a TypeError exception.
+    if (O.mightNotBeObject()) {
+      if (O.mightBeObject()) O.throwIfNotConcrete();
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
     }
-    invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
+    invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue);
 
-    // b. Let succeeded be ? base.[[Set]](GetReferencedName(V), W, GetThisValue(V)).
-    let succeeded = base.$SetPartial(GetReferencedNamePartial(realm, V), W, GetThisValue(realm, V));
+    // 2. Let props be ? ToObject(Properties).
+    let props = ToObject(realm, Properties.throwIfNotConcrete());
 
-    // c. If succeeded is false and IsStrictReference(V) is true, throw a TypeError exception.
-    if (succeeded === false && IsStrictReference(realm, V)) {
+    // 3. Let keys be ? props.[[OwnPropertyKeys]]().
+    let keys = props.$OwnPropertyKeys();
+
+    // 4. Let descriptors be a new empty List.
+    let descriptors = [];
+
+    // 5. Repeat for each element nextKey of keys in List order,
+    for (let nextKey of keys) {
+      // a. Let propDesc be ? props.[[GetOwnProperty]](nextKey).
+      let propDesc = props.$GetOwnProperty(nextKey);
+
+      // b. If propDesc is not undefined and propDesc.[[Enumerable]] is true, then
+      if (propDesc && propDesc.enumerable) {
+        this.ThrowIfMightHaveBeenDeleted(propDesc.value);
+
+        // i. Let descObj be ? Get(props, nextKey).
+        let descObj = Get(realm, props, nextKey);
+
+        // ii. Let desc be ? ToPropertyDescriptor(descObj).
+        let desc = ToPropertyDescriptor(realm, descObj);
+
+        // iii. Append the pair (a two element List) consisting of nextKey and desc to the end of descriptors.
+        descriptors.push([nextKey, desc]);
+      }
+    }
+
+    // 6. For each pair from descriptors in list order,
+    for (let pair of descriptors) {
+      // a. Let P be the first element of pair.
+      let P = pair[0];
+
+      // b. Let desc be the second element of pair.
+      let desc = pair[1];
+
+      // c. Perform ? DefinePropertyOrThrow(O, P, desc).
+      this.DefinePropertyOrThrow(realm, O, P, desc);
+    }
+
+    // 7. Return O.
+    return O;
+  }
+
+  // ECMA262 7.3.3
+  Set(realm: Realm, O: ObjectValue | AbstractObjectValue, P: PropertyKeyValue, V: Value, Throw: boolean): boolean {
+    // 1. Assert: Type(O) is Object.
+
+    // 2. Assert: IsPropertyKey(P) is true.
+    invariant(IsPropertyKey(realm, P), "expected property key");
+
+    // 3. Assert: Type(Throw) is Boolean.
+    invariant(typeof Throw === "boolean", "expected boolean");
+
+    // 4. Let success be ? O.[[Set]](P, V, O).
+    let success = O.$Set(P, V, O);
+
+    // 5. If success is false and Throw is true, throw a TypeError exception.
+    if (success === false && Throw === true) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
     }
 
-    // d. Return.
-    return;
+    // 6. Return success.
+    return success;
   }
 
-  // 7. Else base must be an Environment Record,
-  if (base instanceof EnvironmentRecord) {
-    // a. Return ? base.SetMutableBinding(GetReferencedName(V), W, IsStrictReference(V)) (see 8.1.1).
-    let referencedName = GetReferencedName(realm, V);
-    invariant(typeof referencedName === "string");
-    return base.SetMutableBinding(referencedName, W, IsStrictReference(realm, V));
-  }
+  // ECMA262 7.3.7
+  DefinePropertyOrThrow(
+    realm: Realm,
+    O: ObjectValue | AbstractObjectValue,
+    P: PropertyKeyValue,
+    desc: Descriptor
+  ): boolean {
+    // 1. Assert: Type(O) is Object.
 
-  invariant(false);
-}
+    // 2. Assert: IsPropertyKey(P) is true.
+    invariant(typeof P === "string" || IsPropertyKey(realm, P), "expected property key");
 
-// ECMA262 9.4.2.4
-export function ArraySetLength(realm: Realm, A: ArrayValue, Desc: Descriptor): boolean {
-  // 1. If the [[Value]] field of Desc is absent, then
-  let DescValue = Desc.value;
-  if (!DescValue) {
-    // a. Return OrdinaryDefineOwnProperty(A, "length", Desc).
-    return OrdinaryDefineOwnProperty(realm, A, "length", Desc);
-  }
-  invariant(DescValue instanceof Value);
+    // 3. Let success be ? O.[[DefineOwnProperty]](P, desc).
+    let success = O.$DefineOwnProperty(P, desc);
 
-  // 2. Let newLenDesc be a copy of Desc.
-  let newLenDesc = Object.assign({}, Desc);
-
-  // 3. Let newLen be ? ToUint32(Desc.[[Value]]).
-  let newLen = ToUint32(realm, DescValue);
-
-  // 4. Let numberLen be ? ToNumber(Desc.[[Value]]).
-  let numberLen = ToNumber(realm, DescValue);
-
-  // 5. If newLen ≠ numberLen, throw a RangeError exception.
-  if (newLen !== numberLen) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "should be a uint");
-  }
-
-  // 6. Set newLenDesc.[[Value]] to newLen.
-  newLenDesc.value = new NumberValue(realm, newLen);
-
-  // 7. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").
-  let oldLenDesc = OrdinaryGetOwnProperty(realm, A, "length");
-
-  // 8. Assert: oldLenDesc will never be undefined or an accessor descriptor because Array objects are created
-  //    with a length data property that cannot be deleted or reconfigured.
-  invariant(
-    oldLenDesc !== undefined && !IsAccessorDescriptor(realm, oldLenDesc),
-    "cannot be undefined or an accessor descriptor"
-  );
-
-  // 9. Let oldLen be oldLenDesc.[[Value]].
-  let oldLen = oldLenDesc.value;
-  invariant(oldLen instanceof Value);
-  oldLen = oldLen.throwIfNotConcrete();
-  invariant(oldLen instanceof NumberValue, "should be a number");
-  oldLen = (oldLen.value: number);
-
-  // 10. If newLen ≥ oldLen, then
-  if (newLen >= oldLen) {
-    // a. Return OrdinaryDefineOwnProperty(A, "length", newLenDesc).
-    return OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
-  }
-
-  // 11. If oldLenDesc.[[Writable]] is false, return false.
-  if (!oldLenDesc.writable) return false;
-
-  // 12. If newLenDesc.[[Writable]] is absent or has the value true, let newWritable be true.
-  let newWritable;
-  if (!("writable" in newLenDesc) || newLenDesc.writable === true) {
-    newWritable = true;
-  } else {
-    // 13. Else,
-    // a. Need to defer setting the [[Writable]] attribute to false in case any elements cannot be deleted.
-
-    // b. Let newWritable be false.
-    newWritable = false;
-
-    // c. Set newLenDesc.[[Writable]] to true.
-    newLenDesc.writable = true;
-  }
-
-  // 14. Let succeeded be ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
-  let succeeded = OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
-
-  // 15. If succeeded is false, return false.
-  if (succeeded === false) return false;
-
-  // Here we diverge from the spec: instead of traversing all indices from
-  // oldLen to newLen, only the indices that are actually present are touched.
-  let oldLenCopy = oldLen;
-  let keys = Array.from(A.properties.keys())
-    .map(x => parseInt(x, 10))
-    .filter(x => newLen <= x && x <= oldLenCopy)
-    .sort()
-    .reverse();
-
-  // 16. While newLen < oldLen repeat,
-  for (let key of keys) {
-    // a. Set oldLen to oldLen - 1.
-    oldLen = key;
-
-    // b. Let deleteSucceeded be ! A.[[Delete]](! ToString(oldLen)).
-    let deleteSucceeded = A.$Delete(oldLen + "");
-
-    // c. If deleteSucceeded is false, then
-    if (deleteSucceeded === false) {
-      // i. Set newLenDesc.[[Value]] to oldLen + 1.
-      newLenDesc.value = new NumberValue(realm, oldLen + 1);
-
-      // ii. If newWritable is false, set newLenDesc.[[Writable]] to false.
-      if (newWritable === false) newLenDesc.writable = false;
-
-      // iii. Let succeeded be ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
-      succeeded = OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
-
-      // iv. Return false.
-      return false;
+    // 4. If success is false, throw a TypeError exception.
+    if (success === false) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
     }
+
+    // 5. Return success.
+    return success;
   }
 
-  // 17. If newWritable is false, then
-  if (!newWritable) {
-    // a. Return OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor{[[Writable]]: false}). This call will always return true.
-    return OrdinaryDefineOwnProperty(realm, A, "length", {
-      writable: false,
-    });
-  }
+  // ECMA262 6.2.3.2
+  PutValue(realm: Realm, V: Value | Reference, W: Value): void | boolean | Value {
+    W = W.promoteEmptyToUndefined();
+    // The following two steps are not necessary as we propagate completions with exceptions.
+    // 1. ReturnIfAbrupt(V).
+    // 2. ReturnIfAbrupt(W).
 
-  // 18. Return true.
-  return true;
-}
+    // 3. If Type(V) is not Reference, throw a ReferenceError exception.
+    if (!(V instanceof Reference)) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, "can't put a value to a non-reference");
+    }
 
-// ECMA262 9.1.5.1
-export function OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue): Descriptor | void {
-  // 1. Assert: IsPropertyKey(P) is true.
-  invariant(IsPropertyKey(realm, P), "expected a property key");
+    // 4. Let base be GetBase(V).
+    let base = GetBase(realm, V);
 
-  // 2. If O does not have an own property with key P, return undefined.
-  let existingBinding = InternalGetPropertiesMap(O, P).get(InternalGetPropertiesKey(P));
-  if (!existingBinding) {
-    if (O.isPartialObject()) {
-      invariant(realm.useAbstractInterpretation); // __makePartial will already have thrown an error if not
-      if (O.isSimpleObject()) {
-        if (P instanceof StringValue) P = P.value;
-        if (typeof P === "string") {
-          // In this case it is safe to defer the property access to runtime (at this point in time)
-          invariant(realm.generator);
-          let pname = realm.generator.getAsPropertyNameExpression(P);
-          let absVal = AbstractValue.createTemporalFromBuildFunction(realm, Value, [O], ([node]) =>
-            t.memberExpression(node, pname, !t.isIdentifier(pname))
-          );
-          return { configurabe: true, enumerable: true, value: absVal, writable: true };
-        } else {
-          invariant(P instanceof SymbolValue);
-          // Simple objects don't have symbol properties
-          return undefined;
-        }
+    // 5. If IsUnresolvableReference(V) is true, then
+    if (IsUnresolvableReference(realm, V)) {
+      // a. If IsStrictReference(V) is true, then
+      if (IsStrictReference(realm, V)) {
+        // i. Throw a ReferenceError exception.
+        throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError);
       }
-      AbstractValue.reportIntrospectionError(O, P);
-      throw new FatalError();
+
+      // b. Let globalObj be GetGlobalObject().
+      let globalObj = GetGlobalObject(realm);
+
+      // c. Return ? Set(globalObj, GetReferencedName(V), W, false).
+      return this.Set(realm, globalObj, GetReferencedName(realm, V), W, false);
     }
-    return undefined;
+
+    // 6. Else if IsPropertyReference(V) is true, then
+    if (IsPropertyReference(realm, V)) {
+      // a. If HasPrimitiveBase(V) is true, then
+      if (HasPrimitiveBase(realm, V)) {
+        // i. Assert: In realm case, base will never be null or undefined.
+        invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
+
+        // ii. Set base to ToObject(base).
+        base = ToObjectPartial(realm, base);
+      }
+      invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
+
+      // b. Let succeeded be ? base.[[Set]](GetReferencedName(V), W, GetThisValue(V)).
+      let succeeded = base.$SetPartial(GetReferencedNamePartial(realm, V), W, GetThisValue(realm, V));
+
+      // c. If succeeded is false and IsStrictReference(V) is true, throw a TypeError exception.
+      if (succeeded === false && IsStrictReference(realm, V)) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+      }
+
+      // d. Return.
+      return;
+    }
+
+    // 7. Else base must be an Environment Record,
+    if (base instanceof EnvironmentRecord) {
+      // a. Return ? base.SetMutableBinding(GetReferencedName(V), W, IsStrictReference(V)) (see 8.1.1).
+      let referencedName = GetReferencedName(realm, V);
+      invariant(typeof referencedName === "string");
+      return base.SetMutableBinding(referencedName, W, IsStrictReference(realm, V));
+    }
+
+    invariant(false);
   }
-  realm.callReportPropertyAccess(existingBinding);
-  if (!existingBinding.descriptor) return undefined;
 
-  // 3. Let D be a newly created Property Descriptor with no fields.
-  let D = {};
+  // ECMA262 9.4.2.4
+  ArraySetLength(realm: Realm, A: ArrayValue, Desc: Descriptor): boolean {
+    // 1. If the [[Value]] field of Desc is absent, then
+    let DescValue = Desc.value;
+    if (!DescValue) {
+      // a. Return OrdinaryDefineOwnProperty(A, "length", Desc).
+      return this.OrdinaryDefineOwnProperty(realm, A, "length", Desc);
+    }
+    invariant(DescValue instanceof Value);
 
-  // 4. Let X be O's own property whose key is P.
-  let X = existingBinding.descriptor;
-  invariant(X !== undefined);
+    // 2. Let newLenDesc be a copy of Desc.
+    let newLenDesc = Object.assign({}, Desc);
 
-  // 5. If X is a data property, then
-  if (IsDataDescriptor(realm, X)) {
-    let value = X.value;
-    if (O.isPartialObject() && value instanceof AbstractValue && value.kind !== "resolved") {
-      let realmGenerator = realm.generator;
-      invariant(realmGenerator);
-      value = realmGenerator.derive(value.types, value.values, value.args, value.getBuildNode(), { kind: "resolved" });
-      InternalSetProperty(realm, O, P, {
-        value: value,
-        writable: "writable" in X ? X.writable : false,
-        enumerable: "enumerable" in X ? X.enumerable : false,
-        configurable: "configurable" in X ? X.configurable : false,
+    // 3. Let newLen be ? ToUint32(Desc.[[Value]]).
+    let newLen = ToUint32(realm, DescValue);
+
+    // 4. Let numberLen be ? ToNumber(Desc.[[Value]]).
+    let numberLen = ToNumber(realm, DescValue);
+
+    // 5. If newLen ≠ numberLen, throw a RangeError exception.
+    if (newLen !== numberLen) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "should be a uint");
+    }
+
+    // 6. Set newLenDesc.[[Value]] to newLen.
+    newLenDesc.value = new NumberValue(realm, newLen);
+
+    // 7. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").
+    let oldLenDesc = this.OrdinaryGetOwnProperty(realm, A, "length");
+
+    // 8. Assert: oldLenDesc will never be undefined or an accessor descriptor because Array objects are created
+    //    with a length data property that cannot be deleted or reconfigured.
+    invariant(
+      oldLenDesc !== undefined && !IsAccessorDescriptor(realm, oldLenDesc),
+      "cannot be undefined or an accessor descriptor"
+    );
+
+    // 9. Let oldLen be oldLenDesc.[[Value]].
+    let oldLen = oldLenDesc.value;
+    invariant(oldLen instanceof Value);
+    oldLen = oldLen.throwIfNotConcrete();
+    invariant(oldLen instanceof NumberValue, "should be a number");
+    oldLen = (oldLen.value: number);
+
+    // 10. If newLen ≥ oldLen, then
+    if (newLen >= oldLen) {
+      // a. Return OrdinaryDefineOwnProperty(A, "length", newLenDesc).
+      return this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
+    }
+
+    // 11. If oldLenDesc.[[Writable]] is false, return false.
+    if (!oldLenDesc.writable) return false;
+
+    // 12. If newLenDesc.[[Writable]] is absent or has the value true, let newWritable be true.
+    let newWritable;
+    if (!("writable" in newLenDesc) || newLenDesc.writable === true) {
+      newWritable = true;
+    } else {
+      // 13. Else,
+      // a. Need to defer setting the [[Writable]] attribute to false in case any elements cannot be deleted.
+
+      // b. Let newWritable be false.
+      newWritable = false;
+
+      // c. Set newLenDesc.[[Writable]] to true.
+      newLenDesc.writable = true;
+    }
+
+    // 14. Let succeeded be ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
+    let succeeded = this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
+
+    // 15. If succeeded is false, return false.
+    if (succeeded === false) return false;
+
+    // Here we diverge from the spec: instead of traversing all indices from
+    // oldLen to newLen, only the indices that are actually present are touched.
+    let oldLenCopy = oldLen;
+    let keys = Array.from(A.properties.keys())
+      .map(x => parseInt(x, 10))
+      .filter(x => newLen <= x && x <= oldLenCopy)
+      .sort()
+      .reverse();
+
+    // 16. While newLen < oldLen repeat,
+    for (let key of keys) {
+      // a. Set oldLen to oldLen - 1.
+      oldLen = key;
+
+      // b. Let deleteSucceeded be ! A.[[Delete]](! ToString(oldLen)).
+      let deleteSucceeded = A.$Delete(oldLen + "");
+
+      // c. If deleteSucceeded is false, then
+      if (deleteSucceeded === false) {
+        // i. Set newLenDesc.[[Value]] to oldLen + 1.
+        newLenDesc.value = new NumberValue(realm, oldLen + 1);
+
+        // ii. If newWritable is false, set newLenDesc.[[Writable]] to false.
+        if (newWritable === false) newLenDesc.writable = false;
+
+        // iii. Let succeeded be ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
+        succeeded = this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
+
+        // iv. Return false.
+        return false;
+      }
+    }
+
+    // 17. If newWritable is false, then
+    if (!newWritable) {
+      // a. Return OrdinaryDefineOwnProperty(A, "length", PropertyDescriptor{[[Writable]]: false}). This call will always return true.
+      return this.OrdinaryDefineOwnProperty(realm, A, "length", {
+        writable: false,
       });
     }
 
-    // a. Set D.[[Value]] to the value of X's [[Value]] attribute.
-    D.value = value;
-
-    // b. Set D.[[Writable]] to the value of X's [[Writable]] attribute.
-    D.writable = X.writable;
-  } else {
-    // 6. Else X is an accessor property,
-    invariant(IsAccessorDescriptor(realm, X), "expected accessor property");
-
-    // a. Set D.[[Get]] to the value of X's [[Get]] attribute.
-    D.get = X.get;
-
-    // b. Set D.[[Set]] to the value of X's [[Set]] attribute.
-    D.set = X.set;
+    // 18. Return true.
+    return true;
   }
 
-  // 7. Set D.[[Enumerable]] to the value of X's [[Enumerable]] attribute.
-  D.enumerable = X.enumerable;
+  // ECMA262 9.1.5.1
+  OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue): Descriptor | void {
+    // 1. Assert: IsPropertyKey(P) is true.
+    invariant(IsPropertyKey(realm, P), "expected a property key");
 
-  // 8. Set D.[[Configurable]] to the value of X's [[Configurable]] attribute.
-  D.configurable = X.configurable;
-
-  // 9. Return D.
-  return D;
-}
-
-// ECMA262 9.1.2.1
-export function OrdinarySetPrototypeOf(realm: Realm, O: ObjectValue, V: ObjectValue | NullValue): boolean {
-  // 1. Assert: Either Type(V) is Object or Type(V) is Null.
-  invariant(V instanceof ObjectValue || V instanceof NullValue);
-
-  // 2. Let extensible be the value of the [[Extensible]] internal slot of O.
-  let extensible = O.getExtensible();
-
-  // 3. Let current be the value of the [[Prototype]] internal slot of O.
-  let current = O.$Prototype;
-
-  // 4. If SameValue(V, current) is true, return true.
-  if (SameValue(realm, V, current)) return true;
-
-  // 5. If extensible is false, return false.
-  if (!extensible) return false;
-
-  // 6. Let p be V.
-  let p = V;
-
-  // 7. Let done be false.
-  let done = false;
-
-  // 8. Repeat while done is false,
-  while (!done) {
-    // a. If p is null, let done be true.
-    if (p instanceof NullValue) {
-      done = true;
-    } else if (SameValue(realm, p, O)) {
-      // b. Else if SameValue(p, O) is true, return false.
-      return false;
-    } else {
-      // c. Else,
-      // TODO #1017 i. If the [[GetPrototypeOf]] internal method of p is not the ordinary object internal method defined in 9.1.1, let done be true.
-
-      // ii. Else, let p be the value of p's [[Prototype]] internal slot.
-      p = p.$Prototype;
-    }
-  }
-
-  // 9. Set the value of the [[Prototype]] internal slot of O to V.
-  O.$Prototype = V;
-
-  // 10. Return true.
-  return true;
-}
-
-// ECMA262 13.7.5.15
-export function EnumerateObjectProperties(realm: Realm, O: ObjectValue) {
-  /*global global*/
-  let visited = new global.Set();
-  let obj = O;
-  let keys = O.$OwnPropertyKeys();
-  let index = 0;
-
-  let iterator = new ObjectValue(realm);
-  iterator.defineNativeMethod("next", 0, () => {
-    while (true) {
-      if (index >= keys.length) {
-        let proto = obj.$GetPrototypeOf();
-        if (proto instanceof NullValue) {
-          return CreateIterResultObject(realm, realm.intrinsics.undefined, true);
+    // 2. If O does not have an own property with key P, return undefined.
+    let existingBinding = InternalGetPropertiesMap(O, P).get(InternalGetPropertiesKey(P));
+    if (!existingBinding) {
+      if (O.isPartialObject()) {
+        invariant(realm.useAbstractInterpretation); // __makePartial will already have thrown an error if not
+        if (O.isSimpleObject()) {
+          if (P instanceof StringValue) P = P.value;
+          if (typeof P === "string") {
+            // In this case it is safe to defer the property access to runtime (at this point in time)
+            invariant(realm.generator);
+            let pname = realm.generator.getAsPropertyNameExpression(P);
+            let absVal = AbstractValue.createTemporalFromBuildFunction(realm, Value, [O], ([node]) =>
+              t.memberExpression(node, pname, !t.isIdentifier(pname))
+            );
+            return { configurabe: true, enumerable: true, value: absVal, writable: true };
+          } else {
+            invariant(P instanceof SymbolValue);
+            // Simple objects don't have symbol properties
+            return undefined;
+          }
         }
-        obj = proto;
-        keys = obj.$OwnPropertyKeys();
-        index = 0;
+        AbstractValue.reportIntrospectionError(O, P);
+        throw new FatalError();
       }
-
-      let key = keys[index];
-
-      // Omit symbols.
-      if (!(key instanceof StringValue)) {
-        index += 1;
-        continue;
-      }
-
-      // Omit non-enumerable properties.
-      let desc = obj.$GetOwnProperty(key);
-      if (desc && !desc.enumerable) {
-        ThrowIfMightHaveBeenDeleted(desc.value);
-        index += 1;
-        visited.add(key.value);
-        continue;
-      }
-
-      // Omit duplicates.
-      if (visited.has(key.value)) {
-        index += 1;
-        continue;
-      }
-      visited.add(key.value);
-
-      // Yield the key.
-      return CreateIterResultObject(realm, key, false);
+      return undefined;
     }
-  });
-  return iterator;
-}
+    realm.callReportPropertyAccess(existingBinding);
+    if (!existingBinding.descriptor) return undefined;
 
-export function ThrowIfMightHaveBeenDeleted(
-  value: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
-): void {
-  if (!(value instanceof Value)) return;
-  if (!value.mightHaveBeenDeleted()) return;
-  invariant(value instanceof AbstractValue); // real empty values should never get here
-  AbstractValue.reportIntrospectionError(value);
-  throw new FatalError();
-}
+    // 3. Let D be a newly created Property Descriptor with no fields.
+    let D = {};
 
-export function ThrowIfInternalSlotNotWritable<T: ObjectValue>(realm: Realm, object: T, key: string): T {
-  if (!realm.isNewObject(object)) {
-    AbstractValue.reportIntrospectionError(object, key);
+    // 4. Let X be O's own property whose key is P.
+    let X = existingBinding.descriptor;
+    invariant(X !== undefined);
+
+    // 5. If X is a data property, then
+    if (IsDataDescriptor(realm, X)) {
+      let value = X.value;
+      if (O.isPartialObject() && value instanceof AbstractValue && value.kind !== "resolved") {
+        let realmGenerator = realm.generator;
+        invariant(realmGenerator);
+        value = realmGenerator.derive(value.types, value.values, value.args, value.getBuildNode(), {
+          kind: "resolved",
+        });
+        InternalSetProperty(realm, O, P, {
+          value: value,
+          writable: "writable" in X ? X.writable : false,
+          enumerable: "enumerable" in X ? X.enumerable : false,
+          configurable: "configurable" in X ? X.configurable : false,
+        });
+      }
+
+      // a. Set D.[[Value]] to the value of X's [[Value]] attribute.
+      D.value = value;
+
+      // b. Set D.[[Writable]] to the value of X's [[Writable]] attribute.
+      D.writable = X.writable;
+    } else {
+      // 6. Else X is an accessor property,
+      invariant(IsAccessorDescriptor(realm, X), "expected accessor property");
+
+      // a. Set D.[[Get]] to the value of X's [[Get]] attribute.
+      D.get = X.get;
+
+      // b. Set D.[[Set]] to the value of X's [[Set]] attribute.
+      D.set = X.set;
+    }
+
+    // 7. Set D.[[Enumerable]] to the value of X's [[Enumerable]] attribute.
+    D.enumerable = X.enumerable;
+
+    // 8. Set D.[[Configurable]] to the value of X's [[Configurable]] attribute.
+    D.configurable = X.configurable;
+
+    // 9. Return D.
+    return D;
+  }
+
+  // ECMA262 9.1.2.1
+  OrdinarySetPrototypeOf(realm: Realm, O: ObjectValue, V: ObjectValue | NullValue): boolean {
+    // 1. Assert: Either Type(V) is Object or Type(V) is Null.
+    invariant(V instanceof ObjectValue || V instanceof NullValue);
+
+    // 2. Let extensible be the value of the [[Extensible]] internal slot of O.
+    let extensible = O.getExtensible();
+
+    // 3. Let current be the value of the [[Prototype]] internal slot of O.
+    let current = O.$Prototype;
+
+    // 4. If SameValue(V, current) is true, return true.
+    if (SameValue(realm, V, current)) return true;
+
+    // 5. If extensible is false, return false.
+    if (!extensible) return false;
+
+    // 6. Let p be V.
+    let p = V;
+
+    // 7. Let done be false.
+    let done = false;
+
+    // 8. Repeat while done is false,
+    while (!done) {
+      // a. If p is null, let done be true.
+      if (p instanceof NullValue) {
+        done = true;
+      } else if (SameValue(realm, p, O)) {
+        // b. Else if SameValue(p, O) is true, return false.
+        return false;
+      } else {
+        // c. Else,
+        // TODO #1017 i. If the [[GetPrototypeOf]] internal method of p is not the ordinary object internal method defined in 9.1.1, let done be true.
+
+        // ii. Else, let p be the value of p's [[Prototype]] internal slot.
+        p = p.$Prototype;
+      }
+    }
+
+    // 9. Set the value of the [[Prototype]] internal slot of O to V.
+    O.$Prototype = V;
+
+    // 10. Return true.
+    return true;
+  }
+
+  // ECMA262 13.7.5.15
+  EnumerateObjectProperties(realm: Realm, O: ObjectValue): ObjectValue {
+    /*global global*/
+    let visited = new global.Set();
+    let obj = O;
+    let keys = O.$OwnPropertyKeys();
+    let index = 0;
+
+    let iterator = new ObjectValue(realm);
+    iterator.defineNativeMethod("next", 0, () => {
+      while (true) {
+        if (index >= keys.length) {
+          let proto = obj.$GetPrototypeOf();
+          if (proto instanceof NullValue) {
+            return CreateIterResultObject(realm, realm.intrinsics.undefined, true);
+          }
+          obj = proto;
+          keys = obj.$OwnPropertyKeys();
+          index = 0;
+        }
+
+        let key = keys[index];
+
+        // Omit symbols.
+        if (!(key instanceof StringValue)) {
+          index += 1;
+          continue;
+        }
+
+        // Omit non-enumerable properties.
+        let desc = obj.$GetOwnProperty(key);
+        if (desc && !desc.enumerable) {
+          this.ThrowIfMightHaveBeenDeleted(desc.value);
+          index += 1;
+          visited.add(key.value);
+          continue;
+        }
+
+        // Omit duplicates.
+        if (visited.has(key.value)) {
+          index += 1;
+          continue;
+        }
+        visited.add(key.value);
+
+        // Yield the key.
+        return CreateIterResultObject(realm, key, false);
+      }
+    });
+    return iterator;
+  }
+
+  ThrowIfMightHaveBeenDeleted(
+    value: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
+  ): void {
+    if (!(value instanceof Value)) return;
+    if (!value.mightHaveBeenDeleted()) return;
+    invariant(value instanceof AbstractValue); // real empty values should never get here
+    AbstractValue.reportIntrospectionError(value);
     throw new FatalError();
   }
-  return object;
-}
 
-// ECMA 14.3.9
-export function PropertyDefinitionEvaluation(
-  realm: Realm,
-  MethodDefinition: BabelNodeObjectMethod | BabelNodeClassMethod,
-  object: ObjectValue,
-  env: LexicalEnvironment,
-  strictCode: boolean,
-  enumerable: boolean
-) {
-  // MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
-  if (MethodDefinition.kind === "method") {
-    // 1. Let methodDef be DefineMethod of MethodDefinition with argument object.
-    let methodDef = DefineMethod(realm, MethodDefinition, object, env, strictCode);
+  ThrowIfInternalSlotNotWritable<T: ObjectValue>(realm: Realm, object: T, key: string): T {
+    if (!realm.isNewObject(object)) {
+      AbstractValue.reportIntrospectionError(object, key);
+      throw new FatalError();
+    }
+    return object;
+  }
 
-    // 2. ReturnIfAbrupt(methodDef).
+  // ECMA 14.3.9
+  PropertyDefinitionEvaluation(
+    realm: Realm,
+    MethodDefinition: BabelNodeObjectMethod | BabelNodeClassMethod,
+    object: ObjectValue,
+    env: LexicalEnvironment,
+    strictCode: boolean,
+    enumerable: boolean
+  ): boolean {
+    // MethodDefinition : PropertyName ( StrictFormalParameters ) { FunctionBody }
+    if (MethodDefinition.kind === "method") {
+      // 1. Let methodDef be DefineMethod of MethodDefinition with argument object.
+      let methodDef = DefineMethod(realm, MethodDefinition, object, env, strictCode);
 
-    // 3. Perform SetFunctionName(methodDef.[[closure]], methodDef.[[key]]).
-    SetFunctionName(realm, methodDef.$Closure, methodDef.$Key);
+      // 2. ReturnIfAbrupt(methodDef).
 
-    // 4. Let desc be the Property Descriptor{[[Value]]: methodDef.[[closure]], [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true}.
-    let desc: Descriptor = { value: methodDef.$Closure, writable: true, enumerable: enumerable, configurable: true };
+      // 3. Perform SetFunctionName(methodDef.[[closure]], methodDef.[[key]]).
+      SetFunctionName(realm, methodDef.$Closure, methodDef.$Key);
 
-    // 5. Return DefinePropertyOrThrow(object, methodDef.[[key]], desc).
-    return DefinePropertyOrThrow(realm, object, methodDef.$Key, desc);
-  } else if (MethodDefinition.kind === "generator") {
-    // MethodDefinition : GeneratorMethod
-    // See 14.4.
-    // ECMA 14.4.13
-    // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
+      // 4. Let desc be the Property Descriptor{[[Value]]: methodDef.[[closure]], [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true}.
+      let desc: Descriptor = { value: methodDef.$Closure, writable: true, enumerable: enumerable, configurable: true };
 
-    // 2. ReturnIfAbrupt(propKey).
-    // 3. If the function code for this GeneratorMethod is strict mode code, let strict be true. Otherwise let strict be false.
-    let strict = strictCode || IsStrict(MethodDefinition.body);
+      // 5. Return DefinePropertyOrThrow(object, methodDef.[[key]], desc).
+      return this.DefinePropertyOrThrow(realm, object, methodDef.$Key, desc);
+    } else if (MethodDefinition.kind === "generator") {
+      // MethodDefinition : GeneratorMethod
+      // See 14.4.
+      // ECMA 14.4.13
+      // 1. Let propKey be the result of evaluating PropertyName.
+      let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
 
-    // 4. Let scope be the running execution context’s LexicalEnvironment.
-    let scope = env;
+      // 2. ReturnIfAbrupt(propKey).
+      // 3. If the function code for this GeneratorMethod is strict mode code, let strict be true. Otherwise let strict be false.
+      let strict = strictCode || IsStrict(MethodDefinition.body);
 
-    // 5. Let closure be GeneratorFunctionCreate(Method, StrictFormalParameters, GeneratorBody, scope, strict).
-    let closure = GeneratorFunctionCreate(
-      realm,
-      "method",
-      MethodDefinition.params,
-      MethodDefinition.body,
-      scope,
-      strict
-    );
+      // 4. Let scope be the running execution context’s LexicalEnvironment.
+      let scope = env;
 
-    // 6. Perform MakeMethod(closure, object).
-    MakeMethod(realm, closure, object);
+      // 5. Let closure be GeneratorFunctionCreate(Method, StrictFormalParameters, GeneratorBody, scope, strict).
+      let closure = GeneratorFunctionCreate(
+        realm,
+        "method",
+        MethodDefinition.params,
+        MethodDefinition.body,
+        scope,
+        strict
+      );
 
-    // 7. Let prototype be ObjectCreate(%GeneratorPrototype%).
-    let prototype = ObjectCreate(realm, realm.intrinsics.GeneratorPrototype);
-    prototype.originalConstructor = closure;
+      // 6. Perform MakeMethod(closure, object).
+      MakeMethod(realm, closure, object);
 
-    // 8. Perform MakeConstructor(closure, true, prototype).
-    MakeConstructor(realm, closure, true, prototype);
+      // 7. Let prototype be ObjectCreate(%GeneratorPrototype%).
+      let prototype = ObjectCreate(realm, realm.intrinsics.GeneratorPrototype);
+      prototype.originalConstructor = closure;
 
-    // 9. Perform SetFunctionName(closure, propKey).
-    SetFunctionName(realm, closure, propKey);
+      // 8. Perform MakeConstructor(closure, true, prototype).
+      MakeConstructor(realm, closure, true, prototype);
 
-    // 10. Let desc be the Property Descriptor{[[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true}.
-    let desc: Descriptor = { value: closure, writable: true, enumerable: enumerable, configurable: true };
+      // 9. Perform SetFunctionName(closure, propKey).
+      SetFunctionName(realm, closure, propKey);
 
-    // 11. Return DefinePropertyOrThrow(object, propKey, desc).
-    return DefinePropertyOrThrow(realm, object, propKey, desc);
-  } else if (MethodDefinition.kind === "get") {
-    // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
+      // 10. Let desc be the Property Descriptor{[[Value]]: closure, [[Writable]]: true, [[Enumerable]]: enumerable, [[Configurable]]: true}.
+      let desc: Descriptor = { value: closure, writable: true, enumerable: enumerable, configurable: true };
 
-    // 2. ReturnIfAbrupt(propKey).
+      // 11. Return DefinePropertyOrThrow(object, propKey, desc).
+      return this.DefinePropertyOrThrow(realm, object, propKey, desc);
+    } else if (MethodDefinition.kind === "get") {
+      // 1. Let propKey be the result of evaluating PropertyName.
+      let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
 
-    // 3. If the function code for this MethodDefinition is strict mode code, let strict be true. Otherwise let strict be false.
-    let strict = strictCode || IsStrict(MethodDefinition.body);
+      // 2. ReturnIfAbrupt(propKey).
 
-    // 4. Let scope be the running execution context's LexicalEnvironment.
-    let scope = env;
+      // 3. If the function code for this MethodDefinition is strict mode code, let strict be true. Otherwise let strict be false.
+      let strict = strictCode || IsStrict(MethodDefinition.body);
 
-    // 5. Let formalParameterList be the production FormalParameters:[empty] .
-    let formalParameterList = [];
+      // 4. Let scope be the running execution context's LexicalEnvironment.
+      let scope = env;
 
-    // 6. Let closure be FunctionCreate(Method, formalParameterList, FunctionBody, scope, strict).
-    let closure = FunctionCreate(realm, "method", formalParameterList, MethodDefinition.body, scope, strict);
+      // 5. Let formalParameterList be the production FormalParameters:[empty] .
+      let formalParameterList = [];
 
-    // 7. Perform MakeMethod(closure, object).
-    MakeMethod(realm, closure, object);
+      // 6. Let closure be FunctionCreate(Method, formalParameterList, FunctionBody, scope, strict).
+      let closure = FunctionCreate(realm, "method", formalParameterList, MethodDefinition.body, scope, strict);
 
-    // 8. Perform SetFunctionName(closure, propKey, "get").
-    SetFunctionName(realm, closure, propKey, "get");
+      // 7. Perform MakeMethod(closure, object).
+      MakeMethod(realm, closure, object);
 
-    // 9. Let desc be the PropertyDescriptor{[[Get]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true}.
-    let desc = {
-      get: closure,
-      enumerable: true,
-      configurable: true,
-    };
+      // 8. Perform SetFunctionName(closure, propKey, "get").
+      SetFunctionName(realm, closure, propKey, "get");
 
-    // 10. Return ? DefinePropertyOrThrow(object, propKey, desc).
-    DefinePropertyOrThrow(realm, object, propKey, desc);
-  } else if (MethodDefinition.kind === "set") {
-    // 1. Let propKey be the result of evaluating PropertyName.
-    let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
+      // 9. Let desc be the PropertyDescriptor{[[Get]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true}.
+      let desc = {
+        get: closure,
+        enumerable: true,
+        configurable: true,
+      };
 
-    // 2. ReturnIfAbrupt(propKey).
+      // 10. Return ? DefinePropertyOrThrow(object, propKey, desc).
+      return this.DefinePropertyOrThrow(realm, object, propKey, desc);
+    } else {
+      invariant(MethodDefinition.kind === "set");
+      // 1. Let propKey be the result of evaluating PropertyName.
+      let propKey = EvalPropertyName(MethodDefinition, env, realm, strictCode);
 
-    // 3. If the function code for this MethodDefinition is strict mode code, let strict be true. Otherwise let strict be false.
-    let strict = strictCode || IsStrict(MethodDefinition.body);
+      // 2. ReturnIfAbrupt(propKey).
 
-    // 4. Let scope be the running execution context's LexicalEnvironment.
-    let scope = env;
+      // 3. If the function code for this MethodDefinition is strict mode code, let strict be true. Otherwise let strict be false.
+      let strict = strictCode || IsStrict(MethodDefinition.body);
 
-    // 5. Let closure be FunctionCreate(Method, PropertySetParameterList, FunctionBody, scope, strict).
-    let closure = FunctionCreate(realm, "method", MethodDefinition.params, MethodDefinition.body, scope, strict);
+      // 4. Let scope be the running execution context's LexicalEnvironment.
+      let scope = env;
 
-    // 6. Perform MakeMethod(closure, object).
-    MakeMethod(realm, closure, object);
+      // 5. Let closure be FunctionCreate(Method, PropertySetParameterList, FunctionBody, scope, strict).
+      let closure = FunctionCreate(realm, "method", MethodDefinition.params, MethodDefinition.body, scope, strict);
 
-    // 7. Perform SetFunctionName(closure, propKey, "set").
-    SetFunctionName(realm, closure, propKey, "set");
+      // 6. Perform MakeMethod(closure, object).
+      MakeMethod(realm, closure, object);
 
-    // 8. Let desc be the PropertyDescriptor{[[Set]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true}.
-    let desc = {
-      set: closure,
-      enumerable: true,
-      configurable: true,
-    };
+      // 7. Perform SetFunctionName(closure, propKey, "set").
+      SetFunctionName(realm, closure, propKey, "set");
 
-    // 9. Return ? DefinePropertyOrThrow(object, propKey, desc).
-    DefinePropertyOrThrow(realm, object, propKey, desc);
+      // 8. Let desc be the PropertyDescriptor{[[Set]]: closure, [[Enumerable]]: enumerable, [[Configurable]]: true}.
+      let desc = {
+        set: closure,
+        enumerable: true,
+        configurable: true,
+      };
+
+      // 9. Return ? DefinePropertyOrThrow(object, propKey, desc).
+      return this.DefinePropertyOrThrow(realm, object, propKey, desc);
+    }
   }
 }

--- a/src/methods/regexp.js
+++ b/src/methods/regexp.js
@@ -13,12 +13,12 @@ import type { Realm } from "../realm.js";
 import invariant from "../invariant.js";
 import { NullValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "../values/index.js";
 import { ArrayCreate, OrdinaryCreateFromConstructor, CreateDataProperty } from "./create.js";
-import { DefinePropertyOrThrow, Set } from "./properties.js";
 import { ToString, ToStringPartial, ToLength } from "./to.js";
 import { Get } from "./get.js";
 import { IsCallable } from "./is.js";
 import { Call } from "./call.js";
 import { HasCompatibleType, HasSomeCompatibleType } from "./has.js";
+import { Properties } from "../singletons.js";
 
 // ECMA262 21.2.3.2.3
 export function RegExpCreate(realm: Realm, P: ?Value, F: ?Value): ObjectValue {
@@ -41,7 +41,7 @@ export function RegExpAlloc(realm: Realm, newTarget: ObjectValue): ObjectValue {
 
   // 2. Perform ! DefinePropertyOrThrow(obj, "lastIndex", PropertyDescriptor {[[Writable]]: true,
   //    [[Enumerable]]: false, [[Configurable]]: false}).
-  DefinePropertyOrThrow(realm, obj, "lastIndex", {
+  Properties.DefinePropertyOrThrow(realm, obj, "lastIndex", {
     writable: true,
     enumerable: false,
     configurable: false,
@@ -140,7 +140,7 @@ export function RegExpInitialize(realm: Realm, obj: ObjectValue, pattern: ?Value
   }
 
   // 12. Perform ? Set(obj, "lastIndex", 0, true).
-  Set(realm, obj, "lastIndex", realm.intrinsics.zero, true);
+  Properties.Set(realm, obj, "lastIndex", realm.intrinsics.zero, true);
 
   // 13. Return obj.
   return obj;
@@ -229,7 +229,7 @@ export function RegExpBuiltinExec(realm: Realm, R: ObjectValue, S: string): Obje
     // a. If lastIndex > length, then
     if (lastIndex > length) {
       // i. Perform ? Set(R, "lastIndex", 0, true).
-      Set(realm, R, "lastIndex", realm.intrinsics.zero, true);
+      Properties.Set(realm, R, "lastIndex", realm.intrinsics.zero, true);
       // ii. Return null.
       return realm.intrinsics.null;
     }
@@ -242,7 +242,7 @@ export function RegExpBuiltinExec(realm: Realm, R: ObjectValue, S: string): Obje
       // i. If sticky is true, then
       if (sticky) {
         // 1. Perform ? Set(R, "lastIndex", 0, true).
-        Set(realm, R, "lastIndex", realm.intrinsics.zero, true);
+        Properties.Set(realm, R, "lastIndex", realm.intrinsics.zero, true);
 
         // 2. Return null.
         return realm.intrinsics.null;
@@ -275,7 +275,7 @@ export function RegExpBuiltinExec(realm: Realm, R: ObjectValue, S: string): Obje
   // 15. If global is true or sticky is true, then
   if (global === true || sticky === true) {
     // a. Perform ? Set(R, "lastIndex", e, true).
-    Set(realm, R, "lastIndex", new NumberValue(realm, e), true);
+    Properties.Set(realm, R, "lastIndex", new NumberValue(realm, e), true);
   }
 
   // 16. Let n be the length of r's captures List. (This is the same value as 21.2.2.1's NcapturingParens.)

--- a/src/partial-evaluators/ArrayExpression.js
+++ b/src/partial-evaluators/ArrayExpression.js
@@ -22,9 +22,9 @@ import {
   GetMethod,
   IteratorStep,
   IteratorValue,
-  Set,
 } from "../methods/index.js";
 import { AbstractValue, NumberValue, ObjectValue, StringValue, Value } from "../values/index.js";
+import { Properties } from "../singletons.js";
 
 import invariant from "../invariant.js";
 import * as t from "babel-types";
@@ -152,7 +152,7 @@ export default function(
   // 3. ReturnIfAbrupt(len).
 
   // 4. Perform Set(array, "length", ToUint32(len), false).
-  Set(realm, array, "length", new NumberValue(realm, nextIndex), false);
+  Properties.Set(realm, array, "length", new NumberValue(realm, nextIndex), false);
 
   // 5. NOTE: The above Set cannot fail because of the nature of the object returned by ArrayCreate.
 

--- a/src/partial-evaluators/AssignmentExpression.js
+++ b/src/partial-evaluators/AssignmentExpression.js
@@ -26,7 +26,6 @@ import { FatalError } from "../errors.js";
 import { BooleanValue, ConcreteValue, NullValue, ObjectValue, UndefinedValue, Value } from "../values/index.js";
 import {
   GetValue,
-  PutValue,
   SetFunctionName,
   IsAnonymousFunctionDefinition,
   IsIdentifierRef,
@@ -35,6 +34,7 @@ import {
   composeNormalCompletions,
   unbundleNormalCompletion,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 
 import * as t from "babel-types";
 import invariant from "../invariant.js";
@@ -91,7 +91,7 @@ export default function(
       }
 
       // f. Perform ? PutValue(lref, rval).
-      PutValue(realm, lref, rval);
+      Properties.PutValue(realm, lref, rval);
 
       // g. Return rval.
       let resultAst = t.assignmentExpression(ast.operator, (last: any), (rast: any));

--- a/src/realm.js
+++ b/src/realm.js
@@ -33,7 +33,6 @@ import {
   composePossiblyNormalCompletions,
   Construct,
   incorporateSavedCompletion,
-  ThrowIfMightHaveBeenDeleted,
   ToString,
   updatePossiblyNormalCompletionWithSubsequentEffects,
 } from "./methods/index.js";
@@ -42,6 +41,7 @@ import type { Compatibility, RealmOptions } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
 import { Generator, PreludeGenerator } from "./utils/generator.js";
+import { Properties } from "./singletons.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
 import * as t from "babel-types";
 
@@ -737,7 +737,7 @@ export class Realm {
       if (binding === undefined || binding.descriptor === undefined) continue; // deleted
       invariant(binding.descriptor !== undefined);
       let value = binding.descriptor.value;
-      ThrowIfMightHaveBeenDeleted(value);
+      Properties.ThrowIfMightHaveBeenDeleted(value);
       if (value === undefined) {
         AbstractValue.reportIntrospectionError(abstractValue, key);
         throw new FatalError();

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { PathType } from "./types.js";
+
+export let Path: PathType = (null: any);
+
+export function setPath(singleton: PathType) {
+  Path = singleton;
+}

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -9,10 +9,15 @@
 
 /* @flow */
 
-import type { PathType } from "./types.js";
+import type { PathType, PropertiesType } from "./types.js";
 
 export let Path: PathType = (null: any);
+export let Properties: PropertiesType = (null: any);
 
 export function setPath(singleton: PathType) {
   Path = singleton;
+}
+
+export function setProperties(singleton: PropertiesType) {
+  Properties = singleton;
 }

--- a/src/types.js
+++ b/src/types.js
@@ -289,3 +289,9 @@ export type DebugServerType = {
   checkForActions: BabelNode => void,
   shutdown: () => void,
 };
+
+export type PathType = {
+  implies(condition: AbstractValue): boolean,
+  withCondition<T>(condition: AbstractValue, evaluate: () => T): T,
+  withInverseCondition<T>(condition: AbstractValue, evaluate: () => T): T,
+};

--- a/src/types.js
+++ b/src/types.js
@@ -10,21 +10,24 @@
 /* @flow */
 
 import type {
-  NumberValue,
+  AbstractObjectValue,
   AbstractValue,
+  ArrayValue,
   BooleanValue,
-  NativeFunctionValue,
+  EmptyValue,
   FunctionValue,
+  NativeFunctionValue,
+  NullValue,
+  NumberValue,
   StringValue,
   SymbolValue,
   UndefinedValue,
-  NullValue,
-  EmptyValue,
   Value,
-  AbstractObjectValue,
 } from "./values/index.js";
+import { LexicalEnvironment, Reference } from "./environment.js";
 import { ObjectValue } from "./values/index.js";
-import { BabelNode } from "babel-types";
+import type { BabelNode, BabelNodeClassMethod, BabelNodeObjectMethod } from "babel-types";
+import { Realm } from "./realm.js";
 
 export const ElementSize = {
   Float32: 4,
@@ -294,4 +297,82 @@ export type PathType = {
   implies(condition: AbstractValue): boolean,
   withCondition<T>(condition: AbstractValue, evaluate: () => T): T,
   withInverseCondition<T>(condition: AbstractValue, evaluate: () => T): T,
+};
+
+export type PropertiesType = {
+  // ECMA262 9.1.9.1
+  OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value, Receiver: Value): boolean,
+
+  // ECMA262 6.2.4.4
+  FromPropertyDescriptor(realm: Realm, Desc: ?Descriptor): Value,
+
+  //
+  OrdinaryDelete(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean,
+
+  // ECMA262 7.3.8
+  DeletePropertyOrThrow(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean,
+
+  // ECMA262 6.2.4.6
+  CompletePropertyDescriptor(realm: Realm, Desc: Descriptor): Descriptor,
+
+  // ECMA262 9.1.6.2
+  IsCompatiblePropertyDescriptor(realm: Realm, extensible: boolean, Desc: Descriptor, current: ?Descriptor): boolean,
+
+  // ECMA262 9.1.6.3
+  ValidateAndApplyPropertyDescriptor(
+    realm: Realm,
+    O: void | ObjectValue,
+    P: void | PropertyKeyValue,
+    extensible: boolean,
+    Desc: Descriptor,
+    current: ?Descriptor
+  ): boolean,
+
+  // ECMA262 9.1.6.1
+  OrdinaryDefineOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, Desc: Descriptor): boolean,
+
+  // ECMA262 19.1.2.3.1
+  ObjectDefineProperties(realm: Realm, O: Value, Properties: Value): ObjectValue | AbstractObjectValue,
+
+  // ECMA262 7.3.3
+  Set(realm: Realm, O: ObjectValue | AbstractObjectValue, P: PropertyKeyValue, V: Value, Throw: boolean): boolean,
+
+  // ECMA262 7.3.7
+  DefinePropertyOrThrow(
+    realm: Realm,
+    O: ObjectValue | AbstractObjectValue,
+    P: PropertyKeyValue,
+    desc: Descriptor
+  ): boolean,
+
+  // ECMA262 6.2.3.2
+  PutValue(realm: Realm, V: Value | Reference, W: Value): void | boolean | Value,
+
+  // ECMA262 9.4.2.4
+  ArraySetLength(realm: Realm, A: ArrayValue, Desc: Descriptor): boolean,
+
+  // ECMA262 9.1.5.1
+  OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue): Descriptor | void,
+
+  // ECMA262 9.1.2.1
+  OrdinarySetPrototypeOf(realm: Realm, O: ObjectValue, V: ObjectValue | NullValue): boolean,
+
+  // ECMA262 13.7.5.15
+  EnumerateObjectProperties(realm: Realm, O: ObjectValue): ObjectValue,
+
+  ThrowIfMightHaveBeenDeleted(
+    value: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
+  ): void,
+
+  ThrowIfInternalSlotNotWritable<T: ObjectValue>(realm: Realm, object: T, key: string): T,
+
+  // ECMA 14.3.9
+  PropertyDefinitionEvaluation(
+    realm: Realm,
+    MethodDefinition: BabelNodeObjectMethod | BabelNodeClassMethod,
+    object: ObjectValue,
+    env: LexicalEnvironment,
+    strictCode: boolean,
+    enumerable: boolean
+  ): boolean,
 };

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -12,29 +12,40 @@
 import { AbstractValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
 import invariant from "../invariant.js";
 
-export function withPathCondition<T>(condition: AbstractValue, evaluate: () => T): T {
-  let realm = condition.$Realm;
-  let savedPath = realm.pathConditions;
-  realm.pathConditions = [];
-  try {
-    pushPathCondition(condition);
-    pushRefinedConditions(savedPath);
-    return evaluate();
-  } finally {
-    realm.pathConditions = savedPath;
+export class PathImplementation {
+  implies(condition: AbstractValue): boolean {
+    let path = condition.$Realm.pathConditions;
+    for (let i = path.length - 1; i >= 0; i--) {
+      let pathCondition = path[i];
+      if (pathCondition.implies(condition)) return true;
+    }
+    return false;
   }
-}
 
-export function withInversePathCondition<T>(condition: AbstractValue, evaluate: () => T): T {
-  let realm = condition.$Realm;
-  let savedPath = realm.pathConditions;
-  realm.pathConditions = [];
-  try {
-    pushInversePathCondition(condition);
-    pushRefinedConditions(savedPath);
-    return evaluate();
-  } finally {
-    realm.pathConditions = savedPath;
+  withCondition<T>(condition: AbstractValue, evaluate: () => T): T {
+    let realm = condition.$Realm;
+    let savedPath = realm.pathConditions;
+    realm.pathConditions = [];
+    try {
+      pushPathCondition(condition);
+      pushRefinedConditions(savedPath);
+      return evaluate();
+    } finally {
+      realm.pathConditions = savedPath;
+    }
+  }
+
+  withInverseCondition<T>(condition: AbstractValue, evaluate: () => T): T {
+    let realm = condition.$Realm;
+    let savedPath = realm.pathConditions;
+    realm.pathConditions = [];
+    try {
+      pushInversePathCondition(condition);
+      pushRefinedConditions(savedPath);
+      return evaluate();
+    } finally {
+      realm.pathConditions = savedPath;
+    }
   }
 }
 

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -16,6 +16,7 @@ import invariant from "../invariant.js";
 import { ToBoolean } from "../methods/index.js";
 import { Realm } from "../realm.js";
 import { AbstractValue, BooleanValue, ConcreteValue, Value } from "../values/index.js";
+import { Path } from "../singletons.js";
 
 export default function simplifyAndRefineAbstractValue(
   realm: Realm,
@@ -36,15 +37,6 @@ export default function simplifyAndRefineAbstractValue(
     realm.errorHandler = savedHandler;
     realm.isReadOnly = savedIsReadOnly;
   }
-}
-
-function pathImplies(condition: AbstractValue): boolean {
-  let path = condition.$Realm.pathConditions;
-  for (let i = path.length - 1; i >= 0; i--) {
-    let pathCondition = path[i];
-    if (pathCondition.implies(condition)) return true;
-  }
-  return false;
 }
 
 function simplify(realm, value: Value, isCondition: boolean = false): Value {
@@ -103,16 +95,16 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       if (!c.mightNotBeTrue()) return x;
       if (!c.mightNotBeFalse()) return y;
       invariant(c instanceof AbstractValue);
-      if (pathImplies(c)) return x;
+      if (Path.implies(c)) return x;
       let notc = AbstractValue.createFromUnaryOp(realm, "!", c);
       if (!notc.mightNotBeTrue()) return y;
       if (!notc.mightNotBeFalse()) return x;
       invariant(notc instanceof AbstractValue);
-      if (pathImplies(notc)) return y;
-      if (pathImplies(AbstractValue.createFromBinaryOp(realm, "===", value, x))) return x;
-      if (pathImplies(AbstractValue.createFromBinaryOp(realm, "!==", value, x))) return y;
-      if (pathImplies(AbstractValue.createFromBinaryOp(realm, "!==", value, y))) return x;
-      if (pathImplies(AbstractValue.createFromBinaryOp(realm, "===", value, y))) return y;
+      if (Path.implies(notc)) return y;
+      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, x))) return x;
+      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, x))) return y;
+      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, y))) return x;
+      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, y))) return y;
       // c ? x : x <=> x
       if (x.equals(y)) return x;
       // x ? x : y <=> x || y
@@ -146,8 +138,8 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       invariant(abstractValue instanceof AbstractValue);
       let remainingConcreteValues = [];
       for (let concreteValue of concreteValues) {
-        if (pathImplies(AbstractValue.createFromBinaryOp(realm, "!==", value, concreteValue))) continue;
-        if (pathImplies(AbstractValue.createFromBinaryOp(realm, "===", value, concreteValue))) return concreteValue;
+        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, concreteValue))) continue;
+        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, concreteValue))) return concreteValue;
         remainingConcreteValues.push(concreteValue);
       }
       if (remainingConcreteValues.length === 0) return abstractValue;

--- a/src/values/ArgumentsExotic.js
+++ b/src/values/ArgumentsExotic.js
@@ -12,18 +12,11 @@
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
 import { ObjectValue, Value } from "../values/index.js";
-import {
-  OrdinaryGetOwnProperty,
-  OrdinaryDefineOwnProperty,
-  OrdinaryDelete,
-  Set,
-  OrdinarySet,
-  ThrowIfMightHaveBeenDeleted,
-} from "../methods/properties.js";
 import { IsDataDescriptor, IsAccessorDescriptor } from "../methods/is.js";
 import { HasOwnProperty } from "../methods/has.js";
 import { SameValuePartial } from "../methods/abstract.js";
 import { Get, OrdinaryGet } from "../methods/get.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant";
 
 export default class ArgumentsExotic extends ObjectValue {
@@ -39,11 +32,11 @@ export default class ArgumentsExotic extends ObjectValue {
     let args = this;
 
     // 2. Let desc be OrdinaryGetOwnProperty(args, P).
-    let desc = OrdinaryGetOwnProperty(this.$Realm, args, P);
+    let desc = Properties.OrdinaryGetOwnProperty(this.$Realm, args, P);
 
     // 3. If desc is undefined, return desc.
     if (desc === undefined) return undefined;
-    ThrowIfMightHaveBeenDeleted(desc.value);
+    Properties.ThrowIfMightHaveBeenDeleted(desc.value);
 
     // 4. Let map be args.[[ParameterMap]].
     let map = args.$ParameterMap;
@@ -90,7 +83,7 @@ export default class ArgumentsExotic extends ObjectValue {
     }
 
     // 6. Let allowed be ? OrdinaryDefineOwnProperty(args, P, newArgDesc).
-    let allowed = OrdinaryDefineOwnProperty(this.$Realm, args, P, newArgDesc);
+    let allowed = Properties.OrdinaryDefineOwnProperty(this.$Realm, args, P, newArgDesc);
 
     // 7. If allowed is false, return false.
     if (allowed === false) return false;
@@ -107,7 +100,7 @@ export default class ArgumentsExotic extends ObjectValue {
         if (Desc.value !== undefined) {
           // 1. Let setStatus be Set(map, P, Desc.[[Value]], false).
           invariant(Desc.value instanceof Value);
-          let setStatus = Set(this.$Realm, map, P, Desc.value, false);
+          let setStatus = Properties.Set(this.$Realm, map, P, Desc.value, false);
 
           // 2. Assert: setStatus is true because formal parameters mapped by argument objects are always writable.
           invariant(setStatus === true);
@@ -172,14 +165,14 @@ export default class ArgumentsExotic extends ObjectValue {
     if (isMapped === true) {
       invariant(map);
       // a. Let setStatus be Set(map, P, V, false).
-      let setStatus = Set(this.$Realm, map, P, V, false);
+      let setStatus = Properties.Set(this.$Realm, map, P, V, false);
 
       // b. Assert: setStatus is true because formal parameters mapped by argument objects are always writable.
       invariant(setStatus === true);
     }
 
     // 5. Return ? OrdinarySet(args, P, V, Receiver).
-    return OrdinarySet(this.$Realm, args, P, V, Receiver);
+    return Properties.OrdinarySet(this.$Realm, args, P, V, Receiver);
   }
 
   // ECMA262 9.4.4.5
@@ -195,7 +188,7 @@ export default class ArgumentsExotic extends ObjectValue {
     let isMapped = HasOwnProperty(this.$Realm, map, P);
 
     // 4. Let result be ? OrdinaryDelete(args, P).
-    let result = OrdinaryDelete(this.$Realm, args, P);
+    let result = Properties.OrdinaryDelete(this.$Realm, args, P);
 
     // 5. If result is true and isMapped is true, then
     if (result === true && isMapped === true) {

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -12,14 +12,9 @@
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor, ObjectKind } from "../types.js";
 import { ObjectValue, StringValue, NumberValue, Value } from "./index.js";
-import { ArraySetLength } from "../methods/properties.js";
-import {
-  OrdinaryGetOwnProperty,
-  OrdinaryDefineOwnProperty,
-  ThrowIfMightHaveBeenDeleted,
-} from "../methods/properties.js";
 import { IsAccessorDescriptor, IsPropertyKey, IsArrayIndex } from "../methods/is.js";
 import { ToUint32 } from "../methods/to.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 export default class ArrayValue extends ObjectValue {
@@ -45,12 +40,12 @@ export default class ArrayValue extends ObjectValue {
     // 2. If P is "length", then
     if (P === "length" || (P instanceof StringValue && P.value === "length")) {
       // a. Return ? ArraySetLength(A, Desc).
-      return ArraySetLength(this.$Realm, A, Desc);
+      return Properties.ArraySetLength(this.$Realm, A, Desc);
     } else if (IsArrayIndex(this.$Realm, P)) {
       // 3. Else if P is an array index, then
 
       // a. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").
-      let oldLenDesc = OrdinaryGetOwnProperty(this.$Realm, A, "length");
+      let oldLenDesc = Properties.OrdinaryGetOwnProperty(this.$Realm, A, "length");
 
       // b. Assert: oldLenDesc will never be undefined or an accessor descriptor because Array objects are
       //    created with a length data property that cannot be deleted or reconfigured.
@@ -58,7 +53,7 @@ export default class ArrayValue extends ObjectValue {
         oldLenDesc !== undefined && !IsAccessorDescriptor(this.$Realm, oldLenDesc),
         "cannot be undefined or an accessor descriptor"
       );
-      ThrowIfMightHaveBeenDeleted(oldLenDesc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(oldLenDesc.value);
 
       // c. Let oldLen be oldLenDesc.[[Value]].
       let oldLen = oldLenDesc.value;
@@ -74,7 +69,7 @@ export default class ArrayValue extends ObjectValue {
       if (index >= oldLen && oldLenDesc.writable === false) return false;
 
       // f. Let succeeded be ! OrdinaryDefineOwnProperty(A, P, Desc).
-      let succeeded = OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
+      let succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
 
       // g. If succeeded is false, return false.
       if (succeeded === false) return false;
@@ -85,7 +80,7 @@ export default class ArrayValue extends ObjectValue {
         oldLenDesc.value = new NumberValue(this.$Realm, index + 1);
 
         // ii. Let succeeded be OrdinaryDefineOwnProperty(A, "length", oldLenDesc).
-        succeeded = OrdinaryDefineOwnProperty(this.$Realm, A, "length", oldLenDesc);
+        succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, "length", oldLenDesc);
 
         // iii. Assert: succeeded is true.
         invariant(succeeded, "expected length definition to succeed");
@@ -96,6 +91,6 @@ export default class ArrayValue extends ObjectValue {
     }
 
     // 1. Return OrdinaryDefineOwnProperty(A, P, Desc).
-    return OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
+    return Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
   }
 }

--- a/src/values/IntegerIndexedExotic.js
+++ b/src/values/IntegerIndexedExotic.js
@@ -12,12 +12,12 @@
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
 import { ObjectValue, NumberValue, StringValue, Value, UndefinedValue } from "../values/index.js";
-import { OrdinaryGetOwnProperty, OrdinaryDefineOwnProperty, OrdinarySet } from "../methods/properties.js";
 import { CanonicalNumericIndexString, ToString } from "../methods/to.js";
 import { IsInteger, IsArrayIndex, IsAccessorDescriptor, IsDetachedBuffer, IsPropertyKey } from "../methods/is.js";
 import { OrdinaryGet } from "../methods/get.js";
 import { OrdinaryHasProperty } from "../methods/has.js";
 import { IntegerIndexedElementSet, IntegerIndexedElementGet } from "../methods/typedarray.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant";
 
 export default class IntegerIndexedExotic extends ObjectValue {
@@ -61,7 +61,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
       }
     }
     // 4. Return OrdinaryGetOwnProperty(O, P).
-    return OrdinaryGetOwnProperty(this.$Realm, O, P);
+    return Properties.OrdinaryGetOwnProperty(this.$Realm, O, P);
   }
 
   // ECMA262 9.4.5.2
@@ -182,7 +182,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     }
 
     // 4. Return ! OrdinaryDefineOwnProperty(O, P, Desc).
-    return OrdinaryDefineOwnProperty(this.$Realm, O, P, Desc);
+    return Properties.OrdinaryDefineOwnProperty(this.$Realm, O, P, Desc);
   }
 
   // ECMA262 9.4.5.4
@@ -234,7 +234,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     }
 
     // 3. Return ? OrdinarySet(O, P, V, Receiver).
-    return OrdinarySet(this.$Realm, O, P, V, Receiver);
+    return Properties.OrdinarySet(this.$Realm, O, P, V, Receiver);
   }
 
   // ECMA262 9.4.5.6

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -39,18 +39,13 @@ import type { ECMAScriptSourceFunctionValue, NativeFunctionCallback } from "./in
 import {
   joinValuesAsConditional,
   IsDataDescriptor,
-  OrdinarySetPrototypeOf,
-  OrdinaryDefineOwnProperty,
-  OrdinaryDelete,
   OrdinaryOwnPropertyKeys,
-  OrdinaryGetOwnProperty,
   OrdinaryGet,
   OrdinaryHasProperty,
-  OrdinarySet,
   OrdinaryIsExtensible,
   OrdinaryPreventExtensions,
-  ThrowIfMightHaveBeenDeleted,
 } from "../methods/index.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { typeAnnotation } from "babel-types";
 
@@ -432,7 +427,7 @@ export default class ObjectValue extends ConcreteValue {
     for (let [key, propertyBinding] of this.properties) {
       let desc = propertyBinding.descriptor;
       if (desc === undefined) continue; // deleted
-      ThrowIfMightHaveBeenDeleted(desc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(desc.value);
       let serializedDesc: any = { enumerable: desc.enumerable, configurable: desc.configurable };
       if (desc.value) {
         serializedDesc.writable = desc.writable;
@@ -457,7 +452,7 @@ export default class ObjectValue extends ConcreteValue {
   // ECMA262 9.1.2
   $SetPrototypeOf(V: ObjectValue | NullValue): boolean {
     // 1. Return ! OrdinarySetPrototypeOf(O, V).
-    return OrdinarySetPrototypeOf(this.$Realm, this, V);
+    return Properties.OrdinarySetPrototypeOf(this.$Realm, this, V);
   }
 
   // ECMA262 9.1.3
@@ -475,13 +470,13 @@ export default class ObjectValue extends ConcreteValue {
   // ECMA262 9.1.5
   $GetOwnProperty(P: PropertyKeyValue): Descriptor | void {
     // 1. Return ! OrdinaryGetOwnProperty(O, P).
-    return OrdinaryGetOwnProperty(this.$Realm, this, P);
+    return Properties.OrdinaryGetOwnProperty(this.$Realm, this, P);
   }
 
   // ECMA262 9.1.6
   $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor): boolean {
     // 1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    return OrdinaryDefineOwnProperty(this.$Realm, this, P, Desc);
+    return Properties.OrdinaryDefineOwnProperty(this.$Realm, this, P, Desc);
   }
 
   // ECMA262 9.1.7
@@ -586,7 +581,7 @@ export default class ObjectValue extends ConcreteValue {
   // ECMA262 9.1.9
   $Set(P: PropertyKeyValue, V: Value, Receiver: Value): boolean {
     // 1. Return ? OrdinarySet(O, P, V, Receiver).
-    return OrdinarySet(this.$Realm, this, P, V, Receiver);
+    return Properties.OrdinarySet(this.$Realm, this, P, V, Receiver);
   }
 
   $SetPartial(P: AbstractValue | PropertyKeyValue, V: Value, Receiver: Value): boolean {
@@ -658,7 +653,7 @@ export default class ObjectValue extends ConcreteValue {
       }
       let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", P, new StringValue(this.$Realm, key));
       let newVal = joinValuesAsConditional(this.$Realm, cond, V, oldVal);
-      OrdinarySet(this.$Realm, this, key, newVal, Receiver);
+      Properties.OrdinarySet(this.$Realm, this, key, newVal, Receiver);
     }
 
     return true;
@@ -673,7 +668,7 @@ export default class ObjectValue extends ConcreteValue {
     }
 
     // 1. Return ? OrdinaryDelete(O, P).
-    return OrdinaryDelete(this.$Realm, this, P);
+    return Properties.OrdinaryDelete(this.$Realm, this, P);
   }
 
   // ECMA262 9.1.11

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -18,12 +18,7 @@ import { SameValue, SameValuePartial, SamePropertyKey } from "../methods/abstrac
 import { GetMethod } from "../methods/get.js";
 import { CreateListFromArrayLike } from "../methods/create.js";
 import { IsExtensible, IsPropertyKey, IsDataDescriptor, IsAccessorDescriptor } from "../methods/is.js";
-import {
-  FromPropertyDescriptor,
-  CompletePropertyDescriptor,
-  IsCompatiblePropertyDescriptor,
-  ThrowIfMightHaveBeenDeleted,
-} from "../methods/properties.js";
+import { Properties } from "../singletons.js";
 import { Call } from "../methods/call.js";
 
 function FindPropertyKey(realm: Realm, keys: Array<PropertyKeyValue>, key: PropertyKeyValue): number {
@@ -305,7 +300,7 @@ export default class ProxyValue extends ObjectValue {
     if (trapResultObj instanceof UndefinedValue) {
       // a. If targetDesc is undefined, return undefined.
       if (!targetDesc) return undefined;
-      ThrowIfMightHaveBeenDeleted(targetDesc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(targetDesc.value);
 
       // b. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
       if (!targetDesc.configurable) {
@@ -334,10 +329,10 @@ export default class ProxyValue extends ObjectValue {
     let resultDesc = ToPropertyDescriptor(realm, trapResultObj);
 
     // 14. Call CompletePropertyDescriptor(resultDesc).
-    CompletePropertyDescriptor(realm, resultDesc);
+    Properties.CompletePropertyDescriptor(realm, resultDesc);
 
     // 15. Let valid be IsCompatiblePropertyDescriptor(extensibleTarget, resultDesc, targetDesc).
-    let valid = IsCompatiblePropertyDescriptor(realm, extensibleTarget, resultDesc, targetDesc);
+    let valid = Properties.IsCompatiblePropertyDescriptor(realm, extensibleTarget, resultDesc, targetDesc);
 
     // 16. If valid is false, throw a TypeError exception.
     if (!valid) {
@@ -389,7 +384,7 @@ export default class ProxyValue extends ObjectValue {
     }
 
     // 8. Let descObj be FromPropertyDescriptor(Desc).
-    let descObj = FromPropertyDescriptor(realm, Desc);
+    let descObj = Properties.FromPropertyDescriptor(realm, Desc);
 
     // 9. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P, descObj »)).
     let booleanTrapResult = ToBooleanPartial(
@@ -429,10 +424,10 @@ export default class ProxyValue extends ObjectValue {
       }
     } else {
       // 16. Else targetDesc is not undefined,
-      ThrowIfMightHaveBeenDeleted(targetDesc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(targetDesc.value);
 
       // a. If IsCompatiblePropertyDescriptor(extensibleTarget, Desc, targetDesc) is false, throw a TypeError exception.
-      if (!IsCompatiblePropertyDescriptor(realm, extensibleTarget, Desc, targetDesc)) {
+      if (!Properties.IsCompatiblePropertyDescriptor(realm, extensibleTarget, Desc, targetDesc)) {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
       }
 
@@ -490,7 +485,7 @@ export default class ProxyValue extends ObjectValue {
 
       // b. If targetDesc is not undefined, then
       if (targetDesc) {
-        ThrowIfMightHaveBeenDeleted(targetDesc.value);
+        Properties.ThrowIfMightHaveBeenDeleted(targetDesc.value);
 
         // i. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
         if (!targetDesc.configurable) {
@@ -554,7 +549,7 @@ export default class ProxyValue extends ObjectValue {
 
     // 10. If targetDesc is not undefined, then
     if (targetDesc) {
-      ThrowIfMightHaveBeenDeleted(targetDesc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(targetDesc.value);
 
       // a. If IsDataDescriptor(targetDesc) is true and targetDesc.[[Configurable]] is false and targetDesc.[[Writable]] is false, then
       if (IsDataDescriptor(realm, targetDesc) && targetDesc.configurable === false && targetDesc.writable === false) {
@@ -629,7 +624,7 @@ export default class ProxyValue extends ObjectValue {
 
     // 11. If targetDesc is not undefined, then
     if (targetDesc) {
-      ThrowIfMightHaveBeenDeleted(targetDesc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(targetDesc.value);
 
       // a. If IsDataDescriptor(targetDesc) is true and targetDesc.[[Configurable]] is false and targetDesc.[[Writable]] is false, then
       if (IsDataDescriptor(realm, targetDesc) && !targetDesc.configurable && !targetDesc.writable) {
@@ -700,7 +695,7 @@ export default class ProxyValue extends ObjectValue {
 
     // 11. If targetDesc is undefined, return true.
     if (!targetDesc) return true;
-    ThrowIfMightHaveBeenDeleted(targetDesc.value);
+    Properties.ThrowIfMightHaveBeenDeleted(targetDesc.value);
 
     // 12. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
     if (!targetDesc.configurable) {
@@ -769,7 +764,7 @@ export default class ProxyValue extends ObjectValue {
     for (let key of targetKeys) {
       // a. Let desc be ? target.[[GetOwnProperty]](key).
       let desc = target.$GetOwnProperty(key);
-      if (desc) ThrowIfMightHaveBeenDeleted(desc.value);
+      if (desc) Properties.ThrowIfMightHaveBeenDeleted(desc.value);
 
       // b. If desc is not undefined and desc.[[Configurable]] is false, then
       if (desc && desc.configurable === false) {

--- a/src/values/StringExotic.js
+++ b/src/values/StringExotic.js
@@ -12,10 +12,10 @@
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
 import { ObjectValue, NumberValue, StringValue } from "../values/index.js";
-import { OrdinaryGetOwnProperty, ThrowIfMightHaveBeenDeleted } from "../methods/properties.js";
 import { CanonicalNumericIndexString } from "../methods/to.js";
 import { IsInteger, IsArrayIndex } from "../methods/is.js";
 import { ToString, ToInteger } from "../methods/to.js";
+import { Properties } from "../singletons.js";
 import invariant from "../invariant";
 
 export default class StringExotic extends ObjectValue {
@@ -28,11 +28,11 @@ export default class StringExotic extends ObjectValue {
     // 1. Assert: IsPropertyKey(P) is true.
 
     // 2. Let desc be OrdinaryGetOwnProperty(S, P).
-    let desc = OrdinaryGetOwnProperty(this.$Realm, this, P);
+    let desc = Properties.OrdinaryGetOwnProperty(this.$Realm, this, P);
 
     // 3. If desc is not undefined, return desc.
     if (desc !== undefined) {
-      ThrowIfMightHaveBeenDeleted(desc.value);
+      Properties.ThrowIfMightHaveBeenDeleted(desc.value);
       return desc;
     }
 


### PR DESCRIPTION
In our current setup a big group of beefy modules form an import cycle and Flow needs to analyze the entire cycle together, which makes type checking with Flow very slow for us.

The length of the cycle has also crept up from 52 to 62 in recent months, despite an explicit check-in gate designed to prevent this.

Reducing the cycle is not trivial, since the degree of connectivity from one node to another is quite high and because there is no tooling for finding the least connected node and removing that from the cycle.

So, with this request, I'm starting down the road of introducing an abstract class for each module in the methods directory and then changing the module to into a class where every exported static function becomes an instance method of an implementation class with a singleton instance. The instance is found via the singletons.js module, which does not have dependencies on the implementation modules. The properties of the singleton module are initialized, early on, in the default function of the contruct_realm.js module.

As of yet, the cycle count has not decreased, but two beefy nodes have been exchanged for two smaller nodes.