### PR TITLE
Enable lazy objects mode in test runner

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -104,7 +104,7 @@ function execExternal(externalSpec, code) {
   return String(output.trim());
 }
 
-function argumentCodeWithLazyObjectSupport(code) {
+function augmentCodeWithLazyObjectSupport(code) {
   const mockLazyObjectsSupport = `
     var ${LAZY_OBJECTS_RUNTIME_NAME} = {
       _lazyObjectIds: new Map(),
@@ -343,7 +343,7 @@ function runTest(name, code, options, args) {
           codeToRun = transformWithBabel(codeToRun, [], [["env", { forceAllTransforms: true, modules: false }]]);
         }
         try {
-          codeToRun = argumentCodeWithLazyObjectSupport(codeToRun);
+          codeToRun = augmentCodeWithLazyObjectSupport(codeToRun);
           if (execSpec) actual = execExternal(execSpec, codeToRun);
           else actual = execInContext(codeToRun);
         } catch (e) {

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -54,6 +54,7 @@ function search(dir, relative) {
   return tests;
 }
 
+const LAZY_OBJECTS_RUNTIME_NAME = "LazyObjectsRuntime";
 let tests = search(`${__dirname}/../test/serializer`, "test/serializer");
 
 // run JS subprocess
@@ -103,21 +104,49 @@ function execExternal(externalSpec, code) {
   return String(output.trim());
 }
 
+function argumentCodeWithLazyObjectSupport(code) {
+  const mockLazyObjectsSupport = `
+    var ${LAZY_OBJECTS_RUNTIME_NAME} = {
+      _lazyObjectIds: new Map(),
+      _callback: null,
+      setLazyObjectInitializer: function(callback) {
+        this._callback = callback;
+      },
+      createLazyObject: function(id) {
+        var obj = {};
+        this._lazyObjectIds.set(obj, id);
+        return obj;
+      },
+      hydrateAllObjects: function() {
+        for (const [lazyObj, id] of this._lazyObjectIds) {
+          this._callback(lazyObj, id);
+        }
+        this._lazyObjectIds.clear();
+      }
+    };
+  `;
+  const hydrateLazyObjectsCall = `${LAZY_OBJECTS_RUNTIME_NAME}.hydrateAllObjects();`;
+  code = code.replace("/*force hydrate lazy objects*/", hydrateLazyObjectsCall);
+  return `${mockLazyObjectsSupport}
+    ${code}; // keep newline here as code may end with comment
+    ${hydrateLazyObjectsCall}`;
+}
+
 // run code in a seperate context
 function execInContext(code) {
   let script = new vm.Script(
-    `var global = this; var self = this; ${code}; // keep newline here as code may end with comment
-report(inspect());`,
+    `var global = this;
+    var self = this;
+    ${code}
+    report(inspect());`,
     { cachedDataProduced: false }
   );
-
   let result = "";
   let logOutput = "";
 
   function write(prefix, values) {
     logOutput += "\n" + prefix + values.join("");
   }
-
   script.runInNewContext({
     setTimeout: setTimeout,
     setInterval: setInterval,
@@ -180,6 +209,7 @@ function runTest(name, code, options, args) {
         delayUnsupportedRequires,
         internalDebug: true,
         additionalFunctions: options.additionalFunctions,
+        lazyObjectsRuntime: options.lazyObjectsRuntime,
       };
       let serializer = new Serializer(realm, serializerOptions);
       let sources = [{ filePath: name, fileContents: code }];
@@ -313,6 +343,7 @@ function runTest(name, code, options, args) {
           codeToRun = transformWithBabel(codeToRun, [], [["env", { forceAllTransforms: true, modules: false }]]);
         }
         try {
+          codeToRun = argumentCodeWithLazyObjectSupport(codeToRun);
           if (execSpec) actual = execExternal(execSpec, codeToRun);
           else actual = execInContext(codeToRun);
         } catch (e) {
@@ -408,10 +439,22 @@ function run(args) {
     if (args.es5 && test.file.includes("// es6")) continue;
     //only run specific tests if desired
     if (!test.name.includes(args.filter)) continue;
+    // Skip lazy objects mode for certain known incompatible tests, react compiler and additional-functions tests.
+    const skipLazyObjects =
+      test.file.includes("// skip lazy objects") ||
+      test.name.includes("additional-functions") ||
+      test.name.includes("react");
 
-    for (let [delayInitializations, inlineExpressions] of [[false, false], [true, true]]) {
+    for (let [delayInitializations, inlineExpressions, lazyObjectsRuntime] of [
+      [false, false, undefined],
+      [true, true, undefined],
+      [false, false, LAZY_OBJECTS_RUNTIME_NAME],
+    ]) {
+      if (skipLazyObjects && lazyObjectsRuntime) {
+        continue;
+      }
       total++;
-      let options = { delayInitializations, inlineExpressions };
+      let options = { delayInitializations, inlineExpressions, lazyObjectsRuntime };
       if (runTest(test.name, test.file, options, args)) passed++;
       else failed++;
     }

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -505,9 +505,16 @@ export default function(realm: Realm): ObjectValue {
     if (value instanceof AbstractValue || (value instanceof ObjectValue && value.isPartialObject())) {
       // Return abstract result. This enables cloning via JSON.parse(JSON.stringify(...)).
       let clonedValue = InternalJSONClone(realm, value);
-      let result = AbstractValue.createTemporalFromTemplate(realm, JSONStringify, StringValue, [clonedValue], {
-        kind: "JSON.stringify(...)",
-      });
+      let result = AbstractValue.createTemporalFromTemplate(
+        realm,
+        JSONStringify,
+        StringValue,
+        [clonedValue],
+        {
+          kind: "JSON.stringify(...)",
+        },
+        true
+      );
       if (clonedValue instanceof ObjectValue) {
         let iName = result.intrinsicName;
         invariant(iName);

--- a/src/realm.js
+++ b/src/realm.js
@@ -153,6 +153,7 @@ export class Realm {
     this.compatibility = opts.compatibility || "browser";
     this.maxStackDepth = opts.maxStackDepth || 225;
     this.omitInvariants = !!opts.omitInvariants;
+    this.lazyObjectsRuntime = opts.lazyObjectsRuntime;
 
     this.$TemplateMap = [];
 
@@ -210,6 +211,7 @@ export class Realm {
   contextStack: Array<ExecutionContext> = [];
   $GlobalEnv: LexicalEnvironment;
   intrinsics: Intrinsics;
+  lazyObjectsRuntime: void | string;
 
   react: {
     enabled: boolean,

--- a/src/realm.js
+++ b/src/realm.js
@@ -153,6 +153,8 @@ export class Realm {
     this.compatibility = opts.compatibility || "browser";
     this.maxStackDepth = opts.maxStackDepth || 225;
     this.omitInvariants = !!opts.omitInvariants;
+    // Store in realm so that we can emit magic comment for test-runner.
+    // TODO: remove it once we have better test-runner support.
     this.lazyObjectsRuntime = opts.lazyObjectsRuntime;
 
     this.$TemplateMap = [];

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -77,7 +77,7 @@ export function commonAncestorOf<T: HasParent>(node1: void | T, node2: void | T)
 // Gets map[key] with default value provided by defaultFn
 export function getOrDefault<K, V>(map: Map<K, V>, key: K, defaultFn: () => V): V {
   let value = map.get(key);
-  if (!value) map.set(key, (value = defaultFn()));
+  if (value === undefined) map.set(key, (value = defaultFn()));
   invariant(value !== undefined);
   return value;
 }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -516,7 +516,8 @@ export default class AbstractValue extends Value {
     template: PreludeGenerator => ({}) => BabelNodeExpression,
     resultType: typeof Value,
     operands: Array<Value>,
-    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |}
+    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |},
+    forceHydrateLazyObjects: boolean = false
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
     let temp = AbstractValue.createFromTemplate(realm, template, resultType, operands, "");
@@ -525,7 +526,7 @@ export default class AbstractValue extends Value {
     let args = temp.args;
     let buildNode_ = temp.getBuildNode();
     invariant(realm.generator !== undefined);
-    return realm.generator.derive(types, values, args, buildNode_, optionalArgs);
+    return realm.generator.derive(types, values, args, buildNode_, optionalArgs, forceHydrateLazyObjects);
   }
 
   static createTemporalFromBuildFunction(

--- a/test/serializer/abstract/Error.js
+++ b/test/serializer/abstract/Error.js
@@ -1,3 +1,4 @@
+// skip lazy objects
 let x = global.__abstract ? __abstract("string", "('abc')") : 'abc';
 let err1 = new Error(x);
 err1.name = x;

--- a/test/serializer/abstract/QualifiedCall3.js
+++ b/test/serializer/abstract/QualifiedCall3.js
@@ -1,3 +1,4 @@
+// skip lazy objects
 let bar = {x: 1};
 let foo = global.__abstract ? __abstract(function() { return this.x; }, '(function() { return this.x; })') : function() { return this.x; };
 

--- a/test/serializer/abstract/UpdateExpression3.js
+++ b/test/serializer/abstract/UpdateExpression3.js
@@ -1,3 +1,4 @@
+// skip lazy objects
 foo = {x: 42};
 let obj = global.__makePartial ? __makePartial({x: __abstract('number', 'foo.x')}) : foo;
 let y = obj.x++;

--- a/test/serializer/abstract/require_tracking.js
+++ b/test/serializer/abstract/require_tracking.js
@@ -1,4 +1,5 @@
 // es6
+// skip lazy objects
 // delay unsupported requires
 
 var modules = Object.create(null);

--- a/test/serializer/basic/Factories1.js
+++ b/test/serializer/basic/Factories1.js
@@ -1,10 +1,11 @@
-// Copies of default: 2
+// skip lazy objects
+// Copies of property: 2
 (function() {
-  var a = {"default": 1};
-  var b = {"default": 2};
-  var c = {"default": 3};
-  var d = {"default": 4};
-  var e = {"default": 5};
+  var a = {"property": 1};
+  var b = {"property": 2};
+  var c = {"property": 3};
+  var d = {"property": 4};
+  var e = {"property": 5};
   heap = [a,a,b,b,c,c,d,d,e,e];
-  inspect = function() { return heap[0]["default"]; }
+  inspect = function() { return heap[0]["property"]; }
 })();

--- a/test/serializer/basic/Factories2.js
+++ b/test/serializer/basic/Factories2.js
@@ -1,3 +1,4 @@
+// skip lazy objects
 // Copies of default: 2
 (function() {
   var a = {"default": 1, foo: 11};

--- a/test/serializer/basic/FactorifyVoid0.js
+++ b/test/serializer/basic/FactorifyVoid0.js
@@ -1,3 +1,4 @@
+// skip lazy objects
 // Copies of void 0:1
 // do not inline expressions
 (function() {

--- a/test/serializer/optimizations/require_opt.js
+++ b/test/serializer/optimizations/require_opt.js
@@ -1,5 +1,5 @@
 // es6
-// does not contain:(0)
+// does not contain:require(0)
 var modules = Object.create(null);
 
 __d = define;


### PR DESCRIPTION
Release Note: enable lazy objects mode in test-runner.

Note: I will try @hermanventer's suggestion to move all lazy objects creation to prelude and hydrate them after that in future PR for a better way to deal with lazy objects testing issue.

1. Enables lazy objects mode in test runner. 
2. For JSON.stringify() and for...in constructs that hydrate lazy objects in global code, I added "force hydrate lazy objects" attribute in the generated code telling test-runner to hydrate the objects immediately
3. Disable lazy objects mode for 3 factorify tests and 4 abstract tests.
4. Skip lazy objects mode for react compiler, additional function tests.
5. Fix a bug which only shows up in lazy objects mode: a) if the target body is non-generator body and delay reason is generator body there is no need to wait for it. b) we should use targetBody instead of this._body in emitter if delayReason is a Value.