### PR TITLE
Do not dead-code eliminate do-while in residual fns

### DIFF
--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -210,16 +210,6 @@ export let ClosureRefReplacer = {
       }
     },
   },
-
-  DoWhileStatement: {
-    exit: function(path: BabelTraversePath, state: ClosureRefReplacerState) {
-      let node = path.node;
-      let testTruthiness = getLiteralTruthiness(node.test);
-      if (testTruthiness.known && !testTruthiness.value) {
-        path.replaceWith(node.body);
-      }
-    },
-  },
 };
 
 function visitName(path, state, name, modified) {

--- a/test/serializer/optimizations/residualDeadCode.js
+++ b/test/serializer/optimizations/residualDeadCode.js
@@ -1,6 +1,6 @@
 // does not contain:eliminate
 // contains:preserve
-// conains:do
+// contains:do
 (function () {
   let f = false;
   let t = true;

--- a/test/serializer/optimizations/residualDeadCode.js
+++ b/test/serializer/optimizations/residualDeadCode.js
@@ -1,6 +1,6 @@
 // does not contain:eliminate
-// does not contain:while
 // contains:preserve
+// conains:do
 (function () {
   let f = false;
   let t = true;
@@ -17,7 +17,7 @@
     t || console.log("eliminate me");
 
     while (f) console.log("eliminate me");
-    do { } while (f);
+    do { break; } while (f);
 
     0 ? console.log("eliminate me") : null;
     1 ? null : console.log("eliminate me");


### PR DESCRIPTION
Followup to #1061; I thought of another case where it was too aggressive.

Do-while loops with always-false conditions can't be replaced by their body because their body might contain a break or continue, which is illegal (or will have different semantics) if the loop becomes a normal block. In principle the body of the loop could be walked to find those, but frankly I doubt it will come up enough to be worth it.