### PR TITLE
Fix lazy initializer callback object identifier for delayed statements

### DIFF
--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -164,8 +164,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
   }
 
   /**
-   * Check if the object current emitting is lazy object(inside _lazyObjectInitializers map) and
-   * the its emitting body matches this lazy object's initializer body.
+   * Check if the object currently being emitted is lazy object(inside _lazyObjectInitializers map) and
+   * that its emitting body matches this lazy object's initializer body.
    * This is needed because for "lazy1.p = lazy2" case,
    * we need to replace "lazy1" with "obj" but not for "lazy2".
    */


### PR DESCRIPTION
Release Note: Fix lazy initializer callback object identifier for delayed statements.

Previously we used _currentSerializeLazyObject to track the current serializing object and emit "obj" for lazy object identifier. This may work in some cases but if a statement is delayed because of its dependency, _currentSerializeLazyObject won't track its original lazy object so the logic will not. 
To correct handle delayed statements scenarios, I checked current emitting body matches lazy object's initializer body. 

Test Plan:
For test/serializer/abstract/Set.js, it originally emits:
```js
var __initializerCallback = function (obj, id) {
    switch (id) {
      case 1:
        _0.y = 0;
        break;

      case 2:
        _1.y = 1;
        break;

      case 3:
        _2.y = 2;
        break;

      default:
        throw new Error("Unknown lazy id");
    }
  };
```

Now it emits:
```js
var __initializerCallback = function (obj, id) {
    switch (id) {
      case 1:
        obj.y = 0;
        break;

      case 2:
        obj.y = 1;
        break;

      case 3:
        obj.y = 2;
        break;

      default:
        throw new Error("Unknown lazy id");
    }
  };
```
Note: currently, there is no easy way to only check lazy object mode code pattern in test-runner("Copies of" checks code pattern for all modes). I may enhance test-runner code pattern in future).