### PR TITLE
Treat first operand of a logical operation as a condition

### DIFF
--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -46,9 +46,10 @@ export default function(
     return Environment.GetValue(realm, rref);
   }
   invariant(lval instanceof AbstractValue);
+  let lcond = Environment.GetConditionValue(realm, lref);
 
-  if (!lval.mightNotBeFalse()) return ast.operator === "||" ? env.evaluate(ast.right, strictCode) : lval;
-  if (!lval.mightNotBeTrue()) return ast.operator === "&&" ? env.evaluate(ast.right, strictCode) : lval;
+  if (!lcond.mightNotBeFalse()) return ast.operator === "||" ? env.evaluate(ast.right, strictCode) : lval;
+  if (!lcond.mightNotBeTrue()) return ast.operator === "&&" ? env.evaluate(ast.right, strictCode) : lval;
 
   // Create empty effects for the case where ast.right is not evaluated
   let [compl1, gen1, bindings1, properties1, createdObj1] = construct_empty_effects(realm);

--- a/test/serializer/abstract/Refine7.js
+++ b/test/serializer/abstract/Refine7.js
@@ -1,0 +1,34 @@
+// add at runtime:var global=this;this.nativePerformanceNow = Date.now;
+if (global.__assumeDataProperty) __assumeDataProperty(this, "nativePerformanceNow", function() {
+  if (this.__residual)
+    return __residual("number", function(global) {
+      return global.nativePerformanceNow();
+    }, global);
+  else return this.nativePerformanceNow();
+}, "SKIP_INVARIANT");
+let performanceNow = nativePerformanceNow;
+
+let timespans = {};
+
+function addTimespan(key) {
+  timespans[key] = {};
+}
+
+function startTimespan(key) {
+  if (timespans[key]) return;
+  timespans[key] = { startTime: performanceNow() };
+}
+
+function stopTimespan(key) {
+  const timespan = timespans[key];
+  if (timespan && timespan.startTime) {
+    timespan.endTime = performanceNow();
+    // Following line has a problem
+    timespan.totalTime = timespan.endTime - (timespan.startTime || 0);
+  }
+}
+
+startTimespan("hello");
+stopTimespan("hello");
+
+inspect = function() { return true; }


### PR DESCRIPTION
Release note: Partially fixes #1182

When dealing with x || y and x && y where x is an abstract value, we can avoid evaluating x if it is known to be false in the first case and true in the second. When x is being refined with the path condition, it helps to know that the refined result will only be checked for truthiness. Duly add a call to Environment.GetConditionValue to make this happen.