### PR TITLE
Fix debugger stackframe display

### DIFF
--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -50,21 +50,21 @@ export class DebugServer {
   _realm: Realm;
   _variableManager: VariableManager;
   /* Block until adapter says to run
-  /* runCondition: a function that determines whether the adapter has told
-  /* Prepack to continue running
+  /* ast: the current ast node we are stopped on
   */
-  waitForRun() {
+  waitForRun(ast?: BabelNode) {
     let keepRunning = false;
     let request;
     while (!keepRunning) {
       request = this._channel.readIn();
-      keepRunning = this.processDebuggerCommand(request);
+      keepRunning = this.processDebuggerCommand(request, ast);
     }
   }
 
   // Checking if the debugger needs to take any action on reaching this ast node
   checkForActions(ast: BabelNode) {
     this.checkForBreakpoint(ast);
+
     // last step: set the current location as the previously executed line
     if (ast.loc && ast.loc.source !== null) {
       this._previousExecutedFile = ast.loc.source;
@@ -116,13 +116,13 @@ export class DebugServer {
       // Tell the adapter that Prepack has stopped on this breakpoint
       this._channel.sendBreakpointStopped(breakpoint.filePath, breakpoint.line, breakpoint.column);
       // Wait for the adapter to tell us to run again
-      this.waitForRun();
+      this.waitForRun(ast);
     }
   }
 
   // Process a command from a debugger. Returns whether Prepack should unblock
   // if it is blocked
-  processDebuggerCommand(request: DebuggerRequest) {
+  processDebuggerCommand(request: DebuggerRequest, ast?: BabelNode) {
     let requestID = request.id;
     let command = request.command;
     let args = request.arguments;
@@ -153,7 +153,7 @@ export class DebugServer {
         return true;
       case DebugMessage.STACKFRAMES_COMMAND:
         invariant(args.kind === "stackframe");
-        this.processStackframesCommand(requestID, args);
+        this.processStackframesCommand(requestID, args, ast);
         break;
       case DebugMessage.SCOPES_COMMAND:
         invariant(args.kind === "scopes");
@@ -169,9 +169,16 @@ export class DebugServer {
     return false;
   }
 
-  processStackframesCommand(requestID: number, args: StackframeArguments) {
+  processStackframesCommand(requestID: number, args: StackframeArguments, ast?: BabelNode) {
     let frameInfos: Array<Stackframe> = [];
-    let loc = this._realm.currentLocation;
+    let fileName = "unknown";
+    let line = 0;
+    let column = 0;
+    if (ast && ast.loc) {
+      fileName = ast.loc.source || "unknown";
+      line = ast.loc.start.line;
+      column = ast.loc.start.column;
+    }
 
     // the UI displays the current frame as index 0, so we iterate backwards
     // from the current frame
@@ -181,14 +188,7 @@ export class DebugServer {
       if (frame.function && frame.function.__originalName) {
         functionName = frame.function.__originalName;
       }
-      let fileName = "unknown";
-      let line = 0;
-      let column = 0;
-      if (loc && loc.source) {
-        fileName = loc.source;
-        line = loc.start.line;
-        column = loc.start.column;
-      }
+
       let frameInfo: Stackframe = {
         id: this._realm.contextStack.length - 1 - i,
         functionName: functionName,
@@ -197,7 +197,15 @@ export class DebugServer {
         column: column,
       };
       frameInfos.push(frameInfo);
-      loc = frame.loc;
+      if (frame.loc) {
+        fileName = frame.loc.source || "unknown";
+        line = frame.loc.start.line;
+        column = frame.loc.start.column;
+      } else {
+        fileName = "unknown";
+        line = 0;
+        column = 0;
+      }
     }
     this._channel.sendStackframeResponse(requestID, frameInfos);
   }


### PR DESCRIPTION
Release note: none
Summary:
-pass in the current ast node while Prepack is waiting
-change the current frame to display the current ast loc

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path-to-adapter> --prepackRuntime <prepack runtime command> --sourceFile <file to prepack> --debugInFilePath <input file for debugger> --debugOutFilePath <output file for debugger>`
e.g.: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepackRuntime "node lib/prepack-cli.js" --sourceFile test/serializer/basic/Date.js --debugInFilePath src/debugger/.sessionlogs/engine2adapter.txt --debugOutFilePath src/debugger/.sessionlogs/adapter2engine.txt`