### PR TITLE
Make the implementation of environment.js private.

### DIFF
--- a/scripts/detect_bad_deps.js
+++ b/scripts/detect_bad_deps.js
@@ -41,7 +41,7 @@ exec("flow check --profile", function(error, stdout, stderr) {
     process.exit(1);
   }
   console.log("Biggest cycle: " + cycle_len);
-  let MAX_CYCLE_LEN = 60; // NEVER EVER increase this value
+  let MAX_CYCLE_LEN = 59; // NEVER EVER increase this value
   if (cycle_len > MAX_CYCLE_LEN) {
     console.log("Error: You increased cycle length from the previous high of " + MAX_CYCLE_LEN);
     console.log("This is never OK.");

--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -16,7 +16,7 @@ import initializeGlobal from "./intrinsics/ecma262/global.js";
 import type { RealmOptions } from "./options.js";
 import * as evaluators from "./evaluators/index.js";
 import * as partialEvaluators from "./partial-evaluators/index.js";
-import { NewGlobalEnvironment } from "./methods/index.js";
+import { Environment } from "./singletons.js";
 import { ObjectValue } from "./values/index.js";
 import { DebugServer } from "./debugger/Debugger.js";
 import type { DebugChannel } from "./debugger/channel/DebugChannel.js";
@@ -41,6 +41,6 @@ export default function(opts: RealmOptions = {}, debugChannel: void | DebugChann
   for (let name in partialEvaluators) r.partialEvaluators[name] = partialEvaluators[name];
   r.simplifyAndRefineAbstractValue = simplifyAndRefineAbstractValue.bind(null, r, false);
   r.simplifyAndRefineAbstractCondition = simplifyAndRefineAbstractValue.bind(null, r, true);
-  r.$GlobalEnv = NewGlobalEnvironment(r, r.$GlobalObject, r.$GlobalObject);
+  r.$GlobalEnv = Environment.NewGlobalEnvironment(r, r.$GlobalObject, r.$GlobalObject);
   return r;
 }

--- a/src/environment.js
+++ b/src/environment.js
@@ -49,16 +49,8 @@ import generate from "babel-generator";
 import parse from "./utils/parse.js";
 import invariant from "./invariant.js";
 import traverseFast from "./utils/traverse-fast.js";
-import {
-  ToBooleanPartial,
-  HasProperty,
-  Get,
-  GetValue,
-  IsExtensible,
-  HasOwnProperty,
-  IsDataDescriptor,
-} from "./methods/index.js";
-import { Properties } from "./singletons.js";
+import { ToBooleanPartial, HasProperty, Get, IsExtensible, HasOwnProperty, IsDataDescriptor } from "./methods/index.js";
+import { Environment, Properties } from "./singletons.js";
 import * as t from "babel-types";
 
 const sourceMap = require("source-map");
@@ -987,7 +979,7 @@ export class LexicalEnvironment {
   ): [Completion | Value, BabelNode, Array<BabelNodeStatement>] {
     let [result, partial_ast, partial_io] = this.partiallyEvaluateCompletion(ast, strictCode, metadata);
     if (result instanceof Reference) {
-      result = GetValue(this.realm, result);
+      result = Environment.GetValue(this.realm, result);
     }
     return [result, partial_ast, partial_io];
   }
@@ -1011,7 +1003,7 @@ export class LexicalEnvironment {
 
   evaluateCompletionDeref(ast: BabelNode, strictCode: boolean, metadata?: any): AbruptCompletion | Value {
     let result = this.evaluateCompletion(ast, strictCode, metadata);
-    if (result instanceof Reference) result = GetValue(this.realm, result);
+    if (result instanceof Reference) result = Environment.GetValue(this.realm, result);
     return result;
   }
 
@@ -1100,7 +1092,7 @@ export class LexicalEnvironment {
     }
     if (res instanceof AbruptCompletion) return [res, code];
 
-    return [GetValue(this.realm, res), code];
+    return [Environment.GetValue(this.realm, res), code];
   }
 
   executePartialEvaluator(
@@ -1160,7 +1152,7 @@ export class LexicalEnvironment {
     }
     if (res instanceof AbruptCompletion) return res;
 
-    return GetValue(this.realm, res);
+    return Environment.GetValue(this.realm, res);
   }
 
   fixup_source_locations(ast: BabelNode, map: string) {

--- a/src/evaluators/ArrayExpression.js
+++ b/src/evaluators/ArrayExpression.js
@@ -13,11 +13,11 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { StringValue, NumberValue } from "../values/index.js";
-import { GetIterator, GetValue } from "../methods/index.js";
+import { GetIterator } from "../methods/index.js";
 import { ArrayCreate, CreateDataProperty } from "../methods/index.js";
 import invariant from "../invariant.js";
 import { IteratorStep, IteratorValue } from "../methods/iterator.js";
-import { Properties } from "../singletons.js";
+import { Environment, Properties } from "../singletons.js";
 import type { BabelNodeArrayExpression } from "babel-types";
 
 // ECMA262 2.2.5.3
@@ -47,7 +47,7 @@ export default function(
       let spreadRef = env.evaluate(elem.argument, strictCode);
 
       // 2. Let spreadObj be ? GetValue(spreadRef).
-      let spreadObj = GetValue(realm, spreadRef);
+      let spreadObj = Environment.GetValue(realm, spreadRef);
 
       // 3. Let iterator be ? GetIterator(spreadObj).
       let iterator = GetIterator(realm, spreadObj);
@@ -81,7 +81,7 @@ export default function(
       let initResult = env.evaluate(elem, strictCode);
 
       // 5. Let initValue be ? GetValue(initResult).
-      let initValue = GetValue(realm, initResult);
+      let initValue = Environment.GetValue(realm, initResult);
 
       // 6. Let created be CreateDataProperty(array, ToString(ToUint32(postIndex+padding)), initValue).
       let created = CreateDataProperty(realm, array, new StringValue(realm, nextIndex++ + ""), initValue);

--- a/src/evaluators/AssignmentExpression.js
+++ b/src/evaluators/AssignmentExpression.js
@@ -15,13 +15,11 @@ import { Value, ObjectValue } from "../values/index.js";
 import { Reference } from "../environment.js";
 import {
   DestructuringAssignmentEvaluation,
-  GetReferencedName,
-  GetValue,
   HasOwnProperty,
   IsAnonymousFunctionDefinition,
   IsIdentifierRef,
 } from "../methods/index.js";
-import { Functions, Properties } from "../singletons.js";
+import { Environment, Functions, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeAssignmentExpression, BabelBinaryOperator } from "babel-types";
 import { computeBinary } from "./BinaryExpression.js";
@@ -53,7 +51,7 @@ export default function(
       // c. Let rref be the result of evaluating AssignmentExpression.
       let rref = env.evaluate(AssignmentExpression, strictCode);
       // d. Let rval be ? GetValue(rref).
-      let rval = GetValue(realm, rref);
+      let rval = Environment.GetValue(realm, rref);
       // e. If IsAnonymousFunctionDefinition(AssignmentExpression) and IsIdentifierRef of LeftHandSideExpression are both true, then
       if (
         IsAnonymousFunctionDefinition(realm, AssignmentExpression) &&
@@ -65,7 +63,7 @@ export default function(
         // ii. If hasNameProperty is false, perform SetFunctionName(rval, GetReferencedName(lref)).
         if (!hasNameProperty) {
           invariant(lref instanceof Reference);
-          Functions.SetFunctionName(realm, rval, GetReferencedName(realm, lref));
+          Functions.SetFunctionName(realm, rval, Environment.GetReferencedName(realm, lref));
         }
       }
       // f. Perform ? PutValue(lref, rval).
@@ -81,7 +79,7 @@ export default function(
     let rref = env.evaluate(AssignmentExpression, strictCode);
 
     // 4. Let rval be ? GetValue(rref).
-    let rval = GetValue(realm, rref);
+    let rval = Environment.GetValue(realm, rref);
 
     // 5. Let status be the result of performing DestructuringAssignmentEvaluation of assignmentPattern using rval as the argument.
     DestructuringAssignmentEvaluation(realm, assignmentPattern, rval, strictCode, env);
@@ -97,15 +95,15 @@ export default function(
   // 1. Let lref be the result of evaluating LeftHandSideExpression.
   let lref = env.evaluate(LeftHandSideExpression, strictCode);
   // 2. Let lval be ? GetValue(lref).
-  let lval = GetValue(realm, lref);
+  let lval = Environment.GetValue(realm, lref);
   // 3. Let rref be the result of evaluating AssignmentExpression.
   let rref = env.evaluate(AssignmentExpression, strictCode);
   // 4. Let rval be ? GetValue(rref).
-  let rval = GetValue(realm, rref);
+  let rval = Environment.GetValue(realm, rref);
   // 5. Let op be the @ where AssignmentOperator is @=.
   let op = ((AssignmentOperator.slice(0, -1): any): BabelBinaryOperator);
   // 6. Let r be the result of applying op to lval and rval as if evaluating the expression lval op rval.
-  let r = GetValue(realm, computeBinary(realm, op, lval, rval, ast.left.loc, ast.right.loc));
+  let r = Environment.GetValue(realm, computeBinary(realm, op, lval, rval, ast.left.loc, ast.right.loc));
   // 7. Perform ? PutValue(lref, r).
   Properties.PutValue(realm, lref, r);
   // 8. Return r.

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -24,7 +24,7 @@ import {
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import { GetValue } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import { IsToPrimitivePure, GetToPrimitivePureResultType, IsToNumberPure } from "../methods/index.js";
 import type { BabelNodeBinaryExpression, BabelBinaryOperator, BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
@@ -37,11 +37,11 @@ export default function(
 ): Value {
   // evaluate left
   let lref = env.evaluate(ast.left, strictCode);
-  let lval = GetValue(realm, lref);
+  let lval = Environment.GetValue(realm, lref);
 
   // evaluate right
   let rref = env.evaluate(ast.right, strictCode);
-  let rval = GetValue(realm, rref);
+  let rval = Environment.GetValue(realm, rref);
 
   return computeBinary(realm, ast.operator, lval, rval, ast.left.loc, ast.right.loc, ast.loc);
 }

--- a/src/evaluators/BlockStatement.js
+++ b/src/evaluators/BlockStatement.js
@@ -14,8 +14,7 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
 import { StringValue, Value } from "../values/index.js";
-import { NewDeclarativeEnvironment, BlockDeclarationInstantiation } from "../methods/index.js";
-import { Functions } from "../singletons.js";
+import { Environment, Functions } from "../singletons.js";
 
 // ECMA262 13.2.13
 export default function(
@@ -28,10 +27,10 @@ export default function(
   let oldEnv = realm.getRunningContext().lexicalEnvironment;
 
   // 2. Let blockEnv be NewDeclarativeEnvironment(oldEnv).
-  let blockEnv = NewDeclarativeEnvironment(realm, oldEnv);
+  let blockEnv = Environment.NewDeclarativeEnvironment(realm, oldEnv);
 
   // 3. Perform BlockDeclarationInstantiation(StatementList, blockEnv).
-  BlockDeclarationInstantiation(realm, strictCode, ast.body, blockEnv);
+  Environment.BlockDeclarationInstantiation(realm, strictCode, ast.body, blockEnv);
 
   // 4. Set the running execution context's LexicalEnvironment to blockEnv.
   realm.getRunningContext().lexicalEnvironment = blockEnv;

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -17,16 +17,12 @@ import { EnvironmentRecord } from "../environment.js";
 import { Value } from "../values/index.js";
 import { AbstractValue, BooleanValue, ConcreteValue, FunctionValue, ObjectValue } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { Functions } from "../singletons.js";
+import { Environment, Functions } from "../singletons.js";
 import {
   ArgumentListEvaluation,
   EvaluateDirectCall,
-  GetBase,
-  GetReferencedName,
   GetThisValue,
-  GetValue,
   IsInTailPosition,
-  IsPropertyReference,
   joinEffects,
   SameValue,
   TestIntegrityLevel,
@@ -53,7 +49,7 @@ export default function(
   let ref = env.evaluate(ast.callee, strictCode);
 
   // 2. Let func be ? GetValue(ref).
-  let func = GetValue(realm, ref);
+  let func = Environment.GetValue(realm, ref);
 
   return EvaluateCall(ref, func, ast, strictCode, env, realm);
 }
@@ -161,7 +157,11 @@ function EvaluateCall(
   invariant(func instanceof ConcreteValue);
 
   // 3. If Type(ref) is Reference and IsPropertyReference(ref) is false and GetReferencedName(ref) is "eval", then
-  if (ref instanceof Reference && !IsPropertyReference(realm, ref) && GetReferencedName(realm, ref) === "eval") {
+  if (
+    ref instanceof Reference &&
+    !Environment.IsPropertyReference(realm, ref) &&
+    Environment.GetReferencedName(realm, ref) === "eval"
+  ) {
     // a. If SameValue(func, %eval%) is true, then
     if (SameValue(realm, func, realm.intrinsics.eval)) {
       // i. Let argList be ? ArgumentListEvaluation(Arguments).
@@ -191,13 +191,13 @@ function EvaluateCall(
   // 4. If Type(ref) is Reference, then
   if (ref instanceof Reference) {
     // a. If IsPropertyReference(ref) is true, then
-    if (IsPropertyReference(realm, ref)) {
+    if (Environment.IsPropertyReference(realm, ref)) {
       // i. Let thisValue be GetThisValue(ref).
       thisValue = GetThisValue(realm, ref);
     } else {
       // b. Else, the base of ref is an Environment Record
       // i. Let refEnv be GetBase(ref).
-      let refEnv = GetBase(realm, ref);
+      let refEnv = Environment.GetBase(realm, ref);
       invariant(refEnv instanceof EnvironmentRecord);
 
       // ii. Let thisValue be refEnv.WithBaseObject().

--- a/src/evaluators/CatchClause.js
+++ b/src/evaluators/CatchClause.js
@@ -14,7 +14,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { Value } from "../values/index.js";
 import { ThrowCompletion } from "../completions.js";
 import invariant from "../invariant.js";
-import { NewDeclarativeEnvironment, BoundNames, BindingInitialization } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeCatchClause } from "babel-types";
 
 // ECAM262 13.15.7
@@ -31,13 +31,13 @@ export default function(
   let oldEnv = realm.getRunningContext().lexicalEnvironment;
 
   // 2. Let catchEnv be NewDeclarativeEnvironment(oldEnv).
-  let catchEnv = NewDeclarativeEnvironment(realm, oldEnv);
+  let catchEnv = Environment.NewDeclarativeEnvironment(realm, oldEnv);
 
   // 3. Let catchEnvRec be catchEnv's EnvironmentRecord.
   let catchEnvRec = catchEnv.environmentRecord;
 
   // 4. For each element argName of the BoundNames of CatchParameter, do
-  for (let argName of BoundNames(realm, ast.param)) {
+  for (let argName of Environment.BoundNames(realm, ast.param)) {
     // a. Perform ! catchEnvRec.CreateMutableBinding(argName, false).
     catchEnvRec.CreateMutableBinding(argName, false);
   }
@@ -47,7 +47,7 @@ export default function(
 
   try {
     // 6. Let status be the result of performing BindingInitialization for CatchParameter passing thrownValue and catchEnv as arguments.
-    BindingInitialization(realm, ast.param, thrownValue.value, strictCode, catchEnv);
+    Environment.BindingInitialization(realm, ast.param, thrownValue.value, strictCode, catchEnv);
 
     // 7. If status is an abrupt completion, then
     // a. Set the running execution context's LexicalEnvironment to oldEnv.

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -27,16 +27,13 @@ import {
   Get,
   MakeConstructor,
   CreateMethodProperty,
-  NewDeclarativeEnvironment,
   MakeClassConstructor,
   ObjectCreate,
   ConstructorMethod,
-  GetValue,
   IsStatic,
-  InitializeBoundName,
   NonConstructorMethodDefinitions,
 } from "../methods/index.js";
-import { Functions, Properties } from "../singletons.js";
+import { Environment, Functions, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 function EvaluateClassHeritage(
@@ -45,7 +42,7 @@ function EvaluateClassHeritage(
   strictCode: boolean
 ): ObjectValue | null {
   let ref = realm.getRunningContext().lexicalEnvironment.evaluate(ClassHeritage, strictCode);
-  let val = GetValue(realm, ref);
+  let val = Environment.GetValue(realm, ref);
   if (val instanceof AbstractValue) {
     let error = new CompilerDiagnostic("unknown super class", ClassHeritage.loc, "PP0009", "RecoverableError");
     if (realm.handleError(error) === "Fail") throw new FatalError();
@@ -68,7 +65,7 @@ export function ClassDefinitionEvaluation(
   let lex = env;
 
   // 2. Let classScope be NewDeclarativeEnvironment(lex).
-  let classScope = NewDeclarativeEnvironment(realm, lex);
+  let classScope = Environment.NewDeclarativeEnvironment(realm, lex);
 
   // 3. Let classScopeEnvRec be classScope’s EnvironmentRecord.
   let classScopeEnvRec = classScope.environmentRecord;
@@ -291,7 +288,7 @@ function BindingClassDeclarationEvaluation(
     // 7. Let env be the running execution context’s LexicalEnvironment.
 
     // 8. Let status be InitializeBoundName(className, value, env).
-    InitializeBoundName(realm, className, value, env);
+    Environment.InitializeBoundName(realm, className, value, env);
 
     // 9. ReturnIfAbrupt(status).
 

--- a/src/evaluators/ConditionalExpression.js
+++ b/src/evaluators/ConditionalExpression.js
@@ -13,7 +13,8 @@ import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
 import type { Reference } from "../environment.js";
 import { evaluateWithAbstractConditional } from "./IfStatement.js";
-import { GetValue, ToBoolean } from "../methods/index.js";
+import { ToBoolean } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeConditionalExpression } from "babel-types";
 import invariant from "../invariant.js";
 import type { Realm } from "../realm.js";
@@ -25,7 +26,7 @@ export default function(
   realm: Realm
 ): Value | Reference {
   let exprRef = env.evaluate(ast.test, strictCode);
-  let exprValue = GetValue(realm, exprRef);
+  let exprValue = Environment.GetValue(realm, exprRef);
 
   if (exprValue instanceof ConcreteValue) {
     if (ToBoolean(realm, exprValue)) {

--- a/src/evaluators/DoWhileStatement.js
+++ b/src/evaluators/DoWhileStatement.js
@@ -13,9 +13,10 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { Value } from "../values/index.js";
 import { EmptyValue } from "../values/index.js";
-import { ToBooleanPartial, GetValue, UpdateEmpty } from "../methods/index.js";
+import { ToBooleanPartial, UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
 import { AbruptCompletion, BreakCompletion } from "../completions.js";
+import { Environment } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeDoWhileStatement } from "babel-types";
 
@@ -55,7 +56,7 @@ export default function(
     let exprRef = env.evaluate(test, strictCode);
 
     // e. Let exprValue be ? GetValue(exprRef).
-    let exprValue = GetValue(realm, exprRef);
+    let exprValue = Environment.GetValue(realm, exprRef);
 
     // f. If ToBoolean(exprValue) is false, return NormalCompletion(V).
     if (ToBooleanPartial(realm, exprValue) === false) return V;

--- a/src/evaluators/ExpressionStatement.js
+++ b/src/evaluators/ExpressionStatement.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
-import { GetValue } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeExpressionStatement } from "babel-types";
 
 export default function(
@@ -26,5 +26,5 @@ export default function(
   let exprRef = env.evaluate(ast.expression, strictCode);
 
   // 2. Return ? GetValue(exprRef).
-  return GetValue(realm, exprRef);
+  return Environment.GetValue(realm, exprRef);
 }

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -13,8 +13,9 @@ import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 import { Value, EmptyValue } from "../values/index.js";
 import { AbruptCompletion, BreakCompletion } from "../completions.js";
-import { BoundNames, NewDeclarativeEnvironment, GetValue, ToBooleanPartial, UpdateEmpty } from "../methods/index.js";
+import { ToBooleanPartial, UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
+import { Environment } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeForStatement } from "babel-types";
 
@@ -31,7 +32,7 @@ export function CreatePerIterationEnvironment(realm: Realm, perIterationBindings
     // d. Assert: outer is not null.
     invariant(outer !== null);
     // e. Let thisIterationEnv be NewDeclarativeEnvironment(outer).
-    let thisIterationEnv = NewDeclarativeEnvironment(realm, outer);
+    let thisIterationEnv = Environment.NewDeclarativeEnvironment(realm, outer);
     // f. Let thisIterationEnvRec be thisIterationEnv's EnvironmentRecord.
     let thisIterationEnvRec = thisIterationEnv.environmentRecord;
     // g. For each element bn of perIterationBindings do,
@@ -75,7 +76,7 @@ function ForBodyEvaluation(
       let testRef = env.evaluate(test, strictCode);
 
       // ii. Let testValue be ? GetValue(testRef).
-      let testValue = GetValue(realm, testRef);
+      let testValue = Environment.GetValue(realm, testRef);
 
       // iii. If ToBoolean(testValue) is false, return NormalCompletion(V).
       if (!ToBooleanPartial(realm, testValue)) return V;
@@ -109,7 +110,7 @@ function ForBodyEvaluation(
       let incRef = env.evaluate(increment, strictCode);
 
       // ii. Perform ? GetValue(incRef).
-      GetValue(realm, incRef);
+      Environment.GetValue(realm, incRef);
     }
   }
 
@@ -143,7 +144,7 @@ export default function(
       let oldEnv = env;
 
       // 2. Let loopEnv be NewDeclarativeEnvironment(oldEnv).
-      let loopEnv = NewDeclarativeEnvironment(realm, oldEnv);
+      let loopEnv = Environment.NewDeclarativeEnvironment(realm, oldEnv);
 
       // 3. Let loopEnvRec be loopEnv's EnvironmentRecord.
       let loopEnvRec = loopEnv.environmentRecord;
@@ -152,7 +153,7 @@ export default function(
       let isConst = init.kind === "const";
 
       // 5. Let boundNames be the BoundNames of LexicalDeclaration.
-      let boundNames = BoundNames(realm, init);
+      let boundNames = Environment.BoundNames(realm, init);
 
       // 6. For each element dn of boundNames do
       for (let dn of boundNames) {
@@ -204,7 +205,7 @@ export default function(
       let exprRef = env.evaluate(init, strictCode);
 
       // b. Perform ? GetValue(exprRef).
-      GetValue(realm, exprRef);
+      Environment.GetValue(realm, exprRef);
     }
 
     // 2. Return ? ForBodyEvaluation(the second Expression, the third Expression, Statement, « », labelSet).

--- a/src/evaluators/FunctionExpression.js
+++ b/src/evaluators/FunctionExpression.js
@@ -12,9 +12,9 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
-import { NewDeclarativeEnvironment, MakeConstructor } from "../methods/index.js";
+import { MakeConstructor } from "../methods/index.js";
 import { ObjectCreate } from "../methods/create.js";
-import { Functions, Properties } from "../singletons.js";
+import { Environment, Functions, Properties } from "../singletons.js";
 import { StringValue } from "../values/index.js";
 import IsStrict from "../utils/strict.js";
 import type { BabelNodeFunctionExpression } from "babel-types";
@@ -37,7 +37,7 @@ export default function(
       let scope = env;
 
       // 3. Let funcEnv be NewDeclarativeEnvironment(scope).
-      let funcEnv = NewDeclarativeEnvironment(realm, scope);
+      let funcEnv = Environment.NewDeclarativeEnvironment(realm, scope);
 
       // 4. Let envRec be funcEnv's EnvironmentRecord.
       let envRec = funcEnv.environmentRecord;
@@ -81,7 +81,7 @@ export default function(
       let scope = env;
 
       // 3. Let funcEnv be NewDeclarativeEnvironment(scope).
-      let funcEnv = NewDeclarativeEnvironment(realm, scope);
+      let funcEnv = Environment.NewDeclarativeEnvironment(realm, scope);
 
       // 4. Let envRec be funcEnv's EnvironmentRecord.
       let envRec = funcEnv.environmentRecord;

--- a/src/evaluators/Identifier.js
+++ b/src/evaluators/Identifier.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Reference } from "../environment.js";
-import { ResolveBinding } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeIdentifier } from "babel-types";
 
 // ECMA262 12.1.6
@@ -23,5 +23,5 @@ export default function(
   realm: Realm
 ): Reference {
   // 1. Return ? ResolveBinding(StringValue of Identifier).
-  return ResolveBinding(realm, ast.name, strictCode, env);
+  return Environment.ResolveBinding(realm, ast.name, strictCode, env);
 }

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -15,16 +15,16 @@ import { construct_empty_effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { GetValue, joinEffects, ToBoolean, UpdateEmpty } from "../methods/index.js";
+import { joinEffects, ToBoolean, UpdateEmpty } from "../methods/index.js";
 import type { BabelNode, BabelNodeIfStatement } from "babel-types";
 import invariant from "../invariant.js";
-import { Path } from "../singletons.js";
+import { Environment, Path } from "../singletons.js";
 
 export function evaluate(ast: BabelNodeIfStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value {
   // 1. Let exprRef be the result of evaluating Expression
   let exprRef = env.evaluate(ast.test, strictCode);
   // 2. Let exprValue be ToBoolean(? GetValue(exprRef))
-  let exprValue: Value = GetValue(realm, exprRef);
+  let exprValue: Value = Environment.GetValue(realm, exprRef);
 
   if (exprValue instanceof ConcreteValue) {
     let stmtCompletion;

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -15,7 +15,8 @@ import { construct_empty_effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { GetValue, joinEffects, ToBoolean } from "../methods/index.js";
+import { joinEffects, ToBoolean } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeLogicalExpression } from "babel-types";
 import invariant from "../invariant.js";
 import { Path } from "../singletons.js";
@@ -27,7 +28,7 @@ export default function(
   realm: Realm
 ): Value | Reference {
   let lref = env.evaluate(ast.left, strictCode);
-  let lval = GetValue(realm, lref);
+  let lval = Environment.GetValue(realm, lref);
 
   if (lval instanceof ConcreteValue) {
     let lbool = ToBoolean(realm, lval);
@@ -42,7 +43,7 @@ export default function(
     }
 
     let rref = env.evaluate(ast.right, strictCode);
-    return GetValue(realm, rref);
+    return Environment.GetValue(realm, rref);
   }
   invariant(lval instanceof AbstractValue);
 

--- a/src/evaluators/MemberExpression.js
+++ b/src/evaluators/MemberExpression.js
@@ -13,7 +13,8 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { Reference } from "../environment.js";
 import { StringValue } from "../values/index.js";
-import { GetValue, ToPropertyKeyPartial, RequireObjectCoercible } from "../methods/index.js";
+import { ToPropertyKeyPartial, RequireObjectCoercible } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeMemberExpression } from "babel-types";
 import SuperProperty from "./SuperProperty";
 
@@ -32,7 +33,7 @@ export default function(
   let baseReference = env.evaluate(ast.object, strictCode);
 
   // 2. Let baseValue be ? GetValue(baseReference).
-  let baseValue = GetValue(realm, baseReference);
+  let baseValue = Environment.GetValue(realm, baseReference);
 
   let propertyNameValue;
   if (ast.computed) {
@@ -40,7 +41,7 @@ export default function(
     let propertyNameReference = env.evaluate(ast.property, strictCode);
 
     // 4. Let propertyNameValue be ? GetValue(propertyNameReference).
-    propertyNameValue = GetValue(realm, propertyNameReference);
+    propertyNameValue = Environment.GetValue(realm, propertyNameReference);
   } else {
     // 3. Let propertyNameString be StringValue of IdentifierName.
     propertyNameValue = new StringValue(realm, ast.property.name);

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { ObjectValue } from "../values/index.js";
-import { GetValue } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import { IsConstructor } from "../methods/index.js";
 import { ArgumentListEvaluation } from "../methods/index.js";
 import { Construct } from "../methods/index.js";
@@ -43,7 +43,7 @@ export default function(
   let ref = env.evaluate(constructProduction, strictCode);
 
   // 4. Let constructor be ? GetValue(ref).
-  let constructor = GetValue(realm, ref);
+  let constructor = Environment.GetValue(realm, ref);
 
   let argsList;
 

--- a/src/evaluators/ObjectExpression.js
+++ b/src/evaluators/ObjectExpression.js
@@ -16,14 +16,13 @@ import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbstractValue, ConcreteValue, ObjectValue, StringValue } from "../values/index.js";
 import {
   ObjectCreate,
-  GetValue,
   CreateDataPropertyOrThrow,
   IsAnonymousFunctionDefinition,
   HasOwnProperty,
   ToPropertyKey,
   ToString,
 } from "../methods/index.js";
-import { Functions, Properties } from "../singletons.js";
+import { Environment, Functions, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type {
   BabelNodeObjectExpression,
@@ -55,7 +54,7 @@ function EvalPropertyNamePartial(
   strictCode: boolean
 ): AbstractValue | PropertyKeyValue {
   if (prop.computed) {
-    let propertyKeyName = GetValue(realm, env.evaluate(prop.key, strictCode));
+    let propertyKeyName = Environment.GetValue(realm, env.evaluate(prop.key, strictCode));
     if (propertyKeyName instanceof AbstractValue) return propertyKeyName;
     invariant(propertyKeyName instanceof ConcreteValue);
     return ToPropertyKey(realm, propertyKeyName);
@@ -63,7 +62,7 @@ function EvalPropertyNamePartial(
     if (prop.key.type === "Identifier") {
       return new StringValue(realm, prop.key.name);
     } else {
-      let propertyKeyName = GetValue(realm, env.evaluate(prop.key, strictCode));
+      let propertyKeyName = Environment.GetValue(realm, env.evaluate(prop.key, strictCode));
       invariant(propertyKeyName instanceof ConcreteValue); // syntax only allows literals if !prop.computed
       return ToString(realm, propertyKeyName);
     }
@@ -93,7 +92,7 @@ export default function(
       let exprValueRef = env.evaluate(prop.value, strictCode);
 
       // 4. Let propValue be ? GetValue(exprValueRef).
-      let propValue = GetValue(realm, exprValueRef);
+      let propValue = Environment.GetValue(realm, exprValueRef);
 
       // 5. If IsAnonymousFunctionDefinition(AssignmentExpression) is true, then
       if (IsAnonymousFunctionDefinition(realm, prop.value)) {

--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -21,8 +21,8 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, Value, EmptyValue } from "../values/index.js";
 import { GlobalEnvironmentRecord } from "../environment.js";
-import { BoundNames, stopEffectCaptureJoinApplyAndReturnCompletion } from "../methods/index.js";
-import { Functions } from "../singletons.js";
+import { stopEffectCaptureJoinApplyAndReturnCompletion } from "../methods/index.js";
+import { Environment, Functions } from "../singletons.js";
 import IsStrict from "../utils/strict.js";
 import invariant from "../invariant.js";
 import traverseFast from "../utils/traverse-fast.js";
@@ -53,9 +53,9 @@ export function GlobalDeclarationInstantiation(
   traverseFast(ast, node => {
     if (node.type === "VariableDeclaration") {
       if (node.kind === "var") {
-        varNames = varNames.concat(BoundNames(realm, node));
+        varNames = varNames.concat(Environment.BoundNames(realm, node));
       } else {
-        lexNames = lexNames.concat(BoundNames(realm, node));
+        lexNames = lexNames.concat(Environment.BoundNames(realm, node));
       }
     } else if (node.type === "FunctionExpression" || node.type === "FunctionDeclaration") {
       return true;
@@ -117,7 +117,7 @@ export function GlobalDeclarationInstantiation(
       // ii. NOTE If there are multiple FunctionDeclarations for the same name, the last declaration is used.
 
       // iii. Let fn be the sole element of the BoundNames of d.
-      let fn = BoundNames(realm, d)[0];
+      let fn = Environment.BoundNames(realm, d)[0];
 
       // iv. If fn is not an element of declaredFunctionNames, then
       if (declaredFunctionNames.indexOf(fn) < 0) {
@@ -149,7 +149,7 @@ export function GlobalDeclarationInstantiation(
     // a. If d is a VariableDeclaration or a ForBinding, then
     if (d.type === "VariableDeclaration") {
       // i. For each String vn in the BoundNames of d, do
-      for (let vn of BoundNames(realm, d)) {
+      for (let vn of Environment.BoundNames(realm, d)) {
         // ii. If vn is not an element of declaredFunctionNames, then
         if (declaredFunctionNames.indexOf(vn) < 0) {
           // 1. Let vnDefinable be ? envRec.CanDeclareGlobalVar(vn).
@@ -190,7 +190,7 @@ export function GlobalDeclarationInstantiation(
     // a. NOTE Lexically declared names are only instantiated here but not initialized.
 
     // b. For each element dn of the BoundNames of d do
-    for (let dn of BoundNames(realm, d)) {
+    for (let dn of Environment.BoundNames(realm, d)) {
       // i. If IsConstantDeclaration of d is true, then
       if (d.kind === "const") {
         // 1. Perform ? envRec.CreateImmutableBinding(dn, true).
@@ -206,7 +206,7 @@ export function GlobalDeclarationInstantiation(
   // 17. For each production f in functionsToInitialize, do
   for (let f of functionsToInitialize) {
     // a. Let fn be the sole element of the BoundNames of f.
-    let fn = BoundNames(realm, f)[0];
+    let fn = Environment.BoundNames(realm, f)[0];
 
     // b. Let fo be the result of performing InstantiateFunctionObject for f with argument env.
     let fo = env.evaluate(f, strictCode);

--- a/src/evaluators/ReturnStatement.js
+++ b/src/evaluators/ReturnStatement.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
-import { GetValue } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import { ReturnCompletion } from "../completions.js";
 import type { BabelNodeReturnStatement } from "babel-types";
 
@@ -24,7 +24,7 @@ export default function(
 ): Value {
   let arg;
   if (ast.argument) {
-    arg = GetValue(realm, env.evaluate(ast.argument, strictCode));
+    arg = Environment.GetValue(realm, env.evaluate(ast.argument, strictCode));
   } else {
     arg = realm.intrinsics.undefined;
   }

--- a/src/evaluators/SequenceExpression.js
+++ b/src/evaluators/SequenceExpression.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
-import { GetValue } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeSequenceExpression } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -25,7 +25,7 @@ export default function(
   invariant(ast.expressions.length > 0);
   let val;
   for (let node of ast.expressions) {
-    val = GetValue(realm, env.evaluate(node, strictCode));
+    val = Environment.GetValue(realm, env.evaluate(node, strictCode));
   }
   invariant(val !== undefined);
   return val;

--- a/src/evaluators/SuperCall.js
+++ b/src/evaluators/SuperCall.js
@@ -14,18 +14,13 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { FunctionEnvironmentRecord } from "../environment.js";
 import { Value, UndefinedValue, ObjectValue } from "../values/index.js";
-import {
-  GetNewTarget,
-  ArgumentListEvaluation,
-  Construct,
-  GetThisEnvironment,
-  IsConstructor,
-} from "../methods/index.js";
+import { GetNewTarget, ArgumentListEvaluation, Construct, IsConstructor } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import invariant from "../invariant.js";
 
 function GetSuperConstructor(realm: Realm) {
   // 1. Let envRec be GetThisEnvironment( ).
-  let envRec = GetThisEnvironment(realm);
+  let envRec = Environment.GetThisEnvironment(realm);
 
   // 2. Assert: envRec is a function Environment Record.
   invariant(envRec instanceof FunctionEnvironmentRecord);
@@ -79,7 +74,7 @@ export default function SuperCall(
   // 8. ReturnIfAbrupt(result).
 
   // 9. Let thisER be GetThisEnvironment( ).
-  let thisER = GetThisEnvironment(realm);
+  let thisER = Environment.GetThisEnvironment(realm);
 
   // 10. Return thisER.BindThisValue(result).
   return thisER.BindThisValue(result);

--- a/src/evaluators/SuperProperty.js
+++ b/src/evaluators/SuperProperty.js
@@ -14,13 +14,14 @@ import type { LexicalEnvironment } from "../environment.js";
 import { FunctionEnvironmentRecord } from "../environment.js";
 import { Reference } from "../environment.js";
 import { StringValue } from "../values/index.js";
-import { GetValue, ToPropertyKeyPartial, RequireObjectCoercible, GetThisEnvironment } from "../methods/index.js";
+import { ToPropertyKeyPartial, RequireObjectCoercible } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeMemberExpression } from "babel-types";
 import invariant from "../invariant.js";
 
 function MakeSuperPropertyReference(realm: Realm, propertyKey, strict: boolean): Reference {
   // 1. Let env be GetThisEnvironment( ).
-  let env = GetThisEnvironment(realm);
+  let env = Environment.GetThisEnvironment(realm);
   invariant(env instanceof FunctionEnvironmentRecord);
 
   // 2. If env.HasSuperBinding() is false, throw a ReferenceError exception.
@@ -58,7 +59,7 @@ export default function SuperProperty(
     let propertyNameReference = env.evaluate(ast.property, strictCode);
 
     // 2. Let propertyNameValue be GetValue(propertyNameReference).
-    let propertyNameValue = GetValue(realm, propertyNameReference);
+    let propertyNameValue = Environment.GetValue(realm, propertyNameReference);
 
     // 3. Let propertyKey be ToPropertyKey(propertyNameValue).
     let propertyKey = ToPropertyKeyPartial(realm, propertyNameValue);

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -14,13 +14,8 @@ import type { LexicalEnvironment } from "../environment.js";
 import { AbruptCompletion, BreakCompletion } from "../completions.js";
 import { InternalGetResultValue } from "./ForOfStatement.js";
 import { EmptyValue, Value } from "../values/index.js";
-import {
-  GetValue,
-  NewDeclarativeEnvironment,
-  BlockDeclarationInstantiation,
-  StrictEqualityComparisonPartial,
-  UpdateEmpty,
-} from "../methods/index.js";
+import { StrictEqualityComparisonPartial, UpdateEmpty } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeSwitchStatement, BabelNodeSwitchCase, BabelNodeExpression } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -35,7 +30,7 @@ function CaseSelectorEvaluation(
   let exprRef = env.evaluate(expression, strictCode);
 
   // 2. Return ? GetValue(exprRef).
-  return GetValue(realm, exprRef);
+  return Environment.GetValue(realm, exprRef);
 }
 
 function CaseBlockEvaluation(
@@ -176,17 +171,17 @@ export default function(
   let exprRef = env.evaluate(expression, strictCode);
 
   // 2. Let switchValue be ? GetValue(exprRef).
-  let switchValue = GetValue(realm, exprRef);
+  let switchValue = Environment.GetValue(realm, exprRef);
 
   // 3. Let oldEnv be the running execution context's LexicalEnvironment.
   let oldEnv = realm.getRunningContext().lexicalEnvironment;
 
   // 4. Let blockEnv be NewDeclarativeEnvironment(oldEnv).
-  let blockEnv = NewDeclarativeEnvironment(realm, oldEnv);
+  let blockEnv = Environment.NewDeclarativeEnvironment(realm, oldEnv);
 
   // 5. Perform BlockDeclarationInstantiation(CaseBlock, blockEnv).
   let CaseBlock = cases.map(c => c.consequent).reduce((stmts, case_blk) => stmts.concat(case_blk), []);
-  BlockDeclarationInstantiation(realm, strictCode, CaseBlock, blockEnv);
+  Environment.BlockDeclarationInstantiation(realm, strictCode, CaseBlock, blockEnv);
 
   // 6. Set the running execution context's LexicalEnvironment to blockEnv.
   realm.getRunningContext().lexicalEnvironment = blockEnv;

--- a/src/evaluators/TemplateLiteral.js
+++ b/src/evaluators/TemplateLiteral.js
@@ -14,7 +14,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { StringValue } from "../values/index.js";
 import { ToStringPartial } from "../methods/index.js";
-import { GetValue } from "../methods/environment.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeTemplateLiteral } from "babel-types";
 
 // ECMA262 12.2.9
@@ -34,7 +34,7 @@ export default function(
     // add expression
     let expr = ast.expressions[i];
     if (expr) {
-      str += ToStringPartial(realm, GetValue(realm, env.evaluate(expr, strictCode)));
+      str += ToStringPartial(realm, Environment.GetValue(realm, env.evaluate(expr, strictCode)));
     }
   }
 

--- a/src/evaluators/ThisExpression.js
+++ b/src/evaluators/ThisExpression.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
-import { ResolveThisBinding } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeThisExpression } from "babel-types";
 
 // ECMA262 12.2.2.1
@@ -23,5 +23,5 @@ export default function(
   realm: Realm
 ): Value {
   // 1. Return ? ResolveThisBinding( ).
-  return ResolveThisBinding(realm);
+  return Environment.ResolveThisBinding(realm);
 }

--- a/src/evaluators/ThrowStatement.js
+++ b/src/evaluators/ThrowStatement.js
@@ -13,7 +13,7 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { ThrowCompletion } from "../completions.js";
-import { GetValue } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import type { BabelNodeThrowStatement } from "babel-types";
 
 export default function(
@@ -23,6 +23,6 @@ export default function(
   realm: Realm
 ): Value {
   let exprRef = env.evaluate(ast.argument, strictCode);
-  let exprValue = GetValue(realm, exprRef);
+  let exprValue = Environment.GetValue(realm, exprRef);
   throw new ThrowCompletion(exprValue, ast.loc);
 }

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -13,10 +13,10 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
-import { Add, GetValue, ToNumber, IsToNumberPure } from "../methods/index.js";
+import { Add, ToNumber, IsToNumberPure } from "../methods/index.js";
 import { AbstractValue, NumberValue } from "../values/index.js";
 import type { BabelNodeUpdateExpression } from "babel-types";
-import { Properties } from "../singletons.js";
+import { Environment, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 export default function(
@@ -31,7 +31,7 @@ export default function(
   let expr = env.evaluate(ast.argument, strictCode);
 
   // Let oldValue be ? ToNumber(? GetValue(expr)).
-  let oldExpr = GetValue(realm, expr);
+  let oldExpr = Environment.GetValue(realm, expr);
   if (oldExpr instanceof AbstractValue) {
     if (!IsToNumberPure(realm, oldExpr)) {
       let error = new CompilerDiagnostic(

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -14,15 +14,8 @@ import type { LexicalEnvironment } from "../environment.js";
 import { FatalError } from "../errors.js";
 import type { Value } from "../values/index.js";
 import { ObjectValue, StringValue } from "../values/index.js";
-import {
-  GetValue,
-  ResolveBinding,
-  InitializeReferencedBinding,
-  IsAnonymousFunctionDefinition,
-  HasOwnProperty,
-  BindingInitialization,
-} from "../methods/index.js";
-import { Functions, Properties } from "../singletons.js";
+import { IsAnonymousFunctionDefinition, HasOwnProperty } from "../methods/index.js";
+import { Environment, Functions, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeVariableDeclaration } from "babel-types";
 
@@ -44,10 +37,10 @@ function letAndConst(
 
       // 1. Let lhs be ResolveBinding(StringValue of BindingIdentifier).
       let bindingId = declar.id.name;
-      let lhs = ResolveBinding(realm, bindingId, strictCode);
+      let lhs = Environment.ResolveBinding(realm, bindingId, strictCode);
 
       // 2. Return InitializeReferencedBinding(lhs, undefined).
-      InitializeReferencedBinding(realm, lhs, realm.intrinsics.undefined);
+      Environment.InitializeReferencedBinding(realm, lhs, realm.intrinsics.undefined);
       continue;
     }
 
@@ -55,13 +48,13 @@ function letAndConst(
     let bindingId = declar.id.name;
 
     // 2. Let lhs be ResolveBinding(bindingId).
-    let lhs = ResolveBinding(realm, bindingId, strictCode);
+    let lhs = Environment.ResolveBinding(realm, bindingId, strictCode);
 
     // 3. Let rhs be the result of evaluating Initializer.
     let rhs = env.evaluate(Initializer, strictCode);
 
     // 4. Let value be ? GetValue(rhs).
-    let value = GetValue(realm, rhs);
+    let value = Environment.GetValue(realm, rhs);
 
     // 5. If IsAnonymousFunctionDefinition(Initializer) is true, then
     if (IsAnonymousFunctionDefinition(realm, Initializer)) {
@@ -75,7 +68,7 @@ function letAndConst(
     }
 
     // 6. Return InitializeReferencedBinding(lhs, value).
-    InitializeReferencedBinding(realm, lhs, value);
+    Environment.InitializeReferencedBinding(realm, lhs, value);
   }
 
   return realm.intrinsics.empty;
@@ -107,13 +100,13 @@ export default function(
       let bindingId = declar.id.name;
 
       // 2. Let lhs be ? ResolveBinding(bindingId).
-      let lhs = ResolveBinding(realm, bindingId, strictCode);
+      let lhs = Environment.ResolveBinding(realm, bindingId, strictCode);
 
       // 3. Let rhs be the result of evaluating Initializer.
       let rhs = env.evaluate(Initializer, strictCode);
 
       // 4. Let value be ? GetValue(rhs).
-      let value = GetValue(realm, rhs);
+      let value = Environment.GetValue(realm, rhs);
       if (declar.id && declar.id.name) value.__originalName = bindingId;
 
       // 5. If IsAnonymousFunctionDefinition(Initializer) is true, then
@@ -134,10 +127,10 @@ export default function(
       let rhs = env.evaluate(Initializer, strictCode);
 
       // 2. Let rval be ? GetValue(rhs).
-      let rval = GetValue(realm, rhs);
+      let rval = Environment.GetValue(realm, rhs);
 
       // 3. Return the result of performing BindingInitialization for BindingPattern passing rval and undefined as arguments.
-      BindingInitialization(realm, declar.id, rval, strictCode, undefined);
+      Environment.BindingInitialization(realm, declar.id, rval, strictCode, undefined);
     } else {
       invariant(false, "unrecognized declaration");
     }

--- a/src/evaluators/WithStatement.js
+++ b/src/evaluators/WithStatement.js
@@ -14,7 +14,8 @@ import { LexicalEnvironment, ObjectEnvironmentRecord } from "../environment.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion } from "../completions.js";
 import { AbstractValue, ObjectValue, Value } from "../values/index.js";
-import { ToObjectPartial, GetValue, NewObjectEnvironment, UpdateEmpty } from "../methods/index.js";
+import { ToObjectPartial, UpdateEmpty } from "../methods/index.js";
+import { Environment } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeWithStatement } from "babel-types";
 
@@ -29,7 +30,7 @@ export default function(
   let val = env.evaluate(ast.object, strictCode);
 
   // 2. Let obj be ? ToObject(? GetValue(val)).
-  val = GetValue(realm, val);
+  val = Environment.GetValue(realm, val);
   if (val instanceof AbstractValue || (val instanceof ObjectValue && val.isPartialObject())) {
     let loc = ast.object.loc;
     let error = new CompilerDiagnostic("with object must be a known value", loc, "PP0007", "RecoverableError");
@@ -41,7 +42,7 @@ export default function(
   let oldEnv = env;
 
   // 4. Let newEnv be NewObjectEnvironment(obj, oldEnv).
-  let newEnv = NewObjectEnvironment(realm, obj, oldEnv);
+  let newEnv = Environment.NewObjectEnvironment(realm, obj, oldEnv);
 
   // 5. Set the withEnvironment flag of newEnv's EnvironmentRecord to true.
   invariant(newEnv.environmentRecord instanceof ObjectEnvironmentRecord);

--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -10,11 +10,13 @@
 /* @flow */
 
 import * as Singletons from "./singletons.js";
+import { EnvironmentImplementation } from "./methods/environment.js";
 import { FunctionImplementation } from "./methods/function.js";
 import { PathImplementation } from "./utils/paths.js";
 import { PropertiesImplementation } from "./methods/properties.js";
 
 export default function() {
+  Singletons.setEnvironment(new EnvironmentImplementation());
   Singletons.setFunctions(new FunctionImplementation());
   Singletons.setPath(new PathImplementation());
   Singletons.setProperties((new PropertiesImplementation(): any));

--- a/src/intrinsics/react-mocks/mocks.js
+++ b/src/intrinsics/react-mocks/mocks.js
@@ -12,7 +12,8 @@
 import type { Realm } from "../../realm.js";
 import { parseExpression } from "babylon";
 import { ObjectValue } from "../../values/index.js";
-import { Get, GetValue } from "../../methods/index.js";
+import { Get } from "../../methods/index.js";
+import { Environment } from "../../singletons.js";
 import invariant from "../../invariant";
 
 let reactCode = `
@@ -24,7 +25,7 @@ let reactCode = `
         this.refs = {};
         this.state = {};
       }
-      isReactComponent() { 
+      isReactComponent() {
         return true;
       }
       getChildContext() {}
@@ -42,13 +43,13 @@ let reactCode = `
       };
       var hasOwnProperty = Object.prototype.hasOwnProperty;
       var props = Object.assign({}, element.props);
-    
+
       var key = element.key;
       var ref = element.ref;
       var self = element._self;
       var source = element._source;
       var owner = element._owner;
-    
+
       if (config != null) {
         if (config.ref !== undefined) {
           // owner = ReactCurrentOwner.current;
@@ -84,7 +85,7 @@ let reactCode = `
         }
         props.children = childArray;
       }
-    
+
       return {
         $$typeof: element.$$typeof,
         type: element.type,
@@ -99,7 +100,7 @@ let reactCode = `
 let reactAst = parseExpression(reactCode, { plugins: ["flow"] });
 
 export function createMockReact(realm: Realm): ObjectValue {
-  let reactValue = GetValue(realm, realm.$GlobalEnv.evaluate(reactAst, false));
+  let reactValue = Environment.GetValue(realm, realm.$GlobalEnv.evaluate(reactAst, false));
   reactValue.intrinsicName = `require("react")`;
   invariant(reactValue instanceof ObjectValue);
 

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -23,16 +23,14 @@ import {
   IteratorClose,
   IteratorStep,
   IteratorValue,
-  GetValue,
   IsAnonymousFunctionDefinition,
   IsIdentifierRef,
   HasOwnProperty,
-  GetReferencedName,
   ArrayCreate,
   CreateDataProperty,
   GetV,
 } from "./index.js";
-import { Functions, Properties } from "../singletons.js";
+import { Environment, Functions, Properties } from "../singletons.js";
 import type { BabelNodeLVal, BabelNodeArrayPattern, BabelNodeObjectPattern } from "babel-types";
 
 // ECMA262 12.15.5.2
@@ -220,7 +218,7 @@ export function IteratorDestructuringAssignmentEvaluation(
       let defaultValue = env.evaluate(Initializer, strictCode);
 
       // b. Let v be ? GetValue(defaultValue).
-      v = GetValue(realm, defaultValue);
+      v = Environment.GetValue(realm, defaultValue);
     } else {
       // 5. Else, let v be value.
       v = value;
@@ -265,7 +263,7 @@ export function IteratorDestructuringAssignmentEvaluation(
         // not be called with a value.
         invariant(lref instanceof Reference);
 
-        Functions.SetFunctionName(realm, v, GetReferencedName(realm, lref));
+        Functions.SetFunctionName(realm, v, Environment.GetReferencedName(realm, lref));
       }
     }
 
@@ -411,7 +409,7 @@ export function KeyedDestructuringAssignmentEvaluation(
     let defaultValue = env.evaluate(Initializer, strictCode);
 
     // b. Let rhsValue be ? GetValue(defaultValue).
-    rhsValue = GetValue(realm, defaultValue);
+    rhsValue = Environment.GetValue(realm, defaultValue);
   } else {
     // 4. Else, let rhsValue be v.
     rhsValue = v;
@@ -452,7 +450,7 @@ export function KeyedDestructuringAssignmentEvaluation(
       // not be called with a value.
       invariant(lref instanceof Reference);
 
-      Functions.SetFunctionName(realm, rhsValue, GetReferencedName(realm, lref));
+      Functions.SetFunctionName(realm, rhsValue, Environment.GetReferencedName(realm, lref));
     }
   }
 

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -66,659 +66,976 @@ import type {
   BabelNodePattern,
 } from "babel-types";
 
-// ECMA262 6.2.3
-// IsSuperReference(V). Returns true if this reference has a thisValue component.
-export function IsSuperReference(realm: Realm, V: Reference): boolean {
-  return V.thisValue !== undefined;
-}
-
-// ECMA262 6.2.3
-// HasPrimitiveBase(V). Returns true if Type(base) is Boolean, String, Symbol, or Number.
-export function HasPrimitiveBase(realm: Realm, V: Reference): boolean {
-  let base = GetBase(realm, V);
-  // void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord | AbstractValue;
-  if (!base || base instanceof EnvironmentRecord) return false;
-  let type = base.getType();
-  return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
-}
-
-// ECMA262 6.2.3
-// GetReferencedName(V). Returns the referenced name component of the reference V.
-export function GetReferencedName(realm: Realm, V: Reference): string | SymbolValue {
-  if (V.referencedName instanceof AbstractValue) {
-    AbstractValue.reportIntrospectionError(V.referencedName);
-    throw new FatalError();
-  }
-  return V.referencedName;
-}
-
-export function GetReferencedNamePartial(realm: Realm, V: Reference): AbstractValue | string | SymbolValue {
-  return V.referencedName;
-}
-
-// ECMA262 6.2.3.1
-export function GetValue(realm: Realm, V: Reference | Value): Value {
-  let val = dereference(realm, V);
-  if (val instanceof AbstractValue) return realm.simplifyAndRefineAbstractValue(val);
-  return val;
-}
-
-function dereference(realm: Realm, V: Reference | Value): Value {
-  // This step is not necessary as we propagate completions with exceptions.
-  // 1. ReturnIfAbrupt(V).
-
-  // 2. If Type(V) is not Reference, return V.
-  if (!(V instanceof Reference)) return V;
-
-  // 3. Let base be GetBase(V).
-  let base = GetBase(realm, V);
-
-  // 4. If IsUnresolvableReference(V) is true, throw a ReferenceError exception.
-  if (IsUnresolvableReference(realm, V)) {
-    throw realm.createErrorThrowCompletion(
-      realm.intrinsics.ReferenceError,
-      `${V.referencedName.toString()} is not defined`
-    );
+export class EnvironmentImplementation {
+  // ECMA262 6.2.3
+  // IsSuperReference(V). Returns true if this reference has a thisValue component.
+  IsSuperReference(realm: Realm, V: Reference): boolean {
+    return V.thisValue !== undefined;
   }
 
-  // 5. If IsPropertyReference(V) is true, then
-  if (IsPropertyReference(realm, V)) {
-    // a. If HasPrimitiveBase(V) is true, then
-    if (HasPrimitiveBase(realm, V)) {
-      // i. Assert: In this case, base will never be null or undefined.
-      invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
+  // ECMA262 6.2.3
+  // HasPrimitiveBase(V). Returns true if Type(base) is Boolean, String, Symbol, or Number.
+  HasPrimitiveBase(realm: Realm, V: Reference): boolean {
+    let base = this.GetBase(realm, V);
+    // void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord | AbstractValue;
+    if (!base || base instanceof EnvironmentRecord) return false;
+    let type = base.getType();
+    return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
+  }
 
-      // ii. Let base be ToObject(base).
-      base = ToObjectPartial(realm, base);
+  // ECMA262 6.2.3
+  // GetReferencedName(V). Returns the referenced name component of the reference V.
+  GetReferencedName(realm: Realm, V: Reference): string | SymbolValue {
+    if (V.referencedName instanceof AbstractValue) {
+      AbstractValue.reportIntrospectionError(V.referencedName);
+      throw new FatalError();
     }
-    invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
-
-    // b. Return ? base.[[Get]](GetReferencedName(V), GetThisValue(V)).
-    return base.$GetPartial(GetReferencedNamePartial(realm, V), GetThisValue(realm, V));
+    return V.referencedName;
   }
 
-  // 6. Else base must be an Environment Record,
-  if (base instanceof EnvironmentRecord) {
-    // a. Return ? base.GetBindingValue(GetReferencedName(V), IsStrictReference(V)) (see 8.1.1).
-    let referencedName = GetReferencedName(realm, V);
-    invariant(typeof referencedName === "string");
-    return base.GetBindingValue(referencedName, IsStrictReference(realm, V));
+  GetReferencedNamePartial(realm: Realm, V: Reference): AbstractValue | string | SymbolValue {
+    return V.referencedName;
   }
 
-  invariant(false);
-}
-
-// ECMA262 6.2.3
-// IsStrictReference(V). Returns the strict reference flag component of the reference V.
-export function IsStrictReference(realm: Realm, V: Reference): boolean {
-  return V.strict;
-}
-
-// ECMA262 6.2.3
-// IsPropertyReference(V). Returns true if either the base value is an object or HasPrimitiveBase(V) is true; otherwise returns false.
-export function IsPropertyReference(realm: Realm, V: Reference): boolean {
-  // V.base is AbstractValue | void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord;
-  return V.base instanceof AbstractValue || V.base instanceof ObjectValue || HasPrimitiveBase(realm, V);
-}
-
-// ECMA262 6.2.3
-// GetBase(V). Returns the base value component of the reference V.
-export function GetBase(realm: Realm, V: Reference): void | Value | EnvironmentRecord {
-  return V.base;
-}
-
-// ECMA262 6.2.3
-// IsUnresolvableReference(V). Returns true if the base value is undefined and false otherwise.
-export function IsUnresolvableReference(realm: Realm, V: Reference): boolean {
-  return !V.base;
-}
-
-// ECMA262 8.1.2.2
-export function NewDeclarativeEnvironment(realm: Realm, E: LexicalEnvironment): LexicalEnvironment {
-  // 1. Let env be a new Lexical Environment.
-  let env = new LexicalEnvironment(realm);
-
-  // 2. Let envRec be a new declarative Environment Record containing no bindings.
-  let envRec = new DeclarativeEnvironmentRecord(realm);
-
-  // 3. Set env's EnvironmentRecord to envRec.
-  env.environmentRecord = envRec;
-
-  // 4. Set the outer lexical environment reference of env to E.
-  env.parent = E;
-
-  // 5. Return env.
-  return env;
-}
-
-export function BoundNames(realm: Realm, node: BabelNode): Array<string> {
-  return Object.keys(t.getOuterBindingIdentifiers(node));
-}
-
-// ECMA262 13.3.3.2
-export function ContainsExpression(realm: Realm, node: ?BabelNode): boolean {
-  if (!node) {
-    return false;
+  // ECMA262 6.2.3.1
+  GetValue(realm: Realm, V: Reference | Value): Value {
+    let val = this._dereference(realm, V);
+    if (val instanceof AbstractValue) return realm.simplifyAndRefineAbstractValue(val);
+    return val;
   }
-  switch (node.type) {
-    case "ObjectPattern":
-      for (let prop of ((node: any): BabelNodeObjectPattern).properties) {
-        if (ContainsExpression(realm, prop)) return true;
+
+  _dereference(realm: Realm, V: Reference | Value): Value {
+    // This step is not necessary as we propagate completions with exceptions.
+    // 1. ReturnIfAbrupt(V).
+
+    // 2. If Type(V) is not Reference, return V.
+    if (!(V instanceof Reference)) return V;
+
+    // 3. Let base be GetBase(V).
+    let base = this.GetBase(realm, V);
+
+    // 4. If IsUnresolvableReference(V) is true, throw a ReferenceError exception.
+    if (this.IsUnresolvableReference(realm, V)) {
+      throw realm.createErrorThrowCompletion(
+        realm.intrinsics.ReferenceError,
+        `${V.referencedName.toString()} is not defined`
+      );
+    }
+
+    // 5. If IsPropertyReference(V) is true, then
+    if (this.IsPropertyReference(realm, V)) {
+      // a. If HasPrimitiveBase(V) is true, then
+      if (this.HasPrimitiveBase(realm, V)) {
+        // i. Assert: In this case, base will never be null or undefined.
+        invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
+
+        // ii. Let base be ToObject(base).
+        base = ToObjectPartial(realm, base);
       }
+      invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
+
+      // b. Return ? base.[[Get]](GetReferencedName(V), GetThisValue(V)).
+      return base.$GetPartial(this.GetReferencedNamePartial(realm, V), GetThisValue(realm, V));
+    }
+
+    // 6. Else base must be an Environment Record,
+    if (base instanceof EnvironmentRecord) {
+      // a. Return ? base.GetBindingValue(GetReferencedName(V), IsStrictReference(V)) (see 8.1.1).
+      let referencedName = this.GetReferencedName(realm, V);
+      invariant(typeof referencedName === "string");
+      return base.GetBindingValue(referencedName, this.IsStrictReference(realm, V));
+    }
+
+    invariant(false);
+  }
+
+  // ECMA262 6.2.3
+  // IsStrictReference(V). Returns the strict reference flag component of the reference V.
+  IsStrictReference(realm: Realm, V: Reference): boolean {
+    return V.strict;
+  }
+
+  // ECMA262 6.2.3
+  // IsPropertyReference(V). Returns true if either the base value is an object or HasPrimitiveBase(V) is true; otherwise returns false.
+  IsPropertyReference(realm: Realm, V: Reference): boolean {
+    // V.base is AbstractValue | void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord;
+    return V.base instanceof AbstractValue || V.base instanceof ObjectValue || this.HasPrimitiveBase(realm, V);
+  }
+
+  // ECMA262 6.2.3
+  // GetBase(V). Returns the base value component of the reference V.
+  GetBase(realm: Realm, V: Reference): void | Value | EnvironmentRecord {
+    return V.base;
+  }
+
+  // ECMA262 6.2.3
+  // IsUnresolvableReference(V). Returns true if the base value is undefined and false otherwise.
+  IsUnresolvableReference(realm: Realm, V: Reference): boolean {
+    return !V.base;
+  }
+
+  // ECMA262 8.1.2.2
+  NewDeclarativeEnvironment(realm: Realm, E: LexicalEnvironment): LexicalEnvironment {
+    // 1. Let env be a new Lexical Environment.
+    let env = new LexicalEnvironment(realm);
+
+    // 2. Let envRec be a new declarative Environment Record containing no bindings.
+    let envRec = new DeclarativeEnvironmentRecord(realm);
+
+    // 3. Set env's EnvironmentRecord to envRec.
+    env.environmentRecord = envRec;
+
+    // 4. Set the outer lexical environment reference of env to E.
+    env.parent = E;
+
+    // 5. Return env.
+    return env;
+  }
+
+  BoundNames(realm: Realm, node: BabelNode): Array<string> {
+    return Object.keys(t.getOuterBindingIdentifiers(node));
+  }
+
+  // ECMA262 13.3.3.2
+  ContainsExpression(realm: Realm, node: ?BabelNode): boolean {
+    if (!node) {
       return false;
-    case "ArrayPattern":
-      for (let elem of ((node: any): BabelNodeArrayPattern).elements) {
-        if (ContainsExpression(realm, elem)) return true;
-      }
-      return false;
-    case "RestElement":
-      return ContainsExpression(realm, ((node: any): BabelNodeRestElement).argument);
-    case "AssignmentPattern":
-      return true;
-    default:
-      return false;
-  }
-}
-
-// ECMA262 8.3.2
-export function ResolveBinding(realm: Realm, name: string, strict: boolean, env?: ?LexicalEnvironment): Reference {
-  // 1. If env was not passed or if env is undefined, then
-  if (!env) {
-    // a. Let env be the running execution context's LexicalEnvironment.
-    env = realm.getRunningContext().lexicalEnvironment;
-  }
-
-  // 2. Assert: env is a Lexical Environment.
-  invariant(env instanceof LexicalEnvironment, "expected lexical environment");
-
-  // 3. If the code matching the syntactic production that is being evaluated is contained in strict mode code, let strict be true, else let strict be false.
-
-  // 4. Return ? GetIdentifierReference(env, name, strict).
-  return GetIdentifierReference(realm, env, name, strict);
-}
-
-// ECMA262 8.1.2.1
-export function GetIdentifierReference(
-  realm: Realm,
-  lex: ?LexicalEnvironment,
-  name: string,
-  strict: boolean
-): Reference {
-  // 1. If lex is the value null, then
-  if (!lex) {
-    // a. Return a value of type Reference whose base value is undefined, whose referenced name is name, and whose strict reference flag is strict.
-    return new Reference(undefined, name, strict);
-  }
-
-  // 2. Let envRec be lex's EnvironmentRecord.
-  let envRec = lex.environmentRecord;
-
-  // 3. Let exists be ? envRec.HasBinding(name).
-  let exists = envRec.HasBinding(name);
-
-  // 4. If exists is true, then
-  if (exists) {
-    // a. Return a value of type Reference whose base value is envRec, whose referenced name is name, and whose strict reference flag is strict.
-    return new Reference(envRec, name, strict);
-  } else {
-    // 5. Else,
-    // a. Let outer be the value of lex's outer environment reference.
-    let outer = lex.parent;
-
-    // b. Return ? GetIdentifierReference(outer, name, strict).
-    return GetIdentifierReference(realm, outer, name, strict);
-  }
-}
-
-// ECMA262 6.2.3.4
-export function InitializeReferencedBinding(realm: Realm, V: Reference, W: Value): Value {
-  // 1. ReturnIfAbrupt(V).
-  // 2. ReturnIfAbrupt(W).
-
-  // 3. Assert: Type(V) is Reference.
-  invariant(V instanceof Reference, "expected reference");
-
-  // 4. Assert: IsUnresolvableReference(V) is false.
-  invariant(!IsUnresolvableReference(realm, V), "expected resolvable reference");
-
-  // 5. Let base be GetBase(V).
-  let base = GetBase(realm, V);
-
-  // 6. Assert: base is an Environment Record.
-  invariant(base instanceof EnvironmentRecord, "expected environment record");
-
-  // 7. Return base.InitializeBinding(GetReferencedName(V), W).
-  let referencedName = GetReferencedName(realm, V);
-  invariant(typeof referencedName === "string");
-  return base.InitializeBinding(referencedName, W);
-}
-
-// ECMA262 13.2.14
-export function BlockDeclarationInstantiation(
-  realm: Realm,
-  strictCode: boolean,
-  body: Array<BabelNodeStatement>,
-  env: LexicalEnvironment
-) {
-  // 1. Let envRec be env's EnvironmentRecord.
-  let envRec = env.environmentRecord;
-
-  // 2. Assert: envRec is a declarative Environment Record.
-  invariant(envRec instanceof DeclarativeEnvironmentRecord, "expected declarative environment record");
-
-  // 3. Let declarations be the LexicallyScopedDeclarations of code.
-  let declarations = [];
-  for (let node of body) {
-    if (
-      node.type === "ClassDeclaration" ||
-      node.type === "FunctionDeclaration" ||
-      (node.type === "VariableDeclaration" && node.kind !== "var")
-    ) {
-      declarations.push(node);
+    }
+    switch (node.type) {
+      case "ObjectPattern":
+        for (let prop of ((node: any): BabelNodeObjectPattern).properties) {
+          if (this.ContainsExpression(realm, prop)) return true;
+        }
+        return false;
+      case "ArrayPattern":
+        for (let elem of ((node: any): BabelNodeArrayPattern).elements) {
+          if (this.ContainsExpression(realm, elem)) return true;
+        }
+        return false;
+      case "RestElement":
+        return this.ContainsExpression(realm, ((node: any): BabelNodeRestElement).argument);
+      case "AssignmentPattern":
+        return true;
+      default:
+        return false;
     }
   }
 
-  // 4. For each element d in declarations do
-  for (let d of declarations) {
-    // a. For each element dn of the BoundNames of d do
-    for (let dn of BoundNames(realm, d)) {
-      if (envRec.HasBinding(dn)) {
-        //ECMA262 13.2.1
-        throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, dn + " already declared");
-      }
-      // i. If IsConstantDeclaration of d is true, then
-      if (d.type === "VariableDeclaration" && d.kind === "const") {
-        // 1. Perform ! envRec.CreateImmutableBinding(dn, true).
-        envRec.CreateImmutableBinding(dn, true);
-      } else {
-        // ii. Else,
-        // 1. Perform ! envRec.CreateMutableBinding(dn, false).
-        envRec.CreateMutableBinding(dn, false);
-      }
+  // ECMA262 8.3.2
+  ResolveBinding(realm: Realm, name: string, strict: boolean, env?: ?LexicalEnvironment): Reference {
+    // 1. If env was not passed or if env is undefined, then
+    if (!env) {
+      // a. Let env be the running execution context's LexicalEnvironment.
+      env = realm.getRunningContext().lexicalEnvironment;
     }
 
-    // b. If d is a GeneratorDeclaration production or a FunctionDeclaration production, then
-    if (d.type === "FunctionDeclaration") {
-      // i. Let fn be the sole element of the BoundNames of d.
-      let fn = BoundNames(realm, d)[0];
+    // 2. Assert: env is a Lexical Environment.
+    invariant(env instanceof LexicalEnvironment, "expected lexical environment");
 
-      // ii. Let fo be the result of performing InstantiateFunctionObject for d with argument env.
-      let fo = env.evaluate(d, strictCode);
-      invariant(fo instanceof Value);
+    // 3. If the code matching the syntactic production that is being evaluated is contained in strict mode code, let strict be true, else let strict be false.
 
-      // iii. Perform envRec.InitializeBinding(fn, fo).
-      envRec.InitializeBinding(fn, fo);
+    // 4. Return ? GetIdentifierReference(env, name, strict).
+    return this.GetIdentifierReference(realm, env, name, strict);
+  }
+
+  // ECMA262 8.1.2.1
+  GetIdentifierReference(realm: Realm, lex: ?LexicalEnvironment, name: string, strict: boolean): Reference {
+    // 1. If lex is the value null, then
+    if (!lex) {
+      // a. Return a value of type Reference whose base value is undefined, whose referenced name is name, and whose strict reference flag is strict.
+      return new Reference(undefined, name, strict);
     }
-  }
-}
 
-// ECMA262 8.1.2.5
-export function NewGlobalEnvironment(
-  realm: Realm,
-  G: ObjectValue | AbstractObjectValue,
-  thisValue: ObjectValue | AbstractObjectValue
-) {
-  // 1. Let env be a new Lexical Environment.
-  let env = new LexicalEnvironment(realm);
-
-  // 2. Let objRec be a new object Environment Record containing G as the binding object.
-  let objRec = new ObjectEnvironmentRecord(realm, G);
-
-  // 3. Let dclRec be a new declarative Environment Record containing no bindings.
-  let dclRec = new DeclarativeEnvironmentRecord(realm);
-
-  // 4. Let globalRec be a new global Environment Record.
-  let globalRec = new GlobalEnvironmentRecord(realm);
-
-  // 5. Set globalRec.[[ObjectRecord]] to objRec.
-  globalRec.$ObjectRecord = objRec;
-
-  // 6. Set globalRec.[[GlobalThisValue]] to thisValue.
-  globalRec.$GlobalThisValue = thisValue;
-
-  // 7. Set globalRec.[[DeclarativeRecord]] to dclRec.
-  globalRec.$DeclarativeRecord = dclRec;
-
-  // 8. Set globalRec.[[VarNames]] to a new empty List.
-  globalRec.$VarNames = [];
-
-  // 9. Set env's EnvironmentRecord to globalRec.
-  env.environmentRecord = globalRec;
-
-  // 10. Set the outer lexical environment reference of env to null.
-  env.parent = null;
-
-  // 11. Return env.
-  return env;
-}
-
-// ECMA262 8.1.2.3
-export function NewObjectEnvironment(
-  realm: Realm,
-  O: ObjectValue | AbstractObjectValue,
-  E: LexicalEnvironment
-): LexicalEnvironment {
-  // 1. Let env be a new Lexical Environment.
-  let env = new LexicalEnvironment(realm);
-
-  // 2. Let envRec be a new object Environment Record containing O as the binding object.
-  let envRec = new ObjectEnvironmentRecord(realm, O);
-
-  // 3. Set env's EnvironmentRecord to envRec.
-  env.environmentRecord = envRec;
-
-  // 4. Set the outer lexical environment reference of env to E.
-  env.parent = E;
-
-  // 5. Return env.
-  return env;
-}
-
-// ECMA262 8.1.2.4
-export function NewFunctionEnvironment(
-  realm: Realm,
-  F: ECMAScriptFunctionValue,
-  newTarget?: ObjectValue
-): LexicalEnvironment {
-  // 1. Assert: F is an ECMAScript function.
-  invariant(F instanceof ECMAScriptFunctionValue, "expected a function");
-
-  // 2. Assert: Type(newTarget) is Undefined or Object.
-  invariant(
-    newTarget === undefined || newTarget instanceof ObjectValue,
-    "expected undefined or object value for new target"
-  );
-
-  // 3. Let env be a new Lexical Environment.
-  let env = new LexicalEnvironment(realm);
-
-  // 4. Let envRec be a new function Environment Record containing no bindings.
-  let envRec = new FunctionEnvironmentRecord(realm);
-
-  // 5. Set envRec.[[FunctionObject]] to F.
-  envRec.$FunctionObject = F;
-
-  // 6. If F's [[ThisMode]] internal slot is lexical, set envRec.[[ThisBindingStatus]] to "lexical".
-  if (F.$ThisMode === "lexical") {
-    envRec.$ThisBindingStatus = "lexical";
-  } else {
-    // 7. Else, set envRec.[[ThisBindingStatus]] to "uninitialized".
-    envRec.$ThisBindingStatus = "uninitialized";
-  }
-
-  // 8. Let home be the value of F's [[HomeObject]] internal slot.
-  let home = F.$HomeObject;
-
-  // 9. Set envRec.[[HomeObject]] to home.
-  envRec.$HomeObject = home;
-
-  // 10. Set envRec.[[NewTarget]] to newTarget.
-  envRec.$NewTarget = newTarget;
-
-  // 11. Set env's EnvironmentRecord to envRec.
-  env.environmentRecord = envRec;
-
-  // 12. Set the outer lexical environment reference of env to the value of F's [[Environment]] internal slot.
-  env.parent = F.$Environment;
-
-  // 13. Return env.
-  return env;
-}
-
-// ECMA262 8.3.1
-export function GetActiveScriptOrModule(realm: Realm) {
-  // The GetActiveScriptOrModule abstract operation is used to determine the running script or module, based on the active function object.
-  // GetActiveScriptOrModule performs the following steps:
-  //
-  // If the execution context stack is empty, return null.
-  if (realm.contextStack.length === 0) return null;
-  // Let ec be the topmost execution context on the execution context stack whose Function component's [[ScriptOrModule]] component is not null.
-  // If such an execution context exists, return ec's Function component's [[ScriptOrModule]] slot's value.
-  let ec;
-  for (let i = realm.contextStack.length - 1; i >= 0; i--) {
-    ec = realm.contextStack[i];
-    let F = ec.function;
-    if (F == null) continue;
-    if (F.$ScriptOrModule instanceof Object) {
-      return F.$ScriptOrModule;
-    }
-  }
-  // Otherwise, let ec be the running execution context.
-  ec = realm.getRunningContext();
-  // Assert: ec's ScriptOrModule component is not null.
-  invariant(ec.ScriptOrModule !== null);
-  // Return ec's ScriptOrModule component.
-  return ec.ScriptOrModule;
-}
-
-// ECMA262 8.3.3
-export function GetThisEnvironment(realm: Realm): EnvironmentRecord {
-  // 1. Let lex be the running execution context's LexicalEnvironment.
-  let lex = realm.getRunningContext().lexicalEnvironment;
-
-  // 2. Repeat
-  while (true) {
-    // a. Let envRec be lex's EnvironmentRecord.
+    // 2. Let envRec be lex's EnvironmentRecord.
     let envRec = lex.environmentRecord;
 
-    // b. Let exists be envRec.HasThisBinding().
-    let exists = envRec.HasThisBinding();
+    // 3. Let exists be ? envRec.HasBinding(name).
+    let exists = envRec.HasBinding(name);
 
-    // c. If exists is true, return envRec.
-    if (exists) return envRec;
+    // 4. If exists is true, then
+    if (exists) {
+      // a. Return a value of type Reference whose base value is envRec, whose referenced name is name, and whose strict reference flag is strict.
+      return new Reference(envRec, name, strict);
+    } else {
+      // 5. Else,
+      // a. Let outer be the value of lex's outer environment reference.
+      let outer = lex.parent;
 
-    // d. Let outer be the value of lex's outer environment reference.
-    let outer = lex.parent;
-    invariant(outer);
-
-    // e. Let lex be outer.
-    lex = outer;
-  }
-
-  invariant(false);
-}
-
-// ECMA262 8.3.4
-export function ResolveThisBinding(realm: Realm): NullValue | ObjectValue | AbstractObjectValue | UndefinedValue {
-  // 1. Let envRec be GetThisEnvironment( ).
-  let envRec = GetThisEnvironment(realm);
-
-  // 2. Return ? envRec.GetThisBinding().
-  return envRec.GetThisBinding();
-}
-
-export function BindingInitialization(
-  realm: Realm,
-  node: BabelNodeLVal | BabelNodeVariableDeclaration,
-  value: Value,
-  strictCode: boolean,
-  environment: void | LexicalEnvironment
-) {
-  if (node.type === "ArrayPattern") {
-    // ECMA262 13.3.3.5
-    // 1. Let iterator be ? GetIterator(value).
-    let iterator = GetIterator(realm, value);
-
-    // 2. Let iteratorRecord be Record {[[Iterator]]: iterator, [[Done]]: false}.
-    let iteratorRecord = {
-      $Iterator: iterator,
-      $Done: false,
-    };
-
-    let result;
-
-    // 3. Let result be IteratorBindingInitialization for ArrayBindingPattern using iteratorRecord and environment as arguments.
-    try {
-      result = IteratorBindingInitialization(realm, node.elements, iteratorRecord, strictCode, environment);
-    } catch (error) {
-      // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
-      if (iteratorRecord.$Done === false && error instanceof AbruptCompletion) {
-        throw IteratorClose(realm, iterator, error);
-      }
-      throw error;
-    }
-
-    // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
-    if (iteratorRecord.$Done === false) {
-      let completion = IteratorClose(realm, iterator, new NormalCompletion(realm.intrinsics.undefined));
-      if (completion instanceof AbruptCompletion) {
-        throw completion;
-      }
-    }
-
-    // 5. Return result.
-    return result;
-  } else if (node.type === "ObjectPattern") {
-    // ECMA262 13.3.3.5
-    // BindingPattern : ObjectBindingPattern
-
-    // 1. Perform ? RequireObjectCoercible(value).
-    RequireObjectCoercible(realm, value);
-
-    // 2. Return the result of performing BindingInitialization for ObjectBindingPattern using value and environment as arguments.
-    for (let property of node.properties) {
-      let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
-
-      // 1. Let P be the result of evaluating PropertyName.
-      let P = EvalPropertyName(property, env, realm, strictCode);
-
-      // 2. ReturnIfAbrupt(P).
-
-      // 3. Return the result of performing KeyedBindingInitialization for BindingElement using value, environment, and P as arguments.
-      KeyedBindingInitialization(realm, property.value, value, strictCode, environment, P);
-    }
-  } else if (node.type === "Identifier") {
-    // ECMA262 12.1.5
-    // 1. Let name be StringValue of Identifier.
-    let name = ((node: any): BabelNodeIdentifier).name;
-
-    // 2. Return ? InitializeBoundName(name, value, environment).
-    return InitializeBoundName(realm, name, value, environment);
-  } else {
-    invariant(node.type === "VariableDeclaration");
-    // ECMA262 13.7.5.9
-    for (let decl of ((node: any): BabelNodeVariableDeclaration).declarations) {
-      BindingInitialization(realm, decl.id, value, strictCode, environment);
-    }
-  }
-}
-
-// ECMA262 13.3.3.6
-// ECMA262 14.1.19
-export function IteratorBindingInitialization(
-  realm: Realm,
-  formals: $ReadOnlyArray<BabelNodeLVal | null>,
-  iteratorRecord: { $Iterator: ObjectValue, $Done: boolean },
-  strictCode: boolean,
-  environment: void | LexicalEnvironment
-) {
-  let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
-
-  // Check if the last formal is a rest element. If so then we want to save the
-  // element and handle it separately after we iterate through the other
-  // formals. This also enforces that a rest element may only ever be in the
-  // last position.
-  let restEl;
-  if (formals.length > 0) {
-    let lastFormal = formals[formals.length - 1];
-    if (lastFormal !== null && lastFormal.type === "RestElement") {
-      restEl = lastFormal;
-      formals = formals.slice(0, -1);
+      // b. Return ? GetIdentifierReference(outer, name, strict).
+      return this.GetIdentifierReference(realm, outer, name, strict);
     }
   }
 
-  for (let param of formals) {
-    if (param === null) {
-      // Elision handling in IteratorDestructuringAssignmentEvaluation
+  // ECMA262 6.2.3.4
+  InitializeReferencedBinding(realm: Realm, V: Reference, W: Value): Value {
+    // 1. ReturnIfAbrupt(V).
+    // 2. ReturnIfAbrupt(W).
 
-      // 1. If iteratorRecord.[[Done]] is false, then
-      if (iteratorRecord.$Done === false) {
-        // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
-        let next;
-        try {
-          next = IteratorStep(realm, iteratorRecord.$Iterator);
-        } catch (e) {
-          // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-          if (e instanceof AbruptCompletion) {
-            iteratorRecord.$Done = true;
-          }
-          // c. ReturnIfAbrupt(next).
-          throw e;
-        }
-        // d. If next is false, set iteratorRecord.[[Done]] to true.
-        if (next === false) {
-          iteratorRecord.$Done = true;
-        }
+    // 3. Assert: Type(V) is Reference.
+    invariant(V instanceof Reference, "expected reference");
+
+    // 4. Assert: IsUnresolvableReference(V) is false.
+    invariant(!this.IsUnresolvableReference(realm, V), "expected resolvable reference");
+
+    // 5. Let base be GetBase(V).
+    let base = this.GetBase(realm, V);
+
+    // 6. Assert: base is an Environment Record.
+    invariant(base instanceof EnvironmentRecord, "expected environment record");
+
+    // 7. Return base.InitializeBinding(GetReferencedName(V), W).
+    let referencedName = this.GetReferencedName(realm, V);
+    invariant(typeof referencedName === "string");
+    return base.InitializeBinding(referencedName, W);
+  }
+
+  // ECMA262 13.2.14
+  BlockDeclarationInstantiation(
+    realm: Realm,
+    strictCode: boolean,
+    body: Array<BabelNodeStatement>,
+    env: LexicalEnvironment
+  ) {
+    // 1. Let envRec be env's EnvironmentRecord.
+    let envRec = env.environmentRecord;
+
+    // 2. Assert: envRec is a declarative Environment Record.
+    invariant(envRec instanceof DeclarativeEnvironmentRecord, "expected declarative environment record");
+
+    // 3. Let declarations be the LexicallyScopedDeclarations of code.
+    let declarations = [];
+    for (let node of body) {
+      if (
+        node.type === "ClassDeclaration" ||
+        node.type === "FunctionDeclaration" ||
+        (node.type === "VariableDeclaration" && node.kind !== "var")
+      ) {
+        declarations.push(node);
       }
-      // 2. Return NormalCompletion(empty).
-      continue;
     }
 
-    let Initializer;
-    if (param.type === "AssignmentPattern") {
-      Initializer = param.right;
-      param = param.left;
-    }
-
-    if (param.type === "Identifier") {
-      // SingleNameBinding : BindingIdentifier Initializer
-
-      // 1. Let bindingId be StringValue of BindingIdentifier.
-      let bindingId = param.name;
-
-      // 2. Let lhs be ? ResolveBinding(bindingId, environment).
-      let lhs = ResolveBinding(realm, param.name, strictCode, environment);
-
-      // Initialized later in the algorithm.
-      let v;
-
-      // 3. If iteratorRecord.[[Done]] is false, then
-      if (iteratorRecord.$Done === false) {
-        // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
-        let next: ObjectValue | false;
-        try {
-          next = IteratorStep(realm, iteratorRecord.$Iterator);
-        } catch (e) {
-          // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-          if (e instanceof AbruptCompletion) {
-            iteratorRecord.$Done = true;
-          }
-          // c. ReturnIfAbrupt(next).
-          throw e;
+    // 4. For each element d in declarations do
+    for (let d of declarations) {
+      // a. For each element dn of the BoundNames of d do
+      for (let dn of this.BoundNames(realm, d)) {
+        if (envRec.HasBinding(dn)) {
+          //ECMA262 13.2.1
+          throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, dn + " already declared");
         }
-
-        // d. If next is false, set iteratorRecord.[[Done]] to true.
-        if (next === false) {
-          iteratorRecord.$Done = true;
-          // Normally this assignment would be done in step 4, but we do it
-          // here so that Flow knows `v` will always be initialized by step 5.
-          v = realm.intrinsics.undefined;
+        // i. If IsConstantDeclaration of d is true, then
+        if (d.type === "VariableDeclaration" && d.kind === "const") {
+          // 1. Perform ! envRec.CreateImmutableBinding(dn, true).
+          envRec.CreateImmutableBinding(dn, true);
         } else {
-          // e. Else,
-          // i. Let v be IteratorValue(next).
+          // ii. Else,
+          // 1. Perform ! envRec.CreateMutableBinding(dn, false).
+          envRec.CreateMutableBinding(dn, false);
+        }
+      }
+
+      // b. If d is a GeneratorDeclaration production or a FunctionDeclaration production, then
+      if (d.type === "FunctionDeclaration") {
+        // i. Let fn be the sole element of the BoundNames of d.
+        let fn = this.BoundNames(realm, d)[0];
+
+        // ii. Let fo be the result of performing InstantiateFunctionObject for d with argument env.
+        let fo = env.evaluate(d, strictCode);
+        invariant(fo instanceof Value);
+
+        // iii. Perform envRec.InitializeBinding(fn, fo).
+        envRec.InitializeBinding(fn, fo);
+      }
+    }
+  }
+
+  // ECMA262 8.1.2.5
+  NewGlobalEnvironment(
+    realm: Realm,
+    G: ObjectValue | AbstractObjectValue,
+    thisValue: ObjectValue | AbstractObjectValue
+  ) {
+    // 1. Let env be a new Lexical Environment.
+    let env = new LexicalEnvironment(realm);
+
+    // 2. Let objRec be a new object Environment Record containing G as the binding object.
+    let objRec = new ObjectEnvironmentRecord(realm, G);
+
+    // 3. Let dclRec be a new declarative Environment Record containing no bindings.
+    let dclRec = new DeclarativeEnvironmentRecord(realm);
+
+    // 4. Let globalRec be a new global Environment Record.
+    let globalRec = new GlobalEnvironmentRecord(realm);
+
+    // 5. Set globalRec.[[ObjectRecord]] to objRec.
+    globalRec.$ObjectRecord = objRec;
+
+    // 6. Set globalRec.[[GlobalThisValue]] to thisValue.
+    globalRec.$GlobalThisValue = thisValue;
+
+    // 7. Set globalRec.[[DeclarativeRecord]] to dclRec.
+    globalRec.$DeclarativeRecord = dclRec;
+
+    // 8. Set globalRec.[[VarNames]] to a new empty List.
+    globalRec.$VarNames = [];
+
+    // 9. Set env's EnvironmentRecord to globalRec.
+    env.environmentRecord = globalRec;
+
+    // 10. Set the outer lexical environment reference of env to null.
+    env.parent = null;
+
+    // 11. Return env.
+    return env;
+  }
+
+  // ECMA262 8.1.2.3
+  NewObjectEnvironment(realm: Realm, O: ObjectValue | AbstractObjectValue, E: LexicalEnvironment): LexicalEnvironment {
+    // 1. Let env be a new Lexical Environment.
+    let env = new LexicalEnvironment(realm);
+
+    // 2. Let envRec be a new object Environment Record containing O as the binding object.
+    let envRec = new ObjectEnvironmentRecord(realm, O);
+
+    // 3. Set env's EnvironmentRecord to envRec.
+    env.environmentRecord = envRec;
+
+    // 4. Set the outer lexical environment reference of env to E.
+    env.parent = E;
+
+    // 5. Return env.
+    return env;
+  }
+
+  // ECMA262 8.1.2.4
+  NewFunctionEnvironment(realm: Realm, F: ECMAScriptFunctionValue, newTarget?: ObjectValue): LexicalEnvironment {
+    // 1. Assert: F is an ECMAScript function.
+    invariant(F instanceof ECMAScriptFunctionValue, "expected a function");
+
+    // 2. Assert: Type(newTarget) is Undefined or Object.
+    invariant(
+      newTarget === undefined || newTarget instanceof ObjectValue,
+      "expected undefined or object value for new target"
+    );
+
+    // 3. Let env be a new Lexical Environment.
+    let env = new LexicalEnvironment(realm);
+
+    // 4. Let envRec be a new function Environment Record containing no bindings.
+    let envRec = new FunctionEnvironmentRecord(realm);
+
+    // 5. Set envRec.[[FunctionObject]] to F.
+    envRec.$FunctionObject = F;
+
+    // 6. If F's [[ThisMode]] internal slot is lexical, set envRec.[[ThisBindingStatus]] to "lexical".
+    if (F.$ThisMode === "lexical") {
+      envRec.$ThisBindingStatus = "lexical";
+    } else {
+      // 7. Else, set envRec.[[ThisBindingStatus]] to "uninitialized".
+      envRec.$ThisBindingStatus = "uninitialized";
+    }
+
+    // 8. Let home be the value of F's [[HomeObject]] internal slot.
+    let home = F.$HomeObject;
+
+    // 9. Set envRec.[[HomeObject]] to home.
+    envRec.$HomeObject = home;
+
+    // 10. Set envRec.[[NewTarget]] to newTarget.
+    envRec.$NewTarget = newTarget;
+
+    // 11. Set env's EnvironmentRecord to envRec.
+    env.environmentRecord = envRec;
+
+    // 12. Set the outer lexical environment reference of env to the value of F's [[Environment]] internal slot.
+    env.parent = F.$Environment;
+
+    // 13. Return env.
+    return env;
+  }
+
+  // ECMA262 8.3.1
+  GetActiveScriptOrModule(realm: Realm) {
+    // The GetActiveScriptOrModule abstract operation is used to determine the running script or module, based on the active function object.
+    // GetActiveScriptOrModule performs the following steps:
+    //
+    // If the execution context stack is empty, return null.
+    if (realm.contextStack.length === 0) return null;
+    // Let ec be the topmost execution context on the execution context stack whose Function component's [[ScriptOrModule]] component is not null.
+    // If such an execution context exists, return ec's Function component's [[ScriptOrModule]] slot's value.
+    let ec;
+    for (let i = realm.contextStack.length - 1; i >= 0; i--) {
+      ec = realm.contextStack[i];
+      let F = ec.function;
+      if (F == null) continue;
+      if (F.$ScriptOrModule instanceof Object) {
+        return F.$ScriptOrModule;
+      }
+    }
+    // Otherwise, let ec be the running execution context.
+    ec = realm.getRunningContext();
+    // Assert: ec's ScriptOrModule component is not null.
+    invariant(ec.ScriptOrModule !== null);
+    // Return ec's ScriptOrModule component.
+    return ec.ScriptOrModule;
+  }
+
+  // ECMA262 8.3.3
+  GetThisEnvironment(realm: Realm): EnvironmentRecord {
+    // 1. Let lex be the running execution context's LexicalEnvironment.
+    let lex = realm.getRunningContext().lexicalEnvironment;
+
+    // 2. Repeat
+    while (true) {
+      // a. Let envRec be lex's EnvironmentRecord.
+      let envRec = lex.environmentRecord;
+
+      // b. Let exists be envRec.HasThisBinding().
+      let exists = envRec.HasThisBinding();
+
+      // c. If exists is true, return envRec.
+      if (exists) return envRec;
+
+      // d. Let outer be the value of lex's outer environment reference.
+      let outer = lex.parent;
+      invariant(outer);
+
+      // e. Let lex be outer.
+      lex = outer;
+    }
+
+    invariant(false);
+  }
+
+  // ECMA262 8.3.4
+  ResolveThisBinding(realm: Realm): NullValue | ObjectValue | AbstractObjectValue | UndefinedValue {
+    // 1. Let envRec be GetThisEnvironment( ).
+    let envRec = this.GetThisEnvironment(realm);
+
+    // 2. Return ? envRec.GetThisBinding().
+    return envRec.GetThisBinding();
+  }
+
+  BindingInitialization(
+    realm: Realm,
+    node: BabelNodeLVal | BabelNodeVariableDeclaration,
+    value: Value,
+    strictCode: boolean,
+    environment: void | LexicalEnvironment
+  ): void | boolean | Value {
+    if (node.type === "ArrayPattern") {
+      // ECMA262 13.3.3.5
+      // 1. Let iterator be ? GetIterator(value).
+      let iterator = GetIterator(realm, value);
+
+      // 2. Let iteratorRecord be Record {[[Iterator]]: iterator, [[Done]]: false}.
+      let iteratorRecord = {
+        $Iterator: iterator,
+        $Done: false,
+      };
+
+      let result;
+
+      // 3. Let result be IteratorBindingInitialization for ArrayBindingPattern using iteratorRecord and environment as arguments.
+      try {
+        result = this.IteratorBindingInitialization(realm, node.elements, iteratorRecord, strictCode, environment);
+      } catch (error) {
+        // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
+        if (iteratorRecord.$Done === false && error instanceof AbruptCompletion) {
+          throw IteratorClose(realm, iterator, error);
+        }
+        throw error;
+      }
+
+      // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
+      if (iteratorRecord.$Done === false) {
+        let completion = IteratorClose(realm, iterator, new NormalCompletion(realm.intrinsics.undefined));
+        if (completion instanceof AbruptCompletion) {
+          throw completion;
+        }
+      }
+
+      // 5. Return result.
+      return result;
+    } else if (node.type === "ObjectPattern") {
+      // ECMA262 13.3.3.5
+      // BindingPattern : ObjectBindingPattern
+
+      // 1. Perform ? RequireObjectCoercible(value).
+      RequireObjectCoercible(realm, value);
+
+      // 2. Return the result of performing BindingInitialization for ObjectBindingPattern using value and environment as arguments.
+      for (let property of node.properties) {
+        let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
+
+        // 1. Let P be the result of evaluating PropertyName.
+        let P = EvalPropertyName(property, env, realm, strictCode);
+
+        // 2. ReturnIfAbrupt(P).
+
+        // 3. Return the result of performing KeyedBindingInitialization for BindingElement using value, environment, and P as arguments.
+        this.KeyedBindingInitialization(realm, property.value, value, strictCode, environment, P);
+      }
+    } else if (node.type === "Identifier") {
+      // ECMA262 12.1.5
+      // 1. Let name be StringValue of Identifier.
+      let name = ((node: any): BabelNodeIdentifier).name;
+
+      // 2. Return ? InitializeBoundName(name, value, environment).
+      return this.InitializeBoundName(realm, name, value, environment);
+    } else {
+      invariant(node.type === "VariableDeclaration");
+      // ECMA262 13.7.5.9
+      for (let decl of ((node: any): BabelNodeVariableDeclaration).declarations) {
+        this.BindingInitialization(realm, decl.id, value, strictCode, environment);
+      }
+    }
+  }
+
+  // ECMA262 13.3.3.6
+  // ECMA262 14.1.19
+  IteratorBindingInitialization(
+    realm: Realm,
+    formals: $ReadOnlyArray<BabelNodeLVal | null>,
+    iteratorRecord: { $Iterator: ObjectValue, $Done: boolean },
+    strictCode: boolean,
+    environment: void | LexicalEnvironment
+  ) {
+    let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
+
+    // Check if the last formal is a rest element. If so then we want to save the
+    // element and handle it separately after we iterate through the other
+    // formals. This also enforces that a rest element may only ever be in the
+    // last position.
+    let restEl;
+    if (formals.length > 0) {
+      let lastFormal = formals[formals.length - 1];
+      if (lastFormal !== null && lastFormal.type === "RestElement") {
+        restEl = lastFormal;
+        formals = formals.slice(0, -1);
+      }
+    }
+
+    for (let param of formals) {
+      if (param === null) {
+        // Elision handling in IteratorDestructuringAssignmentEvaluation
+
+        // 1. If iteratorRecord.[[Done]] is false, then
+        if (iteratorRecord.$Done === false) {
+          // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+          let next;
           try {
-            v = IteratorValue(realm, next);
+            next = IteratorStep(realm, iteratorRecord.$Iterator);
           } catch (e) {
-            // ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
             if (e instanceof AbruptCompletion) {
               iteratorRecord.$Done = true;
             }
-            // iii. ReturnIfAbrupt(v).
+            // c. ReturnIfAbrupt(next).
             throw e;
           }
+          // d. If next is false, set iteratorRecord.[[Done]] to true.
+          if (next === false) {
+            iteratorRecord.$Done = true;
+          }
         }
-      } else {
-        // 4. If iteratorRecord.[[Done]] is true, let v be undefined.
-        v = realm.intrinsics.undefined;
+        // 2. Return NormalCompletion(empty).
+        continue;
       }
 
-      // 5. If Initializer is present and v is undefined, then
+      let Initializer;
+      if (param.type === "AssignmentPattern") {
+        Initializer = param.right;
+        param = param.left;
+      }
+
+      if (param.type === "Identifier") {
+        // SingleNameBinding : BindingIdentifier Initializer
+
+        // 1. Let bindingId be StringValue of BindingIdentifier.
+        let bindingId = param.name;
+
+        // 2. Let lhs be ? ResolveBinding(bindingId, environment).
+        let lhs = this.ResolveBinding(realm, param.name, strictCode, environment);
+
+        // Initialized later in the algorithm.
+        let v;
+
+        // 3. If iteratorRecord.[[Done]] is false, then
+        if (iteratorRecord.$Done === false) {
+          // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+          let next: ObjectValue | false;
+          try {
+            next = IteratorStep(realm, iteratorRecord.$Iterator);
+          } catch (e) {
+            // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            if (e instanceof AbruptCompletion) {
+              iteratorRecord.$Done = true;
+            }
+            // c. ReturnIfAbrupt(next).
+            throw e;
+          }
+
+          // d. If next is false, set iteratorRecord.[[Done]] to true.
+          if (next === false) {
+            iteratorRecord.$Done = true;
+            // Normally this assignment would be done in step 4, but we do it
+            // here so that Flow knows `v` will always be initialized by step 5.
+            v = realm.intrinsics.undefined;
+          } else {
+            // e. Else,
+            // i. Let v be IteratorValue(next).
+            try {
+              v = IteratorValue(realm, next);
+            } catch (e) {
+              // ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+              if (e instanceof AbruptCompletion) {
+                iteratorRecord.$Done = true;
+              }
+              // iii. ReturnIfAbrupt(v).
+              throw e;
+            }
+          }
+        } else {
+          // 4. If iteratorRecord.[[Done]] is true, let v be undefined.
+          v = realm.intrinsics.undefined;
+        }
+
+        // 5. If Initializer is present and v is undefined, then
+        if (Initializer && v instanceof UndefinedValue) {
+          // a. Let defaultValue be the result of evaluating Initializer.
+          let defaultValue = env.evaluate(Initializer, strictCode);
+
+          // b. Let v be ? GetValue(defaultValue).
+          v = this.GetValue(realm, defaultValue);
+
+          // c. If IsAnonymousFunctionDefinition(Initializer) is true, then
+          if (IsAnonymousFunctionDefinition(realm, Initializer) && v instanceof ObjectValue) {
+            // i. Let hasNameProperty be ? HasOwnProperty(v, "name").
+            let hasNameProperty = HasOwnProperty(realm, v, "name");
+
+            // ii. If hasNameProperty is false, perform SetFunctionName(v, bindingId).
+            if (hasNameProperty === false) {
+              Functions.SetFunctionName(realm, v, bindingId);
+            }
+          }
+        }
+
+        // 6. If environment is undefined, return ? PutValue(lhs, v).
+        if (!environment) {
+          Properties.PutValue(realm, lhs, v);
+          continue;
+        }
+
+        // 7. Return InitializeReferencedBinding(lhs, v).
+        this.InitializeReferencedBinding(realm, lhs, v);
+        continue;
+      } else {
+        invariant(param.type === "ObjectPattern" || param.type === "ArrayPattern");
+        // BindingElement : BindingPatternInitializer
+
+        // Initialized later in the algorithm.
+        let v;
+
+        // 1. If iteratorRecord.[[Done]] is false, then
+        if (iteratorRecord.$Done === false) {
+          // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+          let next;
+          try {
+            next = IteratorStep(realm, iteratorRecord.$Iterator);
+          } catch (e) {
+            // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            if (e instanceof AbruptCompletion) {
+              iteratorRecord.$Done = true;
+            }
+            // c. ReturnIfAbrupt(next).
+            throw e;
+          }
+
+          // d. If next is false, set iteratorRecord.[[Done]] to true.
+          if (next === false) {
+            iteratorRecord.$Done = true;
+            // Normally this assignment would be done in step 2, but we do it
+            // here so that Flow knows `v` will always be initialized by step 3.
+            v = realm.intrinsics.undefined;
+          } else {
+            // e. Else,
+            // i. Let v be IteratorValue(next).
+            try {
+              v = IteratorValue(realm, next);
+            } catch (e) {
+              // ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
+              if (e instanceof AbruptCompletion) {
+                iteratorRecord.$Done = true;
+              }
+              // iii. ReturnIfAbrupt(v).
+              throw e;
+            }
+          }
+        } else {
+          // 2. If iteratorRecord.[[Done]] is true, let v be undefined.
+          v = realm.intrinsics.undefined;
+        }
+
+        // 3. If Initializer is present and v is undefined, then
+        if (Initializer && v instanceof UndefinedValue) {
+          // a. Let defaultValue be the result of evaluating Initializer.
+          let defaultValue = env.evaluate(Initializer, strictCode);
+
+          // b. Let v be ? GetValue(defaultValue).
+          v = this.GetValue(realm, defaultValue);
+        }
+
+        // 4. Return the result of performing BindingInitialization of BindingPattern with v and environment as the arguments.
+        this.BindingInitialization(realm, param, v, strictCode, environment);
+        continue;
+      }
+    }
+
+    // Handle the rest element if we have one.
+    if (restEl && restEl.argument.type === "Identifier") {
+      // BindingRestElement : ...BindingIdentifier
+
+      // 1. Let lhs be ? ResolveBinding(StringValue of BindingIdentifier, environment).
+      let lhs = this.ResolveBinding(realm, restEl.argument.name, strictCode, environment);
+
+      // 2. Let A be ArrayCreate(0).
+      let A = ArrayCreate(realm, 0);
+
+      // 3. Let n be 0.
+      let n = 0;
+
+      // 4. Repeat,
+      while (true) {
+        // Initialized later in the algorithm.
+        let next: ObjectValue | false;
+
+        // a. If iteratorRecord.[[Done]] is false, then
+        if (iteratorRecord.$Done === false) {
+          // i. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+          try {
+            next = IteratorStep(realm, iteratorRecord.$Iterator);
+          } catch (e) {
+            // ii. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            if (e instanceof AbruptCompletion) {
+              iteratorRecord.$Done = true;
+            }
+            // iii. ReturnIfAbrupt(next).
+            throw e;
+          }
+          // iv. If next is false, set iteratorRecord.[[Done]] to true.
+          if (next === false) {
+            iteratorRecord.$Done = true;
+          }
+        }
+
+        // b. If iteratorRecord.[[Done]] is true, then
+        if (iteratorRecord.$Done === true) {
+          // i. If environment is undefined, return ? PutValue(lhs, A).
+          if (!environment) {
+            Properties.PutValue(realm, lhs, A);
+            break;
+          }
+
+          // ii. Return InitializeReferencedBinding(lhs, A).
+          this.InitializeReferencedBinding(realm, lhs, A);
+          break;
+        }
+
+        // Given the nature of the algorithm this should always be true, however
+        // it is difficult to arrange the code in such a way where Flow's control
+        // flow analysis will pick that up, so we add an invariant here.
+        invariant(next instanceof ObjectValue);
+
+        // c. Let nextValue be IteratorValue(next).
+        let nextValue;
+        try {
+          nextValue = IteratorValue(realm, next);
+        } catch (e) {
+          // d. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
+          if (e instanceof AbruptCompletion) {
+            iteratorRecord.$Done = true;
+          }
+          // e. ReturnIfAbrupt(nextValue).
+          throw e;
+        }
+
+        // f. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
+        let status = CreateDataProperty(realm, A, n.toString(), nextValue);
+
+        // g. Assert: status is true.
+        invariant(status, "expected to create data property");
+
+        // h. Increment n by 1.
+        n += 1;
+      }
+    } else if (restEl) {
+      invariant(restEl.argument.type === "ArrayPattern" || restEl.argument.type === "ObjectPattern");
+      // 1. Let A be ArrayCreate(0).
+      let A = ArrayCreate(realm, 0);
+
+      // 2. Let n be 0.
+      let n = 0;
+
+      // 3. Repeat,
+      while (true) {
+        // Initialized later in the algorithm.
+        let next;
+
+        // a. If iteratorRecord.[[Done]] is false, then
+        if (iteratorRecord.$Done === false) {
+          // i. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
+          try {
+            next = IteratorStep(realm, iteratorRecord.$Iterator);
+          } catch (e) {
+            // ii. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
+            if (e instanceof AbruptCompletion) {
+              iteratorRecord.$Done = true;
+            }
+            // iii. ReturnIfAbrupt(next).
+            throw e;
+          }
+          // iv. If next is false, set iteratorRecord.[[Done]] to true.
+          if (next === false) {
+            iteratorRecord.$Done = true;
+          }
+        }
+
+        // b. If iteratorRecord.[[Done]] is true, then
+        if (iteratorRecord.$Done === true) {
+          // i. Return the result of performing BindingInitialization of BindingPattern with A and environment as the arguments.
+          this.BindingInitialization(realm, restEl.argument, A, strictCode, environment);
+          break;
+        }
+
+        // Given the nature of the algorithm this should always be true, however
+        // it is difficult to arrange the code in such a way where Flow's control
+        // flow analysis will pick that up, so we add an invariant here.
+        invariant(next instanceof ObjectValue);
+
+        // c. Let nextValue be IteratorValue(next).
+        let nextValue;
+        try {
+          nextValue = IteratorValue(realm, next);
+        } catch (e) {
+          // d. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
+          if (e instanceof AbruptCompletion) {
+            iteratorRecord.$Done = true;
+          }
+          // e. ReturnIfAbrupt(nextValue).
+          throw e;
+        }
+
+        // f. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
+        let status = CreateDataProperty(realm, A, n.toString(), nextValue);
+
+        // g. Assert: status is true.
+        invariant(status, "expected to create data property");
+
+        // h. Increment n by 1.
+        n += 1;
+      }
+    }
+  }
+
+  // ECMA262 12.1.5.1
+  InitializeBoundName(
+    realm: Realm,
+    name: string,
+    value: Value,
+    environment: void | LexicalEnvironment
+  ): void | boolean | Value {
+    // 1. Assert: Type(name) is String.
+    invariant(typeof name === "string", "expected name to be a string");
+
+    // 2. If environment is not undefined, then
+    if (environment) {
+      // a. Let env be the EnvironmentRecord component of environment.
+      let env = environment.environmentRecord;
+
+      // b. Perform env.InitializeBinding(name, value).
+      env.InitializeBinding(name, value);
+
+      // c. Return NormalCompletion(undefined).
+      return realm.intrinsics.undefined;
+    } else {
+      // 3. Else,
+      // a. Let lhs be ResolveBinding(name).
+      // Note that the undefined environment implies non-strict.
+      let lhs = this.ResolveBinding(realm, name, false);
+
+      // b. Return ? PutValue(lhs, value).
+      return Properties.PutValue(realm, lhs, value);
+    }
+  }
+
+  // ECMA262 12.3.1.3 and 13.7.5.6
+  IsDestructuring(ast: BabelNode): boolean {
+    switch (ast.type) {
+      case "VariableDeclaration":
+        for (let decl of ((ast: any): BabelNodeVariableDeclaration).declarations) {
+          switch (decl.type) {
+            case "VariableDeclarator":
+              switch (decl.id.type) {
+                case "ArrayPattern":
+                case "AssignmentPattern":
+                case "ObjectPattern":
+                  return true;
+                default:
+                  break;
+              }
+              break;
+            default:
+              break;
+          }
+        }
+        return false;
+      case "ArrayLiteral":
+      case "ObjectLiteral":
+        return true;
+      case "ArrayPattern":
+      case "ObjectPattern":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  // ECMA262 13.3.3.7
+  KeyedBindingInitialization(
+    realm: Realm,
+    node: BabelNodeIdentifier | BabelNodePattern,
+    value: Value,
+    strictCode: boolean,
+    environment: ?LexicalEnvironment,
+    propertyName: PropertyKeyValue
+  ): void | boolean | Value {
+    let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
+
+    let Initializer;
+    if (node.type === "AssignmentPattern") {
+      Initializer = node.right;
+      node = node.left;
+    }
+
+    if (node.type === "Identifier") {
+      // SingleNameBinding : BindingIdentifier Initializer
+
+      // 1. Let bindingId be StringValue of BindingIdentifier.
+      let bindingId = node.name;
+
+      // 2. Let lhs be ? ResolveBinding(bindingId, environment).
+      let lhs = this.ResolveBinding(realm, bindingId, strictCode, environment);
+
+      // 3. Let v be ? GetV(value, propertyName).
+      let v = GetV(realm, value, propertyName);
+
+      // 4. If Initializer is present and v is undefined, then
       if (Initializer && v instanceof UndefinedValue) {
         // a. Let defaultValue be the result of evaluating Initializer.
         let defaultValue = env.evaluate(Initializer, strictCode);
 
         // b. Let v be ? GetValue(defaultValue).
-        v = GetValue(realm, defaultValue);
+        v = this.GetValue(realm, defaultValue);
 
         // c. If IsAnonymousFunctionDefinition(Initializer) is true, then
         if (IsAnonymousFunctionDefinition(realm, Initializer) && v instanceof ObjectValue) {
@@ -732,351 +1049,28 @@ export function IteratorBindingInitialization(
         }
       }
 
-      // 6. If environment is undefined, return ? PutValue(lhs, v).
-      if (!environment) {
-        Properties.PutValue(realm, lhs, v);
-        continue;
-      }
+      // 5. If environment is undefined, return ? PutValue(lhs, v).
+      if (!environment) return Properties.PutValue(realm, lhs, v);
 
-      // 7. Return InitializeReferencedBinding(lhs, v).
-      InitializeReferencedBinding(realm, lhs, v);
-      continue;
-    } else {
-      invariant(param.type === "ObjectPattern" || param.type === "ArrayPattern");
-      // BindingElement : BindingPatternInitializer
+      // 6. Return InitializeReferencedBinding(lhs, v).
+      return this.InitializeReferencedBinding(realm, lhs, v);
+    } else if (node.type === "ObjectPattern" || node.type === "ArrayPattern") {
+      // BindingElement : BindingPattern Initializer
 
-      // Initialized later in the algorithm.
-      let v;
+      // 1. Let v be ? GetV(value, propertyName).
+      let v = GetV(realm, value, propertyName);
 
-      // 1. If iteratorRecord.[[Done]] is false, then
-      if (iteratorRecord.$Done === false) {
-        // a. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
-        let next;
-        try {
-          next = IteratorStep(realm, iteratorRecord.$Iterator);
-        } catch (e) {
-          // b. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-          if (e instanceof AbruptCompletion) {
-            iteratorRecord.$Done = true;
-          }
-          // c. ReturnIfAbrupt(next).
-          throw e;
-        }
-
-        // d. If next is false, set iteratorRecord.[[Done]] to true.
-        if (next === false) {
-          iteratorRecord.$Done = true;
-          // Normally this assignment would be done in step 2, but we do it
-          // here so that Flow knows `v` will always be initialized by step 3.
-          v = realm.intrinsics.undefined;
-        } else {
-          // e. Else,
-          // i. Let v be IteratorValue(next).
-          try {
-            v = IteratorValue(realm, next);
-          } catch (e) {
-            // ii. If v is an abrupt completion, set iteratorRecord.[[Done]] to true.
-            if (e instanceof AbruptCompletion) {
-              iteratorRecord.$Done = true;
-            }
-            // iii. ReturnIfAbrupt(v).
-            throw e;
-          }
-        }
-      } else {
-        // 2. If iteratorRecord.[[Done]] is true, let v be undefined.
-        v = realm.intrinsics.undefined;
-      }
-
-      // 3. If Initializer is present and v is undefined, then
+      // 2. If Initializer is present and v is undefined, then
       if (Initializer && v instanceof UndefinedValue) {
         // a. Let defaultValue be the result of evaluating Initializer.
         let defaultValue = env.evaluate(Initializer, strictCode);
 
         // b. Let v be ? GetValue(defaultValue).
-        v = GetValue(realm, defaultValue);
+        v = this.GetValue(realm, defaultValue);
       }
 
-      // 4. Return the result of performing BindingInitialization of BindingPattern with v and environment as the arguments.
-      BindingInitialization(realm, param, v, strictCode, environment);
-      continue;
+      // 3. Return the result of performing BindingInitialization for BindingPattern passing v and environment as arguments.
+      return this.BindingInitialization(realm, node, v, strictCode, env);
     }
-  }
-
-  // Handle the rest element if we have one.
-  if (restEl && restEl.argument.type === "Identifier") {
-    // BindingRestElement : ...BindingIdentifier
-
-    // 1. Let lhs be ? ResolveBinding(StringValue of BindingIdentifier, environment).
-    let lhs = ResolveBinding(realm, restEl.argument.name, strictCode, environment);
-
-    // 2. Let A be ArrayCreate(0).
-    let A = ArrayCreate(realm, 0);
-
-    // 3. Let n be 0.
-    let n = 0;
-
-    // 4. Repeat,
-    while (true) {
-      // Initialized later in the algorithm.
-      let next: ObjectValue | false;
-
-      // a. If iteratorRecord.[[Done]] is false, then
-      if (iteratorRecord.$Done === false) {
-        // i. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
-        try {
-          next = IteratorStep(realm, iteratorRecord.$Iterator);
-        } catch (e) {
-          // ii. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-          if (e instanceof AbruptCompletion) {
-            iteratorRecord.$Done = true;
-          }
-          // iii. ReturnIfAbrupt(next).
-          throw e;
-        }
-        // iv. If next is false, set iteratorRecord.[[Done]] to true.
-        if (next === false) {
-          iteratorRecord.$Done = true;
-        }
-      }
-
-      // b. If iteratorRecord.[[Done]] is true, then
-      if (iteratorRecord.$Done === true) {
-        // i. If environment is undefined, return ? PutValue(lhs, A).
-        if (!environment) {
-          Properties.PutValue(realm, lhs, A);
-          break;
-        }
-
-        // ii. Return InitializeReferencedBinding(lhs, A).
-        InitializeReferencedBinding(realm, lhs, A);
-        break;
-      }
-
-      // Given the nature of the algorithm this should always be true, however
-      // it is difficult to arrange the code in such a way where Flow's control
-      // flow analysis will pick that up, so we add an invariant here.
-      invariant(next instanceof ObjectValue);
-
-      // c. Let nextValue be IteratorValue(next).
-      let nextValue;
-      try {
-        nextValue = IteratorValue(realm, next);
-      } catch (e) {
-        // d. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-        if (e instanceof AbruptCompletion) {
-          iteratorRecord.$Done = true;
-        }
-        // e. ReturnIfAbrupt(nextValue).
-        throw e;
-      }
-
-      // f. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
-      let status = CreateDataProperty(realm, A, n.toString(), nextValue);
-
-      // g. Assert: status is true.
-      invariant(status, "expected to create data property");
-
-      // h. Increment n by 1.
-      n += 1;
-    }
-  } else if (restEl) {
-    invariant(restEl.argument.type === "ArrayPattern" || restEl.argument.type === "ObjectPattern");
-    // 1. Let A be ArrayCreate(0).
-    let A = ArrayCreate(realm, 0);
-
-    // 2. Let n be 0.
-    let n = 0;
-
-    // 3. Repeat,
-    while (true) {
-      // Initialized later in the algorithm.
-      let next;
-
-      // a. If iteratorRecord.[[Done]] is false, then
-      if (iteratorRecord.$Done === false) {
-        // i. Let next be IteratorStep(iteratorRecord.[[Iterator]]).
-        try {
-          next = IteratorStep(realm, iteratorRecord.$Iterator);
-        } catch (e) {
-          // ii. If next is an abrupt completion, set iteratorRecord.[[Done]] to true.
-          if (e instanceof AbruptCompletion) {
-            iteratorRecord.$Done = true;
-          }
-          // iii. ReturnIfAbrupt(next).
-          throw e;
-        }
-        // iv. If next is false, set iteratorRecord.[[Done]] to true.
-        if (next === false) {
-          iteratorRecord.$Done = true;
-        }
-      }
-
-      // b. If iteratorRecord.[[Done]] is true, then
-      if (iteratorRecord.$Done === true) {
-        // i. Return the result of performing BindingInitialization of BindingPattern with A and environment as the arguments.
-        BindingInitialization(realm, restEl.argument, A, strictCode, environment);
-        break;
-      }
-
-      // Given the nature of the algorithm this should always be true, however
-      // it is difficult to arrange the code in such a way where Flow's control
-      // flow analysis will pick that up, so we add an invariant here.
-      invariant(next instanceof ObjectValue);
-
-      // c. Let nextValue be IteratorValue(next).
-      let nextValue;
-      try {
-        nextValue = IteratorValue(realm, next);
-      } catch (e) {
-        // d. If nextValue is an abrupt completion, set iteratorRecord.[[Done]] to true.
-        if (e instanceof AbruptCompletion) {
-          iteratorRecord.$Done = true;
-        }
-        // e. ReturnIfAbrupt(nextValue).
-        throw e;
-      }
-
-      // f. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
-      let status = CreateDataProperty(realm, A, n.toString(), nextValue);
-
-      // g. Assert: status is true.
-      invariant(status, "expected to create data property");
-
-      // h. Increment n by 1.
-      n += 1;
-    }
-  }
-}
-
-// ECMA262 12.1.5.1
-export function InitializeBoundName(realm: Realm, name: string, value: Value, environment: void | LexicalEnvironment) {
-  // 1. Assert: Type(name) is String.
-  invariant(typeof name === "string", "expected name to be a string");
-
-  // 2. If environment is not undefined, then
-  if (environment) {
-    // a. Let env be the EnvironmentRecord component of environment.
-    let env = environment.environmentRecord;
-
-    // b. Perform env.InitializeBinding(name, value).
-    env.InitializeBinding(name, value);
-
-    // c. Return NormalCompletion(undefined).
-    return realm.intrinsics.undefined;
-  } else {
-    // 3. Else,
-    // a. Let lhs be ResolveBinding(name).
-    // Note that the undefined environment implies non-strict.
-    let lhs = ResolveBinding(realm, name, false);
-
-    // b. Return ? PutValue(lhs, value).
-    return Properties.PutValue(realm, lhs, value);
-  }
-}
-
-// ECMA262 12.3.1.3 and 13.7.5.6
-export function IsDestructuring(ast: BabelNode) {
-  switch (ast.type) {
-    case "VariableDeclaration":
-      for (let decl of ((ast: any): BabelNodeVariableDeclaration).declarations) {
-        switch (decl.type) {
-          case "VariableDeclarator":
-            switch (decl.id.type) {
-              case "ArrayPattern":
-              case "AssignmentPattern":
-              case "ObjectPattern":
-                return true;
-              default:
-                break;
-            }
-            break;
-          default:
-            break;
-        }
-      }
-      return false;
-    case "ArrayLiteral":
-    case "ObjectLiteral":
-      return true;
-    case "ArrayPattern":
-    case "ObjectPattern":
-      return true;
-    default:
-      return false;
-  }
-}
-
-// ECMA262 13.3.3.7
-export function KeyedBindingInitialization(
-  realm: Realm,
-  node: BabelNodeIdentifier | BabelNodePattern,
-  value: Value,
-  strictCode: boolean,
-  environment: ?LexicalEnvironment,
-  propertyName: PropertyKeyValue
-) {
-  let env = environment ? environment : realm.getRunningContext().lexicalEnvironment;
-
-  let Initializer;
-  if (node.type === "AssignmentPattern") {
-    Initializer = node.right;
-    node = node.left;
-  }
-
-  if (node.type === "Identifier") {
-    // SingleNameBinding : BindingIdentifier Initializer
-
-    // 1. Let bindingId be StringValue of BindingIdentifier.
-    let bindingId = node.name;
-
-    // 2. Let lhs be ? ResolveBinding(bindingId, environment).
-    let lhs = ResolveBinding(realm, bindingId, strictCode, environment);
-
-    // 3. Let v be ? GetV(value, propertyName).
-    let v = GetV(realm, value, propertyName);
-
-    // 4. If Initializer is present and v is undefined, then
-    if (Initializer && v instanceof UndefinedValue) {
-      // a. Let defaultValue be the result of evaluating Initializer.
-      let defaultValue = env.evaluate(Initializer, strictCode);
-
-      // b. Let v be ? GetValue(defaultValue).
-      v = GetValue(realm, defaultValue);
-
-      // c. If IsAnonymousFunctionDefinition(Initializer) is true, then
-      if (IsAnonymousFunctionDefinition(realm, Initializer) && v instanceof ObjectValue) {
-        // i. Let hasNameProperty be ? HasOwnProperty(v, "name").
-        let hasNameProperty = HasOwnProperty(realm, v, "name");
-
-        // ii. If hasNameProperty is false, perform SetFunctionName(v, bindingId).
-        if (hasNameProperty === false) {
-          Functions.SetFunctionName(realm, v, bindingId);
-        }
-      }
-    }
-
-    // 5. If environment is undefined, return ? PutValue(lhs, v).
-    if (!environment) return Properties.PutValue(realm, lhs, v);
-
-    // 6. Return InitializeReferencedBinding(lhs, v).
-    return InitializeReferencedBinding(realm, lhs, v);
-  } else if (node.type === "ObjectPattern" || node.type === "ArrayPattern") {
-    // BindingElement : BindingPattern Initializer
-
-    // 1. Let v be ? GetV(value, propertyName).
-    let v = GetV(realm, value, propertyName);
-
-    // 2. If Initializer is present and v is undefined, then
-    if (Initializer && v instanceof UndefinedValue) {
-      // a. Let defaultValue be the result of evaluating Initializer.
-      let defaultValue = env.evaluate(Initializer, strictCode);
-
-      // b. Let v be ? GetValue(defaultValue).
-      v = GetValue(realm, defaultValue);
-    }
-
-    // 3. Return the result of performing BindingInitialization for BindingPattern passing v and environment as arguments.
-    return BindingInitialization(realm, node, v, strictCode, env);
   }
 }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -32,20 +32,16 @@ import { SetIntegrityLevel } from "./integrity.js";
 import { ToString } from "./to.js";
 import {
   Call,
-  GetBase,
-  GetThisEnvironment,
   HasSomeCompatibleType,
   IsAccessorDescriptor,
   IsCallable,
   IsDataDescriptor,
   IsPropertyKey,
-  IsPropertyReference,
-  IsSuperReference,
   joinValuesAsConditional,
   joinEffects,
   ToObjectPartial,
 } from "./index.js";
-import { Path } from "../singletons.js";
+import { Environment, Path } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeTemplateLiteral } from "babel-types";
 
@@ -383,17 +379,17 @@ export function GetV(realm: Realm, V: Value, P: PropertyKeyValue): Value {
 // ECMA262 6.2.3.3
 export function GetThisValue(realm: Realm, V: Reference): Value {
   // 1. Assert: IsPropertyReference(V) is true.
-  invariant(IsPropertyReference(realm, V), "expected property reference");
+  invariant(Environment.IsPropertyReference(realm, V), "expected property reference");
 
   // 2. If IsSuperReference(V) is true, then
-  if (IsSuperReference(realm, V)) {
+  if (Environment.IsSuperReference(realm, V)) {
     invariant(V.thisValue !== undefined);
     // a. Return the value of the thisValue component of the reference V.
     return V.thisValue;
   }
 
   // 3. Return GetBase(V).
-  let result = GetBase(realm, V);
+  let result = Environment.GetBase(realm, V);
   invariant(result instanceof Value);
   return result;
 }
@@ -401,7 +397,7 @@ export function GetThisValue(realm: Realm, V: Reference): Value {
 // ECMA262 8.3.5
 export function GetNewTarget(realm: Realm): UndefinedValue | ObjectValue {
   // 1. Let envRec be GetThisEnvironment( ).
-  let envRec = GetThisEnvironment(realm);
+  let envRec = Environment.GetThisEnvironment(realm);
 
   // 2. Assert: envRec has a [[NewTarget]] field.
   if (!("$NewTarget" in envRec)) {

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -16,7 +16,6 @@ export * from "./construct.js";
 export * from "./create.js";
 export * from "./date.js";
 export * from "./descriptor.js";
-export * from "./environment.js";
 export * from "./get.js";
 export * from "./has.js";
 export * from "./hash.js";

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -37,20 +37,13 @@ import {
   CreateDataProperty,
   equalDescriptors,
   Get,
-  GetBase,
   GetGlobalObject,
-  GetReferencedName,
-  GetReferencedNamePartial,
   GetThisValue,
-  HasPrimitiveBase,
   HasSomeCompatibleType,
   IsAccessorDescriptor,
   IsDataDescriptor,
   IsGenericDescriptor,
   IsPropertyKey,
-  IsPropertyReference,
-  IsStrictReference,
-  IsUnresolvableReference,
   joinEffects,
   MakeConstructor,
   ObjectCreate,
@@ -65,7 +58,7 @@ import {
 } from "../methods/index.js";
 import { type BabelNodeObjectMethod, type BabelNodeClassMethod, isValidIdentifier } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
-import { Functions, Path } from "../singletons.js";
+import { Environment, Functions, Path } from "../singletons.js";
 import IsStrict from "../utils/strict.js";
 import * as t from "babel-types";
 
@@ -879,12 +872,12 @@ export class PropertiesImplementation {
     }
 
     // 4. Let base be GetBase(V).
-    let base = GetBase(realm, V);
+    let base = Environment.GetBase(realm, V);
 
     // 5. If IsUnresolvableReference(V) is true, then
-    if (IsUnresolvableReference(realm, V)) {
+    if (Environment.IsUnresolvableReference(realm, V)) {
       // a. If IsStrictReference(V) is true, then
-      if (IsStrictReference(realm, V)) {
+      if (Environment.IsStrictReference(realm, V)) {
         // i. Throw a ReferenceError exception.
         throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError);
       }
@@ -893,13 +886,13 @@ export class PropertiesImplementation {
       let globalObj = GetGlobalObject(realm);
 
       // c. Return ? Set(globalObj, GetReferencedName(V), W, false).
-      return this.Set(realm, globalObj, GetReferencedName(realm, V), W, false);
+      return this.Set(realm, globalObj, Environment.GetReferencedName(realm, V), W, false);
     }
 
     // 6. Else if IsPropertyReference(V) is true, then
-    if (IsPropertyReference(realm, V)) {
+    if (Environment.IsPropertyReference(realm, V)) {
       // a. If HasPrimitiveBase(V) is true, then
-      if (HasPrimitiveBase(realm, V)) {
+      if (Environment.HasPrimitiveBase(realm, V)) {
         // i. Assert: In realm case, base will never be null or undefined.
         invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
 
@@ -909,10 +902,10 @@ export class PropertiesImplementation {
       invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
 
       // b. Let succeeded be ? base.[[Set]](GetReferencedName(V), W, GetThisValue(V)).
-      let succeeded = base.$SetPartial(GetReferencedNamePartial(realm, V), W, GetThisValue(realm, V));
+      let succeeded = base.$SetPartial(Environment.GetReferencedNamePartial(realm, V), W, GetThisValue(realm, V));
 
       // c. If succeeded is false and IsStrictReference(V) is true, throw a TypeError exception.
-      if (succeeded === false && IsStrictReference(realm, V)) {
+      if (succeeded === false && Environment.IsStrictReference(realm, V)) {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
       }
 
@@ -923,9 +916,9 @@ export class PropertiesImplementation {
     // 7. Else base must be an Environment Record,
     if (base instanceof EnvironmentRecord) {
       // a. Return ? base.SetMutableBinding(GetReferencedName(V), W, IsStrictReference(V)) (see 8.1.1).
-      let referencedName = GetReferencedName(realm, V);
+      let referencedName = Environment.GetReferencedName(realm, V);
       invariant(typeof referencedName === "string");
-      return base.SetMutableBinding(referencedName, W, IsStrictReference(realm, V));
+      return base.SetMutableBinding(referencedName, W, Environment.IsStrictReference(realm, V));
     }
 
     invariant(false);

--- a/src/partial-evaluators/AssignmentExpression.js
+++ b/src/partial-evaluators/AssignmentExpression.js
@@ -25,15 +25,13 @@ import { Reference } from "../environment.js";
 import { FatalError } from "../errors.js";
 import { BooleanValue, ConcreteValue, NullValue, ObjectValue, UndefinedValue, Value } from "../values/index.js";
 import {
-  GetValue,
   IsAnonymousFunctionDefinition,
   IsIdentifierRef,
   HasOwnProperty,
-  GetReferencedName,
   composeNormalCompletions,
   unbundleNormalCompletion,
 } from "../methods/index.js";
-import { Functions, Properties } from "../singletons.js";
+import { Environment, Functions, Properties } from "../singletons.js";
 
 import * as t from "babel-types";
 import invariant from "../invariant.js";
@@ -85,7 +83,7 @@ export default function(
         // ii. If hasNameProperty is false, perform SetFunctionName(rval, GetReferencedName(lref)).
         if (!hasNameProperty) {
           invariant(lref instanceof Reference);
-          Functions.SetFunctionName(realm, rval, GetReferencedName(realm, lref));
+          Functions.SetFunctionName(realm, rval, Environment.GetReferencedName(realm, lref));
         }
       }
 
@@ -115,7 +113,7 @@ export default function(
   [leftCompletion, lref] = unbundleNormalCompletion(lref);
 
   // 2. Let lval be ? GetValue(lref).
-  let lval = GetValue(realm, lref);
+  let lval = Environment.GetValue(realm, lref);
 
   // 3. Let rref be the result of evaluating AssignmentExpression.
   // 4. Let rval be ? GetValue(rref).

--- a/src/partial-evaluators/BlockStatement.js
+++ b/src/partial-evaluators/BlockStatement.js
@@ -15,8 +15,7 @@ import type { LexicalEnvironment } from "../environment.js";
 
 import { Completion, NormalCompletion } from "../completions.js";
 import { EmptyValue, StringValue, Value } from "../values/index.js";
-import { BlockDeclarationInstantiation, NewDeclarativeEnvironment } from "../methods/index.js";
-import { Functions } from "../singletons.js";
+import { Environment, Functions } from "../singletons.js";
 
 import invariant from "../invariant.js";
 import * as t from "babel-types";
@@ -32,10 +31,10 @@ export default function(
   let oldEnv = realm.getRunningContext().lexicalEnvironment;
 
   // 2. Let blockEnv be NewDeclarativeEnvironment(oldEnv).
-  let blockEnv = NewDeclarativeEnvironment(realm, oldEnv);
+  let blockEnv = Environment.NewDeclarativeEnvironment(realm, oldEnv);
 
   // 3. Perform BlockDeclarationInstantiation(StatementList, blockEnv).
-  BlockDeclarationInstantiation(realm, strictCode, ast.body, blockEnv);
+  Environment.BlockDeclarationInstantiation(realm, strictCode, ast.body, blockEnv);
 
   // 4. Set the running execution context's LexicalEnvironment to blockEnv.
   realm.getRunningContext().lexicalEnvironment = blockEnv;

--- a/src/realm.js
+++ b/src/realm.js
@@ -32,7 +32,6 @@ import {
   composeGenerators,
   composePossiblyNormalCompletions,
   Construct,
-  GetValue,
   ToString,
   updatePossiblyNormalCompletionWithSubsequentEffects,
 } from "./methods/index.js";
@@ -41,7 +40,7 @@ import type { Compatibility, RealmOptions } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
 import { Generator, PreludeGenerator } from "./utils/generator.js";
-import { Functions, Properties } from "./singletons.js";
+import { Environment, Functions, Properties } from "./singletons.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
 import * as t from "babel-types";
 
@@ -406,7 +405,7 @@ export class Realm {
       try {
         try {
           c = f();
-          if (c instanceof Reference) c = GetValue(this, c);
+          if (c instanceof Reference) c = Environment.GetValue(this, c);
         } catch (e) {
           if (e instanceof AbruptCompletion) c = e;
           else throw e;

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -14,7 +14,7 @@ import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import type { Effects } from "../realm.js";
 import type { Descriptor, PropertyBinding, ObjectKind } from "../types.js";
-import { IsUnresolvableReference, ToLength, ResolveBinding, HashSet, IsArray, Get } from "../methods/index.js";
+import { ToLength, HashSet, IsArray, Get } from "../methods/index.js";
 import {
   BoundFunctionValue,
   ProxyValue,
@@ -41,6 +41,7 @@ import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
 import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
 import { getSuggestedArrayLiteralLength } from "./utils.js";
+import { Environment } from "../singletons.js";
 
 export type Scope = FunctionValue | Generator;
 
@@ -358,18 +359,18 @@ export class ResidualHeapVisitor {
         let residualFunctionBinding;
         let doesNotMatter = true;
         let reference = this.logger.tryQuery(
-          () => ResolveBinding(this.realm, innerName, doesNotMatter, val.$Environment),
+          () => Environment.ResolveBinding(this.realm, innerName, doesNotMatter, val.$Environment),
           undefined,
           false /* The only reason `ResolveBinding` might fail is because the global object is partial. But in that case, we know that we are dealing with the common scope. */
         );
         if (
           reference === undefined ||
-          IsUnresolvableReference(this.realm, reference) ||
+          Environment.IsUnresolvableReference(this.realm, reference) ||
           reference.base instanceof GlobalEnvironmentRecord
         ) {
           residualFunctionBinding = this.visitGlobalBinding(innerName);
         } else {
-          invariant(!IsUnresolvableReference(this.realm, reference));
+          invariant(!Environment.IsUnresolvableReference(this.realm, reference));
           let referencedBase = reference.base;
           let referencedName: string = (reference.referencedName: any);
           if (typeof referencedName !== "string") {

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -13,9 +13,9 @@ import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../enviro
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { Realm, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
-import { ResolveBinding, Get, IsUnresolvableReference } from "../methods/index.js";
+import { Get } from "../methods/index.js";
 import { AbruptCompletion, Completion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
-import { Functions } from "../singletons.js";
+import { Environment, Functions } from "../singletons.js";
 import { AbstractValue, Value, FunctionValue, ObjectValue, NumberValue, StringValue } from "../values/index.js";
 import * as t from "babel-types";
 import type { BabelNodeIdentifier, BabelNodeLVal, BabelNodeCallExpression } from "babel-types";
@@ -385,7 +385,7 @@ export class Modules {
 
         let doesNotMatter = true;
         let reference = logger.tryQuery(
-          () => ResolveBinding(realm, innerName, doesNotMatter, f.$Environment),
+          () => Environment.ResolveBinding(realm, innerName, doesNotMatter, f.$Environment),
           undefined,
           false
         );
@@ -393,7 +393,7 @@ export class Modules {
           // We couldn't resolve as we came across some behavior that we cannot deal with abstractly
           return false;
         }
-        if (IsUnresolvableReference(realm, reference)) return false;
+        if (Environment.IsUnresolvableReference(realm, reference)) return false;
         let referencedBase = reference.base;
         let referencedName: string = (reference.referencedName: any);
         if (typeof referencedName !== "string") return false;

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -9,11 +9,16 @@
 
 /* @flow */
 
-import type { FunctionType, PathType, PropertiesType } from "./types.js";
+import type { EnvironmentType, FunctionType, PathType, PropertiesType } from "./types.js";
 
+export let Environment: EnvironmentType = (null: any);
 export let Functions: FunctionType = (null: any);
 export let Path: PathType = (null: any);
 export let Properties: PropertiesType = (null: any);
+
+export function setEnvironment(singleton: EnvironmentType) {
+  Environment = singleton;
+}
 
 export function setFunctions(singleton: FunctionType) {
   Functions = singleton;

--- a/src/types.js
+++ b/src/types.js
@@ -27,7 +27,7 @@ import type {
   Value,
 } from "./values/index.js";
 import { AbruptCompletion, Completion, NormalCompletion } from "./completions.js";
-import { LexicalEnvironment, Reference } from "./environment.js";
+import { EnvironmentRecord, LexicalEnvironment, Reference } from "./environment.js";
 import { ObjectValue } from "./values/index.js";
 import type {
   BabelNode,
@@ -35,6 +35,8 @@ import type {
   BabelNodeClassMethod,
   BabelNodeLVal,
   BabelNodeObjectMethod,
+  BabelNodePattern,
+  BabelNodeVariableDeclaration,
 } from "babel-types";
 import { Realm } from "./realm.js";
 
@@ -516,4 +518,125 @@ export type FunctionType = {
     strictCode: boolean,
     functionPrototype?: ObjectValue
   ): { $Key: PropertyKeyValue, $Closure: ECMAScriptSourceFunctionValue },
+};
+
+export type EnvironmentType = {
+  // ECMA262 6.2.3
+  // IsSuperReference(V). Returns true if this reference has a thisValue component.
+  IsSuperReference(realm: Realm, V: Reference): boolean,
+
+  // ECMA262 6.2.3
+  // HasPrimitiveBase(V). Returns true if Type(base) is Boolean, String, Symbol, or Number.
+  HasPrimitiveBase(realm: Realm, V: Reference): boolean,
+
+  // ECMA262 6.2.3
+  // GetReferencedName(V). Returns the referenced name component of the reference V.
+  GetReferencedName(realm: Realm, V: Reference): string | SymbolValue,
+
+  GetReferencedNamePartial(realm: Realm, V: Reference): AbstractValue | string | SymbolValue,
+
+  // ECMA262 6.2.3.1
+  GetValue(realm: Realm, V: Reference | Value): Value,
+
+  // ECMA262 6.2.3
+  // IsStrictReference(V). Returns the strict reference flag component of the reference V.
+  IsStrictReference(realm: Realm, V: Reference): boolean,
+
+  // ECMA262 6.2.3
+  // IsPropertyReference(V). Returns true if either the base value is an object or HasPrimitiveBase(V) is true; otherwise returns false.
+  IsPropertyReference(realm: Realm, V: Reference): boolean,
+
+  // ECMA262 6.2.3
+  // GetBase(V). Returns the base value component of the reference V.
+  GetBase(realm: Realm, V: Reference): void | Value | EnvironmentRecord,
+
+  // ECMA262 6.2.3
+  // IsUnresolvableReference(V). Returns true if the base value is undefined and false otherwise.
+  IsUnresolvableReference(realm: Realm, V: Reference): boolean,
+
+  // ECMA262 8.1.2.2
+  NewDeclarativeEnvironment(realm: Realm, E: LexicalEnvironment): LexicalEnvironment,
+
+  BoundNames(realm: Realm, node: BabelNode): Array<string>,
+
+  // ECMA262 13.3.3.2
+  ContainsExpression(realm: Realm, node: ?BabelNode): boolean,
+
+  // ECMA262 8.3.2
+  ResolveBinding(realm: Realm, name: string, strict: boolean, env?: ?LexicalEnvironment): Reference,
+
+  // ECMA262 8.1.2.1
+  GetIdentifierReference(realm: Realm, lex: ?LexicalEnvironment, name: string, strict: boolean): Reference,
+
+  // ECMA262 6.2.3.4
+  InitializeReferencedBinding(realm: Realm, V: Reference, W: Value): Value,
+
+  // ECMA262 13.2.14
+  BlockDeclarationInstantiation(
+    realm: Realm,
+    strictCode: boolean,
+    body: Array<BabelNodeStatement>,
+    env: LexicalEnvironment
+  ): void,
+
+  // ECMA262 8.1.2.5
+  NewGlobalEnvironment(
+    realm: Realm,
+    G: ObjectValue | AbstractObjectValue,
+    thisValue: ObjectValue | AbstractObjectValue
+  ): void,
+
+  // ECMA262 8.1.2.3
+  NewObjectEnvironment(realm: Realm, O: ObjectValue | AbstractObjectValue, E: LexicalEnvironment): LexicalEnvironment,
+
+  // ECMA262 8.1.2.4
+  NewFunctionEnvironment(realm: Realm, F: ECMAScriptFunctionValue, newTarget?: ObjectValue): LexicalEnvironment,
+
+  // ECMA262 8.3.1
+  GetActiveScriptOrModule(realm: Realm): any,
+
+  // ECMA262 8.3.3
+  GetThisEnvironment(realm: Realm): EnvironmentRecord,
+
+  // ECMA262 8.3.4
+  ResolveThisBinding(realm: Realm): NullValue | ObjectValue | AbstractObjectValue | UndefinedValue,
+
+  BindingInitialization(
+    realm: Realm,
+    node: BabelNodeLVal | BabelNodeVariableDeclaration,
+    value: Value,
+    strictCode: boolean,
+    environment: void | LexicalEnvironment
+  ): void | boolean | Value,
+
+  // ECMA262 13.3.3.6
+  // ECMA262 14.1.19
+  IteratorBindingInitialization(
+    realm: Realm,
+    formals: $ReadOnlyArray<BabelNodeLVal | null>,
+    iteratorRecord: { $Iterator: ObjectValue, $Done: boolean },
+    strictCode: boolean,
+    environment: void | LexicalEnvironment
+  ): void,
+
+  // ECMA262 12.1.5.1
+  InitializeBoundName(
+    realm: Realm,
+    name: string,
+    value: Value,
+    environment: void | LexicalEnvironment
+  ): void | boolean | Value,
+
+  // ECMA262 12.3.1.3 and 13.7.5.6
+  IsDestructuring(ast: BabelNode): boolean,
+
+  // ECMA262 13.3.3.7
+  KeyedBindingInitialization(
+    realm: Realm,
+    node: BabelNodeIdentifier | BabelNodePattern,
+    value: Value,
+    strictCode: boolean,
+    environment: ?LexicalEnvironment,
+    propertyName: PropertyKeyValue
+  ): void | boolean | Value,
 };


### PR DESCRIPTION
Part 3 of the big refactor. Move all the exported functions in environment.js to a class outside of the big cycle.