### PR TITLE
Fix test runner line break issue

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -171,7 +171,7 @@ function execInContext(code) {
 }
 
 function runTest(name, code, options, args) {
-  console.log(chalk.inverse(name) + " " + util.inspect(options));
+  console.log(chalk.inverse(name) + " " + JSON.stringify(options));
   let compatibility = code.includes("// jsc") ? "jsc-600-1-4-17" : undefined;
   let initializeMoreModules = code.includes("// initialize more modules");
   let compileJSXWithBabel = code.includes("// babel:jsx");

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -15,7 +15,6 @@ let prepackSources = require("../lib/prepack-node.js").prepackSources;
 let Serializer = require("../lib/serializer/index.js").default;
 let construct_realm = require("../lib/construct_realm.js").default;
 let initializeGlobals = require("../lib/globals.js").default;
-let util = require("util");
 let chalk = require("chalk");
 let path = require("path");
 let fs = require("fs");


### PR DESCRIPTION
Release Note: None.
After lazy object mode is introduced in test-runner, there is a weird line break in the test runner report. Turns out we used util.inspect() to print the options which seem to introduce line break when the object has more than two fields. 
Using JSON.stringify() fixed the issue.