### PR TITLE
Fix startup for debugger integration with IDE

### DIFF
--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -52,7 +52,7 @@ export class DebugServer {
   /* Block until adapter says to run
   /* ast: the current ast node we are stopped on
   */
-  waitForRun(ast?: BabelNode) {
+  waitForRun(ast: void | BabelNode) {
     let keepRunning = false;
     let request;
     while (!keepRunning) {
@@ -122,7 +122,7 @@ export class DebugServer {
 
   // Process a command from a debugger. Returns whether Prepack should unblock
   // if it is blocked
-  processDebuggerCommand(request: DebuggerRequest, ast?: BabelNode) {
+  processDebuggerCommand(request: DebuggerRequest, ast: void | BabelNode) {
     let requestID = request.id;
     let command = request.command;
     let args = request.arguments;
@@ -169,7 +169,7 @@ export class DebugServer {
     return false;
   }
 
-  processStackframesCommand(requestID: number, args: StackframeArguments, ast?: BabelNode) {
+  processStackframesCommand(requestID: number, args: StackframeArguments, ast: void | BabelNode) {
     let frameInfos: Array<Stackframe> = [];
     let loc = this._getFrameLocation(ast ? ast.loc : null);
     let fileName = loc.fileName;

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -153,7 +153,6 @@ export class DebugServer {
         return true;
       case DebugMessage.STACKFRAMES_COMMAND:
         invariant(args.kind === "stackframe");
-        invariant(ast !== undefined);
         this.processStackframesCommand(requestID, args, ast);
         break;
       case DebugMessage.SCOPES_COMMAND:
@@ -170,9 +169,9 @@ export class DebugServer {
     return false;
   }
 
-  processStackframesCommand(requestID: number, args: StackframeArguments, ast: BabelNode) {
+  processStackframesCommand(requestID: number, args: StackframeArguments, ast?: BabelNode) {
     let frameInfos: Array<Stackframe> = [];
-    let loc = this._getFrameLocation(ast.loc);
+    let loc = this._getFrameLocation(ast ? ast.loc : null);
     let fileName = loc.fileName;
     let line = loc.line;
     let column = loc.column;

--- a/src/debugger/DebuggerConstants.js
+++ b/src/debugger/DebuggerConstants.js
@@ -20,6 +20,6 @@ export class DebuggerConstants {
   // is required
   static PREPACK_THREAD_ID: number = 1;
 
-  // clientID used in initalize requests by the CLI
+  // clientID used in initialize requests by the CLI
   static CLI_CLIENTID: string = "Prepack-Debugger-CLI";
 }

--- a/src/debugger/DebuggerConstants.js
+++ b/src/debugger/DebuggerConstants.js
@@ -19,4 +19,7 @@ export class DebuggerConstants {
   // since Prepack only has 1 thread, we use this constant where a thread ID
   // is required
   static PREPACK_THREAD_ID: number = 1;
+
+  // clientID used in initalize requests by the CLI
+  static CLI_CLIENTID: string = "Prepack-Debugger-CLI";
 }

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -437,7 +437,7 @@ export class UISession {
     // send an initialize request to the adapter to fetch some configuration details
     let initArgs: DebugProtocol.InitializeRequestArguments = {
       // a unique name for each UI (e.g Nuclide, VSCode, CLI)
-      clientID: "Prepack-Debugger-CLI",
+      clientID: DebuggerConstants.CLI_CLIENTID,
       // a unique name for each adapter
       adapterID: "Prepack-Debugger-Adapter",
       linesStartAt1: true,


### PR DESCRIPTION
Release note: none
Summary:
-autosend a continue request after the initial handshake for IDEs
-fix invariant failure in stackframe commands to account for startup

Test Plan:
Usage in CLI: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path-to-adapter> --prepackRuntime <prepack runtime command> --sourceFile <file to prepack> --debugInFilePath <input file for debugger> --debugOutFilePath <output file for debugger>`
e.g.: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepackRuntime "node lib/prepack-cli.js" --sourceFile test/serializer/basic/Date.js --debugInFilePath src/debugger/.sessionlogs/engine2adapter.txt --debugOutFilePath src/debugger/.sessionlogs/adapter2engine.txt` 

In IDE: set some breakpoints in source program, launched Prepack in debugger, continued on each breakpoint, observed Prepack output at the end.