### PR TITLE
Avoid generating two references to intrinsics that are in union.

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1212,6 +1212,11 @@ export class ResidualHeapSerializer {
 
   _serializeAbstractValueHelper(val: AbstractValue): BabelNodeExpression {
     let serializedArgs = val.args.map((abstractArg, i) => this.serializeValue(abstractArg));
+    if (val.kind === "abstractConcreteUnion") {
+      let abstractIndex = val.args.findIndex(v => v instanceof AbstractValue);
+      invariant(abstractIndex >= 0 && abstractIndex < val.args.length);
+      return serializedArgs[abstractIndex];
+    }
     let serializedValue = val.buildNode(serializedArgs);
     if (serializedValue.type === "Identifier") {
       let id = ((serializedValue: any): BabelNodeIdentifier);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -562,7 +562,7 @@ export default class AbstractValue extends Value {
       values = ValuesDomain.topVal;
     }
     let types = TypesDomain.topVal;
-    let [hash, operands] = hashCall("union", ...elements);
+    let [hash, operands] = hashCall("abstractConcreteUnion", ...elements);
     let result = new AbstractValue(realm, types, values, hash, operands, abstractValue._buildNode, {
       kind: "abstractConcreteUnion",
     });

--- a/test/serializer/abstract/Optional3.js
+++ b/test/serializer/abstract/Optional3.js
@@ -1,3 +1,4 @@
+// Copies of f;:1
 function f() { return 123; }
 var g = global.__abstractOrNullOrUndefined ? __abstractOrNullOrUndefined("function", "f") : f;
 z = g && g();


### PR DESCRIPTION
Serializing the arguments of an "abstractConcreteUnion" causes the abstract element to be assigned to a temp twice (once as a argument and once as the union). Avoid this by returning the serialized value of the abstract argument as the result of serializing the union.