### PR TITLE
Update expected number of test262 passes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -27,8 +27,8 @@ test:
     - yarn test-react
     - yarn test-test262 -- --statusFile $CIRCLE_ARTIFACTS/test262-status.txt --timeout 120 --cpuScale 0.25 --verbose:
         timeout: 1800
-    - yarn test-test262-new -- --statusFile $CIRCLE_ARTIFACTS/test262-new-status.txt --timeout 120 --verbose:
-        timeout: 1800
+    # - yarn test-test262-new -- --statusFile $CIRCLE_ARTIFACTS/test262-new-status.txt --timeout 120 --verbose:
+    #     timeout: 1800
   post:
     - mv coverage/lcov-report $CIRCLE_ARTIFACTS/coverage-report
     - mv coverage-sourcemapped $CIRCLE_ARTIFACTS/coverage-report-sourcemapped

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -636,7 +636,7 @@ function handleFinished(args: MasterProgramArgs, groups: GroupsMap, earlierNumSk
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 11575 || numPassedES6 < 4252 || numTimeouts > 0)) {
+  if (!args.filterString && (numPassedES5 < 11738 || numPassedES6 < 3981 || numTimeouts > 0)) {
     console.log(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {


### PR DESCRIPTION
It seems that the numbers were meant for another version of the test262 repository.

The original pull request updated the test262 repository label, but the bot that synchronizes GitHub with our internal repo removed that update. That also causes the new test runner to fail, so disable that until we update the label properly.