### PR TITLE
Remove used callbacks in debug adapter

### DIFF
--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -79,6 +79,7 @@ export class AdapterChannel {
     );
     let callback = this._pendingRequestCallbacks[response.id];
     callback(response);
+    delete this._pendingRequestCallbacks[response.id];
   }
 
   registerChannelEvent(event: string, listener: (response: DebuggerResponse) => void) {

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -29,7 +29,7 @@ export class AdapterChannel {
   _ioWrapper: FileIOWrapper;
   _marshaller: MessageMarshaller;
   _queue: Queue;
-  _pendingRequestCallbacks: { [number]: (DebuggerResponse) => void };
+  _pendingRequestCallbacks: Map<number, (DebuggerResponse) => void>;
   _prepackWaiting: boolean;
   _eventEmitter: EventEmitter;
   _prepackProcess: child_process.ChildProcess;
@@ -68,18 +68,15 @@ export class AdapterChannel {
   }
 
   _addRequestCallback(requestID: number, callback: DebuggerResponse => void) {
-    invariant(!(requestID in this._pendingRequestCallbacks), "Request ID already exists in pending requests");
-    this._pendingRequestCallbacks[requestID] = callback;
+    invariant(!this._pendingRequestCallbacks.has(requestID), "Request ID already exists in pending requests");
+    this._pendingRequestCallbacks.set(requestID, callback);
   }
 
   _processRequestCallback(response: DebuggerResponse) {
-    invariant(
-      response.id in this._pendingRequestCallbacks,
-      "Request ID does not exist in pending requests: " + response.id
-    );
-    let callback = this._pendingRequestCallbacks[response.id];
+    let callback = this._pendingRequestCallbacks.get(response.id);
+    invariant(callback !== undefined, "Request ID does not exist in pending requests: " + response.id);
     callback(response);
-    delete this._pendingRequestCallbacks[response.id];
+    this._pendingRequestCallbacks.delete(response.id);
   }
 
   registerChannelEvent(event: string, listener: (response: DebuggerResponse) => void) {


### PR DESCRIPTION
Release note: none
Summary:
For each debugger request, a callback is stored in the adapter and then invoked when the response is received from Prepack. After this callback is called, it is no longer needed and can be deleted to save some memory

Test Plan:
Usage in CLI: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath <path-to-adapter> --prepackRuntime <prepack runtime command> --sourceFile <file to prepack> --debugInFilePath <input file for debugger> --debugOutFilePath <output file for debugger>`
e.g.: `node lib/debugger/mock-ui/debugger-cli.js --adapterPath lib/debugger/adapter/DebugAdapter.js --prepackRuntime "node lib/prepack-cli.js" --sourceFile test/serializer/basic/Date.js --debugInFilePath src/debugger/.sessionlogs/engine2adapter.txt --debugOutFilePath src/debugger/.sessionlogs/adapter2engine.txt` 

In IDE: set some breakpoints in source program, launched Prepack in debugger, continued on each breakpoint, observed Prepack output at the end.