### PR TITLE
Properly name lexical scopes in debugger

### DIFF
--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -256,12 +256,12 @@ export class DebugServer {
       return "Global";
     } else if (envRec instanceof DeclarativeEnvironmentRecord) {
       if (envRec instanceof FunctionEnvironmentRecord) {
-        return "Local";
+        return "Local: " + (envRec.$FunctionObject.__originalName || "anonymous function");
       } else {
         return "Block";
       }
     } else if (envRec instanceof ObjectEnvironmentRecord) {
-      return "Block";
+      return "With";
     } else {
       invariant(false, "Invalid type of environment record");
     }


### PR DESCRIPTION
Release note: none
Summary:
-properly fetch the lexical scopes for a given stack frame
-each scope is one of: Block scope, Local scope (for functions), or the Global scope

I will make the changes to Variable requests for these different scopes in a separate PR.

Test Plan:
Usage: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path-to-adapter> --prepackRuntime <prepack runtime command> --sourceFile <file to prepack> --debugInFilePath <input file for debugger> --debugOutFilePath <output file for debugger>`
e.g.: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepackRuntime "node lib/prepack-cli.js" --sourceFile test/serializer/basic/Date.js --debugInFilePath src/debugger/.sessionlogs/engine2adapter.txt --debugOutFilePath src/debugger/.sessionlogs/adapter2engine.txt` 