### PR TITLE
Fix lazy object identifier inside ConditionalAssignmentBranch

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -133,13 +133,25 @@ function augmentCodeWithLazyObjectSupport(code, lazyRuntimeName) {
         ${LAZY_OBJECTS_RUNTIME_NAME}.hydrateObject(target);
         return Reflect.get(target, prop);
       },
+      set: function(target, property, value, receiver) {
+        ${LAZY_OBJECTS_RUNTIME_NAME}.hydrateObject(target);
+        return Reflect.set(target, property, value, receiver);
+      },
       has: function(target, prop) {
         ${LAZY_OBJECTS_RUNTIME_NAME}.hydrateObject(target);
         return Reflect.has(target, prop);
       },
+      getOwnPropertyDescriptor: function(target, prop) {
+        ${LAZY_OBJECTS_RUNTIME_NAME}.hydrateObject(target);
+        return Reflect.getOwnPropertyDescriptor(target, prop);
+      },
       ownKeys: function(target) {
         ${LAZY_OBJECTS_RUNTIME_NAME}.hydrateObject(target);
         return Reflect.ownKeys(target);
+      },
+      defineProperty: function(target, property, descriptor) {
+        ${LAZY_OBJECTS_RUNTIME_NAME}.hydrateObject(target);
+        return Reflect.defineProperty(target, property, descriptor);
       },
       isExtensible: function(target) {
         ${LAZY_OBJECTS_RUNTIME_NAME}.hydrateObject(target);

--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -62,7 +62,12 @@ export class ResidualFunctionInitializers {
     if (initializer === undefined)
       this.initializers.set(
         id,
-        (initializer = { id, order: infos.length, values: [], body: { type: "DelayInitializations", entries: [] } })
+        (initializer = {
+          id,
+          order: infos.length,
+          values: [],
+          body: { type: "DelayInitializations", parentBody: undefined, entries: [] },
+        })
       );
     initializer.values.push(val);
     return initializer.body;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -367,11 +367,27 @@ export class ResidualHeapSerializer {
       invariant(consequent instanceof AbstractValue);
       let alternate = absVal.args[2];
       invariant(alternate instanceof AbstractValue);
-      let oldBody = this.emitter.beginEmitting("consequent", { type: "ConditionalAssignmentBranch", entries: [] });
+      let oldBody = this.emitter.beginEmitting(
+        "consequent",
+        {
+          type: "ConditionalAssignmentBranch",
+          parentBody: undefined,
+          entries: [],
+        },
+        /*isChild*/ true
+      );
       this._emitPropertiesWithComputedNames(obj, consequent);
       let consequentBody = this.emitter.endEmitting("consequent", oldBody);
       let consequentStatement = t.blockStatement(consequentBody.entries);
-      oldBody = this.emitter.beginEmitting("alternate", { type: "ConditionalAssignmentBranch", entries: [] });
+      oldBody = this.emitter.beginEmitting(
+        "alternate",
+        {
+          type: "ConditionalAssignmentBranch",
+          parentBody: undefined,
+          entries: [],
+        },
+        /*isChild*/ true
+      );
       this._emitPropertiesWithComputedNames(obj, alternate);
       let alternateBody = this.emitter.endEmitting("alternate", oldBody);
       let alternateStatement = t.blockStatement(alternateBody.entries);
@@ -1390,8 +1406,8 @@ export class ResidualHeapSerializer {
   }
 
   _withGeneratorScope(generator: Generator, callback: SerializedBody => void): Array<BabelNodeStatement> {
-    let newBody = { type: "Generator", entries: [] };
-    let oldBody = this.emitter.beginEmitting(generator, newBody);
+    let newBody = { type: "Generator", parentBody: undefined, entries: [] };
+    let oldBody = this.emitter.beginEmitting(generator, newBody, /*isChild*/ true);
     this.activeGeneratorBodies.set(generator, newBody);
     callback(newBody);
     this.activeGeneratorBodies.delete(generator);

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -29,6 +29,7 @@ export type SerializedBodyType =
 
 export type SerializedBody = {
   type: SerializedBodyType,
+  parentBody: void | SerializedBody,
   entries: Array<BabelNodeStatement>,
 };
 


### PR DESCRIPTION
Release Note: Fix lazy object identifier inside ConditionalAssignmentBranch

Fix #1187. The lazy object identifier logic explicitly checks if the serialization body is lazy object initializer; however, it's possible that object is serializing inside a nested ConditionalAssignmentBranch which the logic will fail.
To fix this issue, I added a "parentBody" field to all serializerBody which chains the serialized body as a chain so that we can check the nested children body cases.
Also, add the remaining 3 hook methods in proxy hook which failed because of this bug.

