### PR TITLE
Implement evaluate requests in debugger

### DIFF
--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -23,6 +23,7 @@ import type {
   Scope,
   VariablesArguments,
   StoppedReason,
+  EvaluateArguments,
 } from "./types.js";
 import type { Realm } from "./../realm.js";
 import { ExecutionContext } from "./../realm.js";
@@ -133,6 +134,10 @@ export class DebugServer {
         this._stepManager.processStepCommand("in", ast);
         this._onDebuggeeResume();
         return true;
+      case DebugMessage.EVALUATE_COMMAND:
+        invariant(args.kind === "evaluate");
+        this.processEvaluateCommand(requestID, args);
+        break;
       default:
         throw new DebuggerError("Invalid command", "Invalid command from adapter: " + command);
     }
@@ -232,6 +237,11 @@ export class DebugServer {
   processVariablesCommand(requestID: number, args: VariablesArguments) {
     let variables = this._variableManager.getVariablesByReference(args.variablesReference);
     this._channel.sendVariablesResponse(requestID, variables);
+  }
+
+  processEvaluateCommand(requestID: number, args: EvaluateArguments) {
+    let evalResult = this._variableManager.evaluate(args.frameId, args.expression);
+    this._channel.sendEvaluateResponse(requestID, evalResult);
   }
 
   // actions that need to happen when Prepack is going to be stopped

--- a/src/debugger/VariableManager.js
+++ b/src/debugger/VariableManager.js
@@ -195,6 +195,7 @@ export class VariableManager {
   evaluate(frameId: void | number, expression: string): EvaluateResult {
     let evalRealm = this._realm;
     let isDirect = false;
+    let isStrict = false;
     if (frameId !== undefined) {
       if (frameId < 0 || frameId >= this._realm.contextStack.length) {
         throw new DebuggerError("Invalid command", "Invalid value for frame ID");
@@ -203,18 +204,13 @@ export class VariableManager {
       let stackIndex = this._realm.contextStack.length - 1 - frameId;
       let context = this._realm.contextStack[stackIndex];
       isDirect = true;
+      isStrict = true;
       evalRealm = context.realm;
     }
 
     let evalString = new StringValue(this._realm, expression);
     try {
-      let value = Functions.PerformEval(
-        this._realm,
-        evalString,
-        evalRealm,
-        /* eval is in strict mode */ true,
-        isDirect
-      );
+      let value = Functions.PerformEval(this._realm, evalString, evalRealm, isStrict, isDirect);
       let varInfo = this._getVariableFromValue(expression, value);
       let result: EvaluateResult = {
         kind: "evaluate",
@@ -226,7 +222,7 @@ export class VariableManager {
     } catch (e) {
       let result: EvaluateResult = {
         kind: "evaluate",
-        displayValue: "Failed to evaluate: " + expression,
+        displayValue: `Failed to evaluate: ${expression}`,
         type: "unknown",
         variablesReference: 0,
       };

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -270,6 +270,25 @@ class PrepackDebugSession extends LoggingDebugSession {
       this.sendResponse(response);
     });
   }
+
+  // Override
+  evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {
+    this._adapterChannel.evaluate(
+      response.request_seq,
+      args.frameId,
+      args.expression,
+      (dbgResponse: DebuggerResponse) => {
+        let evalResult = dbgResponse.result;
+        invariant(evalResult.kind === "evaluate");
+        response.body = {
+          result: evalResult.displayValue,
+          type: evalResult.type,
+          variablesReference: evalResult.variablesReference,
+        };
+        this.sendResponse(response);
+      }
+    );
+  }
 }
 
 DebugSession.run(PrepackDebugSession);

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -159,6 +159,12 @@ export class AdapterChannel {
     this._addRequestCallback(requestID, callback);
   }
 
+  evaluate(requestID: number, frameId: void | number, expression: string, callback: DebuggerResponse => void) {
+    this._queue.enqueue(this._marshaller.marshallEvaluateRequest(requestID, frameId, expression));
+    this.trySendNextRequest();
+    this._addRequestCallback(requestID, callback);
+  }
+
   writeOut(contents: string) {
     this._ioWrapper.writeOutSync(contents);
   }

--- a/src/debugger/channel/DebugChannel.js
+++ b/src/debugger/channel/DebugChannel.js
@@ -12,7 +12,15 @@ import invariant from "./../../invariant.js";
 import { FileIOWrapper } from "./FileIOWrapper.js";
 import { DebugMessage } from "./DebugMessage.js";
 import { MessageMarshaller } from "./MessageMarshaller.js";
-import type { DebuggerRequest, BreakpointsArguments, Stackframe, Scope, Variable, StoppedReason } from "./../types.js";
+import type {
+  DebuggerRequest,
+  BreakpointsArguments,
+  Stackframe,
+  Scope,
+  Variable,
+  StoppedReason,
+  EvaluateResult,
+} from "./../types.js";
 
 //Channel used by the DebugServer in Prepack to communicate with the debug adapter
 export class DebugChannel {
@@ -81,6 +89,10 @@ export class DebugChannel {
 
   sendVariablesResponse(requestID: number, variables: Array<Variable>): void {
     this.writeOut(this._marshaller.marshallVariablesResponse(requestID, variables));
+  }
+
+  sendEvaluateResponse(requestID: number, evalResult: EvaluateResult): void {
+    this.writeOut(this._marshaller.marshallEvaluateResponse(requestID, evalResult));
   }
 
   shutdown() {

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -32,6 +32,8 @@ export class DebugMessage {
   static VARIABLES_COMMAND: string = "Variables-command";
   // Command to step into a function
   static STEPINTO_COMMAND: string = "StepInto-command";
+  // Command to evaluate an expression
+  static EVALUATE_COMMAND: string = "Evaluate-command";
 
   /* Messages from Prepack to adapter with requested information */
   // Respond to the adapter that Prepack is ready
@@ -48,6 +50,8 @@ export class DebugMessage {
   static VARIABLES_RESPONSE: string = "Variables-response";
   // Respond to the adapter with the stepped in location
   static STEPINTO_RESPONSE: string = "StepInto-response";
+  // Respond to the adapter with the evaluation results
+  static EVALUATE_RESPONSE: string = "Evaluate-response";
 
   /* Messages from Prepack to adapter to acknowledge having received the request */
   // Acknowledgement for setting a breakpoint

--- a/src/debugger/channel/MessageMarshaller.js
+++ b/src/debugger/channel/MessageMarshaller.js
@@ -30,6 +30,8 @@ import type {
   StackframeArguments,
   StepIntoArguments,
   StoppedReason,
+  EvaluateArguments,
+  EvaluateResult,
 } from "./../types.js";
 import invariant from "./../../invariant.js";
 import { DebuggerError } from "./../DebuggerError.js";
@@ -95,6 +97,21 @@ export class MessageMarshaller {
     return `${requestID} ${DebugMessage.STEPINTO_COMMAND}`;
   }
 
+  marshallEvaluateRequest(requestID: number, frameId: void | number, expression: string): string {
+    let evalArgs: EvaluateArguments = {
+      kind: "evaluate",
+      expression: expression,
+    };
+    if (frameId !== undefined) {
+      evalArgs.frameId = frameId;
+    }
+    return `${requestID} ${DebugMessage.EVALUATE_COMMAND} ${JSON.stringify(evalArgs)}`;
+  }
+
+  marshallEvaluateResponse(requestID: number, evalResult: EvaluateResult): string {
+    return `${requestID} ${DebugMessage.EVALUATE_RESPONSE} ${JSON.stringify(evalResult)}`;
+  }
+
   unmarshallRequest(message: string): DebuggerRequest {
     let parts = message.split(" ");
     // each request must have a length and a command
@@ -133,6 +150,9 @@ export class MessageMarshaller {
           kind: "stepInto",
         };
         args = stepIntoArgs;
+        break;
+      case DebugMessage.EVALUATE_COMMAND:
+        args = this._unmarshallEvaluateArguments(requestID, parts.slice(2).join(" "));
         break;
       default:
         throw new DebuggerError("Invalid command", "Invalid command from adapter: " + command);
@@ -182,6 +202,14 @@ export class MessageMarshaller {
     return result;
   }
 
+  _unmarshallEvaluateArguments(requestID: number, responseString: string): EvaluateArguments {
+    let evalArgs = JSON.parse(responseString);
+    invariant(evalArgs.hasOwnProperty("kind"), "Evaluate arguments missing kind field");
+    invariant(evalArgs.hasOwnProperty("expression"), "Evaluate arguments missing expression field");
+    if (evalArgs.hasOwnProperty("frameId")) invariant(!isNaN(evalArgs.frameId));
+    return evalArgs;
+  }
+
   unmarshallResponse(message: string): DebuggerResponse {
     try {
       let parts = message.split(" ");
@@ -202,6 +230,8 @@ export class MessageMarshaller {
         dbgResult = this._unmarshallScopesResult(resultString);
       } else if (messageType === DebugMessage.VARIABLES_RESPONSE) {
         dbgResult = this._unmarshallVariablesResult(resultString);
+      } else if (messageType === DebugMessage.EVALUATE_RESPONSE) {
+        dbgResult = this._unmarshallEvaluateResult(resultString);
       } else {
         invariant(false, "Unexpected response type");
       }
@@ -261,6 +291,16 @@ export class MessageMarshaller {
       variables: variables,
     };
     return result;
+  }
+
+  _unmarshallEvaluateResult(resultString: string): EvaluateResult {
+    let evalResult = JSON.parse(resultString);
+    invariant(evalResult.hasOwnProperty("kind"), "eval result missing kind property");
+    invariant(evalResult.kind === "evaluate", "eval result is the wrong kind");
+    invariant(evalResult.hasOwnProperty("displayValue", "eval result missing display value property"));
+    invariant(evalResult.hasOwnProperty("type", "eval result missing type property"));
+    invariant(evalResult.hasOwnProperty("variablesReference", "eval result missing variablesReference property"));
+    return evalResult;
   }
 
   _unmarshallBreakpointsAddResult(resultString: string): BreakpointsAddResult {

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -290,15 +290,22 @@ export class UISession {
         this._sendStepIntoRequest(stepIntoArgs);
         break;
       case "eval":
-        if (parts.length < 3) return false;
+        if (parts.length < 2) return false;
         let evalFrameId = parseInt(parts[1], 10);
-        if (isNaN(evalFrameId)) return false;
-        let expression = parts.slice(2).join(" ");
-        let evaluateArgs: DebugProtocol.EvaluateArguments = {
-          expression: expression,
-          frameId: evalFrameId,
-        };
-        this._sendEvaluateRequest(evaluateArgs);
+        if (isNaN(evalFrameId)) {
+          let expression = parts.slice(1).join(" ");
+          let evaluateArgs: DebugProtocol.EvaluateArguments = {
+            expression: expression,
+          };
+          this._sendEvaluateRequest(evaluateArgs);
+        } else {
+          let expression = parts.slice(2).join(" ");
+          let evaluateArgs: DebugProtocol.EvaluateArguments = {
+            expression: expression,
+            frameId: evalFrameId,
+          };
+          this._sendEvaluateRequest(evaluateArgs);
+        }
         break;
       default:
         // invalid command

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -160,6 +160,8 @@ export class UISession {
       this._processScopesResponse(((response: any): DebugProtocol.ScopesResponse));
     } else if (response.command === "variables") {
       this._processVariablesResponse(((response: any): DebugProtocol.VariablesResponse));
+    } else if (response.command === "evaluate") {
+      this._processEvaluateResponse(((response: any): DebugProtocol.EvaluateResponse));
     }
   }
 
@@ -207,6 +209,13 @@ export class UISession {
         this._uiOutput(`${variable.name}: ${variable.value} ${variable.variablesReference}`);
       }
     }
+  }
+
+  _processEvaluateResponse(response: DebugProtocol.EvaluateResponse) {
+    let evalInfo = response.body;
+    this._uiOutput("Type: " + (evalInfo.type || "unknown"));
+    this._uiOutput(evalInfo.result);
+    this._uiOutput("Variables Reference: " + evalInfo.variablesReference);
   }
 
   // execute a command if it is valid
@@ -279,6 +288,17 @@ export class UISession {
           threadId: DebuggerConstants.PREPACK_THREAD_ID,
         };
         this._sendStepIntoRequest(stepIntoArgs);
+        break;
+      case "eval":
+        if (parts.length < 3) return false;
+        let evalFrameId = parseInt(parts[1], 10);
+        if (isNaN(evalFrameId)) return false;
+        let expression = parts.slice(2).join(" ");
+        let evaluateArgs: DebugProtocol.EvaluateArguments = {
+          expression: expression,
+          frameId: evalFrameId,
+        };
+        this._sendEvaluateRequest(evaluateArgs);
         break;
       default:
         // invalid command
@@ -429,6 +449,17 @@ export class UISession {
       type: "request",
       seq: this._sequenceNum,
       command: "stepIn",
+      arguments: args,
+    };
+    let json = JSON.stringify(message);
+    this._packageAndSend(json);
+  }
+
+  _sendEvaluateRequest(args: DebugProtocol.EvaluateArguments) {
+    let message = {
+      type: "request",
+      seq: this._sequenceNum,
+      command: "evaluate",
       arguments: args,
     };
     let json = JSON.stringify(message);

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -25,7 +25,8 @@ export type DebuggerRequestArguments =
   | StackframeArguments
   | ScopesArguments
   | VariablesArguments
-  | StepIntoArguments;
+  | StepIntoArguments
+  | EvaluateArguments;
 
 export type PrepackLaunchArguments = {
   kind: "launch",
@@ -79,6 +80,12 @@ export type StepIntoArguments = {
   kind: "stepInto",
 };
 
+export type EvaluateArguments = {
+  kind: "evaluate",
+  frameId?: number,
+  expression: string,
+};
+
 export type DebuggerResponse = {
   id: number,
   result: DebuggerResponseResult,
@@ -90,7 +97,8 @@ export type DebuggerResponseResult =
   | BreakpointsAddResult
   | StoppedResult
   | ScopesResult
-  | VariablesResult;
+  | VariablesResult
+  | EvaluateResult;
 
 export type ReadyResult = {
   kind: "ready",
@@ -133,6 +141,13 @@ export type Variable = {
 export type VariablesResult = {
   kind: "variables",
   variables: Array<Variable>,
+};
+
+export type EvaluateResult = {
+  kind: "evaluate",
+  displayValue: string,
+  type: string,
+  variablesReference: number,
 };
 
 // any object that can contain a collection of variables


### PR DESCRIPTION
Release note: none
Summary:
-modify performing evaluate in the debug engine to account for failure to evaluate
-add channel requests and responses to send and receive evaluate
-add evaluate command to CLI

Test Plan:
```
function a(num) {
  if (num === 3) {
    var y = 5;
  } else {
    {
      let abc = 3;
    }

    let z = [1,2,3];
    let e = Symbol("xyz");
    let f = {
      g: 0,
      h: 1,
      i: {
        j: 2,
        k: 3,
      },
    };
    let x = 6;
  }
}

function b(num) {
  a(5);
  a(5);
}
```

Set breakpoints on various lines in the above code and set watch expressions. Saw the correct result for both successful and unsuccessful evaluates.