### PR TITLE
When conditionally returning,  add condition to non returning path

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -106,7 +106,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     consequentEffects: Effects,
     alternate: Completion | Value,
     alternateEffects: Effects,
-    pathCondtions: Array<AbstractValue>,
+    pathConditions: Array<AbstractValue>,
     savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
@@ -138,7 +138,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     this.alternate = alternate;
     this.alternateEffects = alternateEffects;
     this.savedEffects = savedEffects;
-    this.pathCondtions = pathCondtions;
+    this.pathConditions = pathConditions;
     this.savedPathConditions = savedPathConditions;
   }
 
@@ -148,7 +148,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   alternate: Completion | Value;
   alternateEffects: Effects;
   savedEffects: void | Effects;
-  pathCondtions: Array<AbstractValue>;
+  pathConditions: Array<AbstractValue>;
   savedPathConditions: Array<AbstractValue>;
 
   containsBreakOrContinue(): boolean {

--- a/src/completions.js
+++ b/src/completions.js
@@ -106,7 +106,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     consequentEffects: Effects,
     alternate: Completion | Value,
     alternateEffects: Effects,
-    pathCondtion: Array<AbstractValue>,
+    pathCondtions: Array<AbstractValue>,
     savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
@@ -138,7 +138,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     this.alternate = alternate;
     this.alternateEffects = alternateEffects;
     this.savedEffects = savedEffects;
-    this.pathCondtion = pathCondtion;
+    this.pathCondtions = pathCondtions;
     this.savedPathConditions = savedPathConditions;
   }
 
@@ -148,7 +148,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   alternate: Completion | Value;
   alternateEffects: Effects;
   savedEffects: void | Effects;
-  pathCondtion: Array<AbstractValue>;
+  pathCondtions: Array<AbstractValue>;
   savedPathConditions: Array<AbstractValue>;
 
   containsBreakOrContinue(): boolean {

--- a/src/completions.js
+++ b/src/completions.js
@@ -106,7 +106,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     consequentEffects: Effects,
     alternate: Completion | Value,
     alternateEffects: Effects,
-    path: Array<AbstractValue>,
+    pathCondtion: Array<AbstractValue>,
     savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
@@ -138,7 +138,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     this.alternate = alternate;
     this.alternateEffects = alternateEffects;
     this.savedEffects = savedEffects;
-    this.path = path;
+    this.pathCondtion = pathCondtion;
     this.savedPathConditions = savedPathConditions;
   }
 
@@ -148,7 +148,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   alternate: Completion | Value;
   alternateEffects: Effects;
   savedEffects: void | Effects;
-  path: Array<AbstractValue>;
+  pathCondtion: Array<AbstractValue>;
   savedPathConditions: Array<AbstractValue>;
 
   containsBreakOrContinue(): boolean {

--- a/src/completions.js
+++ b/src/completions.js
@@ -106,6 +106,8 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     consequentEffects: Effects,
     alternate: Completion | Value,
     alternateEffects: Effects,
+    path: Array<AbstractValue>,
+    savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
     invariant(
@@ -136,6 +138,8 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     this.alternate = alternate;
     this.alternateEffects = alternateEffects;
     this.savedEffects = savedEffects;
+    this.path = path;
+    this.savedPathConditions = savedPathConditions;
   }
 
   joinCondition: AbstractValue;
@@ -144,6 +148,8 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   alternate: Completion | Value;
   alternateEffects: Effects;
   savedEffects: void | Effects;
+  path: Array<AbstractValue>;
+  savedPathConditions: Array<AbstractValue>;
 
   containsBreakOrContinue(): boolean {
     if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -113,6 +113,7 @@ export function evaluateWithAbstractConditional(
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.
   realm.applyEffects(joinedEffects);
+
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof Value);

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -113,7 +113,6 @@ export function evaluateWithAbstractConditional(
   // Note that the effects of (non joining) abrupt branches are not included
   // in joinedEffects, but are tracked separately inside completion.
   realm.applyEffects(joinedEffects);
-
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof Value);

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1118,10 +1118,10 @@ export class FunctionImplementation {
   // Call this only when a join point has been reached.
   incorporateSavedCompletion(realm: Realm, c: void | AbruptCompletion | Value): void | Completion | Value {
     let savedCompletion = realm.savedCompletion;
-    if (savedCompletion && savedCompletion.savedPathConditions) {
-      realm.pathConditions = savedCompletion.savedPathConditions;
-    }
     if (savedCompletion !== undefined) {
+      if (savedCompletion.savedPathConditions) {
+        realm.pathConditions = savedCompletion.savedPathConditions;
+      }
       realm.savedCompletion = undefined;
       if (c === undefined) return savedCompletion;
       if (c instanceof Value) {

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1118,6 +1118,9 @@ export class FunctionImplementation {
   // Call this only when a join point has been reached.
   incorporateSavedCompletion(realm: Realm, c: void | AbruptCompletion | Value): void | Completion | Value {
     let savedCompletion = realm.savedCompletion;
+    if (savedCompletion && savedCompletion.savedPathConditions) {
+      realm.pathConditions = savedCompletion.savedPathConditions;
+    }
     if (savedCompletion !== undefined) {
       realm.savedCompletion = undefined;
       if (c === undefined) return savedCompletion;

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -458,7 +458,7 @@ export class JoinImplementation {
     let empty_effects = construct_empty_effects(realm);
     let v = realm.intrinsics.empty;
     if (c.consequent instanceof ReturnCompletion) {
-      let negation = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition)
+      let negation = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition);
       invariant(negation instanceof AbstractValue);
       let pathCondition = [negation];
       let pnc = new PossiblyNormalCompletion(

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -458,7 +458,7 @@ export class JoinImplementation {
     let empty_effects = construct_empty_effects(realm);
     let v = realm.intrinsics.empty;
     if (c.consequent instanceof ReturnCompletion) {
-      let pathCondtion = [(AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition): any)];
+      let pathCondition = [(AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition): any)];
       let pnc = new PossiblyNormalCompletion(
         v,
         c.joinCondition,
@@ -466,7 +466,7 @@ export class JoinImplementation {
         empty_effects,
         c.alternate,
         c.alternateEffects,
-        pathCondtion,
+        pathCondition,
         []
       );
       return [c.consequentEffects, pnc];

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -152,9 +152,8 @@ export class JoinImplementation {
     c: PossiblyNormalCompletion
   ): PossiblyNormalCompletion {
     //merge the two pathConditions
-    let mergedPath = [];
-    mergedPath = mergedPath.concat(pnc.pathCondtion);
-    mergedPath = mergedPath.concat(c.pathCondtion);
+    let composedPath = [];
+    composedPath = pnc.pathCondtions.concat(c.pathCondtions);
     let savedPathConditions = pnc.savedPathConditions;
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
@@ -167,7 +166,7 @@ export class JoinImplementation {
           pnc.consequentEffects,
           c,
           newAlternateEffects,
-          mergedPath,
+          composedPath,
           savedPathConditions,
           pnc.savedEffects
         );
@@ -183,7 +182,7 @@ export class JoinImplementation {
         pnc.consequentEffects,
         new_alternate,
         newAlternateEffects,
-        mergedPath,
+        composedPath,
         savedPathConditions,
         pnc.savedEffects
       );
@@ -199,7 +198,7 @@ export class JoinImplementation {
           newConsequentEffects,
           pnc.alternate,
           pnc.alternateEffects,
-          mergedPath,
+          composedPath,
           savedPathConditions,
           pnc.savedEffects
         );
@@ -215,7 +214,7 @@ export class JoinImplementation {
         newConsequentEffects,
         pnc.alternate,
         pnc.alternateEffects,
-        mergedPath,
+        composedPath,
         savedPathConditions,
         pnc.savedEffects
       );
@@ -459,8 +458,13 @@ export class JoinImplementation {
     let v = realm.intrinsics.empty;
     if (c.consequent instanceof ReturnCompletion) {
       let negation = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition);
+      // Simply negating the (known to be abstract) join condition should
+      // not become a concrete value
       invariant(negation instanceof AbstractValue);
-      let pathCondition = [negation];
+      let pathConditions = [negation];
+      if (c.alternate instanceof PossiblyNormalCompletion) {
+        pathConditions = pathConditions.concat(c.alternate.pathCondtions);
+      }
       let pnc = new PossiblyNormalCompletion(
         v,
         c.joinCondition,
@@ -468,7 +472,7 @@ export class JoinImplementation {
         empty_effects,
         c.alternate,
         c.alternateEffects,
-        pathCondition,
+        pathConditions,
         []
       );
       return [c.consequentEffects, pnc];
@@ -606,7 +610,7 @@ export class JoinImplementation {
       if (result2 instanceof PossiblyNormalCompletion) {
         value = result2.value;
         savedEffects = result2.savedEffects;
-        pathConditions = [joinCondition].concat(result2.pathCondtion);
+        pathConditions = [joinCondition].concat(result2.pathCondtions);
         savedPathConditions = result2.savedPathConditions;
       } else {
         pathConditions = [joinCondition];
@@ -632,7 +636,7 @@ export class JoinImplementation {
       if (result1 instanceof PossiblyNormalCompletion) {
         value = result1.value;
         savedEffects = result1.savedEffects;
-        pathConditions = [joinCondition].concat(result1.pathCondtion);
+        pathConditions = [joinCondition].concat(result1.pathCondtions);
         savedPathConditions = result1.savedPathConditions;
       } else {
         pathConditions = [joinCondition];

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -458,7 +458,7 @@ export class JoinImplementation {
     let empty_effects = construct_empty_effects(realm);
     let v = realm.intrinsics.empty;
     if (c.consequent instanceof ReturnCompletion) {
-      let pathCondtion = [AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition)];
+      let pathCondtion = [(AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition): any)];
       let pnc = new PossiblyNormalCompletion(
         v,
         c.joinCondition,

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -458,7 +458,9 @@ export class JoinImplementation {
     let empty_effects = construct_empty_effects(realm);
     let v = realm.intrinsics.empty;
     if (c.consequent instanceof ReturnCompletion) {
-      let pathCondition = [(AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition): any)];
+      let negation = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition)
+      invariant(negation instanceof AbstractValue);
+      let pathCondition = [negation];
       let pnc = new PossiblyNormalCompletion(
         v,
         c.joinCondition,

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -153,7 +153,7 @@ export class JoinImplementation {
   ): PossiblyNormalCompletion {
     //merge the two pathConditions
     let composedPath = [];
-    composedPath = pnc.pathCondtions.concat(c.pathCondtions);
+    composedPath = pnc.pathConditions.concat(c.pathConditions);
     let savedPathConditions = pnc.savedPathConditions;
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
@@ -462,9 +462,6 @@ export class JoinImplementation {
       // not become a concrete value
       invariant(negation instanceof AbstractValue);
       let pathConditions = [negation];
-      if (c.alternate instanceof PossiblyNormalCompletion) {
-        pathConditions = pathConditions.concat(c.alternate.pathCondtions);
-      }
       let pnc = new PossiblyNormalCompletion(
         v,
         c.joinCondition,
@@ -610,7 +607,7 @@ export class JoinImplementation {
       if (result2 instanceof PossiblyNormalCompletion) {
         value = result2.value;
         savedEffects = result2.savedEffects;
-        pathConditions = [joinCondition].concat(result2.pathCondtions);
+        pathConditions = [joinCondition].concat(result2.pathConditions);
         savedPathConditions = result2.savedPathConditions;
       } else {
         pathConditions = [joinCondition];
@@ -636,7 +633,7 @@ export class JoinImplementation {
       if (result1 instanceof PossiblyNormalCompletion) {
         value = result1.value;
         savedEffects = result1.savedEffects;
-        pathConditions = [joinCondition].concat(result1.pathCondtions);
+        pathConditions = [joinCondition].concat(result1.pathConditions);
         savedPathConditions = result1.savedPathConditions;
       } else {
         pathConditions = [joinCondition];

--- a/src/realm.js
+++ b/src/realm.js
@@ -613,12 +613,12 @@ export class Realm {
     if (completion.consequent instanceof AbruptCompletion) {
       Path.pushInverseAndRefine(completion.joinCondition);
       if (completion.alternate instanceof PossiblyNormalCompletion) {
-        completion.alternate.pathCondtions.forEach(Path.pushAndRefine);
+        completion.alternate.pathConditions.forEach(Path.pushAndRefine);
       }
     } else if (completion.alternate instanceof AbruptCompletion) {
       Path.pushAndRefine(completion.joinCondition);
       if (completion.consequent instanceof PossiblyNormalCompletion) {
-        completion.consequent.pathCondtions.forEach(Path.pushAndRefine);
+        completion.consequent.pathConditions.forEach(Path.pushAndRefine);
       }
     }
     return completion.value;

--- a/src/realm.js
+++ b/src/realm.js
@@ -612,8 +612,14 @@ export class Realm {
     }
     if (completion.consequent instanceof AbruptCompletion) {
       Path.pushInverseAndRefine(completion.joinCondition);
+      if (completion.alternate instanceof PossiblyNormalCompletion) {
+        completion.alternate.pathCondtions.forEach(Path.pushAndRefine);
+      }
     } else if (completion.alternate instanceof AbruptCompletion) {
       Path.pushAndRefine(completion.joinCondition);
+      if (completion.consequent instanceof PossiblyNormalCompletion) {
+        completion.consequent.pathCondtions.forEach(Path.pushAndRefine);
+      }
     }
     return completion.value;
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { Intrinsics, PropertyBinding, Descriptor, DebugServerType} from "./types.js";
+import type { Intrinsics, PropertyBinding, Descriptor, DebugServerType } from "./types.js";
 import { CompilerDiagnostic, type ErrorHandlerResult, type ErrorHandler, FatalError } from "./errors.js";
 import {
   AbstractObjectValue,
@@ -611,10 +611,9 @@ export class Realm {
       this.savedCompletion = Join.composePossiblyNormalCompletions(this, this.savedCompletion, completion);
     }
     if (completion.consequent instanceof AbruptCompletion) {
-      Path.pushInverseAndRefine(completion.joinCondition)
-    }
-    else if (completion.alternate instanceof AbruptCompletion) {
-      Path.pushAndRefine(completion.joinCondition)
+      Path.pushInverseAndRefine(completion.joinCondition);
+    } else if (completion.alternate instanceof AbruptCompletion) {
+      Path.pushAndRefine(completion.joinCondition);
     }
     return completion.value;
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { Intrinsics, PropertyBinding, Descriptor, DebugServerType } from "./types.js";
+import type { Intrinsics, PropertyBinding, Descriptor, DebugServerType} from "./types.js";
 import { CompilerDiagnostic, type ErrorHandlerResult, type ErrorHandler, FatalError } from "./errors.js";
 import {
   AbstractObjectValue,
@@ -33,7 +33,7 @@ import type { Compatibility, RealmOptions } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
 import { Generator, PreludeGenerator } from "./utils/generator.js";
-import { Environment, Functions, Join, Properties, To, Widen } from "./singletons.js";
+import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type {
   BabelNode,
   BabelNodeIdentifier,
@@ -605,9 +605,16 @@ export class Realm {
   composeWithSavedCompletion(completion: PossiblyNormalCompletion): Value {
     if (this.savedCompletion === undefined) {
       this.savedCompletion = completion;
+      this.savedCompletion.savedPathConditions = this.pathConditions;
       this.captureEffects(completion);
     } else {
       this.savedCompletion = Join.composePossiblyNormalCompletions(this, this.savedCompletion, completion);
+    }
+    if (completion.consequent instanceof AbruptCompletion) {
+      Path.pushInverseAndRefine(completion.joinCondition)
+    }
+    else if (completion.alternate instanceof AbruptCompletion) {
+      Path.pushAndRefine(completion.joinCondition)
     }
     return completion.value;
   }

--- a/src/types.js
+++ b/src/types.js
@@ -327,7 +327,7 @@ export type PathType = {
   withCondition<T>(condition: AbstractValue, evaluate: () => T): T,
   withInverseCondition<T>(condition: AbstractValue, evaluate: () => T): T,
   pushAndRefine(condition: AbstractValue): void,
-  pushInverseAndRefine(condition: AbstractValue): void
+  pushInverseAndRefine(condition: AbstractValue): void,
 };
 
 export type PropertiesType = {

--- a/src/types.js
+++ b/src/types.js
@@ -326,6 +326,8 @@ export type PathType = {
   impliesNot(condition: AbstractValue): boolean,
   withCondition<T>(condition: AbstractValue, evaluate: () => T): T,
   withInverseCondition<T>(condition: AbstractValue, evaluate: () => T): T,
+  pushAndRefine(condition: AbstractValue): void,
+  pushInverseAndRefine(condition: AbstractValue): void
 };
 
 export type PropertiesType = {

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -58,11 +58,29 @@ export class PathImplementation {
       realm.pathConditions = savedPath;
     }
   }
+
+  pushAndRefine(condition: AbstractValue) {
+    let realm = condition.$Realm;
+    let savedPath = realm.pathConditions;
+    realm.pathConditions = [];
+
+    pushPathCondition(condition);
+    pushRefinedConditions(savedPath);
+  }
+
+    pushInverseAndRefine(condition: AbstractValue) {
+      let realm = condition.$Realm;
+      let savedPath = realm.pathConditions;
+      realm.pathConditions = [];
+
+      pushInversePathCondition(condition);
+      pushRefinedConditions(savedPath);
+    }
 }
 
 // A path condition is an abstract value that is known to be true in a particular code path
 function pushPathCondition(condition: Value) {
-  invariant(condition.mightNotBeFalse()); // it is mistake to assert that false is true
+  invariant(condition.mightNotBeFalse(), "pushing false"); // it is mistake to assert that false is true
   if (condition instanceof ConcreteValue) return;
   if (!condition.mightNotBeTrue()) return;
   invariant(condition instanceof AbstractValue);

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -68,14 +68,14 @@ export class PathImplementation {
     pushRefinedConditions(savedPath);
   }
 
-    pushInverseAndRefine(condition: AbstractValue) {
-      let realm = condition.$Realm;
-      let savedPath = realm.pathConditions;
-      realm.pathConditions = [];
+  pushInverseAndRefine(condition: AbstractValue) {
+    let realm = condition.$Realm;
+    let savedPath = realm.pathConditions;
+    realm.pathConditions = [];
 
-      pushInversePathCondition(condition);
-      pushRefinedConditions(savedPath);
-    }
+    pushInversePathCondition(condition);
+    pushRefinedConditions(savedPath);
+  }
 }
 
 // A path condition is an abstract value that is known to be true in a particular code path

--- a/test/error-handler/conditional-return.js
+++ b/test/error-handler/conditional-return.js
@@ -1,0 +1,22 @@
+// recover-from-errors
+// expected errors: [{location: {"start":{"line":17,"column":14},"end":{"line":17,"column":16 },"identifierName":"n1","source":"test/error-handler/conditional-return.js"}, errorCode: "PP0002", severity: "RecoverableError", message: "might be an object with an unknown valueOf or toString or Symbol.toPrimitive method"}]
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+let n1;
+if (b) n1 = 5;
+let n2 = global.__abstract ? __abstract("number", "7") : 7;
+
+function f() {
+  if (!b) return;
+  // should not fail
+  return n2 - n1;
+}
+
+function g() {
+  f()
+  //condition from line 7 should have been undone and this should fail.
+  return n2 - n1;
+}
+
+g();
+
+inspect = function (){return true;}

--- a/test/serializer/basic/ConditionalReturn.js
+++ b/test/serializer/basic/ConditionalReturn.js
@@ -1,0 +1,12 @@
+let b = global.__abstract ? _abstract("boolean", "true") : true;
+
+let n1;
+if (b) n1 = 5;
+let n2 = global.__abstract ? __abstract("number", "7") : 7;
+
+function f() {
+  if (!b) return;
+  return n2 - n1;
+}
+
+inspect = function() {return f() };

--- a/test/serializer/basic/ConditionalReturn.js
+++ b/test/serializer/basic/ConditionalReturn.js
@@ -1,4 +1,4 @@
-let b = global.__abstract ? _abstract("boolean", "true") : true;
+let b = global.__abstract ? __abstract("boolean", "true") : true;
 
 let n1;
 if (b) n1 = 5;

--- a/test/serializer/basic/ConditionalReturn2.js
+++ b/test/serializer/basic/ConditionalReturn2.js
@@ -1,0 +1,21 @@
+let b =  global.__abstract  ? global.__abstract("boolean", "(true)") : true;
+let b1 =  global.__abstract ?  global.__abstract("boolean", "((true))") : true;
+let n1;
+if (!b1)
+  n1 = 5;
+let n2 = global.__abstract ? __abstract("number", "7") : 7;
+
+function f() {
+  if (b)
+  {
+    if (b1) {
+      return;
+    }
+  }
+  else return;
+
+  return n2 - n1;
+}
+
+// should be undefined
+inspect = function () {return f()}

--- a/test/serializer/basic/ConditionalReturn3.js
+++ b/test/serializer/basic/ConditionalReturn3.js
@@ -1,0 +1,24 @@
+let a = global.__abstract ? __abstract("boolean", "(true)") : true;
+let b = global.__abstract ? __abstract("boolean", "((true))") : true;
+
+let na
+if (!a) na = 10;
+
+let nb
+if (!b) nb = 20;
+
+let n2 = global.__abstract ? __abstract("number", "7") : 7;
+
+function f() {
+  if (b) return;
+  return nb - n2;
+}
+
+function g() {
+  if (a) return;
+  f()
+  return na - n2;
+}
+
+g()
+inspect = function () {return true;}

--- a/test/serializer/basic/PathConditionDeadCode.js
+++ b/test/serializer/basic/PathConditionDeadCode.js
@@ -1,0 +1,13 @@
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+let n1;
+if (b) n1 = 5;
+let n2 = global.__abstract ? __abstract("number", "7") : 7;
+var x = 0;
+function f() {
+  if (!b) return;
+  if (b) throw "foo";
+  //dead
+  x = 42;
+}
+
+inspect = function () {return f()};

--- a/test/serializer/basic/PathConditionThrow.js
+++ b/test/serializer/basic/PathConditionThrow.js
@@ -1,0 +1,17 @@
+let b = global.__abstract ? __abstract("boolean", "true") : true;
+let n1;
+if (b) n1 = 5;
+let n2 = global.__abstract ? __abstract("number", "7") : 7;
+
+function f() {
+  let yy = g();
+  return n2 - yy;
+}
+
+function g() {
+
+  if (!b) throw 10;
+  return (n2 - n1);
+}
+
+inspect = function() {return f()}


### PR DESCRIPTION
Release note: Use conditional returns to refine the path condition. Fixes #1182

When one branch of a conditional is an abrupt completion add the join condition to the path condition. The previous path condition is stored in the saved completion and restored at join point.