### PR TITLE
Avoid unused property reads on simple objects

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -198,7 +198,9 @@ export class PropertiesImplementation {
     invariant(IsPropertyKey(realm, P), "expected property key");
 
     // 2. Let ownDesc be ? O.[[GetOwnProperty]](P).
-    let ownDesc = O.$GetOwnProperty(P);
+    let ownDesc;
+    let existingBinding = InternalGetPropertiesMap(O, P).get(InternalGetPropertiesKey(P));
+    if (existingBinding !== undefined || !(O.isPartialObject() && O.isSimpleObject())) ownDesc = O.$GetOwnProperty(P);
     let ownDescValue = !ownDesc
       ? realm.intrinsics.undefined
       : ownDesc.value === undefined ? realm.intrinsics.undefined : ownDesc.value;
@@ -305,7 +307,10 @@ export class PropertiesImplementation {
         if (!(Receiver instanceof ObjectValue)) return false;
 
         // c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
-        let existingDescriptor = Receiver.$GetOwnProperty(P);
+        let existingDescriptor;
+        let binding = InternalGetPropertiesMap(Receiver, P).get(InternalGetPropertiesKey(P));
+        if (binding !== undefined || !(Receiver.isPartialObject() && Receiver.isSimpleObject()))
+          existingDescriptor = Receiver.$GetOwnProperty(P);
         if (existingDescriptor !== undefined) {
           if (existingDescriptor.descriptor1 === ownDesc) existingDescriptor = ownDesc;
           else if (existingDescriptor.descriptor2 === ownDesc) existingDescriptor = ownDesc;
@@ -748,7 +753,9 @@ export class PropertiesImplementation {
     invariant(O instanceof ObjectValue);
 
     // 1. Let current be ? O.[[GetOwnProperty]](P).
-    let current = O.$GetOwnProperty(P);
+    let current;
+    let binding = InternalGetPropertiesMap(O, P).get(InternalGetPropertiesKey(P));
+    if (binding !== undefined || !(O.isPartialObject() && O.isSimpleObject())) current = O.$GetOwnProperty(P);
 
     // 2. Let extensible be the value of the [[Extensible]] internal slot of O.
     let extensible = O.getExtensible();

--- a/test/serializer/basic/PropertyAssignment.js
+++ b/test/serializer/basic/PropertyAssignment.js
@@ -1,0 +1,6 @@
+// add at runtime:var foo = {};
+// Copies of .bar:2
+var ob = global.__makeSimple ? __makeSimple(__abstract({}, "foo")) :  {};
+ob.bar = {a: 1};
+
+inspect = function() { return JSON.stringify(ob.bar); }


### PR DESCRIPTION
Release note: Fixes #1179

When a property is written to object, the rather convoluted logic for checking if it is allowed and if a setter is involved end up asking the object three times if it already has such a property.

In the case of a simple partial object, this caused three useless references to the property to appear in the generated code, since the absence of a property is regarded as OK and produces a temporal abstract value that just reads from the object at runtime.

Fixed this by adding a special case when writing to a missing property on a simple partial object.