### PR TITLE
Add COC to Prepack

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.
+
 ## Our Development Process
 The GitHub repository is the source of truth for us and all development takes place here.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
-# Code of Conduct
+## Code of Conduct
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.
 


### PR DESCRIPTION
**what is the change?:**
Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet Github community standards.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [Prepack's Community Profile](https://github.com/facebook/prepack/community)
checklist and increase the visibility of our COC.

We also added a link in the `CONTRIBUTING` in case folks miss the separate document.

**test plan:**
Viewing it on my branch -
![screen shot 2017-11-20 at 5 40 32 pm](https://user-images.githubusercontent.com/1114467/33050560-50e9b96c-ce1a-11e7-94bc-78d1d612f235.png)
![screen shot 2017-11-20 at 5 41 06 pm](https://user-images.githubusercontent.com/1114467/33050561-5100f33e-ce1a-11e7-8c08-900173f35403.png)


**issue:**
internal task t23481323