### PR TITLE
Preserve residual function original ordering

### DIFF
--- a/src/evaluators/ArrowFunctionExpression.js
+++ b/src/evaluators/ArrowFunctionExpression.js
@@ -27,6 +27,8 @@ export default function(
   let ConciseBody = ast.body;
   if (ConciseBody.type !== "BlockStatement") {
     ConciseBody = t.blockStatement([t.returnStatement(ConciseBody)]);
+    // Use original array function's location for the new concise body.
+    ConciseBody.loc = ast.body.loc;
   }
 
   // 1. If the function code for this ArrowFunction is strict mode code, let strict be true. Otherwise let strict be false.
@@ -40,6 +42,7 @@ export default function(
 
   // 4. Let closure be FunctionCreate(Arrow, parameters, ConciseBody, scope, strict).
   let closure = Functions.FunctionCreate(realm, "arrow", parameters, ConciseBody, scope, strict);
+  closure.loc = ast.loc;
 
   // 5. Return closure.
   return closure;

--- a/src/evaluators/FunctionExpression.js
+++ b/src/evaluators/FunctionExpression.js
@@ -142,6 +142,7 @@ export default function(
 
       // 3. Let closure be FunctionCreate(Normal, FormalParameters, FunctionBody, scope, strict).
       let closure = Functions.FunctionCreate(realm, "normal", ast.params, ast.body, scope, strict);
+      closure.loc = ast.loc;
 
       // 4. Perform MakeConstructor(closure).
       MakeConstructor(realm, closure);

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -179,8 +179,10 @@ export class ResidualFunctions {
     functionEntries.sort((funcA, funcB) => {
       const funcALocation = funcA[0].loc;
       const funcBLocation = funcB[0].loc;
-      invariant(funcALocation && funcBLocation);
-      invariant(funcALocation.source && funcBLocation.source);
+      if (!funcALocation || !funcBLocation || !funcALocation.source || !funcBLocation.source) {
+        // Preserve the current ordering if there is no source location information available.
+        return -1;
+      }
       if (funcALocation.source !== funcBLocation.source) {
         return funcALocation.source.localeCompare(funcBLocation.source);
       } else if (funcALocation.start.line !== funcBLocation.start.line) {

--- a/test/serializer/basic/FunctionOrdering.js
+++ b/test/serializer/basic/FunctionOrdering.js
@@ -1,0 +1,14 @@
+(function () {
+  first = function() {
+    // Function ordering: 1
+    second();
+    return 10;
+  }
+  var second = function() {
+    // Function ordering: 2
+    return 20;
+  };
+  inspect = function() {
+    return first() + second();
+  }
+})();


### PR DESCRIPTION
Release Note: preserve residual functions' original source ordering.

We serialize the residual functions in random order(based on the visitor's discovery of residual function order) which may result in very bad code locality in real world app. 
Add the feature to preserve residual functions' original source ordering. 

Note:
1. I did not make an option for this feature because I think it should do this by default.
2. To gain better perf, we may introduce some profiler guided optimization in future.