### PR TITLE
Adds more document mock abstracts

### DIFF
--- a/src/intrinsics/dom/document.js
+++ b/src/intrinsics/dom/document.js
@@ -10,10 +10,45 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ObjectValue } from "../../values/index.js";
+import { ObjectValue, AbstractObjectValue } from "../../values/index.js";
+import { createAbstract } from "../prepack/utils.js";
+import { Properties } from "../../singletons.js";
+import invariant from "../../invariant";
 
-export default function(realm: Realm): ObjectValue {
-  let obj = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "document");
+const functions = [
+  "getElementById",
+  "getElementByTag",
+  "getElementByClassName",
+  "getElementByName",
+  "getElementByTagName",
+  "getElementByTagNameNS",
+  "querySelector",
+  "querySelectorAll",
+  "createElement",
+  "createDocumentFragment",
+  "createTextNode",
+];
 
-  return obj;
+export default function(realm: Realm): AbstractObjectValue {
+  // document object
+  let document = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "document", false);
+
+  // check if we can use abstracts
+  if (realm.useAbstractInterpretation) {
+    // common methods on document
+    for (let name of functions) {
+      let func = createAbstract(realm, "function", `document.${name}`);
+      Properties.Set(realm, document, name, func, false);
+    }
+
+    // document.body
+    let body = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "document.body");
+    Properties.Set(realm, document, "body", body, false);
+
+    // make abstract
+    let abstractObject = createAbstract(realm, document, "document");
+    invariant(abstractObject instanceof AbstractObjectValue);
+    return abstractObject;
+  }
+  return document;
 }

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -16,6 +16,7 @@ import {
   BooleanValue,
   FunctionValue,
   NativeFunctionValue,
+  ConcreteValue,
   ObjectValue,
   Value,
   ECMAScriptSourceFunctionValue,
@@ -26,6 +27,13 @@ import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
 import invariant from "../../invariant.js";
 import { createAbstract, parseTypeNameOrTemplate } from "./utils.js";
+
+export function createAbstractFunction(realm: Realm, ...additionalValues: Array<ConcreteValue>): NativeFunctionValue {
+  return new NativeFunctionValue(realm, "global.__abstract", "__abstract", 0, (context, [typeNameOrTemplate, name]) =>
+    // this line really confuses Flow
+    createAbstract(realm, typeNameOrTemplate, ((name: any): string | void), ...additionalValues)
+  );
+}
 
 export default function(realm: Realm): void {
   let global = realm.$GlobalObject;
@@ -47,28 +55,28 @@ export default function(realm: Realm): void {
   // If the abstract value gets somehow embedded in the final heap,
   // it will be referred to by the supplied name in the generated code.
   global.$DefineOwnProperty("__abstract", {
-    value: createAbstract(realm),
+    value: createAbstractFunction(realm),
     writable: true,
     enumerable: false,
     configurable: true,
   });
 
   global.$DefineOwnProperty("__abstractOrNull", {
-    value: createAbstract(realm, realm.intrinsics.null),
+    value: createAbstractFunction(realm, realm.intrinsics.null),
     writable: true,
     enumerable: false,
     configurable: true,
   });
 
   global.$DefineOwnProperty("__abstractOrNullOrUndefined", {
-    value: createAbstract(realm, realm.intrinsics.null, realm.intrinsics.undefined),
+    value: createAbstractFunction(realm, realm.intrinsics.null, realm.intrinsics.undefined),
     writable: true,
     enumerable: false,
     configurable: true,
   });
 
   global.$DefineOwnProperty("__abstractOrUndefined", {
-    value: createAbstract(realm, realm.intrinsics.undefined),
+    value: createAbstractFunction(realm, realm.intrinsics.undefined),
     writable: true,
     enumerable: false,
     configurable: true,

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -15,7 +15,6 @@ import {
   AbstractValue,
   ConcreteValue,
   FunctionValue,
-  NativeFunctionValue,
   StringValue,
   ObjectValue,
   UndefinedValue,
@@ -24,16 +23,23 @@ import buildExpressionTemplate from "../../utils/builder.js";
 import { describeLocation } from "../ecma262/Error.js";
 import { ToStringPartial } from "../../methods/index.js";
 import { ValuesDomain } from "../../domains/index.js";
+import AbstractObjectValue from "../../values/AbstractObjectValue";
 
 const throwTemplateSrc = "(function(){throw new global.Error('abstract value defined at ' + A);})()";
 const throwTemplate = buildExpressionTemplate(throwTemplateSrc);
 
 export function parseTypeNameOrTemplate(
   realm: Realm,
-  typeNameOrTemplate: void | Value
+  typeNameOrTemplate: void | Value | string
 ): { type: typeof Value, template: void | ObjectValue } {
   if (typeNameOrTemplate === undefined || typeNameOrTemplate instanceof UndefinedValue) {
     return { type: Value, template: undefined };
+  } else if (typeof typeNameOrTemplate === "string") {
+    let type = Value.getTypeFromName(typeNameOrTemplate);
+    if (type === undefined) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown typeNameOrTemplate");
+    }
+    return { type, template: undefined };
   } else if (typeNameOrTemplate instanceof StringValue) {
     let typeNameString = ToStringPartial(realm, typeNameOrTemplate);
     let type = Value.getTypeFromName(typeNameString);
@@ -50,52 +56,49 @@ export function parseTypeNameOrTemplate(
   }
 }
 
-export function createAbstract(realm: Realm, ...additionalValues: Array<ConcreteValue>): NativeFunctionValue {
-  return new NativeFunctionValue(
-    realm,
-    "global.__abstract",
-    "__abstract",
-    0,
-    (context, [typeNameOrTemplate: void | Value, name]) => {
-      if (!realm.useAbstractInterpretation) {
-        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
-      }
+export function createAbstract(
+  realm: Realm,
+  typeNameOrTemplate?: Value | string,
+  name?: string,
+  ...additionalValues: Array<ConcreteValue>
+): AbstractValue | AbstractObjectValue {
+  if (!realm.useAbstractInterpretation) {
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
+  }
 
-      let { type, template } = parseTypeNameOrTemplate(realm, typeNameOrTemplate);
+  let { type, template } = parseTypeNameOrTemplate(realm, typeNameOrTemplate);
 
-      let result;
-      let nameString = name ? ToStringPartial(realm, name) : "";
-      if (nameString === "") {
-        let locString;
-        for (let executionContext of realm.contextStack.slice().reverse()) {
-          let caller = executionContext.caller;
-          locString = describeLocation(
-            realm,
-            caller ? caller.function : undefined,
-            caller ? caller.lexicalEnvironment : undefined,
-            executionContext.loc
-          );
-          if (locString !== undefined) break;
-        }
-        let locVal = new StringValue(realm, locString || "(unknown location)");
-        let kind = "__abstract_" + realm.objectCount++; // need not be an object, but must be unique
-        result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
-      } else {
-        let kind = "__abstract_" + nameString; // assume name is unique TODO #1155: check this
-        result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(nameString), type, [], kind);
-        result.intrinsicName = nameString;
-      }
-
-      if (template) result.values = new ValuesDomain(new Set([template]));
-      if (template && !(template instanceof FunctionValue)) {
-        // why exclude functions?
-        template.makePartial();
-        if (nameString) realm.rebuildNestedProperties(result, nameString);
-      }
-
-      if (additionalValues.length > 0)
-        result = AbstractValue.createAbstractConcreteUnion(realm, result, ...additionalValues);
-      return result;
+  let result;
+  let nameString = name ? ToStringPartial(realm, name) : "";
+  if (nameString === "") {
+    let locString;
+    for (let executionContext of realm.contextStack.slice().reverse()) {
+      let caller = executionContext.caller;
+      locString = describeLocation(
+        realm,
+        caller ? caller.function : undefined,
+        caller ? caller.lexicalEnvironment : undefined,
+        executionContext.loc
+      );
+      if (locString !== undefined) break;
     }
-  );
+    let locVal = new StringValue(realm, locString || "(unknown location)");
+    let kind = "__abstract_" + realm.objectCount++; // need not be an object, but must be unique
+    result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
+  } else {
+    let kind = "__abstract_" + nameString; // assume name is unique TODO #1155: check this
+    result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(nameString), type, [], kind);
+    result.intrinsicName = nameString;
+  }
+
+  if (template) result.values = new ValuesDomain(new Set([template]));
+  if (template && !(template instanceof FunctionValue)) {
+    // why exclude functions?
+    template.makePartial();
+    if (nameString) realm.rebuildNestedProperties(result, nameString);
+  }
+
+  if (additionalValues.length > 0)
+    result = AbstractValue.createAbstractConcreteUnion(realm, result, ...additionalValues);
+  return result;
 }


### PR DESCRIPTION
Release note: Adds more `document` abstract mocks

This refactors https://github.com/facebook/prepack/pull/1190 slightly to use it in a more general way. This PR also adds some more `document` object mock abstracts.