### PR TITLE
Debugger Refactor Part I: Change maps to use ES6 Map

### DIFF
--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -12,7 +12,6 @@
 import { PerFileBreakpointMap } from "./PerFileBreakpointMap.js";
 import { Breakpoint } from "./Breakpoint.js";
 import type { Breakpoint as BreakpointType } from "./types.js";
-import invariant from "./../invariant.js";
 
 // Storing BreakpointStores for all source files
 export class BreakpointManager {
@@ -26,20 +25,17 @@ export class BreakpointManager {
   }
 
   _addBreakpoint(bp: BreakpointType) {
-    if (!this._breakpointMaps.has(bp.filePath)) {
-      this._breakpointMaps.set(bp.filePath, new PerFileBreakpointMap(bp.filePath));
-    }
     let breakpointMap = this._breakpointMaps.get(bp.filePath);
-    invariant(breakpointMap);
+    if (!breakpointMap) {
+      breakpointMap = new PerFileBreakpointMap(bp.filePath)
+      this._breakpointMaps.set(bp.filePath, breakpointMap);
+    }
     breakpointMap.addBreakpoint(bp.line, bp.column);
   }
 
   getBreakpoint(filePath: string, lineNum: number, columnNum: number = 0): void | Breakpoint {
-    if (this._breakpointMaps.has(filePath)) {
-      let breakpointMap = this._breakpointMaps.get(filePath);
-      invariant(breakpointMap);
-      return breakpointMap.getBreakpoint(lineNum, columnNum);
-    }
+    let breakpointMap = this._breakpointMaps.get(filePath);
+    if (breakpointMap) return breakpointMap.getBreakpoint(lineNum, columnNum);
     return undefined;
   }
 
@@ -48,11 +44,8 @@ export class BreakpointManager {
   }
 
   _removeBreakpoint(bp: BreakpointType) {
-    if (this._breakpointMaps.has(bp.filePath)) {
-      let breakpointMap = this._breakpointMaps.get(bp.filePath);
-      invariant(breakpointMap);
-      breakpointMap.removeBreakpoint(bp.line, bp.column);
-    }
+    let breakpointMap = this._breakpointMaps.get(bp.filePath);
+    if (breakpointMap) breakpointMap.removeBreakpoint(bp.line, bp.column);
   }
 
   enableBreakpointMulti(breakpoints: Array<BreakpointType>) {
@@ -60,11 +53,8 @@ export class BreakpointManager {
   }
 
   _enableBreakpoint(bp: BreakpointType) {
-    if (this._breakpointMaps.has(bp.filePath)) {
-      let breakpointMap = this._breakpointMaps.get(bp.filePath);
-      invariant(breakpointMap);
-      breakpointMap.enableBreakpoint(bp.line, bp.column);
-    }
+    let breakpointMap = this._breakpointMaps.get(bp.filePath);
+    if (breakpointMap) breakpointMap.enableBreakpoint(bp.line, bp.column);
   }
 
   disableBreakpointMulti(breakpoints: Array<BreakpointType>) {
@@ -72,11 +62,8 @@ export class BreakpointManager {
   }
 
   _disableBreakpoint(bp: BreakpointType) {
-    if (this._breakpointMaps.has(bp.filePath)) {
-      let breakpointMap = this._breakpointMaps.get(bp.filePath);
-      invariant(breakpointMap);
-      breakpointMap.disableBreakpoint(bp.line, bp.column);
-    }
+    let breakpointMap = this._breakpointMaps.get(bp.filePath);
+    if (breakpointMap) breakpointMap.disableBreakpoint(bp.line, bp.column);
   }
 
   _doBreakpointsAction(breakpoints: Array<BreakpointType>, action: BreakpointType => void) {

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -27,7 +27,7 @@ export class BreakpointManager {
   _addBreakpoint(bp: BreakpointType) {
     let breakpointMap = this._breakpointMaps.get(bp.filePath);
     if (!breakpointMap) {
-      breakpointMap = new PerFileBreakpointMap(bp.filePath)
+      breakpointMap = new PerFileBreakpointMap(bp.filePath);
       this._breakpointMaps.set(bp.filePath, breakpointMap);
     }
     breakpointMap.addBreakpoint(bp.line, bp.column);

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -12,29 +12,32 @@
 import { PerFileBreakpointMap } from "./PerFileBreakpointMap.js";
 import { Breakpoint } from "./Breakpoint.js";
 import type { Breakpoint as BreakpointType } from "./types.js";
+import invariant from "./../invariant.js";
 
 // Storing BreakpointStores for all source files
 export class BreakpointManager {
   constructor() {
     this._breakpointMaps = new Map();
   }
-  _breakpointMaps: { [string]: PerFileBreakpointMap };
+  _breakpointMaps: Map<string, PerFileBreakpointMap>;
 
   addBreakpointMulti(breakpoints: Array<BreakpointType>) {
     this._doBreakpointsAction(breakpoints, this._addBreakpoint.bind(this));
   }
 
   _addBreakpoint(bp: BreakpointType) {
-    if (!(bp.filePath in this._breakpointMaps)) {
-      this._breakpointMaps[bp.filePath] = new PerFileBreakpointMap(bp.filePath);
+    if (!(this._breakpointMaps.has(bp.filePath))) {
+      this._breakpointMaps.set(bp.filePath, new PerFileBreakpointMap(bp.filePath));
     }
-    let breakpointMap = this._breakpointMaps[bp.filePath];
+    let breakpointMap = this._breakpointMaps.get(bp.filePath);
+    invariant(breakpointMap);
     breakpointMap.addBreakpoint(bp.line, bp.column);
   }
 
   getBreakpoint(filePath: string, lineNum: number, columnNum: number = 0): void | Breakpoint {
-    if (filePath in this._breakpointMaps) {
-      let breakpointMap = this._breakpointMaps[filePath];
+    if (this._breakpointMaps.has(filePath)) {
+      let breakpointMap = this._breakpointMaps.get(filePath);
+      invariant(breakpointMap);
       return breakpointMap.getBreakpoint(lineNum, columnNum);
     }
     return undefined;
@@ -45,8 +48,10 @@ export class BreakpointManager {
   }
 
   _removeBreakpoint(bp: BreakpointType) {
-    if (bp.filePath in this._breakpointMaps) {
-      this._breakpointMaps[bp.filePath].removeBreakpoint(bp.line, bp.column);
+    if (this._breakpointMaps.has(bp.filePath)) {
+      let breakpointMap = this._breakpointMaps.get(bp.filePath);
+      invariant(breakpointMap);
+      breakpointMap.removeBreakpoint(bp.line, bp.column);
     }
   }
 
@@ -55,8 +60,10 @@ export class BreakpointManager {
   }
 
   _enableBreakpoint(bp: BreakpointType) {
-    if (bp.filePath in this._breakpointMaps) {
-      this._breakpointMaps[bp.filePath].enableBreakpoint(bp.line, bp.column);
+    if (this._breakpointMaps.has(bp.filePath)) {
+      let breakpointMap = this._breakpointMaps.get(bp.filePath);
+      invariant(breakpointMap);
+      breakpointMap.enableBreakpoint(bp.line, bp.column);
     }
   }
 
@@ -65,8 +72,10 @@ export class BreakpointManager {
   }
 
   _disableBreakpoint(bp: BreakpointType) {
-    if (bp.filePath in this._breakpointMaps) {
-      this._breakpointMaps[bp.filePath].disableBreakpoint(bp.line, bp.column);
+    if (this._breakpointMaps.has(bp.filePath)) {
+      let breakpointMap = this._breakpointMaps.get(bp.filePath);
+      invariant(breakpointMap);
+      breakpointMap.disableBreakpoint(bp.line, bp.column);
     }
   }
 

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -26,7 +26,7 @@ export class BreakpointManager {
   }
 
   _addBreakpoint(bp: BreakpointType) {
-    if (!(this._breakpointMaps.has(bp.filePath))) {
+    if (!this._breakpointMaps.has(bp.filePath)) {
       this._breakpointMaps.set(bp.filePath, new PerFileBreakpointMap(bp.filePath));
     }
     let breakpointMap = this._breakpointMaps.get(bp.filePath);

--- a/src/debugger/PerFileBreakpointMap.js
+++ b/src/debugger/PerFileBreakpointMap.js
@@ -10,41 +10,42 @@
 /* @flow */
 
 import { Breakpoint } from "./Breakpoint.js";
+import invariant from "./../invariant.js";
 
 // Storage for all the breakpoints in one source file
 // Each source file will be associated with one PerFileBreakpointMap
 export class PerFileBreakpointMap {
   constructor(filePath: string) {
-    this.filePath = filePath;
-    this.breakpoints = new Map();
+    this._filePath = filePath;
+    this._breakpoints = new Map();
   }
-  filePath: string;
+  _filePath: string;
 
   //map of line:column to Breakpoint objects
-  breakpoints: { [string]: Breakpoint };
+  _breakpoints: Map<string, Breakpoint>;
 
   addBreakpoint(line: number, column: number = 0, temporary?: boolean, enabled?: boolean) {
-    let breakpoint = new Breakpoint(this.filePath, line, column, temporary, enabled);
+    let breakpoint = new Breakpoint(this._filePath, line, column, temporary, enabled);
     let key = this._getKey(line, column);
-    this.breakpoints[key] = breakpoint;
+    this._breakpoints.set(key, breakpoint);
   }
 
   getBreakpoint(line: number, column: number = 0): void | Breakpoint {
     //check for a column breakpoint first, then line breakpoint
     if (column !== 0) {
       let key = this._getKey(line, column);
-      if (key in this.breakpoints) {
-        return this.breakpoints[key];
+      if (this._breakpoints.has(key)) {
+        return this._breakpoints.get(key);
       } else {
         key = this._getKey(line, 0);
-        if (key in this.breakpoints) {
-          return this.breakpoints[key];
+        if (this._breakpoints.has(key)) {
+          return this._breakpoints.get(key);
         }
       }
     } else {
       let key = this._getKey(line, 0);
-      if (key in this.breakpoints) {
-        return this.breakpoints[key];
+      if (this._breakpoints.has(key)) {
+        return this._breakpoints.get(key);
       }
     }
 
@@ -53,22 +54,28 @@ export class PerFileBreakpointMap {
 
   removeBreakpoint(line: number, column: number = 0) {
     let key = this._getKey(line, column);
-    if (key in this.breakpoints) {
-      delete this.breakpoints[key];
+    if (key in this._breakpoints) {
+      this._breakpoints.delete(key);
     }
   }
 
   enableBreakpoint(line: number, column: number = 0) {
     let key = this._getKey(line, column);
-    if (key in this.breakpoints) {
-      this.breakpoints[key].enabled = true;
+    if (this._breakpoints.has(key)) {
+      let breakpoint = this._breakpoints.get(key);
+      // flow complains without this invariant
+      invariant(breakpoint);
+      breakpoint.enabled = true;
     }
   }
 
   disableBreakpoint(line: number, column: number = 0) {
     let key = this._getKey(line, column);
-    if (key in this.breakpoints) {
-      this.breakpoints[key].enabled = false;
+    if (this._breakpoints.has(key)) {
+      let breakpoint = this._breakpoints.get(key);
+      // flow complains without this invariant
+      invariant(breakpoint);
+      breakpoint.enabled = false;
     }
   }
 

--- a/src/debugger/PerFileBreakpointMap.js
+++ b/src/debugger/PerFileBreakpointMap.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import { Breakpoint } from "./Breakpoint.js";
-import invariant from "./../invariant.js";
 
 // Storage for all the breakpoints in one source file
 // Each source file will be associated with one PerFileBreakpointMap
@@ -54,29 +53,21 @@ export class PerFileBreakpointMap {
 
   removeBreakpoint(line: number, column: number = 0) {
     let key = this._getKey(line, column);
-    if (key in this._breakpoints) {
+    if (this._breakpoints.has(key)) {
       this._breakpoints.delete(key);
     }
   }
 
   enableBreakpoint(line: number, column: number = 0) {
     let key = this._getKey(line, column);
-    if (this._breakpoints.has(key)) {
-      let breakpoint = this._breakpoints.get(key);
-      // flow complains without this invariant
-      invariant(breakpoint);
-      breakpoint.enabled = true;
-    }
+    let breakpoint = this._breakpoints.get(key);
+    if (breakpoint) breakpoint.enabled = true;
   }
 
   disableBreakpoint(line: number, column: number = 0) {
     let key = this._getKey(line, column);
-    if (this._breakpoints.has(key)) {
-      let breakpoint = this._breakpoints.get(key);
-      // flow complains without this invariant
-      invariant(breakpoint);
-      breakpoint.enabled = false;
-    }
+    let breakpoint = this._breakpoints.get(key);
+    if (breakpoint) breakpoint.enabled = false;
   }
 
   _getKey(line: number, column: number): string {

--- a/src/debugger/ReferenceMap.js
+++ b/src/debugger/ReferenceMap.js
@@ -18,16 +18,16 @@ export class ReferenceMap<T> {
     this._mapping = new Map();
   }
   _counter: number;
-  _mapping: { [number]: T };
+  _mapping: Map<number, T>;
 
   add(value: T): number {
     this._counter++;
-    this._mapping[this._counter] = value;
+    this._mapping.set(this._counter, value);
     return this._counter;
   }
 
   get(reference: number): void | T {
-    return this._mapping[reference];
+    return this._mapping.get(reference);
   }
 
   clean() {


### PR DESCRIPTION
Release note: none
Summary:
-First part of a number of refactorings to the debugger code. Previously map objects were created as ES6 Map but type annotated as object maps. This PR changes the annotations to ES6 maps to be consistent. Also changes the methods used to `get`, `set`, and `has`.

Refactors to come:
-Centralize try/catch logic in MessageMarshaller _unmarshallXXX
-Centralize MessageMarshaller marshallXXX
-Separate adapter and engine code directories so adapter can move into Nuclide codebase

Test Plan:
```
function a(num) {
  if (num === 3) {
    var y = 5;
  } else {
    {
      let abc = 3;
    }
    var x;
    var y;
    let z = [1,2,3];
    let e = Symbol("xyz");
    let f = {
      g: 0,
      h: 1,
      i: {
        j: 2,
        k: 3,
      },
    };
    let x = 6;
  }
}
```
Set breakpoints on each statement and continued through.
Tested in both CLI and IDE.