### PR TITLE
Centralize debugger stopping

### DIFF
--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -14,16 +14,13 @@ import { Breakpoint } from "./Breakpoint.js";
 import type { Breakpoint as BreakpointType } from "./types.js";
 import { BabelNode } from "babel-types";
 import { IsStatement } from "./../methods/is.js";
-import type { DebugChannel } from "./channel/DebugChannel.js";
 
 // Storing BreakpointStores for all source files
 export class BreakpointManager {
-  constructor(channel: DebugChannel) {
-    this._channel = channel;
+  constructor() {
     this._breakpointMaps = new Map();
   }
   _breakpointMaps: Map<string, PerFileBreakpointMap>;
-  _channel: DebugChannel;
 
   getStoppableBreakpoint(ast: BabelNode): void | Breakpoint {
     if (!IsStatement(ast)) return;

--- a/src/debugger/BreakpointManager.js
+++ b/src/debugger/BreakpointManager.js
@@ -25,22 +25,19 @@ export class BreakpointManager {
   _breakpointMaps: Map<string, PerFileBreakpointMap>;
   _channel: DebugChannel;
 
-  shouldStopOnBreakpoint(ast: BabelNode): boolean {
-    if (!IsStatement(ast)) return false;
+  getStoppableBreakpoint(ast: BabelNode): void | Breakpoint {
+    if (!IsStatement(ast)) return;
     if (ast.loc && ast.loc.source) {
       let location = ast.loc;
       let filePath = location.source;
-      if (filePath === null) return false;
+      if (filePath === null) return;
       let lineNum = location.start.line;
       let colNum = location.start.column;
       // Check whether there is a breakpoint we need to stop on here
       let breakpoint = this._findStoppableBreakpoint(filePath, lineNum, colNum);
-      if (breakpoint === null) return false;
-      // Tell the adapter that Prepack has stopped on this breakpoint
-      this._channel.sendStoppedResponse("Breakpoint", breakpoint.filePath, breakpoint.line, breakpoint.column);
-      return true;
+      if (breakpoint === null) return;
+      return breakpoint;
     }
-    return false;
   }
 
   // Try to find a breakpoint at the given location and check if we should stop on it

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -46,7 +46,7 @@ export class DebugServer {
     this._breakpointManager = new BreakpointManager();
     this._variableManager = new VariableManager(realm);
     this._stepManager = new SteppingManager(this._realm, /* default discard old steppers */ false);
-    this._stopEventManager = new StopEventManager(this._channel);
+    this._stopEventManager = new StopEventManager();
     this.waitForRun(undefined);
   }
   // the collection of breakpoints

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -43,9 +43,9 @@ export class DebugServer {
   constructor(channel: DebugChannel, realm: Realm) {
     this._channel = channel;
     this._realm = realm;
-    this._breakpointManager = new BreakpointManager(this._channel);
+    this._breakpointManager = new BreakpointManager();
     this._variableManager = new VariableManager(realm);
-    this._stepManager = new SteppingManager(this._channel, this._realm, /* default discard old steppers */ false);
+    this._stepManager = new SteppingManager(this._realm, /* default discard old steppers */ false);
     this._stopEventManager = new StopEventManager(this._channel);
     this.waitForRun(undefined);
   }

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -22,7 +22,6 @@ import type {
   Stackframe,
   Scope,
   VariablesArguments,
-  StoppedReason,
   EvaluateArguments,
   SourceData,
 } from "./types.js";
@@ -30,6 +29,8 @@ import type { Realm } from "./../realm.js";
 import { ExecutionContext } from "./../realm.js";
 import { VariableManager } from "./VariableManager.js";
 import { SteppingManager } from "./SteppingManager.js";
+import type { StoppableObject } from "./StopEventManager.js";
+import { StopEventManager } from "./StopEventManager.js";
 import {
   EnvironmentRecord,
   GlobalEnvironmentRecord,
@@ -45,7 +46,8 @@ export class DebugServer {
     this._breakpointManager = new BreakpointManager(this._channel);
     this._variableManager = new VariableManager(realm);
     this._stepManager = new SteppingManager(this._channel, this._realm, /* default discard old steppers */ false);
-    this.waitForRun(undefined, "Entry");
+    this._stopEventManager = new StopEventManager(this._channel);
+    this.waitForRun(undefined);
   }
   // the collection of breakpoints
   _breakpointManager: BreakpointManager;
@@ -54,14 +56,14 @@ export class DebugServer {
   _realm: Realm;
   _variableManager: VariableManager;
   _stepManager: SteppingManager;
+  _stopEventManager: StopEventManager;
   _lastExecuted: SourceData;
 
   /* Block until adapter says to run
   /* ast: the current ast node we are stopped on
   /* reason: the reason the debuggee is stopping
   */
-  waitForRun(ast: void | BabelNode, reason: StoppedReason) {
-    if (ast) this._onDebuggeeStop(ast, reason);
+  waitForRun(ast: void | BabelNode) {
     let keepRunning = false;
     let request;
     while (!keepRunning) {
@@ -73,21 +75,12 @@ export class DebugServer {
   // Checking if the debugger needs to take any action on reaching this ast node
   checkForActions(ast: BabelNode) {
     if (this._checkAndUpdateLastExecuted(ast)) {
-      this.checkForBreakpoint(ast);
-      this.checkStepComplete(ast);
-    }
-  }
-
-  checkForBreakpoint(ast: BabelNode) {
-    if (this._breakpointManager.shouldStopOnBreakpoint(ast)) {
-      this.waitForRun(ast, "Breakpoint");
-    }
-  }
-
-  checkStepComplete(ast: BabelNode) {
-    let steppingType = this._stepManager.getStepperType(ast);
-    if (steppingType) {
-      this.waitForRun(ast, steppingType);
+      let stoppables: Array<StoppableObject> = this._stepManager.getAndDeleteCompletedSteppers(ast);
+      let breakpoint = this._breakpointManager.getStoppableBreakpoint(ast);
+      if (breakpoint) stoppables.push(breakpoint);
+      if (this._stopEventManager.shouldDebuggeeStop(ast, stoppables)) {
+        this.waitForRun(ast);
+      }
     }
   }
 
@@ -252,12 +245,6 @@ export class DebugServer {
   processEvaluateCommand(requestID: number, args: EvaluateArguments) {
     let evalResult = this._variableManager.evaluate(args.frameId, args.expression);
     this._channel.sendEvaluateResponse(requestID, evalResult);
-  }
-
-  // actions that need to happen when Prepack is going to be stopped
-  _onDebuggeeStop(ast: BabelNode, reason: StoppedReason) {
-    if (reason === "Entry") return;
-    this._stepManager.onDebuggeeStop(ast, reason);
   }
 
   // actions that need to happen before Prepack can resume

--- a/src/debugger/Debugger.js
+++ b/src/debugger/Debugger.js
@@ -78,7 +78,10 @@ export class DebugServer {
       let stoppables: Array<StoppableObject> = this._stepManager.getAndDeleteCompletedSteppers(ast);
       let breakpoint = this._breakpointManager.getStoppableBreakpoint(ast);
       if (breakpoint) stoppables.push(breakpoint);
-      if (this._stopEventManager.shouldDebuggeeStop(ast, stoppables)) {
+      let reason = this._stopEventManager.getDebuggeeStopReason(ast, stoppables);
+      if (reason) {
+        invariant(ast.loc && ast.loc.source);
+        this._channel.sendStoppedResponse(reason, ast.loc.source, ast.loc.start.line, ast.loc.start.column);
         this.waitForRun(ast);
       }
     }

--- a/src/debugger/SteppingManager.js
+++ b/src/debugger/SteppingManager.js
@@ -10,21 +10,18 @@
 /* @flow */
 
 import { BabelNode } from "babel-types";
-import type { DebugChannel } from "./channel/DebugChannel.js";
 import invariant from "./../invariant.js";
 import { Stepper, StepIntoStepper, StepOverStepper } from "./Stepper.js";
 import type { Realm } from "./../realm.js";
 import type { StoppableObject } from "./StopEventManager.js";
 
 export class SteppingManager {
-  constructor(channel: DebugChannel, realm: Realm, keepOldSteppers?: boolean) {
-    this._channel = channel;
+  constructor(realm: Realm, keepOldSteppers?: boolean) {
     this._realm = realm;
     this._steppers = [];
     this._keepOldSteppers = false;
     if (keepOldSteppers) this._keepOldSteppers = true;
   }
-  _channel: DebugChannel;
   _realm: Realm;
   _keepOldSteppers: boolean;
   _steppers: Array<Stepper>;

--- a/src/debugger/StopEventManager.js
+++ b/src/debugger/StopEventManager.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import invariant from "./../invariant.js";
-import { DebugChannel } from "./channel/DebugChannel.js";
+import type { DebugChannel } from "./channel/DebugChannel.js";
 import { Breakpoint } from "./Breakpoint.js";
 import { Stepper, StepIntoStepper, StepOverStepper } from "./Stepper.js";
 import { BabelNode } from "babel-types";

--- a/src/debugger/StopEventManager.js
+++ b/src/debugger/StopEventManager.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import invariant from "./../invariant.js";
+import { DebugChannel } from "./channel/DebugChannel.js";
+import { Breakpoint } from "./Breakpoint.js";
+import { Stepper, StepIntoStepper, StepOverStepper } from "./Stepper.js";
+import { BabelNode } from "babel-types";
+
+export type StoppableObject = Breakpoint | Stepper;
+
+export class StopEventManager {
+  constructor(channel: DebugChannel) {
+    this._channel = channel;
+  }
+  _channel: DebugChannel;
+
+  shouldDebuggeeStop(ast: BabelNode, stoppables: Array<StoppableObject>): boolean {
+    if (stoppables.length === 0) return false;
+    let stoppable = stoppables[0];
+    let stoppedReason;
+    if (stoppable instanceof Breakpoint) {
+      stoppedReason = "Breakpoint";
+    } else if (stoppable instanceof StepIntoStepper) {
+      stoppedReason = "Step Into";
+    } else if (stoppable instanceof StepOverStepper) {
+      stoppedReason = "Step Over";
+    } else {
+      invariant(false, "Invalid stoppable object");
+    }
+    invariant(ast.loc && ast.loc.source);
+    this._channel.sendStoppedResponse(stoppedReason, ast.loc.source, ast.loc.start.line, ast.loc.start.column);
+    return true;
+  }
+}

--- a/src/debugger/StopEventManager.js
+++ b/src/debugger/StopEventManager.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import invariant from "./../invariant.js";
-import type { DebugChannel } from "./channel/DebugChannel.js";
 import { Breakpoint } from "./Breakpoint.js";
 import { Stepper, StepIntoStepper, StepOverStepper } from "./Stepper.js";
 import { BabelNode } from "babel-types";
@@ -22,11 +21,6 @@ export type StoppableObject = Breakpoint | Stepper;
 // All stopping related logic is centralized here
 
 export class StopEventManager {
-  constructor(channel: DebugChannel) {
-    this._channel = channel;
-  }
-  _channel: DebugChannel;
-
   // stoppables is a list of objects the debuggee should be stopped on
   // (e.g. breakpoint, completed steppers). The debuggee should stop if there
   // is at least one element in the list. Currently the reason of the first element


### PR DESCRIPTION
Release note: none
Summary:
- refactor stepping manager and breakpoint managers to return the stoppable object
- implement a stop event manager to handle the results of other two managers and decide whether a stop should happen
- remove onDebuggeeStop methods

Test Plan:
```
function a(num) {
  if (num === 3) {
    var y = 5;
  } else {
    {
      let abc = 3;
    }

    let z = [1,2,3];
    let e = Symbol("xyz");
    for (let i = 0; i < 2; i++) xyz++;
    let f = {
      g: 0,
      h: 1,
      i: {
        j: 2,
        k: 3,
      },
    };
    let x = 6;
  }
}
```
Set multiple breakpoints and used sequences of stepping and continuing and saw consistent behaviour.