### PR TITLE
Fix breakpoint skipping same line bug

### DIFF
--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -11,7 +11,7 @@
 
 import { PerFileBreakpointMap } from "./PerFileBreakpointMap.js";
 import { Breakpoint } from "./Breakpoint.js";
-import type { Breakpoint as BreakpointType, StoppedData, StoppedReason } from "./types.js";
+import type { Breakpoint as BreakpointType, SourceData, StoppedReason } from "./types.js";
 import { BabelNode } from "babel-types";
 import { IsStatement } from "./../methods/is.js";
 import type { DebugChannel } from "./channel/DebugChannel.js";
@@ -23,9 +23,10 @@ export class BreakpointManager {
     this._breakpointMaps = new Map();
   }
   _breakpointMaps: Map<string, PerFileBreakpointMap>;
-  _previousStop: StoppedData;
+  _previousStop: SourceData;
   _channel: DebugChannel;
-  _lastExecuted: StoppedData;
+  // the location of the statement that was last executed
+  _lastExecuted: SourceData;
 
   onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
     if (ast.loc && ast.loc.source !== null) {
@@ -37,7 +38,7 @@ export class BreakpointManager {
     }
   }
 
-  isValidBreakpoint(ast: BabelNode): boolean {
+  shouldStopOnBreakpoint(ast: BabelNode): boolean {
     if (!IsStatement(ast)) return false;
     if (ast.loc && ast.loc.source) {
       let location = ast.loc;

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -23,14 +23,13 @@ export class BreakpointManager {
     this._breakpointMaps = new Map();
   }
   _breakpointMaps: Map<string, PerFileBreakpointMap>;
-  _previousStop: SourceData;
   _channel: DebugChannel;
   // the location of the statement that was last executed
   _lastExecuted: SourceData;
 
   onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
     if (ast.loc && ast.loc.source !== null) {
-      this._previousStop = {
+      this._lastExecuted = {
         filePath: ast.loc.source,
         line: ast.loc.start.line,
         column: ast.loc.start.column,
@@ -71,7 +70,7 @@ export class BreakpointManager {
         // Note: for the case when the debugger is supposed to stop on the same
         // breakpoint consecutively (e.g. the statement is in a loop), some other
         // ast node (e.g. block, loop) must have been checked in between so
-        // previousExecutedFile and previousExecutedLine will have changed
+        // lastExecuted will have changed
         if (breakpoint.column !== 0) {
           // this is a column breakpoint
           if (

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -75,7 +75,7 @@ export class DebugServer {
   }
 
   checkForBreakpoint(ast: BabelNode) {
-    if (this._breakpointManager.isValidBreakpoint(ast)) {
+    if (this._breakpointManager.shouldStopOnBreakpoint(ast)) {
       this.waitForRun(ast, "Breakpoint");
     }
   }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -24,6 +24,7 @@ import type {
   VariablesArguments,
   StoppedReason,
   EvaluateArguments,
+  SourceData,
 } from "./types.js";
 import type { Realm } from "./../realm.js";
 import { ExecutionContext } from "./../realm.js";
@@ -53,6 +54,7 @@ export class DebugServer {
   _realm: Realm;
   _variableManager: VariableManager;
   _stepManager: SteppingManager;
+  _lastExecuted: SourceData;
 
   /* Block until adapter says to run
   /* ast: the current ast node we are stopped on
@@ -70,8 +72,10 @@ export class DebugServer {
 
   // Checking if the debugger needs to take any action on reaching this ast node
   checkForActions(ast: BabelNode) {
-    this.checkForBreakpoint(ast);
-    this.checkStepComplete(ast);
+    if (this._checkAndUpdateLastExecuted(ast)) {
+      this.checkForBreakpoint(ast);
+      this.checkStepComplete(ast);
+    }
   }
 
   checkForBreakpoint(ast: BabelNode) {
@@ -247,7 +251,6 @@ export class DebugServer {
   // actions that need to happen when Prepack is going to be stopped
   _onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
     if (reason === "Entry") return;
-    this._breakpointManager.onDebuggeeStop(ast, reason);
     this._stepManager.onDebuggeeStop(ast, reason);
   }
 
@@ -255,6 +258,29 @@ export class DebugServer {
   _onDebuggeeResume() {
     // resets the variable manager
     this._variableManager.clean();
+  }
+
+  _checkAndUpdateLastExecuted(ast: BabelNode): boolean {
+    if (ast.loc && ast.loc.source) {
+      let filePath = ast.loc.source;
+      let line = ast.loc.start.line;
+      let column = ast.loc.start.column;
+      if (
+        this._lastExecuted &&
+        filePath === this._lastExecuted.filePath &&
+        line === this._lastExecuted.line &&
+        column === this._lastExecuted.column
+      ) {
+        return false;
+      }
+      this._lastExecuted = {
+        filePath: filePath,
+        line: line,
+        column: column,
+      };
+      return true;
+    }
+    return false;
   }
 
   shutdown() {

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -265,6 +265,7 @@ export class DebugServer {
       let filePath = ast.loc.source;
       let line = ast.loc.start.line;
       let column = ast.loc.start.column;
+      // check if the current location is same as the last one
       if (
         this._lastExecuted &&
         filePath === this._lastExecuted.filePath &&

--- a/src/debugger/Stepper.js
+++ b/src/debugger/Stepper.js
@@ -8,7 +8,7 @@
  */
 
 /* @flow */
-import type { StoppedData } from "./types.js";
+import type { SourceData } from "./types.js";
 import { IsStatement } from "./../methods/is.js";
 import { BabelNode } from "babel-types";
 import invariant from "./../invariant.js";
@@ -21,7 +21,7 @@ export class Stepper {
       column: column,
     };
   }
-  _stepStartData: StoppedData;
+  _stepStartData: SourceData;
 
   isComplete(ast: BabelNode): boolean {
     invariant(false, "Abstract method, please override");

--- a/src/debugger/types.js
+++ b/src/debugger/types.js
@@ -163,7 +163,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 
 export type StoppedReason = "Entry" | "Breakpoint" | "Step Into";
 
-export type StoppedData = {
+export type SourceData = {
   filePath: string,
   line: number,
   column: number,


### PR DESCRIPTION
Release note: none
Summary:
Previously when checking for a breakpoint, there is a check to not stop on the same statement as the previous stop in the debugger. This does not allow cases where the debugger should stop on the same statement (e.g. in a loop, or multiple executions of the same function with a breakpoint in it). This PR changes the comparison to the last executed statement instead of the last stopped statement.

Test Plan:
```
function b(num) {
  a(5);
  a(5);
}
```
Set a single breakpoint inside `a` and observe that it is stopped on twice.