### PR TITLE
Better preserve the residual function ordering

### DIFF
--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -777,7 +777,7 @@ export class FunctionImplementation {
     F.$FormalParameters = ParameterList;
 
     // 7. Set the [[ECMAScriptCode]] internal slot of F to Body.
-    ((Body: any): FunctionBodyAstNode).uniqueTag = realm.functionBodyUniqueTagSeed++;
+    ((Body: any): FunctionBodyAstNode).uniqueOrderedTag = realm.functionBodyUniqueTagSeed++;
     F.$ECMAScriptCode = Body;
 
     // 8. Set the [[ScriptOrModule]] internal slot of F to GetActiveScriptOrModule().

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -144,7 +144,7 @@ export let ClosureRefReplacer = {
     }
 
     const functionExpression: BabelNodeFunctionExpression = path.node;
-    const functionTag = ((functionExpression.body: any): FunctionBodyAstNode).uniqueTag;
+    const functionTag = ((functionExpression.body: any): FunctionBodyAstNode).uniqueOrderedTag;
     if (!functionTag) {
       // Un-interpreted nested function.
       return;

--- a/src/types.js
+++ b/src/types.js
@@ -124,8 +124,9 @@ export type Descriptor = {
 };
 
 export type FunctionBodyAstNode = {
-  // Function body ast node will have uniqueTag after interpreted.
-  uniqueTag?: number,
+  // Function body ast node will have uniqueOrderedTag after being interpreted.
+  // This tag value is unique and sorted in ast DFS traversal ordering.
+  uniqueOrderedTag?: number,
 };
 
 export type PropertyBinding = {


### PR DESCRIPTION
Release Note: N/A

Original implementation uses ast node source location to preserve the function ordering. This works fine most of the time but will fail if sourcemap is applied to the JS bundle. 
The new implementation leverages AST traversal ordering. Since we already have a uniqueTag for function Ast node, I just reuse it for checking ordering.