### PR TITLE
Display concrete object variables in debugger

### DIFF
--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -36,7 +36,7 @@ export class DebugServer {
     this._lastRunRequestID = 0;
     this._channel = channel;
     this._realm = realm;
-    this._variableManager = new VariableManager();
+    this._variableManager = new VariableManager(realm);
     this.waitForRun();
   }
   // the collection of breakpoints

--- a/src/debugger/VariableManager.js
+++ b/src/debugger/VariableManager.js
@@ -70,7 +70,7 @@ export class VariableManager {
         if (IsDataDescriptor(this._realm, binding.descriptor)) {
           let value = binding.descriptor.value;
           if (value instanceof Value) {
-            let variable = this._getVariableFromValue(binding.key, value);
+            let variable = this._getVariableFromValue(name, value);
             variables.push(variable);
           }
         }

--- a/src/debugger/VariableManager.js
+++ b/src/debugger/VariableManager.js
@@ -14,6 +14,8 @@ import { ReferenceMap } from "./ReferenceMap.js";
 import { LexicalEnvironment, DeclarativeEnvironmentRecord } from "./../environment.js";
 import { Value, ConcreteValue, PrimitiveValue, ObjectValue } from "./../values/index.js";
 import invariant from "./../invariant.js";
+import type { Realm } from "./../realm.js";
+import { IsDataDescriptor } from "./../methods/is.js";
 
 // This class manages the handling of variable requests in the debugger
 // The DebugProtocol specifies collections of variables are to be fetched using a
@@ -21,14 +23,16 @@ import invariant from "./../invariant.js";
 // variablesReferences to pass to the UI and then perform lookups for those
 // variablesReferences when they are requested.
 export class VariableManager {
-  constructor() {
+  constructor(realm: Realm) {
     this._containerCache = new Map();
     this._referenceMap = new ReferenceMap();
+    this._realm = realm;
   }
   // cache for created references
   _containerCache: Map<VariableContainer, number>;
   // map for looking up references
   _referenceMap: ReferenceMap<VariableContainer>;
+  _realm: Realm;
 
   // Given a container, either returns a cached reference for that container if
   // it exists or return a new reference
@@ -49,9 +53,30 @@ export class VariableManager {
     if (!container) return [];
     if (container instanceof LexicalEnvironment) {
       return this._getVariablesFromEnv(container);
+    } else if (container instanceof ObjectValue) {
+      return this._getVariablesFromObject(container);
+    } else {
+      invariant(false, "Invalid variable container");
     }
-    // TODO: implement retrieving variables for other types of containers
-    return [];
+  }
+
+  _getVariablesFromObject(object: ObjectValue): Array<Variable> {
+    let variables = [];
+    let names = object.properties.keys();
+    for (let name of names) {
+      let binding = object.properties.get(name);
+      invariant(binding !== undefined);
+      if (binding.descriptor) {
+        if (IsDataDescriptor(this._realm, binding.descriptor)) {
+          let value = binding.descriptor.value;
+          if (value instanceof Value) {
+            let variable = this._getVariableFromValue(binding.key, value);
+            variables.push(variable);
+          }
+        }
+      }
+    }
+    return variables;
   }
 
   _getVariablesFromEnv(env: LexicalEnvironment): Array<Variable> {
@@ -91,14 +116,14 @@ export class VariableManager {
         name: name,
         value: value.toDisplayString(),
         variablesReference: 0,
-      }
+      };
       return variable;
     } else if (value instanceof ObjectValue) {
       let variable: Variable = {
         name: name,
         value: "Object",
         variablesReference: this.getReferenceForValue(value),
-      }
+      };
       return variable;
     } else {
       invariant(false, "Concrete value must be primitive or object");

--- a/src/debugger/VariableManager.js
+++ b/src/debugger/VariableManager.js
@@ -12,7 +12,8 @@
 import type { VariableContainer, Variable } from "./types.js";
 import { ReferenceMap } from "./ReferenceMap.js";
 import { LexicalEnvironment, DeclarativeEnvironmentRecord } from "./../environment.js";
-import { Value, ConcreteValue, PrimitiveValue } from "./../values/index.js";
+import { Value, ConcreteValue, PrimitiveValue, ObjectValue } from "./../values/index.js";
+import invariant from "./../invariant.js";
 
 // This class manages the handling of variable requests in the debugger
 // The DebugProtocol specifies collections of variables are to be fetched using a
@@ -68,31 +69,40 @@ export class VariableManager {
     for (let name in bindings) {
       let binding = bindings[name];
       if (binding.value) {
-        let displayValue = this._getDisplayValue(binding.value);
-        let variable: Variable = {
-          name: name,
-          value: displayValue,
-          variablesReference: 0,
-        };
+        let variable = this._getVariableFromValue(name, binding.value);
         variables.push(variable);
       }
     }
     return variables;
   }
 
-  _getDisplayValue(value: Value): string {
-    let displayValue = "to be supported";
+  _getVariableFromValue(name: string, value: Value): Variable {
     if (value instanceof ConcreteValue) {
-      displayValue = this._getConcreteDisplayValue(value);
+      return this._getVariableFromConcreteValue(name, value);
+    } else {
+      invariant(false, "Unsupported type of: " + name);
     }
-    return displayValue;
+    // TODO: implement variables request for abstract values
   }
 
-  _getConcreteDisplayValue(value: ConcreteValue): string {
+  _getVariableFromConcreteValue(name: string, value: ConcreteValue): Variable {
     if (value instanceof PrimitiveValue) {
-      return value.toDisplayString();
+      let variable: Variable = {
+        name: name,
+        value: value.toDisplayString(),
+        variablesReference: 0,
+      }
+      return variable;
+    } else if (value instanceof ObjectValue) {
+      let variable: Variable = {
+        name: name,
+        value: "Object",
+        variablesReference: this.getReferenceForValue(value),
+      }
+      return variable;
+    } else {
+      invariant(false, "Concrete value must be primitive or object");
     }
-    return "to be supported";
   }
 
   clean() {

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -11,6 +11,8 @@
 
 import type { LexicalEnvironment } from "./../environment.js";
 import * as DebugProtocol from "vscode-debugprotocol";
+import { ObjectValue } from "./../values/index.js";
+
 export type DebuggerRequest = {
   id: number,
   command: string,
@@ -123,7 +125,7 @@ export type VariablesResult = {
 };
 
 // any object that can contain a collection of variables
-export type VariableContainer = LexicalEnvironment;
+export type VariableContainer = LexicalEnvironment | ObjectValue;
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   noDebug?: boolean,
   sourceFile: string,


### PR DESCRIPTION
Release note: none
Summary:
-For object variables, create a new reference for this object as a variable container
-Pass this object and the reference to the UI

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path-to-adapter> --prepackRuntime <prepack runtime command> --sourceFile <file to prepack> --debugInFilePath <input file for debugger> --debugOutFilePath <output file for debugger>`
e.g.: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepackRuntime "node lib/prepack-cli.js" --sourceFile test/serializer/basic/Date.js --debugInFilePath src/debugger/.sessionlogs/engine2adapter.txt --debugOutFilePath src/debugger/.sessionlogs/adapter2engine.txt`