### PR TITLE
Send multiple breakpoints in one debugger request

### DIFF
--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -16,27 +16,27 @@ import type { Breakpoint as BreakpointType } from "./types.js";
 // Storing BreakpointStores for all source files
 export class BreakpointManager {
   constructor() {
-    this.breakpointMaps = new Map();
+    this._breakpointMaps = new Map();
   }
-  breakpointMaps: { [string]: PerFileBreakpointMap };
+  _breakpointMaps: { [string]: PerFileBreakpointMap };
 
   addBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this.addBreakpoint(bp.filePath, bp.line, bp.column);
+      this._addBreakpoint(bp.filePath, bp.line, bp.column);
     }
   }
 
-  addBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (!(filePath in this.breakpointMaps)) {
-      this.breakpointMaps[filePath] = new PerFileBreakpointMap(filePath);
+  _addBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
+    if (!(filePath in this._breakpointMaps)) {
+      this._breakpointMaps[filePath] = new PerFileBreakpointMap(filePath);
     }
-    let breakpointMap = this.breakpointMaps[filePath];
+    let breakpointMap = this._breakpointMaps[filePath];
     breakpointMap.addBreakpoint(lineNum, columnNum);
   }
 
   getBreakpoint(filePath: string, lineNum: number, columnNum: number = 0): void | Breakpoint {
-    if (filePath in this.breakpointMaps) {
-      let breakpointMap = this.breakpointMaps[filePath];
+    if (filePath in this._breakpointMaps) {
+      let breakpointMap = this._breakpointMaps[filePath];
       return breakpointMap.getBreakpoint(lineNum, columnNum);
     }
     return undefined;
@@ -44,37 +44,37 @@ export class BreakpointManager {
 
   removeBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this.removeBreakpoint(bp.filePath, bp.line, bp.column);
+      this._removeBreakpoint(bp.filePath, bp.line, bp.column);
     }
   }
 
-  removeBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (filePath in this.breakpointMaps) {
-      this.breakpointMaps[filePath].removeBreakpoint(lineNum, columnNum);
+  _removeBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
+    if (filePath in this._breakpointMaps) {
+      this._breakpointMaps[filePath].removeBreakpoint(lineNum, columnNum);
     }
   }
 
   enableBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this.enableBreakpoint(bp.filePath, bp.line, bp.column);
+      this._enableBreakpoint(bp.filePath, bp.line, bp.column);
     }
   }
 
-  enableBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (filePath in this.breakpointMaps) {
-      this.breakpointMaps[filePath].enableBreakpoint(lineNum, columnNum);
+  _enableBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
+    if (filePath in this._breakpointMaps) {
+      this._breakpointMaps[filePath].enableBreakpoint(lineNum, columnNum);
     }
   }
 
   disableBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this.disableBreakpoint(bp.filePath, bp.line, bp.column);
+      this._disableBreakpoint(bp.filePath, bp.line, bp.column);
     }
   }
 
-  disableBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (filePath in this.breakpointMaps) {
-      this.breakpointMaps[filePath].disableBreakpoint(lineNum, columnNum);
+  _disableBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
+    if (filePath in this._breakpointMaps) {
+      this._breakpointMaps[filePath].disableBreakpoint(lineNum, columnNum);
     }
   }
 }

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -11,13 +11,20 @@
 
 import { PerFileBreakpointMap } from "./PerFileBreakpointMap.js";
 import { Breakpoint } from "./Breakpoint.js";
+import type { Breakpoint  as BreakpointType } from "./types.js";
 
 // Storing BreakpointStores for all source files
-export class BreakpointCollection {
+export class BreakpointManager {
   constructor() {
     this.breakpointMaps = new Map();
   }
   breakpointMaps: { [string]: PerFileBreakpointMap };
+
+  addBreakpointMulti(breakpoints: Array<BreakpointType>) {
+    for (let bp of breakpoints) {
+      this.addBreakpoint(bp.filePath, bp.line, bp.column);
+    }
+  }
 
   addBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
     if (!(filePath in this.breakpointMaps)) {
@@ -35,15 +42,33 @@ export class BreakpointCollection {
     return undefined;
   }
 
+  removeBreakpointMulti(breakpoints: Array<BreakpointType>) {
+    for (let bp of breakpoints) {
+      this.removeBreakpoint(bp.filePath, bp.line, bp.column);
+    }
+  }
+
   removeBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
     if (filePath in this.breakpointMaps) {
       this.breakpointMaps[filePath].removeBreakpoint(lineNum, columnNum);
     }
   }
 
+  enableBreakpointMulti(breakpoints: Array<BreakpointType>) {
+    for (let bp of breakpoints) {
+      this.enableBreakpoint(bp.filePath, bp.line, bp.column);
+    }
+  }
+
   enableBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
     if (filePath in this.breakpointMaps) {
       this.breakpointMaps[filePath].enableBreakpoint(lineNum, columnNum);
+    }
+  }
+
+  disableBreakpointMulti(breakpoints: Array<BreakpointType>) {
+    for (let bp of breakpoints) {
+      this.disableBreakpoint(bp.filePath, bp.line, bp.column);
     }
   }
 

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -21,9 +21,7 @@ export class BreakpointManager {
   _breakpointMaps: { [string]: PerFileBreakpointMap };
 
   addBreakpointMulti(breakpoints: Array<BreakpointType>) {
-    for (let bp of breakpoints) {
-      this._addBreakpoint(bp);
-    }
+    this._doBreakpointsAction(breakpoints, this._addBreakpoint.bind(this));
   }
 
   _addBreakpoint(bp: BreakpointType) {
@@ -43,9 +41,7 @@ export class BreakpointManager {
   }
 
   removeBreakpointMulti(breakpoints: Array<BreakpointType>) {
-    for (let bp of breakpoints) {
-      this._removeBreakpoint(bp);
-    }
+    this._doBreakpointsAction(breakpoints, this._removeBreakpoint.bind(this));
   }
 
   _removeBreakpoint(bp: BreakpointType) {
@@ -55,9 +51,7 @@ export class BreakpointManager {
   }
 
   enableBreakpointMulti(breakpoints: Array<BreakpointType>) {
-    for (let bp of breakpoints) {
-      this._enableBreakpoint(bp);
-    }
+    this._doBreakpointsAction(breakpoints, this._enableBreakpoint.bind(this));
   }
 
   _enableBreakpoint(bp: BreakpointType) {
@@ -67,14 +61,18 @@ export class BreakpointManager {
   }
 
   disableBreakpointMulti(breakpoints: Array<BreakpointType>) {
-    for (let bp of breakpoints) {
-      this._disableBreakpoint(bp);
-    }
+    this._doBreakpointsAction(breakpoints, this._disableBreakpoint.bind(this));
   }
 
   _disableBreakpoint(bp: BreakpointType) {
     if (bp.filePath in this._breakpointMaps) {
       this._breakpointMaps[bp.filePath].disableBreakpoint(bp.line, bp.column);
+    }
+  }
+
+  _doBreakpointsAction(breakpoints: Array<BreakpointType>, action: BreakpointType => void) {
+    for (let bp of breakpoints) {
+      action(bp);
     }
   }
 }

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -11,7 +11,7 @@
 
 import { PerFileBreakpointMap } from "./PerFileBreakpointMap.js";
 import { Breakpoint } from "./Breakpoint.js";
-import type { Breakpoint  as BreakpointType } from "./types.js";
+import type { Breakpoint as BreakpointType } from "./types.js";
 
 // Storing BreakpointStores for all source files
 export class BreakpointManager {

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -22,16 +22,16 @@ export class BreakpointManager {
 
   addBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this._addBreakpoint(bp.filePath, bp.line, bp.column);
+      this._addBreakpoint(bp);
     }
   }
 
-  _addBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (!(filePath in this._breakpointMaps)) {
-      this._breakpointMaps[filePath] = new PerFileBreakpointMap(filePath);
+  _addBreakpoint(bp: BreakpointType) {
+    if (!(bp.filePath in this._breakpointMaps)) {
+      this._breakpointMaps[bp.filePath] = new PerFileBreakpointMap(bp.filePath);
     }
-    let breakpointMap = this._breakpointMaps[filePath];
-    breakpointMap.addBreakpoint(lineNum, columnNum);
+    let breakpointMap = this._breakpointMaps[bp.filePath];
+    breakpointMap.addBreakpoint(bp.line, bp.column);
   }
 
   getBreakpoint(filePath: string, lineNum: number, columnNum: number = 0): void | Breakpoint {
@@ -44,37 +44,37 @@ export class BreakpointManager {
 
   removeBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this._removeBreakpoint(bp.filePath, bp.line, bp.column);
+      this._removeBreakpoint(bp);
     }
   }
 
-  _removeBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (filePath in this._breakpointMaps) {
-      this._breakpointMaps[filePath].removeBreakpoint(lineNum, columnNum);
+  _removeBreakpoint(bp: BreakpointType) {
+    if (bp.filePath in this._breakpointMaps) {
+      this._breakpointMaps[bp.filePath].removeBreakpoint(bp.line, bp.column);
     }
   }
 
   enableBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this._enableBreakpoint(bp.filePath, bp.line, bp.column);
+      this._enableBreakpoint(bp);
     }
   }
 
-  _enableBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (filePath in this._breakpointMaps) {
-      this._breakpointMaps[filePath].enableBreakpoint(lineNum, columnNum);
+  _enableBreakpoint(bp: BreakpointType) {
+    if (bp.filePath in this._breakpointMaps) {
+      this._breakpointMaps[bp.filePath].enableBreakpoint(bp.line, bp.column);
     }
   }
 
   disableBreakpointMulti(breakpoints: Array<BreakpointType>) {
     for (let bp of breakpoints) {
-      this._disableBreakpoint(bp.filePath, bp.line, bp.column);
+      this._disableBreakpoint(bp);
     }
   }
 
-  _disableBreakpoint(filePath: string, lineNum: number, columnNum: number = 0) {
-    if (filePath in this._breakpointMaps) {
-      this._breakpointMaps[filePath].disableBreakpoint(lineNum, columnNum);
+  _disableBreakpoint(bp: BreakpointType) {
+    if (bp.filePath in this._breakpointMaps) {
+      this._breakpointMaps[bp.filePath].disableBreakpoint(bp.line, bp.column);
     }
   }
 }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -129,23 +129,31 @@ export class DebugServer {
     switch (command) {
       case DebugMessage.BREAKPOINT_ADD_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.addBreakpoint(args.filePath, args.line, args.column);
-        this._channel.sendBreakpointAcknowledge(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, requestID, args);
+        for (let bp of args.breakpoints) {
+          this._breakpoints.addBreakpoint(bp.filePath, bp.line, bp.column);
+        }
+        this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_REMOVE_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.removeBreakpoint(args.filePath, args.line, args.column);
-        this._channel.sendBreakpointAcknowledge(DebugMessage.BREAKPOINT_REMOVE_ACKNOWLEDGE, requestID, args);
+        for (let bp of args.breakpoints) {
+          this._breakpoints.removeBreakpoint(bp.filePath, bp.line, bp.column);
+        }
+        this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_REMOVE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_ENABLE_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.enableBreakpoint(args.filePath, args.line, args.column);
-        this._channel.sendBreakpointAcknowledge(DebugMessage.BREAKPOINT_ENABLE_ACKNOWLEDGE, requestID, args);
+        for (let bp of args.breakpoints) {
+          this._breakpoints.enableBreakpoint(bp.filePath, bp.line, bp.column);
+        }
+        this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_ENABLE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_DISABLE_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.disableBreakpoint(args.filePath, args.line, args.column);
-        this._channel.sendBreakpointAcknowledge(DebugMessage.BREAKPOINT_DISABLE_ACKNOWLEDGE, requestID, args);
+        for (let bp of args.breakpoints) {
+          this._breakpoints.disableBreakpoint(bp.filePath, bp.line, bp.column);
+        }
+        this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_DISABLE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.PREPACK_RUN_COMMAND:
         invariant(args.kind === "run");

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { BabelNode } from "babel-types";
-import { BreakpointCollection } from "./BreakpointCollection.js";
+import { BreakpointManager } from "./BreakpointManager.js";
 import { Breakpoint } from "./Breakpoint.js";
 import invariant from "../invariant.js";
 import type { DebugChannel } from "./channel/DebugChannel.js";
@@ -30,7 +30,7 @@ import { VariableManager } from "./VariableManager.js";
 
 export class DebugServer {
   constructor(channel: DebugChannel, realm: Realm) {
-    this._breakpoints = new BreakpointCollection();
+    this._breakpoints = new BreakpointManager();
     this._previousExecutedLine = 0;
     this._previousExecutedCol = 0;
     this._lastRunRequestID = 0;
@@ -40,7 +40,7 @@ export class DebugServer {
     this.waitForRun();
   }
   // the collection of breakpoints
-  _breakpoints: BreakpointCollection;
+  _breakpoints: BreakpointManager;
   _previousExecutedFile: void | string;
   _previousExecutedLine: number;
   _previousExecutedCol: number;
@@ -129,30 +129,22 @@ export class DebugServer {
     switch (command) {
       case DebugMessage.BREAKPOINT_ADD_COMMAND:
         invariant(args.kind === "breakpoint");
-        for (let bp of args.breakpoints) {
-          this._breakpoints.addBreakpoint(bp.filePath, bp.line, bp.column);
-        }
+        this._breakpoints.addBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_REMOVE_COMMAND:
         invariant(args.kind === "breakpoint");
-        for (let bp of args.breakpoints) {
-          this._breakpoints.removeBreakpoint(bp.filePath, bp.line, bp.column);
-        }
+        this._breakpoints.removeBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_REMOVE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_ENABLE_COMMAND:
         invariant(args.kind === "breakpoint");
-        for (let bp of args.breakpoints) {
-          this._breakpoints.enableBreakpoint(bp.filePath, bp.line, bp.column);
-        }
+        this._breakpoints.enableBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_ENABLE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_DISABLE_COMMAND:
         invariant(args.kind === "breakpoint");
-        for (let bp of args.breakpoints) {
-          this._breakpoints.disableBreakpoint(bp.filePath, bp.line, bp.column);
-        }
+        this._breakpoints.disableBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_DISABLE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.PREPACK_RUN_COMMAND:

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -68,6 +68,7 @@ class PrepackDebugSession extends LoggingDebugSession {
    * to interrogate the features the debug adapter provides.
    */
   initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+    debugger;
     // Let the UI know that we can start accepting breakpoint requests.
     // The UI will end the configuration sequence by calling 'configurationDone' request.
     this.sendEvent(new InitializedEvent());
@@ -117,6 +118,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     if (!args.source.path || !args.breakpoints) return;
     let filePath = args.source.path;
     let breakpointInfos = [];
+    debugger;
     for (const breakpoint of args.breakpoints) {
       let line = breakpoint.line;
       let column = 0;
@@ -133,6 +135,20 @@ class PrepackDebugSession extends LoggingDebugSession {
       breakpointInfos.push(breakpointInfo);
     }
     this._adapterChannel.setBreakpoints(response.request_seq, breakpointInfos, (dbgResponse: DebuggerResponse) => {
+      let result = dbgResponse.result;
+      invariant(result.kind === "breakpoint-add");
+      let source: DebugProtocol.Source = {
+        path: result.filePath,
+      }
+      let breakpoint: DebugProtocol.Breakpoint = {
+        verified: true,
+        source: source,
+        line: result.line,
+        column: result.column,
+      };
+      response.body = {
+        breakpoints: [breakpoint],
+      };
       this.sendResponse(response);
     });
   }

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -51,7 +51,7 @@ export class AdapterChannel {
       this._eventEmitter.emit(DebugMessage.PREPACK_READY_RESPONSE, result);
       this.trySendNextRequest();
     } else if (messageType === DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE) {
-      let dbgResponse = this._marshaller.unmarshallBreakpointAddResponse(requestID);
+      let dbgResponse = this._marshaller.unmarshallBreakpointAddResponse(requestID, parts.slice(2));
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, requestID, dbgResponse);
       // Prepack acknowledged adding a breakpoint
       this._prepackWaiting = true;

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -41,45 +41,17 @@ export class AdapterChannel {
   }
 
   _processPrepackMessage(message: string) {
-    let parts = message.split(" ");
-    let requestID = parseInt(parts[0], 10);
-    invariant(!isNaN(requestID));
-    let messageType = parts[1];
-    if (messageType === DebugMessage.PREPACK_READY_RESPONSE) {
-      let result = this._marshaller.unmarshallReadyResponse(requestID);
-      this._prepackWaiting = true;
-      this._eventEmitter.emit(DebugMessage.PREPACK_READY_RESPONSE, result);
-      this.trySendNextRequest();
-    } else if (messageType === DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE) {
-      let dbgResponse = this._marshaller.unmarshallBreakpointsAddResponse(requestID, parts.slice(2).join(" "));
-      this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, requestID, dbgResponse);
-      // Prepack acknowledged adding a breakpoint
-      this._prepackWaiting = true;
-      this._processRequestCallback(requestID, dbgResponse);
-      this.trySendNextRequest();
-    } else if (messageType === DebugMessage.BREAKPOINT_STOPPED_RESPONSE) {
-      let dbgResponse = this._marshaller.unmarshallBreakpointStoppedResponse(requestID, parts.slice(2));
+    let dbgResponse = this._marshaller.unmarshallResponse(message);
+    if (dbgResponse.result.kind === "ready") {
+      this._eventEmitter.emit(DebugMessage.PREPACK_READY_RESPONSE, dbgResponse);
+    } else if (dbgResponse.result.kind === "breakpoint-add") {
+      this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, dbgResponse.id, dbgResponse);
+    } else if (dbgResponse.result.kind === "breakpoint-stopped") {
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_STOPPED_RESPONSE, dbgResponse);
-      // Prepack stopped on a breakpoint
-      this._prepackWaiting = true;
-      this._processRequestCallback(requestID, dbgResponse);
-      this.trySendNextRequest();
-    } else if (messageType === DebugMessage.STACKFRAMES_RESPONSE) {
-      let dbgResponse = this._marshaller.unmarshallStackframesResponse(requestID, parts.slice(2).join(" "));
-      this._prepackWaiting = true;
-      this._processRequestCallback(requestID, dbgResponse);
-      this.trySendNextRequest();
-    } else if (messageType === DebugMessage.SCOPES_RESPONSE) {
-      let dbgResponse = this._marshaller.unmarshallScopesResponse(requestID, parts.slice(2).join(" "));
-      this._prepackWaiting = true;
-      this._processRequestCallback(requestID, dbgResponse);
-      this.trySendNextRequest();
-    } else if (messageType === DebugMessage.VARIABLES_RESPONSE) {
-      let dbgResponse = this._marshaller.unmarshallVariablesResponse(requestID, parts.slice(2).join(" "));
-      this._prepackWaiting = true;
-      this._processRequestCallback(requestID, dbgResponse);
-      this.trySendNextRequest();
     }
+    this._prepackWaiting = true;
+    this._processRequestCallback(dbgResponse);
+    this.trySendNextRequest();
   }
 
   // Check to see if the next request to Prepack can be sent and send it if so
@@ -100,12 +72,12 @@ export class AdapterChannel {
     this._pendingRequestCallbacks[requestID] = callback;
   }
 
-  _processRequestCallback(requestID: number, response: DebuggerResponse) {
+  _processRequestCallback(response: DebuggerResponse) {
     invariant(
-      requestID in this._pendingRequestCallbacks,
-      "Request ID does not exist in pending requests: " + requestID
+      response.id in this._pendingRequestCallbacks,
+      "Request ID does not exist in pending requests: " + response.id
     );
-    let callback = this._pendingRequestCallbacks[requestID];
+    let callback = this._pendingRequestCallbacks[response.id];
     callback(response);
   }
 

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -15,7 +15,7 @@ import EventEmitter from "events";
 import invariant from "./../../invariant.js";
 import { DebugMessage } from "./DebugMessage.js";
 import child_process from "child_process";
-import type { BreakpointArguments, DebuggerResponse, PrepackLaunchArguments } from "./../types.js";
+import type { Breakpoint, DebuggerResponse, PrepackLaunchArguments } from "./../types.js";
 
 //Channel used by the debug adapter to communicate with Prepack
 export class AdapterChannel {
@@ -51,7 +51,7 @@ export class AdapterChannel {
       this._eventEmitter.emit(DebugMessage.PREPACK_READY_RESPONSE, result);
       this.trySendNextRequest();
     } else if (messageType === DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE) {
-      let dbgResponse = this._marshaller.unmarshallBreakpointAddResponse(requestID, parts.slice(2));
+      let dbgResponse = this._marshaller.unmarshallBreakpointsAddResponse(requestID, parts.slice(2).join(" "));
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, requestID, dbgResponse);
       // Prepack acknowledged adding a breakpoint
       this._prepackWaiting = true;
@@ -157,10 +157,8 @@ export class AdapterChannel {
     this._addRequestCallback(requestID, callback);
   }
 
-  setBreakpoints(requestID: number, breakpoints: Array<BreakpointArguments>, callback: DebuggerResponse => void) {
-    for (const breakpoint of breakpoints) {
-      this._queue.enqueue(this._marshaller.marshallSetBreakpointsRequest(requestID, breakpoint));
-    }
+  setBreakpoints(requestID: number, breakpoints: Array<Breakpoint>, callback: DebuggerResponse => void) {
+    this._queue.enqueue(this._marshaller.marshallSetBreakpointsRequest(requestID, breakpoints));
     this.trySendNextRequest();
     this._addRequestCallback(requestID, callback);
   }

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -16,7 +16,8 @@ import { DebuggerError } from "./../DebuggerError.js";
 import type {
   DebuggerRequest,
   DebuggerRequestArguments,
-  BreakpointArguments,
+  Breakpoint,
+  BreakpointsArguments,
   RunArguments,
   StackframeArguments,
   Stackframe,
@@ -82,7 +83,7 @@ export class DebugChannel {
         args = runArgs;
         break;
       case DebugMessage.BREAKPOINT_ADD_COMMAND:
-        args = this._marshaller.unmarshallBreakpointArguments(requestID, parts.slice(2));
+        args = this._marshaller.unmarshallBreakpointsArguments(requestID, parts.slice(2).join(" "));
         break;
       case DebugMessage.STACKFRAMES_COMMAND:
         let stackFrameArgs: StackframeArguments = {
@@ -116,14 +117,12 @@ export class DebugChannel {
     this._requestReceived = false;
   }
 
-  sendBreakpointAcknowledge(messageType: string, requestID: number, args: BreakpointArguments): void {
-    this.writeOut(
-      this._marshaller.marshallBreakpointAcknowledge(requestID, messageType, args.filePath, args.line, args.column)
-    );
+  sendBreakpointsAcknowledge(messageType: string, requestID: number, args: BreakpointsArguments): void {
+    this.writeOut(this._marshaller.marshallBreakpointAcknowledge(requestID, messageType, args.breakpoints));
   }
 
   sendBreakpointStopped(filePath: string, line: number, column: number): void {
-    let breakpointInfo: BreakpointArguments = {
+    let breakpointInfo: Breakpoint = {
       kind: "breakpoint",
       filePath: filePath,
       line: line,

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -31,13 +31,11 @@ export class DebugChannel {
     this._requestReceived = false;
     this._ioWrapper = ioWrapper;
     this._marshaller = new MessageMarshaller();
-    this._lastRunRequestID = 0;
   }
 
   _requestReceived: boolean;
   _ioWrapper: FileIOWrapper;
   _marshaller: MessageMarshaller;
-  _lastRunRequestID: number;
 
   /*
   /* Only called in the beginning to check if a debugger is attached
@@ -65,48 +63,7 @@ export class DebugChannel {
   readIn(): DebuggerRequest {
     let message = this._ioWrapper.readInSync();
     this._requestReceived = true;
-
-    let parts = message.split(" ");
-    // each request must have a length and a command
-    invariant(parts.length >= 2, "Request is not well formed");
-    // unique ID for each request
-    let requestID = parseInt(parts[0], 10);
-    invariant(!isNaN(requestID), "Request ID must be a number");
-    let command = parts[1];
-    let args: DebuggerRequestArguments;
-    switch (command) {
-      case DebugMessage.PREPACK_RUN_COMMAND:
-        this._lastRunRequestID = requestID;
-        let runArgs: RunArguments = {
-          kind: "run",
-        };
-        args = runArgs;
-        break;
-      case DebugMessage.BREAKPOINT_ADD_COMMAND:
-        args = this._marshaller.unmarshallBreakpointsArguments(requestID, parts.slice(2).join(" "));
-        break;
-      case DebugMessage.STACKFRAMES_COMMAND:
-        let stackFrameArgs: StackframeArguments = {
-          kind: "stackframe",
-        };
-        args = stackFrameArgs;
-        break;
-      case DebugMessage.SCOPES_COMMAND:
-        args = this._marshaller.unmarshallScopesArguments(requestID, parts[2]);
-        break;
-      case DebugMessage.VARIABLES_COMMAND:
-        args = this._marshaller.unmarshallVariablesArguments(requestID, parts[2]);
-        break;
-      default:
-        throw new DebuggerError("Invalid command", "Invalid command from adapter: " + command);
-    }
-    invariant(args !== undefined);
-    let result: DebuggerRequest = {
-      id: requestID,
-      command: command,
-      arguments: args,
-    };
-    return result;
+    return this._marshaller.unmarshallRequest(message);
   }
 
   // Write out a response to the debug adapter
@@ -128,7 +85,7 @@ export class DebugChannel {
       line: line,
       column: column,
     };
-    this.writeOut(this._marshaller.marshallBreakpointStopped(this._lastRunRequestID, breakpointInfo));
+    this.writeOut(this._marshaller.marshallBreakpointStopped(breakpointInfo));
   }
 
   sendStackframeResponse(requestID: number, stackframes: Array<Stackframe>): void {

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -12,18 +12,7 @@ import invariant from "./../../invariant.js";
 import { FileIOWrapper } from "./FileIOWrapper.js";
 import { DebugMessage } from "./DebugMessage.js";
 import { MessageMarshaller } from "./MessageMarshaller.js";
-import { DebuggerError } from "./../DebuggerError.js";
-import type {
-  DebuggerRequest,
-  DebuggerRequestArguments,
-  Breakpoint,
-  BreakpointsArguments,
-  RunArguments,
-  StackframeArguments,
-  Stackframe,
-  Scope,
-  Variable,
-} from "./../types.js";
+import type { DebuggerRequest, Breakpoint, BreakpointsArguments, Stackframe, Scope, Variable } from "./../types.js";
 
 //Channel used by the DebugServer in Prepack to communicate with the debug adapter
 export class DebugChannel {
@@ -101,6 +90,6 @@ export class DebugChannel {
   }
 
   sendPrepackFinish(): void {
-    this.writeOut(this._marshaller.marshallPrepackFinish(this._lastRunRequestID));
+    this.writeOut(this._marshaller.marshallPrepackFinish());
   }
 }

--- a/src/debugger/channel/MessageMarshaller.js
+++ b/src/debugger/channel/MessageMarshaller.js
@@ -193,9 +193,18 @@ export class MessageMarshaller {
     }
   }
 
-  unmarshallBreakpointAddResponse(requestID: number): DebuggerResponse {
+  unmarshallBreakpointAddResponse(requestID: number, parts: Array<string>): DebuggerResponse {
+    invariant(parts.length === 3, "Incorrect number of arguments in breakpoint stopped response");
+    let filePath = parts[0];
+    let line = parseInt(parts[1], 10);
+    invariant(!isNaN(line), "Invalid line number");
+    let column = parseInt(parts[2], 10);
+    invariant(!isNaN(column), "Invalid column number");
     let result: BreakpointAddResult = {
       kind: "breakpoint-add",
+      filePath: filePath,
+      line: line,
+      column: column,
     };
     let dbgResponse: DebuggerResponse = {
       id: requestID,

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -20,7 +20,7 @@ export type DebuggerRequest = {
 };
 
 export type DebuggerRequestArguments =
-  | BreakpointArguments
+  | BreakpointsArguments
   | RunArguments
   | StackframeArguments
   | ScopesArguments
@@ -37,11 +37,15 @@ export type PrepackLaunchArguments = {
   exitCallback: () => void,
 };
 
-export type BreakpointArguments = {
-  kind: "breakpoint",
+export type Breakpoint = {
   filePath: string,
   line: number,
   column: number,
+};
+
+export type BreakpointsArguments = {
+  kind: "breakpoint",
+  breakpoints: Array<Breakpoint>,
 };
 
 export type RunArguments = {
@@ -78,7 +82,7 @@ export type DebuggerResponse = {
 export type DebuggerResponseResult =
   | ReadyResult
   | StackframeResult
-  | BreakpointAddResult
+  | BreakpointsAddResult
   | BreakpointStoppedResult
   | ScopesResult
   | VariablesResult;
@@ -92,11 +96,9 @@ export type StackframeResult = {
   stackframes: Array<Stackframe>,
 };
 
-export type BreakpointAddResult = {
+export type BreakpointsAddResult = {
   kind: "breakpoint-add",
-  filePath: string,
-  line: number,
-  column: number,
+  breakpoints: Array<Breakpoint>,
 };
 
 export type BreakpointStoppedResult = {

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -85,7 +85,8 @@ export type DebuggerResponseResult =
   | BreakpointsAddResult
   | BreakpointStoppedResult
   | ScopesResult
-  | VariablesResult;
+  | VariablesResult
+  | FinishResult;
 
 export type ReadyResult = {
   kind: "ready",
@@ -127,6 +128,10 @@ export type Variable = {
 export type VariablesResult = {
   kind: "variables",
   variables: Array<Variable>,
+};
+
+export type FinishResult = {
+  kind: "finish",
 };
 
 // any object that can contain a collection of variables

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -94,6 +94,9 @@ export type StackframeResult = {
 
 export type BreakpointAddResult = {
   kind: "breakpoint-add",
+  filePath: string,
+  line: number,
+  column: number,
 };
 
 export type BreakpointStoppedResult = {


### PR DESCRIPTION
Release note: none
Summary:
Previously, the DebugAdapter sends breakpoint requests one by one to Prepack. This works for the CLI because breakpoints are set one at a time. For an IDE, multiple breakpoints are sent in a single request upon startup and a single response with all the breakpoints set is expected. This PR sends allows sending multiple breakpoints in a single request to Prepack and a single response is received.

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path-to-adapter> --prepackRuntime <prepack runtime command> --sourceFile <file to prepack> --debugInFilePath <input file for debugger> --debugOutFilePath <output file for debugger>`
e.g.: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepackRuntime "node lib/prepack-cli.js" --sourceFile test/serializer/basic/Date.js --debugInFilePath src/debugger/.sessionlogs/engine2adapter.txt --debugOutFilePath src/debugger/.sessionlogs/adapter2engine.txt` 