### PR TITLE
Make Error object use constructor for creation during lazy mode

### DIFF
--- a/test/serializer/abstract/Error.js
+++ b/test/serializer/abstract/Error.js
@@ -1,4 +1,4 @@
-// skip lazy objects
+// does not contain:setPrototypeOf
 let x = global.__abstract ? __abstract("string", "('abc')") : 'abc';
 let err1 = new Error(x);
 err1.name = x;

--- a/test/serializer/abstract/Throw2.js
+++ b/test/serializer/abstract/Throw2.js
@@ -1,3 +1,4 @@
+// does not contain:setPrototypeOf
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 try {


### PR DESCRIPTION
Release Note: Error object will correctly use constructor for creation during lazy mode.

This change fixes a bug that lazy objects feature did not use constructor for creating Error object. 