### PR TITLE
Fix: Repeated argument identifiers with inlined expressions.

### DIFF
--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -214,7 +214,7 @@ export class Referentializer {
 
           invariant(residualBinding.referentialized);
           if (residualBinding.declarativeEnvironmentRecord && residualBinding.scope) {
-            instance.scopeInstances.add(residualBinding.scope);
+            instance.scopeInstances.set(residualBinding.scope.name, residualBinding.scope);
           }
         }
       }

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -352,9 +352,9 @@ export class ResidualFunctions {
             ((t.cloneDeep(funcBody): any): BabelNodeBlockStatement)
           );
           let scopeInitialization = [];
-          for (let scope of scopeInstances) {
+          for (let [scopeName, scope] of scopeInstances) {
             scopeInitialization.push(
-              t.variableDeclaration("var", [t.variableDeclarator(t.identifier(scope.name), t.numericLiteral(scope.id))])
+              t.variableDeclaration("var", [t.variableDeclarator(t.identifier(scopeName), t.numericLiteral(scope.id))])
             );
             scopeInitialization = scopeInitialization.concat(
               this.referentializer.getReferentializedScopeInitialization(scope)
@@ -433,8 +433,8 @@ export class ResidualFunctions {
         }
 
         let scopeInitialization = [];
-        for (let scope of normalInstances[0].scopeInstances) {
-          factoryParams.push(t.identifier(scope.name));
+        for (let [scopeName, scope] of normalInstances[0].scopeInstances) {
+          factoryParams.push(t.identifier(scopeName));
           scopeInitialization = scopeInitialization.concat(
             this.referentializer.getReferentializedScopeInitialization(scope)
           );
@@ -481,8 +481,8 @@ export class ResidualFunctions {
             invariant(serializedValue);
             return serializedValue;
           });
-          for (let { id } of instance.scopeInstances) {
-            flatArgs.push(t.numericLiteral(id));
+          for (let entry of instance.scopeInstances) {
+            flatArgs.push(t.numericLiteral(entry[1].id));
           }
           let funcNode;
           let firstUsage = this.firstFunctionUsages.get(functionValue);

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -396,7 +396,7 @@ export class ResidualHeapVisitor {
       residualFunctionBindings,
       initializationStatements: [],
       functionValue: val,
-      scopeInstances: new Set(),
+      scopeInstances: new Map(),
     });
   }
 

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -52,7 +52,7 @@ export type FunctionInstance = {
   insertionPoint?: BodyReference,
   // Additional function that the function instance was declared inside of (if any)
   containingAdditionalFunction?: FunctionValue,
-  scopeInstances: Set<ScopeBinding>,
+  scopeInstances: Map<string, ScopeBinding>,
   initializationStatements: Array<BabelNodeStatement>,
 };
 

--- a/test/serializer/basic/CapturedScope.js
+++ b/test/serializer/basic/CapturedScope.js
@@ -1,4 +1,5 @@
 // serialized function clone count: 0
+// does not contain:__scope_2_unique27277, __scope_2_unique27277
 function f (x) {
   var valueA = 0;
   var valueB = 1;


### PR DESCRIPTION
PrePack generates duplicate argument names when inlining expressions. Take for instance the test in test/serializer/basic/CapturedScope.js. PrePacked with --inlineExpressions it generates several functions like

```
var $_1 = function (c, __scope_2, __scope_2) {
    var __captured__scope_2 = __scope_1(__scope_2);

    var __captured__scope_2 = __scope_1(__scope_2);

    __captured__scope_2[1]++;
    __captured__scope_2[2]++;
    return c();
  };
```

Test plan: `yarn test-serializer`

Fixes #1136 