### PR TITLE
Fix invariant failure in serializer

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1280,10 +1280,12 @@ export class ResidualHeapSerializer {
         let value = this.realm.getGlobalLetBinding(boundName);
         // Check for let binding vs global property
         if (value) {
-          let id = this.serializeValue(value, true, "let");
+          let rval = residualFunctionBinding.value;
+          invariant(rval !== undefined && value.equals(rval));
+          let id = this.serializeValue(rval, true, "let");
           // increment ref count one more time as the value has been
           // referentialized (stored in a variable) by serializeValue
-          this.residualHeapValueIdentifiers.incrementReferenceCount(value);
+          this.residualHeapValueIdentifiers.incrementReferenceCount(rval);
           residualFunctionBinding.serializedValue = id;
         } else {
           residualFunctionBinding.serializedValue = this.preludeGenerator.globalReference(boundName);

--- a/test/serializer/abstract/TemporalCSE.js
+++ b/test/serializer/abstract/TemporalCSE.js
@@ -1,0 +1,12 @@
+this.glob = 123;
+let b = global.__abstract ? __abstract("boolean", "true"): true;
+let y;
+if (b) {
+  y = glob;
+}
+let z;
+if (b) {
+  z = glob;
+}
+
+inspect = function () { return y + " " + z; }


### PR DESCRIPTION
For global let bindings, the serializer ignored the CSE value provided by the visitor. This led to an invariant failure when looking up the scope of a value that had been replaced by an equivalent value during CSE analysis in the visitor.