### PR TITLE
Adds more React mocks

### DIFF
--- a/src/evaluators/JSXElement.js
+++ b/src/evaluators/JSXElement.js
@@ -23,8 +23,9 @@ import type {
   BabelNodeJSXSpreadAttribute,
   BabelNodeJSXExpressionContainer,
 } from "babel-types";
-import { ArrayValue, StringValue, Value, NumberValue, ObjectValue, SymbolValue } from "../values/index.js";
-import { convertJSXExpressionToIdentifier } from "../react/jsx";
+import { ArrayValue, StringValue, Value, NumberValue, ObjectValue } from "../values/index.js";
+import { getReactElementSymbol } from "../react/utils.js";
+import { convertJSXExpressionToIdentifier } from "../react/jsx.js";
 import * as t from "babel-types";
 import { Get } from "../methods/index.js";
 import { Create, Environment, Properties } from "../singletons.js";
@@ -37,8 +38,6 @@ let RESERVED_PROPS = {
   __self: true,
   __source: true,
 };
-
-let reactElementSymbolKey = "react.element";
 
 // taken from Babel
 function cleanJSXElementLiteralChild(child: string): null | string {
@@ -281,28 +280,6 @@ function evaluateJSXAttributes(
     attributes,
     children,
   };
-}
-
-function getReactElementSymbol(realm: Realm): SymbolValue {
-  let reactElementSymbol = realm.react.reactElementSymbol;
-  if (reactElementSymbol !== undefined) {
-    return reactElementSymbol;
-  }
-  let SymbolFor = realm.intrinsics.Symbol.properties.get("for");
-  if (SymbolFor !== undefined) {
-    let SymbolForDescriptor = SymbolFor.descriptor;
-
-    if (SymbolForDescriptor !== undefined) {
-      let SymbolForValue = SymbolForDescriptor.value;
-      if (SymbolForValue !== undefined && typeof SymbolForValue.$Call === "function") {
-        realm.react.reactElementSymbol = reactElementSymbol = SymbolForValue.$Call(realm.intrinsics.Symbol, [
-          new StringValue(realm, reactElementSymbolKey),
-        ]);
-      }
-    }
-  }
-  invariant(reactElementSymbol instanceof SymbolValue, `ReactElement "$$typeof" property was not a symbol`);
-  return reactElementSymbol;
 }
 
 function createReactProps(

--- a/src/intrinsics/react-mocks/mocks.js
+++ b/src/intrinsics/react-mocks/mocks.js
@@ -80,23 +80,23 @@ let reactCode = `
     PureComponent.prototype.isPureReactComponent = true;
 
     function forEachChildren() {
-      // TODO
+      throw new Error("TODO: React.Children.forEach is not yet supported");
     }
 
     function mapChildren() {
-      // TODO
+      throw new Error("TODO: React.Children.map is not yet supported");
     }
 
     function countChildren() {
-      // TODO
+      throw new Error("TODO: React.Children.count is not yet supported");
     }
 
     function onlyChild() {
-      // TODO
+      throw new Error("TODO: React.Children.only is not yet supported");
     }
 
     function toArray() {
-      // TODO
+      throw new Error("TODO: React.Children.toArray is not yet supported");
     }
 
     function createElement(type, config, children) {

--- a/src/intrinsics/react-mocks/mocks.js
+++ b/src/intrinsics/react-mocks/mocks.js
@@ -54,10 +54,8 @@ let reactCode = `
 
     class Component {
       constructor(props, context) {
-        this.props = props || {};
-        this.context = context || {};
-        this.refs = {};
-        this.state = {};
+        // we don't set any properties here
+        // this is simply a stub
       }
       getChildContext() {}
     }

--- a/src/intrinsics/react-mocks/mocks.js
+++ b/src/intrinsics/react-mocks/mocks.js
@@ -54,8 +54,8 @@ let reactCode = `
 
     class Component {
       constructor(props, context) {
-        // we don't set any properties here
-        // this is simply a stub
+        // stub, this constructor is never evaluated
+        throw new Error("React.Component constructor should never evaluate");
       }
       getChildContext() {}
     }
@@ -64,17 +64,12 @@ let reactCode = `
 
     class PureComponent {
       constructor(props, context) {
-        this.props = props || {};
-        this.context = context || {};
-        this.refs = {};
-        this.state = {};
+        // stub, this constructor is never evaluated
+        throw new Error("React.PureComponent constructor should never evaluate");
       }
-      isReactComponent() {
-        return true;
-      }
-      getChildContext() {}
     }
 
+    PureComponent.prototype.isReactComponent = {};
     PureComponent.prototype.isPureReactComponent = true;
 
     function forEachChildren() {

--- a/src/intrinsics/react-mocks/mocks.js
+++ b/src/intrinsics/react-mocks/mocks.js
@@ -11,14 +11,60 @@
 
 import type { Realm } from "../../realm.js";
 import { parseExpression } from "babylon";
-import { ObjectValue, ECMAScriptFunctionValue } from "../../values/index.js";
+import { ObjectValue, ECMAScriptFunctionValue, ECMAScriptSourceFunctionValue } from "../../values/index.js";
 import { Get } from "../../methods/index.js";
 import { Environment } from "../../singletons.js";
+import { getReactElementSymbol } from "../../react/utils.js";
 import invariant from "../../invariant";
 
+// most of the code here was taken from https://github.com/facebook/react/blob/master/packages/react/src/ReactElement.js
 let reactCode = `
-  {
-    Component: class Component {
+  function createReact(REACT_ELEMENT_TYPE, ReactCurrentOwner) {
+    var hasOwnProperty = Object.prototype.hasOwnProperty;
+    var RESERVED_PROPS = {
+      key: true,
+      ref: true,
+      __self: true,
+      __source: true,
+    };
+
+    var ReactElement = function(type, key, ref, self, source, owner, props) {
+      return {
+        // This tag allow us to uniquely identify this as a React Element
+        $$typeof: REACT_ELEMENT_TYPE,
+    
+        // Built-in properties that belong on the element
+        type: type,
+        key: key,
+        ref: ref,
+        props: props,
+    
+        // Record the component responsible for creating this element.
+        _owner: owner,
+      };
+    };
+
+    function hasValidRef(config) {
+      return config.ref !== undefined;
+    }
+    
+    function hasValidKey(config) {
+      return config.key !== undefined;
+    }
+
+    class Component {
+      constructor(props, context) {
+        this.props = props || {};
+        this.context = context || {};
+        this.refs = {};
+        this.state = {};
+      }
+      getChildContext() {}
+    }
+
+    Component.prototype.isReactComponent = {};
+
+    class PureComponent {
       constructor(props, context) {
         this.props = props || {};
         this.context = context || {};
@@ -29,34 +75,126 @@ let reactCode = `
         return true;
       }
       getChildContext() {}
-    },
-    createElement: function() {
-      // TODO
-    },
-    cloneElement(element, config, children) {
-      var propName;
-      var RESERVED_PROPS = {
-        key: true,
-        ref: true,
-        __self: true,
-        __source: true,
-      };
-      var hasOwnProperty = Object.prototype.hasOwnProperty;
-      var props = Object.assign({}, element.props);
+    }
 
-      var key = element.key;
-      var ref = element.ref;
-      var self = element._self;
-      var source = element._source;
-      var owner = element._owner;
+    PureComponent.prototype.isPureReactComponent = true;
+
+    function forEachChildren() {
+      // TODO
+    }
+
+    function mapChildren() {
+      // TODO
+    }
+
+    function countChildren() {
+      // TODO
+    }
+
+    function onlyChild() {
+      // TODO
+    }
+
+    function toArray() {
+      // TODO
+    }
+
+    function createElement(type, config, children) {
+      var propName;
+
+      // Reserved names are extracted
+      var props = {};
+
+      var key = null;
+      var ref = null;
+      var self = null;
+      var source = null;
 
       if (config != null) {
-        if (config.ref !== undefined) {
-          // owner = ReactCurrentOwner.current;
+        if (hasValidRef(config)) {
+          ref = config.ref;
         }
-        if (config.key !== undefined) {
+        if (hasValidKey(config)) {
           key = '' + config.key;
         }
+    
+        self = config.__self === undefined ? null : config.__self;
+        source = config.__source === undefined ? null : config.__source;
+        // Remaining properties are added to a new props object
+        for (propName in config) {
+          if (
+            hasOwnProperty.call(config, propName) &&
+            !RESERVED_PROPS.hasOwnProperty(propName)
+          ) {
+            props[propName] = config[propName];
+          }
+        }
+      }
+
+      // Children can be more than one argument, and those are transferred onto
+      // the newly allocated props object.
+      var childrenLength = arguments.length - 2;
+      if (childrenLength === 1) {
+        props.children = children;
+      } else if (childrenLength > 1) {
+        var childArray = Array(childrenLength);
+        for (var i = 0; i < childrenLength; i++) {
+          childArray[i] = arguments[i + 2];
+        }
+        props.children = childArray;
+      }
+    
+      // Resolve default props
+      if (type && type.defaultProps) {
+        var defaultProps = type.defaultProps;
+        for (propName in defaultProps) {
+          if (props[propName] === undefined) {
+            props[propName] = defaultProps[propName];
+          }
+        }
+      }
+    
+      return ReactElement(
+        type,
+        key,
+        ref,
+        self,
+        source,
+        ReactCurrentOwner.current,
+        props,
+      );
+    }
+
+    function cloneElement(element, config, children) {
+      var propName;
+      
+      // Original props are copied
+      var props = Object.assign({}, element.props);
+    
+      // Reserved names are extracted
+      var key = element.key;
+      var ref = element.ref;
+      // Self is preserved since the owner is preserved.
+      var self = element._self;
+      // Source is preserved since cloneElement is unlikely to be targeted by a
+      // transpiler, and the original source is probably a better indicator of the
+      // true owner.
+      var source = element._source;
+    
+      // Owner will be preserved, unless ref is overridden
+      var owner = element._owner;
+    
+      if (config != null) {
+        if (hasValidRef(config)) {
+          // Silently steal the ref from the parent.
+          ref = config.ref;
+          owner = ReactCurrentOwner.current;
+        }
+        if (hasValidKey(config)) {
+          key = '' + config.key;
+        }
+    
+        // Remaining properties override existing props
         var defaultProps;
         if (element.type && element.type.defaultProps) {
           defaultProps = element.type.defaultProps;
@@ -75,6 +213,9 @@ let reactCode = `
           }
         }
       }
+    
+      // Children can be more than one argument, and those are transferred onto
+      // the newly allocated props object.
       var childrenLength = arguments.length - 2;
       if (childrenLength === 1) {
         props.children = children;
@@ -85,22 +226,49 @@ let reactCode = `
         }
         props.children = childArray;
       }
+    
+      return ReactElement(element.type, key, ref, self, source, owner, props);
+    }
 
-      return {
-        $$typeof: element.$$typeof,
-        type: element.type,
-        key: key,
-        ref: ref,
-        props: props,
-        _owner: owner,
-      };
-    },
+    function isValidElement(object) {
+      return (
+        typeof object === 'object' &&
+        object !== null &&
+        object.$$typeof === REACT_ELEMENT_TYPE
+      );
+    }
+
+    return {
+      Children: {
+        forEach: forEachChildren,
+        map: mapChildren,
+        count: countChildren,
+        only: onlyChild,
+        toArray,
+      },
+      Component,
+      PureComponent,
+      createElement,
+      cloneElement,
+      isValidElement,
+    };
   }
 `;
 let reactAst = parseExpression(reactCode, { plugins: ["flow"] });
 
 export function createMockReact(realm: Realm): ObjectValue {
-  let reactValue = Environment.GetValue(realm, realm.$GlobalEnv.evaluate(reactAst, false));
+  let reactFactory = Environment.GetValue(realm, realm.$GlobalEnv.evaluate(reactAst, false));
+  invariant(reactFactory instanceof ECMAScriptSourceFunctionValue);
+
+  let currentOwner = (realm.react.currentOwner = new ObjectValue(
+    realm,
+    realm.intrinsics.ObjectPrototype,
+    "currentOwner"
+  ));
+  // this is to get around Flow getting confused
+  let factory = reactFactory.$Call;
+  invariant(factory !== undefined);
+  let reactValue = factory(realm.intrinsics.undefined, [getReactElementSymbol(realm), currentOwner]);
   reactValue.intrinsicName = `require("react")`;
   invariant(reactValue instanceof ObjectValue);
 
@@ -115,6 +283,9 @@ export function createMockReact(realm: Realm): ObjectValue {
 
   let reactCloneElementValue = Get(realm, reactValue, "cloneElement");
   reactCloneElementValue.intrinsicName = `require("react").cloneElement`;
+
+  let reactCreateElementValue = Get(realm, reactValue, "createElement");
+  reactCreateElementValue.intrinsicName = `require("react").createElement`;
 
   return reactValue;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -169,6 +169,7 @@ export class Realm {
       enabled: opts.reactEnabled || false,
       flowRequired: true,
       reactElementSymbol: undefined,
+      currentOwner: undefined,
     };
 
     this.errorHandler = opts.errorHandler;
@@ -207,6 +208,7 @@ export class Realm {
     enabled: boolean,
     flowRequired: boolean,
     reactElementSymbol?: SymbolValue,
+    currentOwner?: ObjectValue,
   };
 
   $GlobalObject: ObjectValue | AbstractObjectValue;


### PR DESCRIPTION
Release note: none

This PR adds more of the internal React methods and functions to the `react-mocks`. It also adds the concept of `currentOwner` to the `realm.react` so we can actually process this during the React reconcilation at some point in the future.