### PR TITLE
Improve React class component serialization

### DIFF
--- a/src/flow/abstractObjectFactories.js
+++ b/src/flow/abstractObjectFactories.js
@@ -56,17 +56,20 @@ function _createAbstractArray(realm: Realm, name: string): AbstractValue {
   return value;
 }
 
-function _createAbstractObject(
+export function createAbstractObject(
   realm: Realm,
   name: string | null,
-  objectTypes: ObjectTypeTemplate | null
+  objectTypes: ObjectTypeTemplate | null,
+  template?: ObjectValue
 ): AbstractObjectValue {
   if (name === null) {
     name = "unknown";
   }
   let value = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(name), ObjectValue, [], name);
   value.intrinsicName = name;
-  let template = createObject(realm, objectTypes, name);
+  if (template === undefined) {
+    template = createObject(realm, objectTypes, name);
+  }
   template.makePartial();
   template.makeSimple();
   value.values = new ValuesDomain(new Set([template]));
@@ -75,7 +78,7 @@ function _createAbstractObject(
   return value;
 }
 
-export function createAbstractObject(
+export function createAbstractObjectFromFlowTypes(
   realm: Realm,
   name: string | null,
   objectTypes: ObjectTypeTemplate | null | string
@@ -85,7 +88,7 @@ export function createAbstractObject(
       objectTypes === "empty" || objectTypes === "object",
       `Expected an object or a string of "empty" or "object" for createAbstractObject() paramater "objectTypes"`
     );
-    return _createAbstractObject(realm, name, null);
+    return createAbstractObject(realm, name, null);
   }
   if (objectTypes !== null) {
     let propTypeObject = {};
@@ -98,7 +101,7 @@ export function createAbstractObject(
         if (value === "array") {
           propTypeObject[key] = _createAbstractArray(realm, propertyName);
         } else if (value === "object") {
-          propTypeObject[key] = _createAbstractObject(realm, propertyName, null);
+          propTypeObject[key] = createAbstractObject(realm, propertyName, null);
         } else {
           propTypeObject[key] = createAbstractByType(realm, value, propertyName);
         }
@@ -109,9 +112,9 @@ export function createAbstractObject(
       }
     });
 
-    return _createAbstractObject(realm, name, propTypeObject);
+    return createAbstractObject(realm, name, propTypeObject);
   } else {
-    return _createAbstractObject(realm, name, null);
+    return createAbstractObject(realm, name, null);
   }
 }
 


### PR DESCRIPTION
Release notes: none

This PR aims to improve the generated output from folding React class components. Previously, the serialized output looked something like this:

```jsx
var $f_2 = function () {
    var _4 = this;
    var _$3 = _4.render;
    var _$4 = _4.render;
    var _$5 = _4.render;
    _4.render = $f_2;
    var _$6 = _4.state;
    var _$7 = _4.state;
    var _$8 = _4.state;
    var _5 = this.state;
    _4.state = _5;
    var _$9 = _4.refs;
    var _$a = _4.refs;
    var _$b = _4.refs;
    var _6 = this.refs;
    _4.refs = _6;
    var _$c = _4.props;
    var _$d = _4.props;
    var _$e = _4.props;
    var _7 = this.props;
    _4.props = _7;
    var _$f = _4.context;
    var _$g = _4.context;
    var _$h = _4.context;
    var _8 = this.context;
    _4.context = _8;
    var _$i = this.state;
    var _$j = this.state.title;
    return <span><span>{_$j}</span></span>;
};
```

With the changes in this PR, it looks like this:

```jsx
  var $f_2 = function () {
    var _$3 = this.state;
    var _$4 = this.state.title;
    return <span><span>{_$4}</span></span>;
  };
```