### PR TITLE
Fix hash for intrinsic abstract objects

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -128,9 +128,11 @@ export default function(realm: Realm): void {
             if (locString !== undefined) break;
           }
           let locVal = new StringValue(realm, locString || "(unknown location)");
-          result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], throwTemplateSrc);
+          let kind = "__abstract_" + realm.objectCount++; // need not be an object, but must be unique
+          result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
         } else {
-          result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(nameString), type, [], nameString);
+          let kind = "__abstract_" + nameString; // assume name is unique TODO #1155: check this
+          result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(nameString), type, [], kind);
           result.intrinsicName = nameString;
         }
 

--- a/test/serializer/abstract/IntrinsicObjectCSE.js
+++ b/test/serializer/abstract/IntrinsicObjectCSE.js
@@ -1,0 +1,12 @@
+// add at runtime:global.ob = { foo: { a: {} }, bar: { b: {} } };
+if (global.__abstract) {
+  __assumeDataProperty(this, "ob", __abstract({
+    foo: __abstract({ a: __abstract({}) }),
+    bar: __abstract({ b: __abstract({}) }),
+  }));
+}
+
+let x = ob.foo.a;
+let y = ob.bar.b;
+
+inspect = function() { return x === y; }


### PR DESCRIPTION
Creating a nameless intrinsic object could result in an abstract value with a useless hash in cases where the location is unknown. Instead, use a unique counter.