### PR TITLE
Better lazy objects mock test runner support

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -121,7 +121,6 @@ function augmentCodeWithLazyObjectSupport(code, lazyRuntimeName) {
         const AlreadyHydratedLazyId = -1;
         const lazyId = this._lazyObjectIds.get(obj);
         if (lazyId === AlreadyHydratedLazyId) {
-          // Already being hydrated.
           return;
         }
         this._callback(obj, lazyId);
@@ -377,7 +376,6 @@ function runTest(name, code, options, args) {
         if (compileJSXWithBabel) {
           newCode = transformWithBabel(newCode, ["transform-react-jsx"]);
         }
-        if (args.verbose) console.log(newCode);
         let markersIssue = false;
         for (let { positive, value, start } of markersToFind) {
           let found = newCode.indexOf(value, start) !== -1;
@@ -391,6 +389,7 @@ function runTest(name, code, options, args) {
         if (!execSpec && options.lazyObjectsRuntime !== undefined) {
           codeToRun = augmentCodeWithLazyObjectSupport(codeToRun, args.lazyObjectsRuntime);
         }
+        if (args.verbose) console.log(codeToRun);
         codeIterations.push(codeToRun);
         if (args.es5) {
           codeToRun = transformWithBabel(codeToRun, [], [["env", { forceAllTransforms: true, modules: false }]]);

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -506,16 +506,9 @@ export default function(realm: Realm): ObjectValue {
     if (value instanceof AbstractValue || (value instanceof ObjectValue && value.isPartialObject())) {
       // Return abstract result. This enables cloning via JSON.parse(JSON.stringify(...)).
       let clonedValue = InternalJSONClone(realm, value);
-      let result = AbstractValue.createTemporalFromTemplate(
-        realm,
-        JSONStringify,
-        StringValue,
-        [clonedValue],
-        {
-          kind: "JSON.stringify(...)",
-        },
-        true
-      );
+      let result = AbstractValue.createTemporalFromTemplate(realm, JSONStringify, StringValue, [clonedValue], {
+        kind: "JSON.stringify(...)",
+      });
       if (clonedValue instanceof ObjectValue) {
         let iName = result.intrinsicName;
         invariant(iName);

--- a/src/options.js
+++ b/src/options.js
@@ -17,7 +17,6 @@ export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "node-source-ma
 export type RealmOptions = {
   compatibility?: Compatibility,
   debugNames?: boolean,
-  lazyObjectsRuntime?: string,
   errorHandler?: ErrorHandler,
   mathRandomSeed?: string,
   omitInvariants?: boolean,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -52,7 +52,6 @@ export type PrepackOptions = {|
 export function getRealmOptions({
   compatibility = "browser",
   debugNames = false,
-  lazyObjectsRuntime,
   errorHandler,
   mathRandomSeed,
   omitInvariants = false,
@@ -67,7 +66,6 @@ export function getRealmOptions({
   return {
     compatibility,
     debugNames,
-    lazyObjectsRuntime,
     errorHandler,
     mathRandomSeed,
     omitInvariants,

--- a/src/realm.js
+++ b/src/realm.js
@@ -145,9 +145,6 @@ export class Realm {
     this.compatibility = opts.compatibility || "browser";
     this.maxStackDepth = opts.maxStackDepth || 225;
     this.omitInvariants = !!opts.omitInvariants;
-    // Store in realm so that we can emit magic comment for test-runner.
-    // TODO: remove it once we have better test-runner support.
-    this.lazyObjectsRuntime = opts.lazyObjectsRuntime;
 
     this.$TemplateMap = [];
 
@@ -205,7 +202,6 @@ export class Realm {
   contextStack: Array<ExecutionContext> = [];
   $GlobalEnv: LexicalEnvironment;
   intrinsics: Intrinsics;
-  lazyObjectsRuntime: void | string;
 
   react: {
     enabled: boolean,

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -275,7 +275,10 @@ export class ResidualHeapSerializer {
         invariant(proto);
         let serializedProto = this.serializeValue(proto);
         let uid = this.getSerializeObjectIdentifier(obj);
-        let condition = t.binaryExpression("!==", t.memberExpression(uid, protoExpression), serializedProto);
+        const fetchedPrototype = this.realm.isCompatibleWith(this.realm.MOBILE_JSC_VERSION)
+          ? t.memberExpression(uid, protoExpression)
+          : t.callExpression(this.preludeGenerator.memoizeReference("Object.getPrototypeOf"), [uid]);
+        let condition = t.binaryExpression("!==", fetchedPrototype, serializedProto);
         let throwblock = t.blockStatement([
           t.throwStatement(t.newExpression(t.identifier("Error"), [t.stringLiteral("unexpected prototype")])),
         ]);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -268,7 +268,7 @@ export class Generator {
       // duplicate args to ensure refcount > 1
       args: [o, targetObject, sourceObject, targetObject, sourceObject],
       buildNode: ([obj, tgt, src, obj1, tgt1, src1]) => {
-        const forInLoopStatement = t.forInStatement(
+        return t.forInStatement(
           lh,
           obj,
           t.blockStatement([
@@ -281,10 +281,6 @@ export class Generator {
             ),
           ])
         );
-        if (this.realm.lazyObjectsRuntime) {
-          forInLoopStatement.leadingComments = [({ type: "BlockComment", value: "force hydrate lazy objects" }: any)];
-        }
-        return forInLoopStatement;
       },
     });
   }
@@ -294,8 +290,7 @@ export class Generator {
     values: ValuesDomain,
     args: Array<Value>,
     buildNode_: AbstractValueBuildNodeFunction | BabelNodeExpression,
-    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |},
-    forceHydrateLazyObjects: boolean = false
+    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |}
   ): AbstractValue {
     invariant(buildNode_ instanceof Function || args.length === 0);
     let id = t.identifier(this.preludeGenerator.nameGenerator.generate("derived"));
@@ -309,7 +304,7 @@ export class Generator {
       declared: res,
       args,
       buildNode: (nodes: Array<BabelNodeExpression>) => {
-        const statement = t.variableDeclaration("var", [
+        return t.variableDeclaration("var", [
           t.variableDeclarator(
             id,
             (buildNode_: any) instanceof Function
@@ -317,10 +312,6 @@ export class Generator {
               : ((buildNode_: any): BabelNodeExpression)
           ),
         ]);
-        if (forceHydrateLazyObjects && this.realm.lazyObjectsRuntime) {
-          statement.leadingComments = [({ type: "BlockComment", value: "force hydrate lazy objects" }: any)];
-        }
-        return statement;
       },
     });
     let type = types.getType();

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -541,8 +541,7 @@ export default class AbstractValue extends Value {
     template: PreludeGenerator => ({}) => BabelNodeExpression,
     resultType: typeof Value,
     operands: Array<Value>,
-    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |},
-    forceHydrateLazyObjects: boolean = false
+    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |}
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
     let temp = AbstractValue.createFromTemplate(realm, template, resultType, operands, "");
@@ -551,7 +550,7 @@ export default class AbstractValue extends Value {
     let args = temp.args;
     let buildNode_ = temp.getBuildNode();
     invariant(realm.generator !== undefined);
-    return realm.generator.derive(types, values, args, buildNode_, optionalArgs, forceHydrateLazyObjects);
+    return realm.generator.derive(types, values, args, buildNode_, optionalArgs);
   }
 
   static createTemporalFromBuildFunction(

--- a/test/serializer/abstract/QualifiedCall3.js
+++ b/test/serializer/abstract/QualifiedCall3.js
@@ -1,4 +1,3 @@
-// skip lazy objects
 let bar = {x: 1};
 let foo = global.__abstract ? __abstract(function() { return this.x; }, '(function() { return this.x; })') : function() { return this.x; };
 

--- a/test/serializer/abstract/UpdateExpression3.js
+++ b/test/serializer/abstract/UpdateExpression3.js
@@ -1,4 +1,3 @@
-// skip lazy objects
 foo = {x: 42};
 let obj = global.__makePartial ? __makePartial({x: __abstract('number', 'foo.x')}) : foo;
 let y = obj.x++;

--- a/test/serializer/abstract/require_tracking.js
+++ b/test/serializer/abstract/require_tracking.js
@@ -1,5 +1,4 @@
 // es6
-// skip lazy objects
 // delay unsupported requires
 
 var modules = Object.create(null);

--- a/test/serializer/basic/EfficientPrototypeSetting.js
+++ b/test/serializer/basic/EfficientPrototypeSetting.js
@@ -1,10 +1,10 @@
 // does not contain:__proto__ =
 (function() {
-    var x = {};
-    var proto = {};
+    var x = {x: 1};
+    var proto = {p: 2};
     x.__proto__ = proto;
     inspect = function() {
-        let p = x.__proto__;
+        let p = Object.getPrototypeOf(x);
         return p === proto;
     }
 })();

--- a/test/serializer/optimizations/proto.js
+++ b/test/serializer/optimizations/proto.js
@@ -3,5 +3,5 @@ let o = {};
 Object.setPrototypeOf(o, proto);
 global.x = o;
 inspect = function() {
-  return x.__proto__.a;
+  return Object.getPrototypeOf(x).a;
 }


### PR DESCRIPTION
@hermanventer suggests use Proxy to mock test-runner hydration for Lazy Objects which is very promising. Here are the improvements using proxy hook mocking:
1. More accurate hydration simulation
2. The 4 failed tests all succeed now.
3. All test mocking support are in test-runner now. No need to serialize ugly test runner comment.
4. I find real bugs after switching to Proxy simulation.

I also changed the test-runner a bit to output full runnable code when test-runner failed. This makes lazy object debugging much easier.