### PR TITLE
Set up debugger variables requests

### DIFF
--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -149,7 +149,7 @@ export class DebugServer {
         break;
       case DebugMessage.PREPACK_RUN_COMMAND:
         invariant(args.kind === "run");
-        this._doPreRunActions();
+        this._onDebuggeeResume();
         return true;
       case DebugMessage.STACKFRAMES_COMMAND:
         invariant(args.kind === "stackframe");
@@ -242,7 +242,7 @@ export class DebugServer {
   }
 
   // actions that need to happen before Prepack can resume
-  _doPreRunActions() {
+  _onDebuggeeResume() {
     // resets the variable manager
     this._variableManager.clean();
   }

--- a/src/debugger/ReferenceMap.js
+++ b/src/debugger/ReferenceMap.js
@@ -14,9 +14,11 @@
 // specifies fetching variable collections via unique IDs
 export class ReferenceMap<T> {
   constructor() {
-    this._mapping = [];
+    // index 0 is reserved for indicating there are no nested variables so we
+    // don't let any defined value occupy it here
+    this._mapping = [undefined];
   }
-  _mapping: Array<T>;
+  _mapping: Array<void | T>;
 
   add(value: T): number {
     this._mapping.push(value);

--- a/src/debugger/ReferenceMap.js
+++ b/src/debugger/ReferenceMap.js
@@ -14,18 +14,24 @@
 // specifies fetching variable collections via unique IDs
 export class ReferenceMap<T> {
   constructor() {
-    // index 0 is reserved for indicating there are no nested variables so we
-    // don't let any defined value occupy it here
-    this._mapping = [undefined];
+    this._counter = 0;
+    this._mapping = new Map();
   }
-  _mapping: Array<void | T>;
+  _counter: number;
+  _mapping: { [number]: T };
 
   add(value: T): number {
-    this._mapping.push(value);
-    return this._mapping.length - 1;
+    this._counter++;
+    this._mapping[this._counter] = value;
+    return this._counter;
   }
 
   get(reference: number): void | T {
     return this._mapping[reference];
+  }
+
+  clean() {
+    this._counter = 0;
+    this._mapping = new Map();
   }
 }

--- a/src/debugger/VariableFactory.js
+++ b/src/debugger/VariableFactory.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { VariableContainer, Variable } from "./types.js";
+import { ReferenceMap } from "./ReferenceMap.js";
+import { LexicalEnvironment, DeclarativeEnvironmentRecord } from "./../environment.js";
+import { Value, ConcreteValue, PrimitiveValue } from "./../values/index.js";
+
+export class VariableFactory {
+  constructor() {
+    this._referenceMap = new ReferenceMap();
+  }
+  _referenceMap: ReferenceMap<VariableContainer>;
+
+  createReference(value: VariableContainer): number {
+    return this._referenceMap.add(value);
+  }
+
+  getVariablesByReference(reference: number): Array<Variable> {
+    let container = this._referenceMap.get(reference);
+    if (!container) return [];
+    if (container instanceof LexicalEnvironment) {
+      return this._getVariablesFromEnv(container);
+    }
+    return [];
+  }
+
+  _getVariablesFromEnv(env: LexicalEnvironment): Array<Variable> {
+    let envRecord = env.environmentRecord;
+    if (envRecord instanceof DeclarativeEnvironmentRecord) {
+      return this._getVariablesFromDeclarativeEnv(envRecord);
+    }
+    return [];
+  }
+
+  _getVariablesFromDeclarativeEnv(env: DeclarativeEnvironmentRecord): Array<Variable> {
+    let variables = [];
+    let bindings = env.bindings;
+    for (let name in bindings) {
+      let binding = bindings[name];
+      if (binding.value) {
+        let displayValue = this._getDisplayValue(binding.value);
+        let variable: Variable = {
+          name: name,
+          value: displayValue,
+          variablesReference: 0,
+        };
+        variables.push(variable);
+      }
+    }
+    return variables;
+  }
+
+  _getDisplayValue(value: Value): string {
+    let displayValue = "to be supported";
+    if (value instanceof ConcreteValue) {
+      displayValue = this._getConcreteDisplayValue(value);
+    }
+    return displayValue;
+  }
+
+  _getConcreteDisplayValue(value: ConcreteValue): string {
+    if (value instanceof PrimitiveValue) {
+      return value.toDisplayString();
+    }
+    return "to be supported";
+  }
+}

--- a/src/debugger/VariableManager.js
+++ b/src/debugger/VariableManager.js
@@ -33,7 +33,7 @@ export class VariableManager {
   // it exists or return a new reference
   getReferenceForValue(value: VariableContainer): number {
     let cachedRef = this._containerCache.get(value);
-    if (cachedRef) {
+    if (cachedRef !== undefined) {
       return cachedRef;
     }
 
@@ -49,6 +49,7 @@ export class VariableManager {
     if (container instanceof LexicalEnvironment) {
       return this._getVariablesFromEnv(container);
     }
+    // TODO: implement retrieving variables for other types of containers
     return [];
   }
 
@@ -57,6 +58,7 @@ export class VariableManager {
     if (envRecord instanceof DeclarativeEnvironmentRecord) {
       return this._getVariablesFromDeclarativeEnv(envRecord);
     }
+    // TODO: implement retrieving variables for other kinds of environment records
     return [];
   }
 

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -197,6 +197,31 @@ class PrepackDebugSession extends LoggingDebugSession {
       this.sendResponse(response);
     });
   }
+
+  variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments): void {
+    this._adapterChannel.getVariables(
+      response.request_seq,
+      args.variablesReference,
+      (dbgResponse: DebuggerResponse) => {
+        let result = dbgResponse.result;
+        invariant(result.kind === "variables");
+        let variableInfos = result.variables;
+        let variables: Array<DebugProtocol.Variable> = [];
+        for (const varInfo of variableInfos) {
+          let variable: DebugProtocol.Variable = {
+            name: varInfo.name,
+            value: varInfo.value,
+            variablesReference: varInfo.variablesReference,
+          };
+          variables.push(variable);
+        }
+        response.body = {
+          variables: variables,
+        };
+        this.sendResponse(response);
+      }
+    );
+  }
 }
 
 DebugSession.run(PrepackDebugSession);

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -74,6 +74,11 @@ export class AdapterChannel {
       this._prepackWaiting = true;
       this._processRequestCallback(requestID, dbgResponse);
       this.trySendNextRequest();
+    } else if (messageType === DebugMessage.VARIABLES_RESPONSE) {
+      let dbgResponse = this._marshaller.unmarshallVariablesResponse(requestID, parts.slice(2).join(" "));
+      this._prepackWaiting = true;
+      this._processRequestCallback(requestID, dbgResponse);
+      this.trySendNextRequest();
     }
   }
 
@@ -160,6 +165,12 @@ export class AdapterChannel {
 
   getScopes(requestID: number, frameId: number, callback: DebuggerResponse => void) {
     this._queue.enqueue(this._marshaller.marshallScopesRequest(requestID, frameId));
+    this.trySendNextRequest();
+    this._addRequestCallback(requestID, callback);
+  }
+
+  getVariables(requestID: number, variablesReference: number, callback: DebuggerResponse => void) {
+    this._queue.enqueue(this._marshaller.marshallVariablesRequest(requestID, variablesReference));
     this.trySendNextRequest();
     this._addRequestCallback(requestID, callback);
   }

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -21,6 +21,7 @@ import type {
   StackframeArguments,
   Stackframe,
   Scope,
+  Variable,
 } from "./../types.js";
 
 //Channel used by the DebugServer in Prepack to communicate with the debug adapter
@@ -92,6 +93,9 @@ export class DebugChannel {
       case DebugMessage.SCOPES_COMMAND:
         args = this._marshaller.unmarshallScopesArguments(requestID, parts[2]);
         break;
+      case DebugMessage.VARIABLES_COMMAND:
+        args = this._marshaller.unmarshallVariablesArguments(requestID, parts[2]);
+        break;
       default:
         throw new DebuggerError("Invalid command", "Invalid command from adapter: " + command);
     }
@@ -134,6 +138,10 @@ export class DebugChannel {
 
   sendScopesResponse(requestID: number, scopes: Array<Scope>): void {
     this.writeOut(this._marshaller.marshallScopesResponse(requestID, scopes));
+  }
+
+  sendVariablesResponse(requestID: number, variables: Array<Variable>): void {
+    this.writeOut(this._marshaller.marshallVariablesResponse(requestID, variables));
   }
 
   sendPrepackFinish(): void {

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -28,6 +28,8 @@ export class DebugMessage {
   static STACKFRAMES_COMMAND: string = "Stackframes-command";
   // Command to fetch scopes
   static SCOPES_COMMAND: string = "Scopes-command";
+  // Command to fetch variables
+  static VARIABLES_COMMAND: string = "Variables-command";
 
   /* Messages from Prepack to adapter with requested information */
   // Respond to the adapter that Prepack is ready
@@ -40,6 +42,8 @@ export class DebugMessage {
   static STACKFRAMES_RESPONSE: string = "Stackframes-response";
   // Respond to the adapter with the requested scopes
   static SCOPES_RESPONSE: string = "Scopes-response";
+  // Respond to the adapter with the requested variables
+  static VARIABLES_RESPONSE: string = "Variables-response";
 
   /* Messages from Prepack to adapter to acknowledge having received the request */
   // Acknowledgement for setting a breakpoint

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -141,6 +141,8 @@ export class UISession {
       this._processStackTraceResponse(((response: any): DebugProtocol.StackTraceResponse));
     } else if (response.command === "scopes") {
       this._processScopesResponse(((response: any): DebugProtocol.ScopesResponse));
+    } else if (response.command === "variables") {
+      this._processVariablesResponse(((response: any): DebugProtocol.VariablesResponse));
     }
   }
 
@@ -174,6 +176,17 @@ export class UISession {
   _processThreadsResponse(response: DebugProtocol.ThreadsResponse) {
     for (const thread of response.body.threads) {
       this._uiOutput(`${thread.id}: ${thread.name}`);
+    }
+  }
+
+  _processVariablesResponse(response: DebugProtocol.VariablesResponse) {
+    for (const variable of response.body.variables) {
+      if (variable.variablesReference === 0) {
+        // 0 means there are not more nested variables to return
+        this._uiOutput(`${variable.name}: ${variable.value}`);
+      } else {
+        this._uiOutput(`${variable.name}: ${variable.value} ${variable.variablesReference}`);
+      }
     }
   }
 
@@ -231,6 +244,15 @@ export class UISession {
           frameId: frameId,
         };
         this._sendScopesRequest(scopesArgs);
+        break;
+      case "variables":
+        if (parts.length !== 2) return false;
+        let varRef = parseInt(parts[1], 10);
+        if (isNaN(varRef)) return false;
+        let variableArgs: DebugProtocol.VariablesArguments = {
+          variablesReference: varRef,
+        };
+        this._sendVariablesRequest(variableArgs);
         break;
       default:
         // invalid command
@@ -359,6 +381,17 @@ export class UISession {
       type: "request",
       seq: this._sequenceNum,
       command: "scopes",
+      arguments: args,
+    };
+    let json = JSON.stringify(message);
+    this._packageAndSend(json);
+  }
+
+  _sendVariablesRequest(args: DebugProtocol.VariablesArguments) {
+    let message = {
+      type: "request",
+      seq: this._sequenceNum,
+      command: "variables",
       arguments: args,
     };
     let json = JSON.stringify(message);

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -17,7 +17,12 @@ export type DebuggerRequest = {
   arguments: DebuggerRequestArguments,
 };
 
-export type DebuggerRequestArguments = BreakpointArguments | RunArguments | StackframeArguments | ScopesArguments;
+export type DebuggerRequestArguments =
+  | BreakpointArguments
+  | RunArguments
+  | StackframeArguments
+  | ScopesArguments
+  | VariablesArguments;
 
 export type PrepackLaunchArguments = {
   kind: "launch",
@@ -56,6 +61,11 @@ export type ScopesArguments = {
   frameId: number,
 };
 
+export type VariablesArguments = {
+  kind: "variables",
+  variablesReference: number,
+};
+
 export type DebuggerResponse = {
   id: number,
   result: DebuggerResponseResult,
@@ -66,7 +76,8 @@ export type DebuggerResponseResult =
   | StackframeResult
   | BreakpointAddResult
   | BreakpointStoppedResult
-  | ScopesResult;
+  | ScopesResult
+  | VariablesResult;
 
 export type ReadyResult = {
   kind: "ready",
@@ -96,6 +107,17 @@ export type Scope = {
 export type ScopesResult = {
   kind: "scopes",
   scopes: Array<Scope>,
+};
+
+export type Variable = {
+  name: string,
+  value: string,
+  variablesReference: number,
+};
+
+export type VariablesResult = {
+  kind: "variables",
+  variables: Array<Variable>,
 };
 
 // any object that can contain a collection of variables

--- a/src/values/BooleanValue.js
+++ b/src/values/BooleanValue.js
@@ -42,4 +42,8 @@ export default class BooleanValue extends PrimitiveValue {
   _serialize(): boolean {
     return this.value;
   }
+
+  toDisplayString(): string {
+    return this.value.toString();
+  }
 }

--- a/src/values/NullValue.js
+++ b/src/values/NullValue.js
@@ -27,4 +27,8 @@ export default class NullValue extends PrimitiveValue {
   mightBeFalse(): boolean {
     return true;
   }
+
+  toDisplayValue(): string {
+    return "null";
+  }
 }

--- a/src/values/NumberValue.js
+++ b/src/values/NumberValue.js
@@ -42,4 +42,8 @@ export default class NumberValue extends PrimitiveValue {
   _serialize(): number {
     return this.value;
   }
+
+  toDisplayString(): string {
+    return this.value.toString();
+  }
 }

--- a/src/values/PrimitiveValue.js
+++ b/src/values/PrimitiveValue.js
@@ -22,4 +22,8 @@ export default class PrimitiveValue extends ConcreteValue {
   throwIfNotConcretePrimitive(): PrimitiveValue {
     return this;
   }
+
+  toDisplayString(): string {
+    invariant(false, "abstract method; please override");
+  }
 }

--- a/src/values/StringValue.js
+++ b/src/values/StringValue.js
@@ -40,4 +40,8 @@ export default class StringValue extends PrimitiveValue {
   _serialize(): string {
     return this.value;
   }
+
+  toDisplayString(): string {
+    return `"${this.value}"`;
+  }
 }

--- a/src/values/SymbolValue.js
+++ b/src/values/SymbolValue.js
@@ -44,4 +44,13 @@ export default class SymbolValue extends PrimitiveValue {
   _serialize(): Symbol {
     return Symbol(this.$Description);
   }
+
+  toDisplayString(): string {
+    if (this.$Description) {
+      if (this.$Description instanceof PrimitiveValue) {
+        return `Symbol(${this.$Description.toDisplayString()})`;
+      }
+    }
+    return "Symbol(to be supported)";
+  }
 }

--- a/src/values/UndefinedValue.js
+++ b/src/values/UndefinedValue.js
@@ -27,4 +27,8 @@ export default class UndefinedValue extends PrimitiveValue {
   mightBeFalse(): boolean {
     return true;
   }
+
+  toDisplayString(): string {
+    return "undefined";
+  }
 }


### PR DESCRIPTION
Release note: none
Summary:
-send a variables request from the CLI and receive a response from the engine
-make a toDisplayString method for each PrimitiveValue
-start a VariableFactory class to handle all logic for retrieving and displaying variables
-fetch and display primitive type variables in DeclarativeEnvironmentRecord

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path_to_adapter> --prepack <command_to_run_prepack> --inFilePath <debug_input_file_path> --outFilePath <debug_output_file_path>`
e.g. `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepack "lib/prepack-cli.js test/serializer/basic/Date.js" --inFilePath src/debugger/.sessionlogs/engine2adapter.txt --outFilePath src/debugger/.sessionlogs/adapter2engine.txt`

Supported commands so far:
-`breakpoint add <filePath> <line> ?<column>`: sets a breakpoint at the specified location. If `column` is specified, it is a column breakpoint, otherwise it is a line breakpoint.
-`threads`: display the threads (only 1 in Prepack)
-`stackframes`: fetch the current stack frames when stopped at a breakpoint
-`scopes <frameId>`: fetch the scopes for the given frameId
-`variables <variablesReference>`: fetch variables for the given variablesReference
-`run`: tell Prepack to continue executing, either upon entry or when stopped at a breakpoint
-`exit`: quit the debugger.