### PR TITLE
Implement step over in debugger

### DIFF
--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -85,7 +85,7 @@ export class DebugServer {
   }
 
   checkStepComplete(ast: BabelNode) {
-    let steppingType = this._stepManager.isStepComplete(ast);
+    let steppingType = this._stepManager.getStepperType(ast);
     if (steppingType) {
       this.waitForRun(ast, steppingType);
     }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -139,6 +139,11 @@ export class DebugServer {
         this._stepManager.processStepCommand("in", ast);
         this._onDebuggeeResume();
         return true;
+      case DebugMessage.STEPOVER_COMMAND:
+        invariant(ast !== undefined);
+        this._stepManager.processStepCommand("over", ast);
+        this._onDebuggeeResume();
+        return true;
       case DebugMessage.EVALUATE_COMMAND:
         invariant(args.kind === "evaluate");
         this.processEvaluateCommand(requestID, args);

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -44,7 +44,7 @@ export class DebugServer {
     this._realm = realm;
     this._breakpointManager = new BreakpointManager(this._channel);
     this._variableManager = new VariableManager(realm);
-    this._stepManager = new SteppingManager(this._channel);
+    this._stepManager = new SteppingManager(this._channel, this._realm, /* default discard old steppers */ false);
     this.waitForRun(undefined, "Entry");
   }
   // the collection of breakpoints
@@ -85,8 +85,9 @@ export class DebugServer {
   }
 
   checkStepComplete(ast: BabelNode) {
-    if (this._stepManager.isStepComplete(ast)) {
-      this.waitForRun(ast, "Step Into");
+    let steppingType = this._stepManager.isStepComplete(ast);
+    if (steppingType) {
+      this.waitForRun(ast, steppingType);
     }
   }
 

--- a/src/debugger/Stepper.js
+++ b/src/debugger/Stepper.js
@@ -27,7 +27,7 @@ export class Stepper {
     invariant(false, "Abstract method, please override");
   }
 
-  isValidStopLocation(ast: BabelNode) {
+  isAstLocationChanged(ast: BabelNode) {
     // we should only step to statements
     if (!IsStatement(ast)) return false;
     let loc = ast.loc;
@@ -58,7 +58,7 @@ export class StepIntoStepper extends Stepper {
 
   // Override
   isComplete(ast: BabelNode, currentStackSize: number): boolean {
-    return this.isValidStopLocation(ast);
+    return this.isAstLocationChanged(ast);
   }
 }
 
@@ -70,7 +70,7 @@ export class StepOverStepper extends Stepper {
   _startStackSize: number;
 
   isComplete(ast: BabelNode, currentStackSize: number): boolean {
-    if (!this.isValidStopLocation(ast)) return false;
+    if (!this.isAstLocationChanged(ast)) return false;
     if (currentStackSize <= this._startStackSize) {
       // two cases here:
       // if current stack length < starting stack length, the program must have

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -11,20 +11,29 @@
 
 import { BabelNode } from "babel-types";
 import type { DebugChannel } from "./channel/DebugChannel.js";
-import type { StoppedReason } from "./types.js";
+import type { StoppedReason, SteppingType } from "./types.js";
 import invariant from "./../invariant.js";
-import { StepIntoStepper } from "./Stepper.js";
+import { Stepper, StepIntoStepper, StepOverStepper } from "./Stepper.js";
+import type { Realm } from "./../realm.js";
 
 export class SteppingManager {
-  constructor(channel: DebugChannel) {
+  constructor(channel: DebugChannel, realm: Realm, keepOldSteppers?: boolean) {
     this._channel = channel;
+    this._realm = realm;
+    this._steppers = [];
+    this._keepOldSteppers = false;
+    if (keepOldSteppers) this._keepOldSteppers = true;
   }
   _channel: DebugChannel;
-  _stepInto: void | StepIntoStepper;
+  _realm: Realm;
+  _keepOldSteppers: boolean;
+  _steppers: Array<Stepper>;
 
   processStepCommand(kind: "in" | "over" | "out", currentNode: BabelNode) {
     if (kind === "in") {
       this._processStepIn(currentNode);
+    } else if (kind === "over") {
+      this._processStepOver(currentNode);
     }
     // TODO: implement stepOver and stepOut
   }
@@ -32,29 +41,52 @@ export class SteppingManager {
   _processStepIn(ast: BabelNode) {
     invariant(this._stepInto === undefined);
     invariant(ast.loc && ast.loc.source);
-    this._stepInto = new StepIntoStepper(ast.loc.source, ast.loc.start.line, ast.loc.start.column);
+    if (!this._keepOldSteppers) {
+      this._steppers = [];
+    }
+    this._steppers.push(new StepIntoStepper(ast.loc.source, ast.loc.start.line, ast.loc.start.column));
   }
 
-  isStepComplete(ast: BabelNode): boolean {
-    if (ast.loc && ast.loc.source) {
-      if (this._stepInto && this._stepInto.isComplete(ast)) {
-        this._stepInto = undefined;
-        this._channel.sendStoppedResponse("Step Into", ast.loc.source, ast.loc.start.line, ast.loc.start.column);
-        return true;
+  _processStepOver(ast: BabelNode) {
+    invariant(ast.loc && ast.loc.source);
+    if (!this._keepOldSteppers) {
+      this._steppers = [];
+    }
+    this._steppers.push(
+      new StepOverStepper(ast.loc.source, ast.loc.start.line, ast.loc.start.column, this._realm.contextStack.length)
+    );
+  }
+
+  isStepComplete(ast: BabelNode): void | SteppingType {
+    let completedStepperType = this._anyStepperComplete(ast);
+    if (completedStepperType) {
+      invariant(ast.loc && ast.loc.source);
+      this._channel.sendStoppedResponse(completedStepperType, ast.loc.source, ast.loc.start.line, ast.loc.start.column);
+      return completedStepperType;
+    }
+    return undefined;
+  }
+
+  _anyStepperComplete(ast: BabelNode): void | SteppingType {
+    let i = 0;
+    let completedStepperType;
+    while (i < this._steppers.length) {
+      let stepper = this._steppers[i];
+      if (stepper.isComplete(ast, this._realm)) {
+        if (stepper instanceof StepIntoStepper) completedStepperType = "Step Into";
+        if (stepper instanceof StepOverStepper) completedStepperType = "Step Over";
+        this._steppers.splice(i, 1);
+      } else {
+        i++;
       }
     }
-    return false;
+    return completedStepperType;
   }
 
   onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
-    if (reason !== "Step Into") {
-      // stopped for another reason, e.g. breakpoint
-      if (this._stepInto !== undefined) {
-        // we're in the middle of a step into, but debuggee has stopped for another reason here first, so cancel this step into
-        this._stepInto = undefined;
-      }
+    if (reason === "Breakpoint") {
+      // stopped for breakpoint, clear any steppers that would complete here too
+      this._anyStepperComplete(ast);
     }
-
-    //TODO: handle other stepping related stopped reasons when they are implemented
   }
 }

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -85,8 +85,14 @@ export class SteppingManager {
 
   onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
     if (reason === "Breakpoint") {
-      // stopped for breakpoint, clear any steppers that would complete here too
-      this._anyStepperComplete(ast);
+      // stopped for breakpoint
+      if (this._keepOldSteppers) {
+        // remove only steppers that would complete
+        this._anyStepperComplete(ast);
+      } else {
+        // remove all steppers
+        this._steppers = [];
+      }
     }
   }
 }

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -58,7 +58,7 @@ export class SteppingManager {
   }
 
   isStepComplete(ast: BabelNode): void | SteppingType {
-    let completedStepperType = this._anyStepperComplete(ast);
+    let completedStepperType = this._checkCompleteSteppers(ast);
     if (completedStepperType) {
       invariant(ast.loc && ast.loc.source);
       this._channel.sendStoppedResponse(completedStepperType, ast.loc.source, ast.loc.start.line, ast.loc.start.column);
@@ -67,12 +67,12 @@ export class SteppingManager {
     return undefined;
   }
 
-  _anyStepperComplete(ast: BabelNode): void | SteppingType {
+  _checkCompleteSteppers(ast: BabelNode): void | SteppingType {
     let i = 0;
     let completedStepperType;
     while (i < this._steppers.length) {
       let stepper = this._steppers[i];
-      if (stepper.isComplete(ast, this._realm)) {
+      if (stepper.isComplete(ast, this._realm.contextStack.length)) {
         if (stepper instanceof StepIntoStepper) completedStepperType = "Step Into";
         if (stepper instanceof StepOverStepper) completedStepperType = "Step Over";
         this._steppers.splice(i, 1);
@@ -88,7 +88,7 @@ export class SteppingManager {
       // stopped for breakpoint
       if (this._keepOldSteppers) {
         // remove only steppers that would complete
-        this._anyStepperComplete(ast);
+        this._checkCompleteSteppers(ast);
       } else {
         // remove all steppers
         this._steppers = [];

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -57,7 +57,7 @@ export class SteppingManager {
     );
   }
 
-  isStepComplete(ast: BabelNode): void | SteppingType {
+  getStepperType(ast: BabelNode): void | SteppingType {
     let completedStepperType = this._checkCompleteSteppers(ast);
     if (completedStepperType) {
       invariant(ast.loc && ast.loc.source);

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -272,6 +272,13 @@ class PrepackDebugSession extends LoggingDebugSession {
   }
 
   // Override
+  nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments): void {
+    this._adapterChannel.stepOver(response.request_seq, (dbgResponse: DebuggerResponse) => {
+      this.sendResponse(response);
+    });
+  }
+
+  // Override
   evaluateRequest(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments): void {
     this._adapterChannel.evaluate(
       response.request_seq,

--- a/src/debugger/channel/AdapterChannel.js
+++ b/src/debugger/channel/AdapterChannel.js
@@ -159,6 +159,12 @@ export class AdapterChannel {
     this._addRequestCallback(requestID, callback);
   }
 
+  stepOver(requestID: number, callback: DebuggerResponse => void) {
+    this._queue.enqueue(this._marshaller.marshallStepOverRequest(requestID));
+    this.trySendNextRequest();
+    this._addRequestCallback(requestID, callback);
+  }
+
   evaluate(requestID: number, frameId: void | number, expression: string, callback: DebuggerResponse => void) {
     this._queue.enqueue(this._marshaller.marshallEvaluateRequest(requestID, frameId, expression));
     this.trySendNextRequest();

--- a/src/debugger/channel/DebugMessage.js
+++ b/src/debugger/channel/DebugMessage.js
@@ -32,6 +32,8 @@ export class DebugMessage {
   static VARIABLES_COMMAND: string = "Variables-command";
   // Command to step into a function
   static STEPINTO_COMMAND: string = "StepInto-command";
+  // Command to step over a function
+  static STEPOVER_COMMAND: string = "StepOver-command";
   // Command to evaluate an expression
   static EVALUATE_COMMAND: string = "Evaluate-command";
 

--- a/src/debugger/channel/MessageMarshaller.js
+++ b/src/debugger/channel/MessageMarshaller.js
@@ -29,6 +29,7 @@ import type {
   RunArguments,
   StackframeArguments,
   StepIntoArguments,
+  StepOverArguments,
   StoppedReason,
   EvaluateArguments,
   EvaluateResult,
@@ -97,6 +98,10 @@ export class MessageMarshaller {
     return `${requestID} ${DebugMessage.STEPINTO_COMMAND}`;
   }
 
+  marshallStepOverRequest(requestID: number): string {
+    return `${requestID} ${DebugMessage.STEPOVER_COMMAND}`;
+  }
+
   marshallEvaluateRequest(requestID: number, frameId: void | number, expression: string): string {
     let evalArgs: EvaluateArguments = {
       kind: "evaluate",
@@ -150,6 +155,13 @@ export class MessageMarshaller {
           kind: "stepInto",
         };
         args = stepIntoArgs;
+        break;
+      case DebugMessage.STEPOVER_COMMAND:
+        this._lastRunRequestID = requestID;
+        let stepOverArgs: StepOverArguments = {
+          kind: "stepOver",
+        };
+        args = stepOverArgs;
         break;
       case DebugMessage.EVALUATE_COMMAND:
         args = this._unmarshallEvaluateArguments(requestID, parts.slice(2).join(" "));

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -289,6 +289,13 @@ export class UISession {
         };
         this._sendStepIntoRequest(stepIntoArgs);
         break;
+      case "stepOver":
+        if (parts.length !== 1) return false;
+        let stepOverArgs: DebugProtocol.NextArguments = {
+          threadId: DebuggerConstants.PREPACK_THREAD_ID,
+        };
+        this._sendStepOverRequest(stepOverArgs);
+        break;
       case "eval":
         if (parts.length < 2) return false;
         let evalFrameId = parseInt(parts[1], 10);
@@ -456,6 +463,17 @@ export class UISession {
       type: "request",
       seq: this._sequenceNum,
       command: "stepIn",
+      arguments: args,
+    };
+    let json = JSON.stringify(message);
+    this._packageAndSend(json);
+  }
+
+  _sendStepOverRequest(args: DebugProtocol.NextArguments) {
+    let message = {
+      type: "request",
+      seq: this._sequenceNum,
+      command: "next",
       arguments: args,
     };
     let json = JSON.stringify(message);

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -161,7 +161,8 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   debugOutFilePath: string,
 }
 
-export type StoppedReason = "Entry" | "Breakpoint" | "Step Into";
+export type SteppingType = "Step Into" | "Step Over";
+export type StoppedReason = "Entry" | "Breakpoint" | SteppingType;
 
 export type SourceData = {
   filePath: string,

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -26,6 +26,7 @@ export type DebuggerRequestArguments =
   | ScopesArguments
   | VariablesArguments
   | StepIntoArguments
+  | StepOverArguments
   | EvaluateArguments;
 
 export type PrepackLaunchArguments = {
@@ -78,6 +79,10 @@ export type VariablesArguments = {
 
 export type StepIntoArguments = {
   kind: "stepInto",
+};
+
+export type StepOverArguments = {
+  kind: "stepOver",
 };
 
 export type EvaluateArguments = {


### PR DESCRIPTION
Release note: none
Summary:
-refactor step manager to account for other types of steppers
-add step over class
-setup pipeline to make stepover requests

Test Plan:
```
function a(num) {
  if (num === 3) {
    var y = 5;
  } else {
    {
      let abc = 3;
    }

    let z = [1,2,3];
    let e = Symbol("xyz");
    let f = {
      g: 0,
      h: 1,
      i: {
        j: 2,
        k: 3,
      },
    };
    let x = 6;
  }
}

function b(num) {
  a(5);
  a(5);
}

function c() {
  b(3);
  b(4);
}
```
Breakpoints on lines 8, 26, 27, 31, 32
Testing stepover on function calls, stepover on other statements (behaviour same as step into), different sequences of continue, step into, and step over commands
Tested in both CLI and IDE.