### PR TITLE
Display basic information about abstract values in debugger

### DIFF
--- a/src/debugger/VariableManager.js
+++ b/src/debugger/VariableManager.js
@@ -11,8 +11,21 @@
 
 import type { VariableContainer, Variable } from "./types.js";
 import { ReferenceMap } from "./ReferenceMap.js";
-import { LexicalEnvironment, DeclarativeEnvironmentRecord } from "./../environment.js";
-import { Value, ConcreteValue, PrimitiveValue, ObjectValue, AbstractValue } from "./../values/index.js";
+import {
+  LexicalEnvironment,
+  EnvironmentRecord,
+  DeclarativeEnvironmentRecord,
+  ObjectEnvironmentRecord,
+  GlobalEnvironmentRecord,
+} from "./../environment.js";
+import {
+  Value,
+  ConcreteValue,
+  PrimitiveValue,
+  ObjectValue,
+  AbstractObjectValue,
+  AbstractValue,
+} from "./../values/index.js";
 import invariant from "./../invariant.js";
 import type { Realm } from "./../realm.js";
 import { IsDataDescriptor } from "./../methods/is.js";
@@ -52,7 +65,7 @@ export class VariableManager {
     let container = this._referenceMap.get(reference);
     if (!container) return [];
     if (container instanceof LexicalEnvironment) {
-      return this._getVariablesFromEnv(container);
+      return this._getVariablesFromEnvRecord(container.environmentRecord);
     } else if (container instanceof ObjectValue) {
       return this._getVariablesFromObject(container);
     } else if (container instanceof AbstractValue) {
@@ -96,13 +109,25 @@ export class VariableManager {
     return contents;
   }
 
-  _getVariablesFromEnv(env: LexicalEnvironment): Array<Variable> {
-    let envRecord = env.environmentRecord;
+  _getVariablesFromEnvRecord(envRecord: EnvironmentRecord): Array<Variable> {
     if (envRecord instanceof DeclarativeEnvironmentRecord) {
       return this._getVariablesFromDeclarativeEnv(envRecord);
+    } else if (envRecord instanceof ObjectEnvironmentRecord) {
+      if (envRecord.object instanceof ObjectValue) {
+        return this._getVariablesFromObject(envRecord.object);
+      } else if (envRecord.object instanceof AbstractObjectValue) {
+        // TODO: call _getVariablesFromAbstractObject when it is implemented
+        return [];
+      } else {
+        invariant(false, "Invalid type of object environment record");
+      }
+    } else if (envRecord instanceof GlobalEnvironmentRecord) {
+      let declVars = this._getVariablesFromEnvRecord(envRecord.$DeclarativeRecord);
+      let objVars = this._getVariablesFromEnvRecord(envRecord.$ObjectRecord);
+      return declVars.concat(objVars);
+    } else {
+      invariant(false, "Invalid type of environment record");
     }
-    // TODO: implement retrieving variables for other kinds of environment records
-    return [];
   }
 
   _getVariablesFromDeclarativeEnv(env: DeclarativeEnvironmentRecord): Array<Variable> {
@@ -155,7 +180,7 @@ export class VariableManager {
     } else if (value instanceof ObjectValue) {
       let variable: Variable = {
         name: name,
-        value: "Object",
+        value: value.getKind(),
         variablesReference: this.getReferenceForValue(value),
       };
       return variable;

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -11,7 +11,7 @@
 
 import type { LexicalEnvironment } from "./../environment.js";
 import * as DebugProtocol from "vscode-debugprotocol";
-import { ObjectValue } from "./../values/index.js";
+import { ObjectValue, AbstractValue } from "./../values/index.js";
 
 export type DebuggerRequest = {
   id: number,
@@ -135,7 +135,7 @@ export type FinishResult = {
 };
 
 // any object that can contain a collection of variables
-export type VariableContainer = LexicalEnvironment | ObjectValue;
+export type VariableContainer = LexicalEnvironment | ObjectValue | AbstractValue;
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
   noDebug?: boolean,
   sourceFile: string,


### PR DESCRIPTION
Release note: none
Summary:
-For abstract values, display the kind and the args fields
-Specify the type of abstract value based on the types field

Test Plan:
```
function a() {
  let z = __abstract("boolean", "true");
  let y = __abstract("number");
  let x = __abstract("string");
  let w = __abstract("object");
  let v = __abstract("function");
  let u = 3;
  if (z) {
    u = 5;
  }
  console.log(u);
}

a();
```
Used the above code in the IDE debugger with a breakpoint on line 11 and inspected the displayed variables.