### PR TITLE
Implement stepIn requests in debugger

### DIFF
--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -11,14 +11,81 @@
 
 import { PerFileBreakpointMap } from "./PerFileBreakpointMap.js";
 import { Breakpoint } from "./Breakpoint.js";
-import type { Breakpoint as BreakpointType } from "./types.js";
+import type { Breakpoint as BreakpointType, StoppedData, StoppedReason } from "./types.js";
+import { BabelNode } from "babel-types";
+import { IsStatement } from "./../methods/is.js";
+import type { DebugChannel } from "./channel/DebugChannel.js";
 
 // Storing BreakpointStores for all source files
 export class BreakpointManager {
-  constructor() {
+  constructor(channel: DebugChannel) {
+    this._channel = channel;
     this._breakpointMaps = new Map();
   }
   _breakpointMaps: { [string]: PerFileBreakpointMap };
+  _previousStop: StoppedData;
+  _channel: DebugChannel;
+
+  onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
+    if (reason === "Breakpoint") return;
+    if (ast.loc && ast.loc.source !== null) {
+      this._previousStop = {
+        filePath: ast.loc.source,
+        line: ast.loc.start.line,
+        column: ast.loc.start.column,
+      };
+    }
+  }
+
+  isValidBreakpoint(ast: BabelNode): boolean {
+    if (!IsStatement(ast)) return false;
+    if (ast.loc && ast.loc.source) {
+      let location = ast.loc;
+      let filePath = location.source;
+      if (filePath === null) return false;
+      let lineNum = location.start.line;
+      let colNum = location.start.column;
+      // Check whether there is a breakpoint we need to stop on here
+      let breakpoint = this._findStoppableBreakpoint(filePath, lineNum, colNum);
+      if (breakpoint === null) return false;
+      // Tell the adapter that Prepack has stopped on this breakpoint
+      this._channel.sendStoppedResponse("Breakpoint", breakpoint.filePath, breakpoint.line, breakpoint.column);
+      return true;
+    }
+    return false;
+  }
+
+  // Try to find a breakpoint at the given location and check if we should stop on it
+  _findStoppableBreakpoint(filePath: string, lineNum: number, colNum: number): null | Breakpoint {
+    let breakpoint = this.getBreakpoint(filePath, lineNum, colNum);
+    if (breakpoint && breakpoint.enabled) {
+      if (this._previousStop) {
+        // checking if this is the same file and line we stopped at last time
+        // if so, we should skip it this time
+        // Note: for the case when the debugger is supposed to stop on the same
+        // breakpoint consecutively (e.g. the statement is in a loop), some other
+        // ast node (e.g. block, loop) must have been checked in between so
+        // previousExecutedFile and previousExecutedLine will have changed
+        if (breakpoint.column !== 0) {
+          // this is a column breakpoint
+          if (
+            filePath === this._previousStop.filePath &&
+            lineNum === this._previousStop.line &&
+            colNum === this._previousStop.column
+          ) {
+            return null;
+          }
+        } else {
+          // this is a line breakpoint
+          if (filePath === this._previousStop.filePath && lineNum === this._previousStop.column) {
+            return null;
+          }
+        }
+      }
+      return breakpoint;
+    }
+    return null;
+  }
 
   addBreakpointMulti(breakpoints: Array<BreakpointType>) {
     this._doBreakpointsAction(breakpoints, this._addBreakpoint.bind(this));

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -27,7 +27,6 @@ export class BreakpointManager {
   _channel: DebugChannel;
 
   onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
-    if (reason === "Breakpoint") return;
     if (ast.loc && ast.loc.source !== null) {
       this._previousStop = {
         filePath: ast.loc.source,
@@ -77,7 +76,7 @@ export class BreakpointManager {
           }
         } else {
           // this is a line breakpoint
-          if (filePath === this._previousStop.filePath && lineNum === this._previousStop.column) {
+          if (filePath === this._previousStop.filePath && lineNum === this._previousStop.line) {
             return null;
           }
         }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -75,7 +75,7 @@ export class DebugServer {
   // Checking if the debugger needs to take any action on reaching this ast node
   checkForActions(ast: BabelNode) {
     this.checkForBreakpoint(ast);
-    this.checkStepIn(ast);
+    this.checkStepComplete(ast);
     // set the current location as the previously executed line
     if (ast.loc && ast.loc.source !== null) {
       this._previousExecutedFile = ast.loc.source;
@@ -131,7 +131,7 @@ export class DebugServer {
     }
   }
 
-  checkStepIn(ast: BabelNode) {
+  checkStepComplete(ast: BabelNode) {
     if (this._stepManager.isStepInComplete(ast)) {
       this.waitForRun(ast);
     }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -132,7 +132,7 @@ export class DebugServer {
   }
 
   checkStepComplete(ast: BabelNode) {
-    if (this._stepManager.isStepInComplete(ast)) {
+    if (this._stepManager.isStepComplete(ast)) {
       this.waitForRun(ast);
     }
   }
@@ -180,7 +180,7 @@ export class DebugServer {
         invariant(args.kind === "variables");
         this.processVariablesCommand(requestID, args);
         break;
-      case DebugMessage.STEPIN_COMMAND:
+      case DebugMessage.STEPINTO_COMMAND:
         invariant(ast !== undefined);
         this._stepManager.processStepCommand("in", ast);
         this._onDebuggeeResume();

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -125,7 +125,7 @@ export class DebugServer {
       let breakpoint = this.findStoppableBreakpoint(filePath, lineNum, colNum);
       if (breakpoint === null) return;
       // Tell the adapter that Prepack has stopped on this breakpoint
-      this._channel.sendPrepackStopped("Breakpoint", breakpoint.filePath, breakpoint.line, breakpoint.column);
+      this._channel.sendStoppedResponse("Breakpoint", breakpoint.filePath, breakpoint.line, breakpoint.column);
       // Wait for the adapter to tell us to run again
       this.waitForRun(ast);
     }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -11,7 +11,6 @@
 
 import { BreakpointManager } from "./BreakpointManager.js";
 import type { BabelNode, BabelNodeSourceLocation } from "babel-types";
-import { Breakpoint } from "./Breakpoint.js";
 import invariant from "../invariant.js";
 import type { DebugChannel } from "./channel/DebugChannel.js";
 import { DebugMessage } from "./channel/DebugMessage.js";
@@ -23,6 +22,7 @@ import type {
   Stackframe,
   Scope,
   VariablesArguments,
+  StoppedReason,
 } from "./types.js";
 import type { Realm } from "./../realm.js";
 import { ExecutionContext } from "./../realm.js";
@@ -38,32 +38,27 @@ import {
 
 export class DebugServer {
   constructor(channel: DebugChannel, realm: Realm) {
-    this._breakpoints = new BreakpointManager();
-    this._previousExecutedLine = 0;
-    this._previousExecutedCol = 0;
-    this._lastRunRequestID = 0;
     this._channel = channel;
     this._realm = realm;
+    this._breakpointManager = new BreakpointManager(this._channel);
     this._variableManager = new VariableManager(realm);
     this._stepManager = new SteppingManager(this._channel);
-    this.waitForRun();
+    this.waitForRun(undefined, "Entry");
   }
   // the collection of breakpoints
-  _breakpoints: BreakpointManager;
-  _previousExecutedFile: void | string;
-  _previousExecutedLine: number;
-  _previousExecutedCol: number;
+  _breakpointManager: BreakpointManager;
   // the channel to communicate with the adapter
   _channel: DebugChannel;
-  _lastRunRequestID: number;
   _realm: Realm;
   _variableManager: VariableManager;
   _stepManager: SteppingManager;
 
   /* Block until adapter says to run
   /* ast: the current ast node we are stopped on
+  /* reason: the reason the debuggee is stopping
   */
-  waitForRun(ast: void | BabelNode) {
+  waitForRun(ast: void | BabelNode, reason: StoppedReason) {
+    if (ast) this._onDebuggeeStop(ast, reason);
     let keepRunning = false;
     let request;
     while (!keepRunning) {
@@ -76,64 +71,17 @@ export class DebugServer {
   checkForActions(ast: BabelNode) {
     this.checkForBreakpoint(ast);
     this.checkStepComplete(ast);
-    // set the current location as the previously executed line
-    if (ast.loc && ast.loc.source !== null) {
-      this._previousExecutedFile = ast.loc.source;
-      this._previousExecutedLine = ast.loc.start.line;
-      this._previousExecutedCol = ast.loc.start.column;
-    }
-  }
-
-  // Try to find a breakpoint at the given location and check if we should stop on it
-  findStoppableBreakpoint(filePath: string, lineNum: number, colNum: number): null | Breakpoint {
-    let breakpoint = this._breakpoints.getBreakpoint(filePath, lineNum, colNum);
-    if (breakpoint && breakpoint.enabled) {
-      // checking if this is the same file and line we stopped at last time
-      // if so, we should skip it this time
-      // Note: for the case when the debugger is supposed to stop on the same
-      // breakpoint consecutively (e.g. the statement is in a loop), some other
-      // ast node (e.g. block, loop) must have been checked in between so
-      // previousExecutedFile and previousExecutedLine will have changed
-      if (breakpoint.column !== 0) {
-        // this is a column breakpoint
-        if (
-          filePath === this._previousExecutedFile &&
-          lineNum === this._previousExecutedLine &&
-          colNum === this._previousExecutedCol
-        ) {
-          return null;
-        }
-      } else {
-        // this is a line breakpoint
-        if (filePath === this._previousExecutedFile && lineNum === this._previousExecutedLine) {
-          return null;
-        }
-      }
-      return breakpoint;
-    }
-    return null;
   }
 
   checkForBreakpoint(ast: BabelNode) {
-    if (ast.loc && ast.loc.source) {
-      let location = ast.loc;
-      let filePath = location.source;
-      if (filePath === null) return;
-      let lineNum = location.start.line;
-      let colNum = location.start.column;
-      // Check whether there is a breakpoint we need to stop on here
-      let breakpoint = this.findStoppableBreakpoint(filePath, lineNum, colNum);
-      if (breakpoint === null) return;
-      // Tell the adapter that Prepack has stopped on this breakpoint
-      this._channel.sendStoppedResponse("Breakpoint", breakpoint.filePath, breakpoint.line, breakpoint.column);
-      // Wait for the adapter to tell us to run again
-      this.waitForRun(ast);
+    if (this._breakpointManager.isValidBreakpoint(ast)) {
+      this.waitForRun(ast, "Breakpoint");
     }
   }
 
   checkStepComplete(ast: BabelNode) {
     if (this._stepManager.isStepComplete(ast)) {
-      this.waitForRun(ast);
+      this.waitForRun(ast, "Step Into");
     }
   }
 
@@ -146,22 +94,22 @@ export class DebugServer {
     switch (command) {
       case DebugMessage.BREAKPOINT_ADD_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.addBreakpointMulti(args.breakpoints);
+        this._breakpointManager.addBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_REMOVE_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.removeBreakpointMulti(args.breakpoints);
+        this._breakpointManager.removeBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_REMOVE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_ENABLE_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.enableBreakpointMulti(args.breakpoints);
+        this._breakpointManager.enableBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_ENABLE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.BREAKPOINT_DISABLE_COMMAND:
         invariant(args.kind === "breakpoint");
-        this._breakpoints.disableBreakpointMulti(args.breakpoints);
+        this._breakpointManager.disableBreakpointMulti(args.breakpoints);
         this._channel.sendBreakpointsAcknowledge(DebugMessage.BREAKPOINT_DISABLE_ACKNOWLEDGE, requestID, args);
         break;
       case DebugMessage.PREPACK_RUN_COMMAND:
@@ -284,6 +232,12 @@ export class DebugServer {
   processVariablesCommand(requestID: number, args: VariablesArguments) {
     let variables = this._variableManager.getVariablesByReference(args.variablesReference);
     this._channel.sendVariablesResponse(requestID, variables);
+  }
+
+  // actions that need to happen when Prepack is going to be stopped
+  _onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
+    if (reason === "Entry") return;
+    this._breakpointManager.onDebuggeeStop(ast, reason);
   }
 
   // actions that need to happen before Prepack can resume

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -125,7 +125,7 @@ export class DebugServer {
       let breakpoint = this.findStoppableBreakpoint(filePath, lineNum, colNum);
       if (breakpoint === null) return;
       // Tell the adapter that Prepack has stopped on this breakpoint
-      this._channel.sendBreakpointStopped(breakpoint.filePath, breakpoint.line, breakpoint.column);
+      this._channel.sendPrepackStopped("Breakpoint", breakpoint.filePath, breakpoint.line, breakpoint.column);
       // Wait for the adapter to tell us to run again
       this.waitForRun(ast);
     }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -238,6 +238,7 @@ export class DebugServer {
   _onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
     if (reason === "Entry") return;
     this._breakpointManager.onDebuggeeStop(ast, reason);
+    this._stepManager.onDebuggeeStop(ast, reason);
   }
 
   // actions that need to happen before Prepack can resume

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -11,7 +11,7 @@
 
 import { BabelNode } from "babel-types";
 import type { DebugChannel } from "./channel/DebugChannel.js";
-import type { StepInData } from "./types.js";
+import type { StepIntoData } from "./types.js";
 import invariant from "./../invariant.js";
 import { IsStatement } from "./../methods/is.js";
 
@@ -20,7 +20,7 @@ export class SteppingManager {
     this._channel = channel;
   }
   _channel: DebugChannel;
-  _stepInData: void | StepInData;
+  _stepIntoData: void | StepIntoData;
 
   processStepCommand(kind: "in" | "over" | "out", currentNode: BabelNode) {
     if (kind === "in") {
@@ -32,25 +32,25 @@ export class SteppingManager {
   _processStepIn(ast: BabelNode) {
     invariant(this._steppInData === undefined);
     invariant(ast.loc && ast.loc.source);
-    this._stepInData = {
+    this._stepIntoData = {
       prevStopFile: ast.loc.source,
       prevStopLine: ast.loc.start.line,
       prevStopColumn: ast.loc.start.column,
     };
   }
 
-  isStepInComplete(ast: BabelNode): boolean {
-    if (this._isStepInComplete(ast)) {
+  isStepComplete(ast: BabelNode): boolean {
+    if (this._isStepIntoComplete(ast)) {
       if (ast.loc && ast.loc.source) {
-        this._stepInData = undefined;
-        this._channel.sendStoppedResponse("Step In", ast.loc.source, ast.loc.start.line, ast.loc.start.column);
+        this._stepIntoData = undefined;
+        this._channel.sendStoppedResponse("Step Into", ast.loc.source, ast.loc.start.line, ast.loc.start.column);
         return true;
       }
     }
     return false;
   }
 
-  _isStepInComplete(ast: BabelNode): boolean {
+  _isStepIntoComplete(ast: BabelNode): boolean {
     // we should only step to statements
     if (!IsStatement(ast)) return false;
     let loc = ast.loc;
@@ -59,11 +59,11 @@ export class SteppingManager {
     let line = loc.start.line;
     let column = loc.start.column;
     if (!filePath) return false;
-    if (this._stepInData) {
+    if (this._stepIntoData) {
       if (
-        filePath === this._stepInData.prevStopFile &&
-        line === this._stepInData.prevStopLine &&
-        column === this._stepInData.prevStopColumn
+        filePath === this._stepIntoData.prevStopFile &&
+        line === this._stepIntoData.prevStopLine &&
+        column === this._stepIntoData.prevStopColumn
       ) {
         return false;
       }

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -11,7 +11,7 @@
 
 import { BabelNode } from "babel-types";
 import type { DebugChannel } from "./channel/DebugChannel.js";
-import type { StepIntoData } from "./types.js";
+import type { StepIntoData, StoppedReason } from "./types.js";
 import invariant from "./../invariant.js";
 import { IsStatement } from "./../methods/is.js";
 
@@ -72,5 +72,17 @@ export class SteppingManager {
     }
 
     return true;
+  }
+
+  onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
+    if (reason !== "Step Into") {
+      // stopped for another reason, ie breakpoint
+      if (this._stepIntoData !== undefined) {
+        // we're in the middle of a step into, but debuggee has stopped for another reason here first, so cancel this step into
+        this._stepIntoData = undefined;
+      }
+    }
+
+    //TODO: handle other stepping related stopped reasons when they are implemented
   }
 }

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -30,7 +30,6 @@ export class SteppingManager {
   }
 
   _processStepIn(ast: BabelNode) {
-    invariant(this._stepInData === undefined);
     invariant(ast.loc && ast.loc.source);
     this._stepInData = {
       prevStopFile: ast.loc.source,
@@ -40,7 +39,7 @@ export class SteppingManager {
   }
 
   isStepInComplete(ast: BabelNode): boolean {
-    if (this._isValidStepInLocation(ast)) {
+    if (this._isStepInComplete(ast)) {
       if (ast.loc && ast.loc.source) {
         this._stepInData = undefined;
         this._channel.sendPrepackStopped("Step In", ast.loc.source, ast.loc.start.line, ast.loc.start.column);
@@ -50,7 +49,8 @@ export class SteppingManager {
     return false;
   }
 
-  _isValidStepInLocation(ast: BabelNode): boolean {
+  _isStepInComplete(ast: BabelNode): boolean {
+    // we should only step to statements
     if (!IsStatement(ast)) return false;
     let loc = ast.loc;
     if (!loc) return false;

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -30,6 +30,7 @@ export class SteppingManager {
   }
 
   _processStepIn(ast: BabelNode) {
+    invariant(this._steppInData === undefined);
     invariant(ast.loc && ast.loc.source);
     this._stepInData = {
       prevStopFile: ast.loc.source,
@@ -42,7 +43,7 @@ export class SteppingManager {
     if (this._isStepInComplete(ast)) {
       if (ast.loc && ast.loc.source) {
         this._stepInData = undefined;
-        this._channel.sendPrepackStopped("Step In", ast.loc.source, ast.loc.start.line, ast.loc.start.column);
+        this._channel.sendStoppedResponse("Step In", ast.loc.source, ast.loc.start.line, ast.loc.start.column);
         return true;
       }
     }

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { BabelNode } from "babel-types";
+import type { DebugChannel } from "./channel/DebugChannel.js";
+import type { StepInData } from "./types.js";
+import invariant from "./../invariant.js";
+import { IsStatement } from "./../methods/is.js";
+
+export class SteppingManager {
+  constructor(channel: DebugChannel) {
+    this._channel = channel;
+  }
+  _channel: DebugChannel;
+  _stepInData: void | StepInData;
+
+  processStepCommand(kind: "in" | "over" | "out", currentNode: BabelNode) {
+    if (kind === "in") {
+      this._processStepIn(currentNode);
+    }
+    // TODO: implement stepOver and stepOut
+  }
+
+  _processStepIn(ast: BabelNode) {
+    invariant(this._stepInData === undefined);
+    invariant(ast.loc && ast.loc.source);
+    this._stepInData = {
+      prevStopFile: ast.loc.source,
+      prevStopLine: ast.loc.start.line,
+      prevStopColumn: ast.loc.start.column,
+    };
+  }
+
+  isStepInComplete(ast: BabelNode): boolean {
+    if (this._isValidStepInLocation(ast)) {
+      if (ast.loc && ast.loc.source) {
+        this._stepInData = undefined;
+        this._channel.sendPrepackStopped("Step In", ast.loc.source, ast.loc.start.line, ast.loc.start.column);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _isValidStepInLocation(ast: BabelNode): boolean {
+    if (!IsStatement(ast)) return false;
+    let loc = ast.loc;
+    if (!loc) return false;
+    let filePath = loc.source;
+    let line = loc.start.line;
+    let column = loc.start.column;
+    if (!filePath) return false;
+    if (this._stepInData) {
+      if (
+        filePath === this._stepInData.prevStopFile &&
+        line === this._stepInData.prevStopLine &&
+        column === this._stepInData.prevStopColumn
+      ) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -70,7 +70,7 @@ class PrepackDebugSession extends LoggingDebugSession {
    * The 'initialize' request is the first request called by the UI
    * to interrogate the features the debug adapter provides.
    */
-   // Override
+  // Override
   initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
     // Let the UI know that we can start accepting breakpoint requests.
     // The UI will end the configuration sequence by calling 'configurationDone' request.

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -44,7 +44,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_READY_RESPONSE, (response: DebuggerResponse) => {
       this.sendEvent(new StoppedEvent("entry", DebuggerConstants.PREPACK_THREAD_ID));
     });
-    this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_STOPPED_RESPONSE, (response: DebuggerResponse) => {
+    this._adapterChannel.registerChannelEvent(DebugMessage.STOPPED_RESPONSE, (response: DebuggerResponse) => {
       let result = response.result;
       invariant(result.kind === "stopped");
       this.sendEvent(
@@ -54,12 +54,12 @@ class PrepackDebugSession extends LoggingDebugSession {
         )
       );
     });
-    this._adapterChannel.registerChannelEvent(DebugMessage.STEPIN_RESPONSE, (response: DebuggerResponse) => {
+    this._adapterChannel.registerChannelEvent(DebugMessage.STEPINTO_RESPONSE, (response: DebuggerResponse) => {
       let result = response.result;
-      invariant(result.kind === "stepIn");
+      invariant(result.kind === "stepInto");
       this.sendEvent(
         new StoppedEvent(
-          "Stepped to " + `${result.filePath} ${result.line}:${result.column}`,
+          "Stepped into " + `${result.filePath} ${result.line}:${result.column}`,
           DebuggerConstants.PREPACK_THREAD_ID
         )
       );
@@ -266,7 +266,7 @@ class PrepackDebugSession extends LoggingDebugSession {
 
   // Override
   stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void {
-    this._adapterChannel.stepIn(response.request_seq, (dbgResponse: DebuggerResponse) => {
+    this._adapterChannel.stepInto(response.request_seq, (dbgResponse: DebuggerResponse) => {
       this.sendResponse(response);
     });
   }

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -44,19 +44,16 @@ class PrepackDebugSession extends LoggingDebugSession {
     this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_READY_RESPONSE, (response: DebuggerResponse) => {
       this.sendEvent(new StoppedEvent("entry", DebuggerConstants.PREPACK_THREAD_ID));
     });
-    this._adapterChannel.registerChannelEvent(
-      DebugMessage.BREAKPOINT_STOPPED_RESPONSE,
-      (response: DebuggerResponse) => {
-        let result = response.result;
-        invariant(result.kind === "breakpoint-stopped");
-        this.sendEvent(
-          new StoppedEvent(
-            "breakpoint " + `${result.filePath} ${result.line}:${result.column}`,
-            DebuggerConstants.PREPACK_THREAD_ID
-          )
-        );
-      }
-    );
+    this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_STOPPED_RESPONSE, (response: DebuggerResponse) => {
+      let result = response.result;
+      invariant(result.kind === "stopped");
+      this.sendEvent(
+        new StoppedEvent(
+          `${result.reason}: ${result.filePath} ${result.line}:${result.column}`,
+          DebuggerConstants.PREPACK_THREAD_ID
+        )
+      );
+    });
     this._adapterChannel.registerChannelEvent(DebugMessage.STEPIN_RESPONSE, (response: DebuggerResponse) => {
       let result = response.result;
       invariant(result.kind === "stepIn");

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -57,6 +57,16 @@ class PrepackDebugSession extends LoggingDebugSession {
         );
       }
     );
+    this._adapterChannel.registerChannelEvent(DebugMessage.STEPIN_RESPONSE, (response: DebuggerResponse) => {
+      let result = response.result;
+      invariant(result.kind === "stepIn");
+      this.sendEvent(
+        new StoppedEvent(
+          "Stepped to " + `${result.filePath} ${result.line}:${result.column}`,
+          DebuggerConstants.PREPACK_THREAD_ID
+        )
+      );
+    });
   }
 
   /**
@@ -246,6 +256,12 @@ class PrepackDebugSession extends LoggingDebugSession {
         this.sendResponse(response);
       }
     );
+  }
+
+  stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void {
+    this._adapterChannel.stepIn(response.request_seq, (dbgResponse: DebuggerResponse) => {
+      this.sendResponse(response);
+    });
   }
 }
 

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -70,6 +70,7 @@ class PrepackDebugSession extends LoggingDebugSession {
    * The 'initialize' request is the first request called by the UI
    * to interrogate the features the debug adapter provides.
    */
+   // Override
   initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
     // Let the UI know that we can start accepting breakpoint requests.
     // The UI will end the configuration sequence by calling 'configurationDone' request.
@@ -83,6 +84,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     this.sendResponse(response);
   }
 
+  // Override
   configurationDoneRequest(
     response: DebugProtocol.ConfigurationDoneResponse,
     args: DebugProtocol.ConfigurationDoneArguments
@@ -95,6 +97,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     this.sendResponse(response);
   }
 
+  // Override
   launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
     // set up the communication channel
     this._adapterChannel = new AdapterChannel(args.debugInFilePath, args.debugOutFilePath);
@@ -119,6 +122,7 @@ class PrepackDebugSession extends LoggingDebugSession {
   /**
    * Request Prepack to continue running when it is stopped
   */
+  // Override
   continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments): void {
     // send a Run request to Prepack and try to send the next request
     this._adapterChannel.run(response.request_seq, (dbgResponse: DebuggerResponse) => {
@@ -126,6 +130,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     });
   }
 
+  // Override
   setBreakPointsRequest(
     response: DebugProtocol.SetBreakpointsResponse,
     args: DebugProtocol.SetBreakpointsArguments
@@ -171,6 +176,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     });
   }
 
+  // Override
   stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): void {
     this._adapterChannel.getStackFrames(response.request_seq, (dbgResponse: DebuggerResponse) => {
       let result = dbgResponse.result;
@@ -197,6 +203,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     });
   }
 
+  // Override
   threadsRequest(response: DebugProtocol.ThreadsResponse): void {
     // There will only be 1 thread, so respond immediately
     let thread: DebugProtocol.Thread = {
@@ -209,6 +216,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     this.sendResponse(response);
   }
 
+  // Override
   scopesRequest(response: DebugProtocol.ScopesResponse, args: DebugProtocol.ScopesArguments): void {
     this._adapterChannel.getScopes(response.request_seq, args.frameId, (dbgResponse: DebuggerResponse) => {
       let result = dbgResponse.result;
@@ -230,6 +238,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     });
   }
 
+  // Override
   variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments): void {
     this._adapterChannel.getVariables(
       response.request_seq,
@@ -255,6 +264,7 @@ class PrepackDebugSession extends LoggingDebugSession {
     );
   }
 
+  // Override
   stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void {
     this._adapterChannel.stepIn(response.request_seq, (dbgResponse: DebuggerResponse) => {
       this.sendResponse(response);

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -46,8 +46,8 @@ export class AdapterChannel {
       this._eventEmitter.emit(DebugMessage.PREPACK_READY_RESPONSE, dbgResponse);
     } else if (dbgResponse.result.kind === "breakpoint-add") {
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, dbgResponse.id, dbgResponse);
-    } else if (dbgResponse.result.kind === "breakpoint-stopped") {
-      this._eventEmitter.emit(DebugMessage.BREAKPOINT_STOPPED_RESPONSE, dbgResponse);
+    } else if (dbgResponse.result.kind === "stopped") {
+      this._eventEmitter.emit(DebugMessage.PREPACK_STOPPED_RESPONSE, dbgResponse);
     } else if (dbgResponse.result.kind === "stepIn") {
       this._eventEmitter.emit(DebugMessage.STEPIN_RESPONSE, dbgResponse);
     }

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -47,9 +47,9 @@ export class AdapterChannel {
     } else if (dbgResponse.result.kind === "breakpoint-add") {
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, dbgResponse.id, dbgResponse);
     } else if (dbgResponse.result.kind === "stopped") {
-      this._eventEmitter.emit(DebugMessage.PREPACK_STOPPED_RESPONSE, dbgResponse);
-    } else if (dbgResponse.result.kind === "stepIn") {
-      this._eventEmitter.emit(DebugMessage.STEPIN_RESPONSE, dbgResponse);
+      this._eventEmitter.emit(DebugMessage.STOPPED_RESPONSE, dbgResponse);
+    } else if (dbgResponse.result.kind === "stepInto") {
+      this._eventEmitter.emit(DebugMessage.STEPINTO_RESPONSE, dbgResponse);
     }
     this._prepackWaiting = true;
     this._processRequestCallback(dbgResponse);
@@ -155,8 +155,8 @@ export class AdapterChannel {
     this._addRequestCallback(requestID, callback);
   }
 
-  stepIn(requestID: number, callback: DebuggerResponse => void) {
-    this._queue.enqueue(this._marshaller.marshallStepInRequest(requestID));
+  stepInto(requestID: number, callback: DebuggerResponse => void) {
+    this._queue.enqueue(this._marshaller.marshallStepIntoRequest(requestID));
     this.trySendNextRequest();
     this._addRequestCallback(requestID, callback);
   }

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -48,6 +48,8 @@ export class AdapterChannel {
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, dbgResponse.id, dbgResponse);
     } else if (dbgResponse.result.kind === "breakpoint-stopped") {
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_STOPPED_RESPONSE, dbgResponse);
+    } else if (dbgResponse.result.kind === "stepIn") {
+      this._eventEmitter.emit(DebugMessage.STEPIN_RESPONSE, dbgResponse);
     }
     this._prepackWaiting = true;
     this._processRequestCallback(dbgResponse);
@@ -149,6 +151,12 @@ export class AdapterChannel {
 
   getVariables(requestID: number, variablesReference: number, callback: DebuggerResponse => void) {
     this._queue.enqueue(this._marshaller.marshallVariablesRequest(requestID, variablesReference));
+    this.trySendNextRequest();
+    this._addRequestCallback(requestID, callback);
+  }
+
+  stepIn(requestID: number, callback: DebuggerResponse => void) {
+    this._queue.enqueue(this._marshaller.marshallStepInRequest(requestID));
     this.trySendNextRequest();
     this._addRequestCallback(requestID, callback);
   }

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -91,7 +91,7 @@ export class DebugChannel {
   }
 
   sendStepInResponse(filePath: string, line: number, column: number) {
-    this.writeOut(this._marshaller.marshallStepInResponse(filePath, line, column));
+    this.writeOut(this._marshaller.marshallPrepackStopped("Step In", filePath, line, column));
   }
 
   shutdown() {

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -12,14 +12,7 @@ import invariant from "./../../invariant.js";
 import { FileIOWrapper } from "./FileIOWrapper.js";
 import { DebugMessage } from "./DebugMessage.js";
 import { MessageMarshaller } from "./MessageMarshaller.js";
-import type {
-  DebuggerRequest,
-  BreakpointsArguments,
-  Stackframe,
-  Scope,
-  Variable,
-  PrepackStoppedReason,
-} from "./../types.js";
+import type { DebuggerRequest, BreakpointsArguments, Stackframe, Scope, Variable, StoppedReason } from "./../types.js";
 
 //Channel used by the DebugServer in Prepack to communicate with the debug adapter
 export class DebugChannel {
@@ -74,8 +67,8 @@ export class DebugChannel {
     this.writeOut(this._marshaller.marshallBreakpointAcknowledge(requestID, messageType, args.breakpoints));
   }
 
-  sendPrepackStopped(reason: PrepackStoppedReason, filePath: string, line: number, column: number): void {
-    this.writeOut(this._marshaller.marshallPrepackStopped(reason, filePath, line, column));
+  sendStoppedResponse(reason: StoppedReason, filePath: string, line: number, column: number): void {
+    this.writeOut(this._marshaller.marshallStoppedResponse(reason, filePath, line, column));
   }
 
   sendStackframeResponse(requestID: number, stackframes: Array<Stackframe>): void {

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -12,7 +12,14 @@ import invariant from "./../../invariant.js";
 import { FileIOWrapper } from "./FileIOWrapper.js";
 import { DebugMessage } from "./DebugMessage.js";
 import { MessageMarshaller } from "./MessageMarshaller.js";
-import type { DebuggerRequest, Breakpoint, BreakpointsArguments, Stackframe, Scope, Variable } from "./../types.js";
+import type {
+  DebuggerRequest,
+  BreakpointsArguments,
+  Stackframe,
+  Scope,
+  Variable,
+  PrepackStoppedReason,
+} from "./../types.js";
 
 //Channel used by the DebugServer in Prepack to communicate with the debug adapter
 export class DebugChannel {
@@ -67,14 +74,8 @@ export class DebugChannel {
     this.writeOut(this._marshaller.marshallBreakpointAcknowledge(requestID, messageType, args.breakpoints));
   }
 
-  sendBreakpointStopped(filePath: string, line: number, column: number): void {
-    let breakpointInfo: Breakpoint = {
-      kind: "breakpoint",
-      filePath: filePath,
-      line: line,
-      column: column,
-    };
-    this.writeOut(this._marshaller.marshallBreakpointStopped(breakpointInfo));
+  sendPrepackStopped(reason: PrepackStoppedReason, filePath: string, line: number, column: number): void {
+    this.writeOut(this._marshaller.marshallPrepackStopped(reason, filePath, line, column));
   }
 
   sendStackframeResponse(requestID: number, stackframes: Array<Stackframe>): void {

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -89,7 +89,12 @@ export class DebugChannel {
     this.writeOut(this._marshaller.marshallVariablesResponse(requestID, variables));
   }
 
-  sendPrepackFinish(): void {
-    this.writeOut(this._marshaller.marshallPrepackFinish());
+  sendStepInResponse(filePath: string, line: number, column: number) {
+    this.writeOut(this._marshaller.marshallStepInResponse(filePath, line, column));
+  }
+
+  shutdown() {
+    this._ioWrapper.clearInFile();
+    this._ioWrapper.clearOutFile();
   }
 }

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -90,10 +90,6 @@ export class DebugChannel {
     this.writeOut(this._marshaller.marshallVariablesResponse(requestID, variables));
   }
 
-  sendStepInResponse(filePath: string, line: number, column: number) {
-    this.writeOut(this._marshaller.marshallPrepackStopped("Step In", filePath, line, column));
-  }
-
   shutdown() {
     this._ioWrapper.clearInFile();
     this._ioWrapper.clearOutFile();

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -31,7 +31,7 @@ export class DebugMessage {
   // Command to fetch variables
   static VARIABLES_COMMAND: string = "Variables-command";
   // Command to step into a function
-  static STEPIN_COMMAND: string = "StepIn-command";
+  static STEPINTO_COMMAND: string = "StepInto-command";
 
   /* Messages from Prepack to adapter with requested information */
   // Respond to the adapter that Prepack is ready
@@ -39,7 +39,7 @@ export class DebugMessage {
   // Respond to the adapter that Prepack is finished
   static PREPACK_FINISH_RESPONSE: string = "PrepackFinish";
   // Respond to the adapter that Prepack has stopped
-  static PREPACK_STOPPED_RESPONSE: string = "Prepack-stopped-response";
+  static STOPPED_RESPONSE: string = "Stopped-response";
   // Respond to the adapter with the request stackframes
   static STACKFRAMES_RESPONSE: string = "Stackframes-response";
   // Respond to the adapter with the requested scopes
@@ -47,7 +47,7 @@ export class DebugMessage {
   // Respond to the adapter with the requested variables
   static VARIABLES_RESPONSE: string = "Variables-response";
   // Respond to the adapter with the stepped in location
-  static STEPIN_RESPONSE: string = "StepIn-response";
+  static STEPINTO_RESPONSE: string = "StepInto-response";
 
   /* Messages from Prepack to adapter to acknowledge having received the request */
   // Acknowledgement for setting a breakpoint

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -38,8 +38,8 @@ export class DebugMessage {
   static PREPACK_READY_RESPONSE: string = "PrepackReady";
   // Respond to the adapter that Prepack is finished
   static PREPACK_FINISH_RESPONSE: string = "PrepackFinish";
-  // Respond to the adapter that Prepack has stopped on a breakpoint
-  static BREAKPOINT_STOPPED_RESPONSE: string = "Breakpoint-stopped-response";
+  // Respond to the adapter that Prepack has stopped
+  static PREPACK_STOPPED_RESPONSE: string = "Prepack-stopped-response";
   // Respond to the adapter with the request stackframes
   static STACKFRAMES_RESPONSE: string = "Stackframes-response";
   // Respond to the adapter with the requested scopes

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -30,6 +30,8 @@ export class DebugMessage {
   static SCOPES_COMMAND: string = "Scopes-command";
   // Command to fetch variables
   static VARIABLES_COMMAND: string = "Variables-command";
+  // Command to step into a function
+  static STEPIN_COMMAND: string = "StepIn-command";
 
   /* Messages from Prepack to adapter with requested information */
   // Respond to the adapter that Prepack is ready
@@ -44,6 +46,8 @@ export class DebugMessage {
   static SCOPES_RESPONSE: string = "Scopes-response";
   // Respond to the adapter with the requested variables
   static VARIABLES_RESPONSE: string = "Variables-response";
+  // Respond to the adapter with the stepped in location
+  static STEPIN_RESPONSE: string = "StepIn-response";
 
   /* Messages from Prepack to adapter to acknowledge having received the request */
   // Acknowledgement for setting a breakpoint

--- a/src/debugger/channel/MessageMarshaller.js
+++ b/src/debugger/channel/MessageMarshaller.js
@@ -28,7 +28,7 @@ import type {
   DebuggerRequestArguments,
   RunArguments,
   StackframeArguments,
-  StepInArguments,
+  StepIntoArguments,
   StoppedReason,
 } from "./../types.js";
 import invariant from "./../../invariant.js";
@@ -52,7 +52,7 @@ export class MessageMarshaller {
       line: line,
       column: column,
     };
-    return `${this._lastRunRequestID} ${DebugMessage.PREPACK_STOPPED_RESPONSE} ${JSON.stringify(result)}`;
+    return `${this._lastRunRequestID} ${DebugMessage.STOPPED_RESPONSE} ${JSON.stringify(result)}`;
   }
 
   marshallDebuggerStart(requestID: number): string {
@@ -91,8 +91,8 @@ export class MessageMarshaller {
     return `${requestID} ${DebugMessage.VARIABLES_RESPONSE} ${JSON.stringify(variables)}`;
   }
 
-  marshallStepInRequest(requestID: number): string {
-    return `${requestID} ${DebugMessage.STEPIN_COMMAND}`;
+  marshallStepIntoRequest(requestID: number): string {
+    return `${requestID} ${DebugMessage.STEPINTO_COMMAND}`;
   }
 
   unmarshallRequest(message: string): DebuggerRequest {
@@ -127,12 +127,12 @@ export class MessageMarshaller {
       case DebugMessage.VARIABLES_COMMAND:
         args = this._unmarshallVariablesArguments(requestID, parts[2]);
         break;
-      case DebugMessage.STEPIN_COMMAND:
+      case DebugMessage.STEPINTO_COMMAND:
         this._lastRunRequestID = requestID;
-        let stepInArgs: StepInArguments = {
-          kind: "stepIn",
+        let stepIntoArgs: StepIntoArguments = {
+          kind: "stepInto",
         };
-        args = stepInArgs;
+        args = stepIntoArgs;
         break;
       default:
         throw new DebuggerError("Invalid command", "Invalid command from adapter: " + command);
@@ -156,7 +156,7 @@ export class MessageMarshaller {
       dbgResponse = this._unmarshallReadyResponse(requestID);
     } else if (messageType === DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE) {
       dbgResponse = this._unmarshallBreakpointsAddResponse(requestID, parts.slice(2).join(" "));
-    } else if (messageType === DebugMessage.PREPACK_STOPPED_RESPONSE) {
+    } else if (messageType === DebugMessage.STOPPED_RESPONSE) {
       dbgResponse = this._unmarshallStoppedResponse(requestID, parts.slice(2).join(" "));
     } else if (messageType === DebugMessage.STACKFRAMES_RESPONSE) {
       dbgResponse = this._unmarshallStackframesResponse(requestID, parts.slice(2).join(" "));

--- a/src/debugger/channel/MessageMarshaller.js
+++ b/src/debugger/channel/MessageMarshaller.js
@@ -29,7 +29,7 @@ import type {
   RunArguments,
   StackframeArguments,
   StepInArguments,
-  PrepackStoppedReason,
+  StoppedReason,
 } from "./../types.js";
 import invariant from "./../../invariant.js";
 import { DebuggerError } from "./../DebuggerError.js";
@@ -44,7 +44,7 @@ export class MessageMarshaller {
     return `${requestID} ${messageType} ${JSON.stringify(breakpoints)}`;
   }
 
-  marshallPrepackStopped(reason: PrepackStoppedReason, filePath: string, line: number, column: number): string {
+  marshallStoppedResponse(reason: StoppedReason, filePath: string, line: number, column: number): string {
     let result: StoppedResult = {
       kind: "stopped",
       reason: reason,
@@ -157,7 +157,7 @@ export class MessageMarshaller {
     } else if (messageType === DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE) {
       dbgResponse = this._unmarshallBreakpointsAddResponse(requestID, parts.slice(2).join(" "));
     } else if (messageType === DebugMessage.PREPACK_STOPPED_RESPONSE) {
-      dbgResponse = this._unmarshallPrepackStoppedResponse(requestID, parts.slice(2).join(" "));
+      dbgResponse = this._unmarshallStoppedResponse(requestID, parts.slice(2).join(" "));
     } else if (messageType === DebugMessage.STACKFRAMES_RESPONSE) {
       dbgResponse = this._unmarshallStackframesResponse(requestID, parts.slice(2).join(" "));
     } else if (messageType === DebugMessage.SCOPES_RESPONSE) {
@@ -306,7 +306,7 @@ export class MessageMarshaller {
     }
   }
 
-  _unmarshallPrepackStoppedResponse(requestID: number, responseStr: string): DebuggerResponse {
+  _unmarshallStoppedResponse(requestID: number, responseStr: string): DebuggerResponse {
     try {
       let result = JSON.parse(responseStr);
       invariant(result.kind === "stopped");

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -141,6 +141,8 @@ export class UISession {
           });
         } else if (event.body.reason.startsWith("breakpoint")) {
           this._uiOutput("Prepack stopped on: " + event.body.reason);
+        } else {
+          this._uiOutput(event.body.reason);
         }
       }
     }
@@ -270,6 +272,13 @@ export class UISession {
           variablesReference: varRef,
         };
         this._sendVariablesRequest(variableArgs);
+        break;
+      case "stepIn":
+        if (parts.length !== 1) return false;
+        let stepInArgs: DebugProtocol.StepInArguments = {
+          threadId: DebuggerConstants.PREPACK_THREAD_ID,
+        };
+        this._sendStepInRequest(stepInArgs);
         break;
       default:
         // invalid command
@@ -409,6 +418,17 @@ export class UISession {
       type: "request",
       seq: this._sequenceNum,
       command: "variables",
+      arguments: args,
+    };
+    let json = JSON.stringify(message);
+    this._packageAndSend(json);
+  }
+
+  _sendStepInRequest(args: DebugProtocol.StepInArguments) {
+    let message = {
+      type: "request",
+      seq: this._sequenceNum,
+      command: "stepIn",
       arguments: args,
     };
     let json = JSON.stringify(message);

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -273,12 +273,12 @@ export class UISession {
         };
         this._sendVariablesRequest(variableArgs);
         break;
-      case "stepIn":
+      case "stepInto":
         if (parts.length !== 1) return false;
-        let stepInArgs: DebugProtocol.StepInArguments = {
+        let stepIntoArgs: DebugProtocol.StepInArguments = {
           threadId: DebuggerConstants.PREPACK_THREAD_ID,
         };
-        this._sendStepInRequest(stepInArgs);
+        this._sendStepIntoRequest(stepIntoArgs);
         break;
       default:
         // invalid command
@@ -424,7 +424,7 @@ export class UISession {
     this._packageAndSend(json);
   }
 
-  _sendStepInRequest(args: DebugProtocol.StepInArguments) {
+  _sendStepIntoRequest(args: DebugProtocol.StepInArguments) {
     let message = {
       type: "request",
       seq: this._sequenceNum,

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -88,7 +88,7 @@ export type DebuggerResponseResult =
   | ReadyResult
   | StackframeResult
   | BreakpointsAddResult
-  | BreakpointStoppedResult
+  | StoppedResult
   | ScopesResult
   | VariablesResult
   | StepInResult
@@ -108,8 +108,9 @@ export type BreakpointsAddResult = {
   breakpoints: Array<Breakpoint>,
 };
 
-export type BreakpointStoppedResult = {
-  kind: "breakpoint-stopped",
+export type StoppedResult = {
+  kind: "stopped",
+  reason: PrepackStoppedReason,
   filePath: string,
   line: number,
   column: number,
@@ -157,6 +158,8 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   debugInFilePath: string,
   debugOutFilePath: string,
 }
+
+export type PrepackStoppedReason = "Breakpoint" | "Step In";
 
 export type StepInData = {
   prevStopFile: string,

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -90,9 +90,7 @@ export type DebuggerResponseResult =
   | BreakpointsAddResult
   | StoppedResult
   | ScopesResult
-  | VariablesResult
-  | StepInResult
-  | FinishResult;
+  | VariablesResult;
 
 export type ReadyResult = {
   kind: "ready",
@@ -135,17 +133,6 @@ export type Variable = {
 export type VariablesResult = {
   kind: "variables",
   variables: Array<Variable>,
-};
-
-export type StepInResult = {
-  kind: "stepIn",
-  filePath: string,
-  line: number,
-  column: number,
-};
-
-export type FinishResult = {
-  kind: "finish",
 };
 
 // any object that can contain a collection of variables

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -158,9 +158,8 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   debugOutFilePath: string,
 }
 
-export type SteppingInfo = {
-  kind: "in" | "over" | "out",
-  stoppedFile: string,
-  stoppedLine: number,
-  stoppedColumn: number,
+export type StepInData = {
+  prevStopFile: string,
+  prevStopLine: number,
+  prevStopColumn: number,
 };

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -25,7 +25,7 @@ export type DebuggerRequestArguments =
   | StackframeArguments
   | ScopesArguments
   | VariablesArguments
-  | StepInArguments;
+  | StepIntoArguments;
 
 export type PrepackLaunchArguments = {
   kind: "launch",
@@ -75,8 +75,8 @@ export type VariablesArguments = {
   variablesReference: number,
 };
 
-export type StepInArguments = {
-  kind: "stepIn",
+export type StepIntoArguments = {
+  kind: "stepInto",
 };
 
 export type DebuggerResponse = {
@@ -146,9 +146,9 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   debugOutFilePath: string,
 }
 
-export type StoppedReason = "Breakpoint" | "Step In";
+export type StoppedReason = "Breakpoint" | "Step Into";
 
-export type StepInData = {
+export type StepIntoData = {
   prevStopFile: string,
   prevStopLine: number,
   prevStopColumn: number,

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -24,7 +24,8 @@ export type DebuggerRequestArguments =
   | RunArguments
   | StackframeArguments
   | ScopesArguments
-  | VariablesArguments;
+  | VariablesArguments
+  | StepInArguments;
 
 export type PrepackLaunchArguments = {
   kind: "launch",
@@ -74,6 +75,10 @@ export type VariablesArguments = {
   variablesReference: number,
 };
 
+export type StepInArguments = {
+  kind: "stepIn",
+};
+
 export type DebuggerResponse = {
   id: number,
   result: DebuggerResponseResult,
@@ -86,6 +91,7 @@ export type DebuggerResponseResult =
   | BreakpointStoppedResult
   | ScopesResult
   | VariablesResult
+  | StepInResult
   | FinishResult;
 
 export type ReadyResult = {
@@ -130,6 +136,13 @@ export type VariablesResult = {
   variables: Array<Variable>,
 };
 
+export type StepInResult = {
+  kind: "stepIn",
+  filePath: string,
+  line: number,
+  column: number,
+};
+
 export type FinishResult = {
   kind: "finish",
 };
@@ -144,3 +157,10 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   debugInFilePath: string,
   debugOutFilePath: string,
 }
+
+export type SteppingInfo = {
+  kind: "in" | "over" | "out",
+  stoppedFile: string,
+  stoppedLine: number,
+  stoppedColumn: number,
+};

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -155,7 +155,5 @@ export type StoppedData = {
 };
 
 export type StepIntoData = {
-  prevStopFile: string,
-  prevStopLine: number,
-  prevStopColumn: number,
+  prevStopData: void | StoppedData,
 };

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -108,7 +108,7 @@ export type BreakpointsAddResult = {
 
 export type StoppedResult = {
   kind: "stopped",
-  reason: PrepackStoppedReason,
+  reason: StoppedReason,
   filePath: string,
   line: number,
   column: number,
@@ -146,7 +146,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   debugOutFilePath: string,
 }
 
-export type PrepackStoppedReason = "Breakpoint" | "Step In";
+export type StoppedReason = "Breakpoint" | "Step In";
 
 export type StepInData = {
   prevStopFile: string,

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -146,7 +146,13 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   debugOutFilePath: string,
 }
 
-export type StoppedReason = "Breakpoint" | "Step Into";
+export type StoppedReason = "Entry" | "Breakpoint" | "Step Into";
+
+export type StoppedData = {
+  filePath: string,
+  line: number,
+  column: number,
+};
 
 export type StepIntoData = {
   prevStopFile: string,

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -31,6 +31,7 @@ import { Value } from "../values/index.js";
 import invariant from "../invariant.js";
 import { HasName, HasCompatibleType } from "./has.js";
 import type { BabelNodeExpression, BabelNodeCallExpression, BabelNodeLVal, BabelNodeClassMethod } from "babel-types";
+import { BabelNode } from "babel-types";
 
 // ECMA262 22.1.3.1.1
 export function IsConcatSpreadable(realm: Realm, O: Value): boolean {
@@ -349,4 +350,43 @@ export function IsIntrospectionError(realm: Realm, value: Value): boolean {
 export function IsStatic(classElement: BabelNodeClassMethod): boolean {
   // $FlowFixMe need to backport static property to BabelNodeClassMethod
   return classElement.static;
+}
+
+export function IsStatement(node: BabelNode): boolean {
+  if (node.type === "BlockStatement") return true;
+  if (node.type === "BreakStatement") return true;
+  if (node.type === "ContinueStatement") return true;
+  if (node.type === "DebuggerStatement") return true;
+  if (node.type === "DoWhileStatement") return true;
+  if (node.type === "EmptyStatement") return true;
+  if (node.type === "ExpressionStatement") return true;
+  if (node.type === "ForInStatement") return true;
+  if (node.type === "ForStatement") return true;
+  if (node.type === "FunctionDeclaration") return true;
+  if (node.type === "IfStatement") return true;
+  if (node.type === "LabeledStatement") return true;
+  if (node.type === "ReturnStatement") return true;
+  if (node.type === "SwitchStatement") return true;
+  if (node.type === "ThrowStatement") return true;
+  if (node.type === "TryStatement") return true;
+  if (node.type === "VariableDeclaration") return true;
+  if (node.type === "WhileStatement") return true;
+  if (node.type === "WithStatement") return true;
+  if (node.type === "ClassDeclaration") return true;
+  if (node.type === "ExportAllDeclaration") return true;
+  if (node.type === "ExportDefaultDeclaration") return true;
+  if (node.type === "ExportNamedDeclaration") return true;
+  if (node.type === "ForOfStatement") return true;
+  if (node.type === "ImportDeclaration") return true;
+  if (node.type === "DeclareClass") return true;
+  if (node.type === "DeclareFunction") return true;
+  if (node.type === "DeclareInterface") return true;
+  if (node.type === "DeclareModule") return true;
+  if (node.type === "DeclareModuleExports") return true;
+  if (node.type === "DeclareTypeAlias") return true;
+  if (node.type === "DeclareVariable") return true;
+  if (node.type === "InterfaceDeclaration") return true;
+  if (node.type === "TypeAlias") return true;
+  if (node.type === "ForAwaitStatement") return true;
+  return false;
 }

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -353,40 +353,44 @@ export function IsStatic(classElement: BabelNodeClassMethod): boolean {
 }
 
 export function IsStatement(node: BabelNode): boolean {
-  if (node.type === "BlockStatement") return true;
-  if (node.type === "BreakStatement") return true;
-  if (node.type === "ContinueStatement") return true;
-  if (node.type === "DebuggerStatement") return true;
-  if (node.type === "DoWhileStatement") return true;
-  if (node.type === "EmptyStatement") return true;
-  if (node.type === "ExpressionStatement") return true;
-  if (node.type === "ForInStatement") return true;
-  if (node.type === "ForStatement") return true;
-  if (node.type === "FunctionDeclaration") return true;
-  if (node.type === "IfStatement") return true;
-  if (node.type === "LabeledStatement") return true;
-  if (node.type === "ReturnStatement") return true;
-  if (node.type === "SwitchStatement") return true;
-  if (node.type === "ThrowStatement") return true;
-  if (node.type === "TryStatement") return true;
-  if (node.type === "VariableDeclaration") return true;
-  if (node.type === "WhileStatement") return true;
-  if (node.type === "WithStatement") return true;
-  if (node.type === "ClassDeclaration") return true;
-  if (node.type === "ExportAllDeclaration") return true;
-  if (node.type === "ExportDefaultDeclaration") return true;
-  if (node.type === "ExportNamedDeclaration") return true;
-  if (node.type === "ForOfStatement") return true;
-  if (node.type === "ImportDeclaration") return true;
-  if (node.type === "DeclareClass") return true;
-  if (node.type === "DeclareFunction") return true;
-  if (node.type === "DeclareInterface") return true;
-  if (node.type === "DeclareModule") return true;
-  if (node.type === "DeclareModuleExports") return true;
-  if (node.type === "DeclareTypeAlias") return true;
-  if (node.type === "DeclareVariable") return true;
-  if (node.type === "InterfaceDeclaration") return true;
-  if (node.type === "TypeAlias") return true;
-  if (node.type === "ForAwaitStatement") return true;
-  return false;
+  switch (node.type) {
+    case "BlockStatement":
+    case "BreakStatement":
+    case "ContinueStatement":
+    case "DebuggerStatement":
+    case "DoWhileStatement":
+    case "EmptyStatement":
+    case "ExpressionStatement":
+    case "ForInStatement":
+    case "ForStatement":
+    case "FunctionDeclaration":
+    case "IfStatement":
+    case "LabeledStatement":
+    case "ReturnStatement":
+    case "SwitchStatement":
+    case "ThrowStatement":
+    case "TryStatement":
+    case "VariableDeclaration":
+    case "WhileStatement":
+    case "WithStatement":
+    case "ClassDeclaration":
+    case "ExportAllDeclaration":
+    case "ExportDefaultDeclaration":
+    case "ExportNamedDeclaration":
+    case "ForOfStatement":
+    case "ImportDeclaration":
+    case "DeclareClass":
+    case "DeclareFunction":
+    case "DeclareInterface":
+    case "DeclareModule":
+    case "DeclareModuleExports":
+    case "DeclareTypeAlias":
+    case "DeclareVariable":
+    case "InterfaceDeclaration":
+    case "TypeAlias":
+    case "ForAwaitStatement":
+      return true;
+    default:
+      return false;
+  }
 }


### PR DESCRIPTION
Release note: none
Summary:
-implement step in requests in the debugger: set a flag when a stepIn request is received, on each evaluate call on an ast node, check whether that node is a statement and it can be stopped on
-remove a redundant PREPACK_FINISHED message from Prepack to the adapter that interferes with the stepIn request on the last statement. The adapter already tracks when Prepack is finished by listening for the "exit" event.

Test Plan:
```
function a(num) {
  if (num === 3) {
    var y = 5;
  } else {
    {
      let abc = 3;
    }
    let z = [1,2,3];
    let e = Symbol("xyz");
    let f = {
      g: 0,
      h: 1,
      i: {
        j: 2,
        k: 3,
      },
    };
    let x = 6;
  }
}
a();
```
Breakpoints on line 2 and stepIn requests until the end of the program.
Verified in both CLI and IDE.