### PR TITLE
Start counting lazy object ids from 1 instead of 0.

### DIFF
--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -83,7 +83,7 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       statistics,
       react
     );
-    this._lazyObjectIdSeed = 0;
+    this._lazyObjectIdSeed = 1;
     this._valueLazyIds = new Map();
     this._lazyObjectInitializers = new Map();
     this._callbackLazyObjectParam = t.identifier("obj");


### PR DESCRIPTION
The lazy object id should start from 1 so 0 can be preserved for "missing" semantics. 