### PR TITLE
in es5 bablify the original code, not just the prepacked result

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -380,6 +380,9 @@ function runTest(name, code, options, args) {
       let i = code.indexOf(injectAtRuntime);
       addedCode = code.substring(i + injectAtRuntime.length, code.indexOf("\n", i));
     }
+    if (args.es5) {
+      code = transformWithBabel(code, [], [["env", { forceAllTransforms: true, modules: false }]]);
+    }
     let unique = 27277;
     let oldUniqueSuffix = "";
     let expectedCode = code;


### PR DESCRIPTION
Not sure why I didn't do it this way in the first place. Instead of applying babel to the prepacked code, apply it to them input source code. Make it an apples to apples comparison 