### PR TITLE
Do not let thrown objects escape from delayed modules

### DIFF
--- a/test/serializer/optimizations/require_throws1.js
+++ b/test/serializer/optimizations/require_throws1.js
@@ -1,0 +1,108 @@
+// delay unsupported requires
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+  try {
+
+    var _moduleObject = { exports: exports };
+
+    factory(global, require, _moduleObject, exports, dependencyMap);
+
+    module.factory = undefined;
+
+    return module.exports = _moduleObject.exports;
+  } catch (e) {
+    module.hasError = true;
+    module.isInitialized = false;
+    module.exports = undefined;
+    throw e;
+  }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+define(function(global, require, module, exports) {
+  throw new Error('Requiring module "0", which threw an exception.');
+}, 0, null);
+
+define(function(global, require, module, exports) {
+  var x = require(0);
+  module.exports = function() { return x.notmagic; }
+}, 1, null);
+
+var f = require(1);
+
+inspect = function() { return f(); }


### PR DESCRIPTION
The logic for delaying modules that fail to prepack did the wrong thing with modules that always throw, by leaking the exception object while backing out the effects of the require call.

To keep things simple all modules that end abruptly are now delayed (when the option is specified) and the exception is discarded.

Eventually, we should just get rid of the delay logic, but for now it seems like useful backup. Feel free, however, to insist that we get rid of it right away.