### PR TITLE
Implement to.js privately

### DIFF
--- a/scripts/detect_bad_deps.js
+++ b/scripts/detect_bad_deps.js
@@ -41,7 +41,7 @@ exec("flow check --profile", function(error, stdout, stderr) {
     process.exit(1);
   }
   console.log("Biggest cycle: " + cycle_len);
-  let MAX_CYCLE_LEN = 57; // NEVER EVER increase this value
+  let MAX_CYCLE_LEN = 56; // NEVER EVER increase this value
   if (cycle_len > MAX_CYCLE_LEN) {
     console.log("Error: You increased cycle length from the previous high of " + MAX_CYCLE_LEN);
     console.log("This is never OK.");

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -16,7 +16,7 @@ import { Realm, ExecutionContext } from "../lib/realm.js";
 import construct_realm from "../lib/construct_realm.js";
 import initializeGlobals from "../lib/globals.js";
 import { DetachArrayBuffer } from "../lib/methods/arraybuffer.js";
-import { ToStringPartial } from "../lib/methods/to.js";
+import { To } from "../lib/singletons.js";
 import { Get } from "../lib/methods/get.js";
 import invariant from "../lib/invariant.js";
 
@@ -744,7 +744,6 @@ function workerRun(args: WorkerProgramArgs) {
 
 function handleTestResultsMultiProcess(err: ?Error, test: TestFileInfo, testResults: TestResult[]): void {
   if (err) {
-    // $FlowFixMe flow says "process.send" could be undefined
     process.send(new ErrorMessage(err));
   } else {
     let msg = new DoneMessage(test);
@@ -752,7 +751,6 @@ function handleTestResultsMultiProcess(err: ?Error, test: TestFileInfo, testResu
       msg.testResults.push(t);
     }
     try {
-      // $FlowFixMe flow says "process.send" could be undefined
       process.send(msg);
     } catch (jsonCircularSerializationErr) {
       // JSON circular serialization, ThrowCompletion is too deep to be
@@ -764,7 +762,6 @@ function handleTestResultsMultiProcess(err: ?Error, test: TestFileInfo, testResu
         }
       }
       // now try again
-      // $FlowFixMe flow says "process.send" could be undefined
       process.send(msg);
     }
   }
@@ -1018,9 +1015,9 @@ function runTest(
 
           if (err.value instanceof ObjectValue) {
             if (err.value.$HasProperty("stack")) {
-              interpreterStack = ToStringPartial(realm, Get(realm, err.value, "stack"));
+              interpreterStack = To.ToStringPartial(realm, Get(realm, err.value, "stack"));
             } else {
-              interpreterStack = ToStringPartial(realm, Get(realm, err.value, "message"));
+              interpreterStack = To.ToStringPartial(realm, Get(realm, err.value, "message"));
             }
             // filter out if the error stack is due to async
             if (interpreterStack.includes("async ")) {

--- a/scripts/test262.js
+++ b/scripts/test262.js
@@ -22,7 +22,7 @@ import { DetachArrayBuffer } from "../lib/methods/arraybuffer.js";
 import construct_realm from "../lib/construct_realm.js";
 import { ObjectValue, StringValue } from "../lib/values/index.js";
 import { Realm, ExecutionContext } from "../lib/realm.js";
-import { ToStringPartial } from "../lib/methods/to.js";
+import { To } from "../lib/singletons.js";
 import { Get } from "../lib/methods/get.js";
 
 const filters = yaml.safeLoad(fs.readFileSync(path.join(__dirname, "./test262-filters.yml"), "utf8"));
@@ -131,9 +131,9 @@ function execute(timeout: number, test: TestObject): Result {
 
           if (err.value instanceof ObjectValue) {
             if (err.value.$HasProperty("stack")) {
-              interpreterStack = ToStringPartial(realm, Get(realm, err.value, "stack"));
+              interpreterStack = To.ToStringPartial(realm, Get(realm, err.value, "stack"));
             } else {
-              interpreterStack = ToStringPartial(realm, Get(realm, err.value, "message"));
+              interpreterStack = To.ToStringPartial(realm, Get(realm, err.value, "message"));
             }
             // filter out if the error stack is due to async
             if (interpreterStack.includes("async ")) {

--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -21,15 +21,9 @@ import {
   InstanceofOperator,
   IsCallable,
   StrictEqualityComparison,
-  ToBoolean,
-  ToInt32,
-  ToNumber,
-  ToPrimitiveOrAbstract,
-  ToPropertyKey,
-  ToString,
-  ToUint32,
 } from "../methods/index.js";
 import type { Realm } from "../realm.js";
+import { To } from "../singletons.js";
 import {
   AbstractValue,
   BooleanValue,
@@ -112,21 +106,21 @@ export default class ValuesDomain {
   static computeBinary(realm: Realm, op: BabelBinaryOperator, lval: ConcreteValue, rval: ConcreteValue): Value {
     if (op === "+") {
       // ECMA262 12.8.3 The Addition Operator
-      let lprim = ToPrimitiveOrAbstract(realm, lval);
-      let rprim = ToPrimitiveOrAbstract(realm, rval);
+      let lprim = To.ToPrimitiveOrAbstract(realm, lval);
+      let rprim = To.ToPrimitiveOrAbstract(realm, rval);
 
       if (lprim instanceof AbstractValue || rprim instanceof AbstractValue) {
         return AbstractValue.createFromBinaryOp(realm, op, lprim, rprim);
       }
 
       if (lprim instanceof StringValue || rprim instanceof StringValue) {
-        let lstr = ToString(realm, lprim);
-        let rstr = ToString(realm, rprim);
+        let lstr = To.ToString(realm, lprim);
+        let rstr = To.ToString(realm, rprim);
         return new StringValue(realm, lstr + rstr);
       }
 
-      let lnum = ToNumber(realm, lprim);
-      let rnum = ToNumber(realm, rprim);
+      let lnum = To.ToNumber(realm, lprim);
+      let rnum = To.ToNumber(realm, rprim);
       return Add(realm, lnum, rnum);
     } else if (op === "<" || op === ">" || op === ">=" || op === "<=") {
       // ECMA262 12.10.3
@@ -161,13 +155,13 @@ export default class ValuesDomain {
       }
     } else if (op === ">>>") {
       // ECMA262 12.9.5.1
-      let lnum = ToUint32(realm, lval);
-      let rnum = ToUint32(realm, rval);
+      let lnum = To.ToUint32(realm, lval);
+      let rnum = To.ToUint32(realm, rval);
 
       return new NumberValue(realm, lnum >>> rnum);
     } else if (op === "<<" || op === ">>") {
-      let lnum = ToInt32(realm, lval);
-      let rnum = ToUint32(realm, rval);
+      let lnum = To.ToInt32(realm, lval);
+      let rnum = To.ToUint32(realm, rval);
 
       if (op === "<<") {
         // ECMA262 12.9.3.1
@@ -180,17 +174,17 @@ export default class ValuesDomain {
       // ECMA262 12.6.3
 
       // 5. Let base be ? ToNumber(leftValue).
-      let base = ToNumber(realm, lval);
+      let base = To.ToNumber(realm, lval);
 
       // 6. Let exponent be ? ToNumber(rightValue).
-      let exponent = ToNumber(realm, rval);
+      let exponent = To.ToNumber(realm, rval);
 
       // 7. Return the result of Applying the ** operator with base and exponent as specified in 12.7.3.4.
       return new NumberValue(realm, Math.pow(base, exponent));
     } else if (op === "%" || op === "/" || op === "*" || op === "-") {
       // ECMA262 12.7.3
-      let lnum = ToNumber(realm, lval);
-      let rnum = ToNumber(realm, rval);
+      let lnum = To.ToNumber(realm, lval);
+      let rnum = To.ToNumber(realm, rval);
 
       if (isNaN(rnum)) return realm.intrinsics.NaN;
       if (isNaN(lnum)) return realm.intrinsics.NaN;
@@ -231,10 +225,10 @@ export default class ValuesDomain {
       // ECMA262 12.12.3
 
       // 5. Let lnum be ? ToInt32(lval).
-      let lnum: number = ToInt32(realm, lval);
+      let lnum: number = To.ToInt32(realm, lval);
 
       // 6. Let rnum be ? ToInt32(rval).
-      let rnum: number = ToInt32(realm, rval);
+      let rnum: number = To.ToInt32(realm, rval);
 
       // 7. Return the result of applying the bitwise operator @ to lnum and rnum. The result is a signed 32 bit integer.
       if (op === "&") {
@@ -253,7 +247,7 @@ export default class ValuesDomain {
       }
 
       // 6. Return ? HasProperty(rval, ToPropertyKey(lval)).
-      return new BooleanValue(realm, HasProperty(realm, rval, ToPropertyKey(realm, lval)));
+      return new BooleanValue(realm, HasProperty(realm, rval, To.ToPropertyKey(realm, lval)));
     } else if (op === "instanceof") {
       // ECMA262 12.10.3
 
@@ -299,7 +293,7 @@ export default class ValuesDomain {
   // Note that calling this can result in user code running, which can side-effect the heap.
   // If that is not the desired behavior, mark the realm as read-only for the duration of the call.
   static computeLogical(realm: Realm, op: BabelNodeLogicalOperator, lval: ConcreteValue, rval: ConcreteValue): Value {
-    let lbool = ToBoolean(realm, lval);
+    let lbool = To.ToBoolean(realm, lval);
 
     if (op === "&&") {
       // ECMA262 12.13.3
@@ -318,12 +312,12 @@ export default class ValuesDomain {
       // ECMA262 12.5.6.1
       // 1. Let expr be the result of evaluating UnaryExpression.
       // 2. Return ? ToNumber(? GetValue(expr)).
-      return new NumberValue(realm, ToNumber(realm, value));
+      return new NumberValue(realm, To.ToNumber(realm, value));
     } else if (op === "-") {
       // ECMA262 12.5.7.1
       // 1. Let expr be the result of evaluating UnaryExpression.
       // 2. Let oldValue be ? ToNumber(? GetValue(expr)).
-      let oldValue = ToNumber(realm, value);
+      let oldValue = To.ToNumber(realm, value);
 
       // 3. If oldValue is NaN, return NaN.
       if (isNaN(oldValue)) {
@@ -336,7 +330,7 @@ export default class ValuesDomain {
       // ECMA262 12.5.8
       // 1. Let expr be the result of evaluating UnaryExpression.
       // 2. Let oldValue be ? ToInt32(? GetValue(expr)).
-      let oldValue = ToInt32(realm, value);
+      let oldValue = To.ToInt32(realm, value);
 
       // 3. Return the result of applying bitwise complement to oldValue. The result is a signed 32-bit integer.
       return new NumberValue(realm, ~oldValue);
@@ -344,7 +338,7 @@ export default class ValuesDomain {
       // ECMA262 12.6.9
       // 1. Let expr be the result of evaluating UnaryExpression.
       // 2. Let oldValue be ToBoolean(? GetValue(expr)).
-      let oldValue = ToBoolean(realm, value);
+      let oldValue = To.ToBoolean(realm, value);
 
       // 3. If oldValue is true, return false.
       if (oldValue === true) return realm.intrinsics.false;

--- a/src/environment.js
+++ b/src/environment.js
@@ -49,8 +49,8 @@ import generate from "babel-generator";
 import parse from "./utils/parse.js";
 import invariant from "./invariant.js";
 import traverseFast from "./utils/traverse-fast.js";
-import { ToBooleanPartial, HasProperty, Get, IsExtensible, HasOwnProperty, IsDataDescriptor } from "./methods/index.js";
-import { Environment, Properties } from "./singletons.js";
+import { HasProperty, Get, IsExtensible, HasOwnProperty, IsDataDescriptor } from "./methods/index.js";
+import { Environment, Properties, To } from "./singletons.js";
 import * as t from "babel-types";
 
 const sourceMap = require("source-map");
@@ -328,7 +328,7 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
     // 7. If Type(unscopables) is Object, then
     if (unscopables instanceof ObjectValue || unscopables instanceof AbstractObjectValue) {
       // a. Let blocked be ToBoolean(? Get(unscopables, N)).
-      let blocked = ToBooleanPartial(realm, Get(realm, unscopables, N));
+      let blocked = To.ToBooleanPartial(realm, Get(realm, unscopables, N));
 
       // b. If blocked is true, return false.
       if (blocked) return false;

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -24,8 +24,7 @@ import {
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import { Environment } from "../singletons.js";
-import { IsToPrimitivePure, GetToPrimitivePureResultType, IsToNumberPure } from "../methods/index.js";
+import { Environment, To } from "../singletons.js";
 import type { BabelNodeBinaryExpression, BabelBinaryOperator, BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -70,8 +69,8 @@ export function getPureBinaryOperationResultType(
     throw new FatalError();
   }
   if (op === "+") {
-    let ltype = GetToPrimitivePureResultType(realm, lval);
-    let rtype = GetToPrimitivePureResultType(realm, rval);
+    let ltype = To.GetToPrimitivePureResultType(realm, lval);
+    let rtype = To.GetToPrimitivePureResultType(realm, rval);
     if (ltype === undefined || rtype === undefined) {
       let loc = ltype === undefined ? lloc : rloc;
       let error = new CompilerDiagnostic(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
@@ -88,13 +87,13 @@ export function getPureBinaryOperationResultType(
     if (ltype === StringValue || rtype === StringValue) return StringValue;
     return NumberValue;
   } else if (op === "<" || op === ">" || op === ">=" || op === "<=") {
-    return reportErrorIfNotPure(IsToPrimitivePure, BooleanValue);
+    return reportErrorIfNotPure(To.IsToPrimitivePure.bind(To), BooleanValue);
   } else if (op === "!=" || op === "==") {
     let ltype = lval.getType();
     let rtype = rval.getType();
     if (ltype === NullValue || ltype === UndefinedValue || rtype === NullValue || rtype === UndefinedValue)
       return BooleanValue;
-    return reportErrorIfNotPure(IsToPrimitivePure, BooleanValue);
+    return reportErrorIfNotPure(To.IsToPrimitivePure.bind(To), BooleanValue);
   } else if (op === "===" || op === "!==") {
     return BooleanValue;
   } else if (
@@ -110,7 +109,7 @@ export function getPureBinaryOperationResultType(
     op === "*" ||
     op === "-"
   ) {
-    return reportErrorIfNotPure(IsToNumberPure, NumberValue);
+    return reportErrorIfNotPure(To.IsToNumberPure.bind(To), NumberValue);
   } else if (op === "in" || op === "instanceof") {
     if (rval.mightNotBeObject()) {
       let error = new CompilerDiagnostic(

--- a/src/evaluators/ConditionalExpression.js
+++ b/src/evaluators/ConditionalExpression.js
@@ -13,8 +13,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
 import type { Reference } from "../environment.js";
 import { evaluateWithAbstractConditional } from "./IfStatement.js";
-import { ToBoolean } from "../methods/index.js";
-import { Environment } from "../singletons.js";
+import { Environment, To } from "../singletons.js";
 import type { BabelNodeConditionalExpression } from "babel-types";
 import invariant from "../invariant.js";
 import type { Realm } from "../realm.js";
@@ -29,7 +28,7 @@ export default function(
   let exprValue = Environment.GetConditionValue(realm, exprRef);
 
   if (exprValue instanceof ConcreteValue) {
-    if (ToBoolean(realm, exprValue)) {
+    if (To.ToBoolean(realm, exprValue)) {
       return env.evaluate(ast.consequent, strictCode);
     } else {
       return env.evaluate(ast.alternate, strictCode);

--- a/src/evaluators/DoWhileStatement.js
+++ b/src/evaluators/DoWhileStatement.js
@@ -13,10 +13,10 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { Value } from "../values/index.js";
 import { EmptyValue } from "../values/index.js";
-import { ToBooleanPartial, UpdateEmpty } from "../methods/index.js";
+import { UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
 import { AbruptCompletion, BreakCompletion } from "../completions.js";
-import { Environment } from "../singletons.js";
+import { Environment, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeDoWhileStatement } from "babel-types";
 
@@ -59,7 +59,7 @@ export default function(
     let exprValue = Environment.GetValue(realm, exprRef);
 
     // f. If ToBoolean(exprValue) is false, return NormalCompletion(V).
-    if (ToBooleanPartial(realm, exprValue) === false) return V;
+    if (To.ToBooleanPartial(realm, exprValue) === false) return V;
   }
 
   invariant(false);

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -29,12 +29,11 @@ import {
   IteratorStep,
   IteratorValue,
   IteratorClose,
-  ToObjectPartial,
   UpdateEmpty,
   DestructuringAssignmentEvaluation,
   GetIterator,
 } from "../methods/index.js";
-import { Environment, Properties } from "../singletons.js";
+import { Environment, Properties, To } from "../singletons.js";
 import type {
   BabelNode,
   BabelNodeForOfStatement,
@@ -152,7 +151,7 @@ export function ForInOfHeadEvaluation(
     }
 
     // b. Let obj be ToObject(exprValue).
-    let obj = ToObjectPartial(realm, exprValue);
+    let obj = To.ToObjectPartial(realm, exprValue);
 
     // c. Return ? EnumerateObjectProperties(obj).
     if (obj.isPartialObject() || obj instanceof AbstractObjectValue) {

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -13,9 +13,9 @@ import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 import { Value, EmptyValue } from "../values/index.js";
 import { AbruptCompletion, BreakCompletion } from "../completions.js";
-import { ToBooleanPartial, UpdateEmpty } from "../methods/index.js";
+import { UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
-import { Environment } from "../singletons.js";
+import { Environment, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeForStatement } from "babel-types";
 
@@ -79,7 +79,7 @@ function ForBodyEvaluation(
       let testValue = Environment.GetValue(realm, testRef);
 
       // iii. If ToBoolean(testValue) is false, return NormalCompletion(V).
-      if (!ToBooleanPartial(realm, testValue)) return V;
+      if (!To.ToBooleanPartial(realm, testValue)) return V;
     }
 
     // b. Let result be the result of evaluating stmt.

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -15,10 +15,10 @@ import { construct_empty_effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { ToBoolean, UpdateEmpty } from "../methods/index.js";
+import { UpdateEmpty } from "../methods/index.js";
 import type { BabelNode, BabelNodeIfStatement } from "babel-types";
 import invariant from "../invariant.js";
-import { Environment, Join, Path } from "../singletons.js";
+import { Environment, Join, Path, To } from "../singletons.js";
 
 export function evaluate(ast: BabelNodeIfStatement, strictCode: boolean, env: LexicalEnvironment, realm: Realm): Value {
   // 1. Let exprRef be the result of evaluating Expression
@@ -28,7 +28,7 @@ export function evaluate(ast: BabelNodeIfStatement, strictCode: boolean, env: Le
 
   if (exprValue instanceof ConcreteValue) {
     let stmtCompletion;
-    if (ToBoolean(realm, exprValue)) {
+    if (To.ToBoolean(realm, exprValue)) {
       // 3.a. Let stmtCompletion be the result of evaluating the first Statement
       stmtCompletion = env.evaluateCompletion(ast.consequent, strictCode);
     } else {

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -15,11 +15,10 @@ import { construct_empty_effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { ToBoolean } from "../methods/index.js";
 import { Environment } from "../singletons.js";
 import type { BabelNodeLogicalExpression } from "babel-types";
 import invariant from "../invariant.js";
-import { Join, Path } from "../singletons.js";
+import { Join, Path, To } from "../singletons.js";
 
 export default function(
   ast: BabelNodeLogicalExpression,
@@ -31,7 +30,7 @@ export default function(
   let lval = Environment.GetValue(realm, lref);
 
   if (lval instanceof ConcreteValue) {
-    let lbool = ToBoolean(realm, lval);
+    let lbool = To.ToBoolean(realm, lval);
 
     if (ast.operator === "&&") {
       // ECMA262 12.13.3

--- a/src/evaluators/MemberExpression.js
+++ b/src/evaluators/MemberExpression.js
@@ -13,8 +13,8 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { Reference } from "../environment.js";
 import { StringValue } from "../values/index.js";
-import { ToPropertyKeyPartial, RequireObjectCoercible } from "../methods/index.js";
-import { Environment } from "../singletons.js";
+import { RequireObjectCoercible } from "../methods/index.js";
+import { Environment, To } from "../singletons.js";
 import type { BabelNodeMemberExpression } from "babel-types";
 import SuperProperty from "./SuperProperty";
 
@@ -51,7 +51,7 @@ export default function(
   let bv = RequireObjectCoercible(realm, baseValue, ast.object.loc);
 
   // 6. Let propertyKey be ? ToPropertyKey(propertyNameValue).
-  let propertyKey = ToPropertyKeyPartial(realm, propertyNameValue);
+  let propertyKey = To.ToPropertyKeyPartial(realm, propertyNameValue);
 
   // 7. If the code matched by the syntactic production that is being evaluated is strict mode code, let strict be true, else let strict be false.
   let strict = strictCode;

--- a/src/evaluators/ObjectExpression.js
+++ b/src/evaluators/ObjectExpression.js
@@ -14,8 +14,8 @@ import type { LexicalEnvironment } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbstractValue, ConcreteValue, ObjectValue, StringValue } from "../values/index.js";
-import { IsAnonymousFunctionDefinition, HasOwnProperty, ToPropertyKey, ToString } from "../methods/index.js";
-import { Create, Environment, Functions, Properties } from "../singletons.js";
+import { IsAnonymousFunctionDefinition, HasOwnProperty } from "../methods/index.js";
+import { Create, Environment, Functions, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type {
   BabelNodeObjectExpression,
@@ -50,14 +50,14 @@ function EvalPropertyNamePartial(
     let propertyKeyName = Environment.GetValue(realm, env.evaluate(prop.key, strictCode));
     if (propertyKeyName instanceof AbstractValue) return propertyKeyName;
     invariant(propertyKeyName instanceof ConcreteValue);
-    return ToPropertyKey(realm, propertyKeyName);
+    return To.ToPropertyKey(realm, propertyKeyName);
   } else {
     if (prop.key.type === "Identifier") {
       return new StringValue(realm, prop.key.name);
     } else {
       let propertyKeyName = Environment.GetValue(realm, env.evaluate(prop.key, strictCode));
       invariant(propertyKeyName instanceof ConcreteValue); // syntax only allows literals if !prop.computed
-      return ToString(realm, propertyKeyName);
+      return To.ToString(realm, propertyKeyName);
     }
   }
 }

--- a/src/evaluators/SuperProperty.js
+++ b/src/evaluators/SuperProperty.js
@@ -14,8 +14,8 @@ import type { LexicalEnvironment } from "../environment.js";
 import { FunctionEnvironmentRecord } from "../environment.js";
 import { Reference } from "../environment.js";
 import { StringValue } from "../values/index.js";
-import { ToPropertyKeyPartial, RequireObjectCoercible } from "../methods/index.js";
-import { Environment } from "../singletons.js";
+import { RequireObjectCoercible } from "../methods/index.js";
+import { Environment, To } from "../singletons.js";
 import type { BabelNodeMemberExpression } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -62,7 +62,7 @@ export default function SuperProperty(
     let propertyNameValue = Environment.GetValue(realm, propertyNameReference);
 
     // 3. Let propertyKey be ToPropertyKey(propertyNameValue).
-    let propertyKey = ToPropertyKeyPartial(realm, propertyNameValue);
+    let propertyKey = To.ToPropertyKeyPartial(realm, propertyNameValue);
 
     // 4. ReturnIfAbrupt(propertyKey).
 

--- a/src/evaluators/TemplateLiteral.js
+++ b/src/evaluators/TemplateLiteral.js
@@ -13,8 +13,7 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { StringValue } from "../values/index.js";
-import { ToStringPartial } from "../methods/index.js";
-import { Environment } from "../singletons.js";
+import { Environment, To } from "../singletons.js";
 import type { BabelNodeTemplateLiteral } from "babel-types";
 
 // ECMA262 12.2.9
@@ -34,7 +33,7 @@ export default function(
     // add expression
     let expr = ast.expressions[i];
     if (expr) {
-      str += ToStringPartial(realm, Environment.GetValue(realm, env.evaluate(expr, strictCode)));
+      str += To.ToStringPartial(realm, Environment.GetValue(realm, env.evaluate(expr, strictCode)));
     }
   }
 

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -27,8 +27,8 @@ import {
 } from "../values/index.js";
 import { Reference, EnvironmentRecord } from "../environment.js";
 import invariant from "../invariant.js";
-import { ToBoolean, ToObject, ToNumber, ToInt32, IsCallable, IsToNumberPure } from "../methods/index.js";
-import { Environment } from "../singletons.js";
+import { IsCallable } from "../methods/index.js";
+import { Environment, To } from "../singletons.js";
 import type { BabelNodeUnaryExpression } from "babel-types";
 
 function isInstance(proto, Constructor): boolean {
@@ -62,12 +62,12 @@ export default function(
     // 2. Return ? ToNumber(? GetValue(expr)).
     let value = Environment.GetValue(realm, expr);
     if (value instanceof AbstractValue) {
-      if (!IsToNumberPure(realm, value)) reportError();
+      if (!To.IsToNumberPure(realm, value)) reportError();
       return AbstractValue.createFromUnaryOp(realm, "+", value);
     }
     invariant(value instanceof ConcreteValue);
 
-    return new NumberValue(realm, ToNumber(realm, value));
+    return new NumberValue(realm, To.ToNumber(realm, value));
   } else if (ast.operator === "-") {
     // ECMA262 12.5.7.1
 
@@ -77,11 +77,11 @@ export default function(
     // 2. Let oldValue be ? ToNumber(? GetValue(expr)).
     let value = Environment.GetValue(realm, expr);
     if (value instanceof AbstractValue) {
-      if (!IsToNumberPure(realm, value)) reportError();
+      if (!To.IsToNumberPure(realm, value)) reportError();
       return AbstractValue.createFromUnaryOp(realm, "-", value);
     }
     invariant(value instanceof ConcreteValue);
-    let oldValue = ToNumber(realm, value);
+    let oldValue = To.ToNumber(realm, value);
 
     // 3. If oldValue is NaN, return NaN.
     if (isNaN(oldValue)) {
@@ -99,11 +99,11 @@ export default function(
     // 2. Let oldValue be ? ToInt32(? GetValue(expr)).
     let value = Environment.GetValue(realm, expr);
     if (value instanceof AbstractValue) {
-      if (!IsToNumberPure(realm, value)) reportError();
+      if (!To.IsToNumberPure(realm, value)) reportError();
       return AbstractValue.createFromUnaryOp(realm, "~", value);
     }
     invariant(value instanceof ConcreteValue);
-    let oldValue = ToInt32(realm, value);
+    let oldValue = To.ToInt32(realm, value);
 
     // 3. Return the result of applying bitwise complement to oldValue. The result is a signed 32-bit integer.
     return new NumberValue(realm, ~oldValue);
@@ -117,7 +117,7 @@ export default function(
     let value = Environment.GetValue(realm, expr);
     if (value instanceof AbstractValue) return AbstractValue.createFromUnaryOp(realm, "!", value);
     invariant(value instanceof ConcreteValue);
-    let oldValue = ToBoolean(realm, value);
+    let oldValue = To.ToBoolean(realm, value);
 
     // 3. If oldValue is true, return false.
     if (oldValue === true) return realm.intrinsics.false;
@@ -205,7 +205,7 @@ export default function(
       let base = Environment.GetBase(realm, ref);
       // Constructing the reference checks that base is coercible to an object hence
       invariant(base instanceof ConcreteValue || base instanceof AbstractObjectValue);
-      let baseObj = base instanceof ConcreteValue ? ToObject(realm, base) : base;
+      let baseObj = base instanceof ConcreteValue ? To.ToObject(realm, base) : base;
 
       // c. Let deleteStatus be ? baseObj.[[Delete]](GetReferencedName(ref)).
       let deleteStatus = baseObj.$Delete(Environment.GetReferencedName(realm, ref));

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -13,10 +13,10 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Value } from "../values/index.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
-import { Add, ToNumber, IsToNumberPure } from "../methods/index.js";
+import { Add } from "../methods/index.js";
 import { AbstractValue, NumberValue } from "../values/index.js";
 import type { BabelNodeUpdateExpression } from "babel-types";
-import { Environment, Properties } from "../singletons.js";
+import { Environment, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 
 export default function(
@@ -33,7 +33,7 @@ export default function(
   // Let oldValue be ? ToNumber(? GetValue(expr)).
   let oldExpr = Environment.GetValue(realm, expr);
   if (oldExpr instanceof AbstractValue) {
-    if (!IsToNumberPure(realm, oldExpr)) {
+    if (!To.IsToNumberPure(realm, oldExpr)) {
       let error = new CompilerDiagnostic(
         "might be a symbol or an object with an unknown valueOf or toString or Symbol.toPrimitive method",
         ast.argument.loc,
@@ -52,7 +52,7 @@ export default function(
       return oldExpr;
     }
   }
-  let oldValue = ToNumber(realm, oldExpr);
+  let oldValue = To.ToNumber(realm, oldExpr);
 
   if (ast.prefix) {
     if (ast.operator === "++") {

--- a/src/evaluators/WithStatement.js
+++ b/src/evaluators/WithStatement.js
@@ -14,8 +14,8 @@ import { LexicalEnvironment, ObjectEnvironmentRecord } from "../environment.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion } from "../completions.js";
 import { AbstractValue, ObjectValue, Value } from "../values/index.js";
-import { ToObjectPartial, UpdateEmpty } from "../methods/index.js";
-import { Environment } from "../singletons.js";
+import { UpdateEmpty } from "../methods/index.js";
+import { Environment, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeWithStatement } from "babel-types";
 
@@ -36,7 +36,7 @@ export default function(
     let error = new CompilerDiagnostic("with object must be a known value", loc, "PP0007", "RecoverableError");
     if (realm.handleError(error) === "Fail") throw new FatalError();
   }
-  let obj = ToObjectPartial(realm, val);
+  let obj = To.ToObjectPartial(realm, val);
 
   // 3. Let oldEnv be the running execution context's LexicalEnvironment.
   let oldEnv = env;

--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -16,6 +16,7 @@ import { FunctionImplementation } from "./methods/function.js";
 import { JoinImplementation } from "./methods/join.js";
 import { PathImplementation } from "./utils/paths.js";
 import { PropertiesImplementation } from "./methods/properties.js";
+import { ToImplementation } from "./methods/to.js";
 import { WidenImplementation } from "./methods/widen.js";
 
 export default function() {
@@ -25,5 +26,6 @@ export default function() {
   Singletons.setJoin(new JoinImplementation());
   Singletons.setPath(new PathImplementation());
   Singletons.setProperties((new PropertiesImplementation(): any));
+  Singletons.setTo((new ToImplementation(): any));
   Singletons.setWiden((new WidenImplementation(): any));
 }

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -30,9 +30,8 @@ import {
   IsConstructor,
   IsCallable,
 } from "../../methods/index.js";
-import { ToString, ToUint32, ToObject, ToLength } from "../../methods/to.js";
 import { GetIterator, IteratorClose, IteratorStep, IteratorValue } from "../../methods/iterator.js";
-import { Create, Properties } from "../../singletons.js";
+import { Create, Properties, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -85,7 +84,7 @@ export default function(realm: Realm): NativeFunctionValue {
         // 7. Else,
 
         // a. Let intLen be ToUint32(len).
-        intLen = ToUint32(realm, len.throwIfNotConcreteNumber());
+        intLen = To.ToUint32(realm, len.throwIfNotConcreteNumber());
 
         // b If intLen ≠ len, throw a RangeError exception.
         if (intLen !== len.value) {
@@ -123,7 +122,7 @@ export default function(realm: Realm): NativeFunctionValue {
       // 8. Repeat, while k < numberOfArgs
       while (k < numberOfArgs) {
         // a. Let Pk be ! ToString(k).
-        let Pk = ToString(realm, new NumberValue(realm, k));
+        let Pk = To.ToString(realm, new NumberValue(realm, k));
 
         // b. Let itemK be items[k].
         let itemK = items[k];
@@ -187,8 +186,8 @@ export default function(realm: Realm): NativeFunctionValue {
         // a. Let kValue be items[k].
         let kValue = items[k];
 
-        // b. Let Pk be ! ToString(k).
-        let Pk = ToString(realm, new NumberValue(realm, k));
+        // b. Let Pk be ! To.ToString(k).
+        let Pk = To.ToString(realm, new NumberValue(realm, k));
 
         // c. Perform ? CreateDataPropertyOrThrow(A, Pk, kValue).
         Create.CreateDataPropertyOrThrow(realm, A, Pk, kValue);
@@ -267,7 +266,7 @@ export default function(realm: Realm): NativeFunctionValue {
           }
 
           // ii. Let Pk be ! ToString(k).
-          let Pk = ToString(realm, new NumberValue(realm, k));
+          let Pk = To.ToString(realm, new NumberValue(realm, k));
 
           // iii. Let next be ? IteratorStep(iterator).
           let next = IteratorStep(realm, iterator);
@@ -327,10 +326,10 @@ export default function(realm: Realm): NativeFunctionValue {
       invariant(items instanceof ObjectValue);
 
       // 7. Let arrayLike be ! ToObject(items).
-      let arrayLike = ToObject(realm, items);
+      let arrayLike = To.ToObject(realm, items);
 
       // 8. Let len be ? ToLength(? Get(arrayLike, "length")).
-      let len = ToLength(realm, Get(realm, arrayLike, "length"));
+      let len = To.ToLength(realm, Get(realm, arrayLike, "length"));
 
       let A;
       // 9. If IsConstructor(C) is true, then
@@ -350,7 +349,7 @@ export default function(realm: Realm): NativeFunctionValue {
       // 12. Repeat, while k < len
       while (k < len) {
         // a. Let Pk be ! ToString(k).
-        let Pk = ToString(realm, new NumberValue(realm, k));
+        let Pk = To.ToString(realm, new NumberValue(realm, k));
 
         // b. Let kValue be ? Get(arrayLike, Pk).
         let kValue = Get(realm, arrayLike, Pk);

--- a/src/intrinsics/ecma262/ArrayBuffer.js
+++ b/src/intrinsics/ecma262/ArrayBuffer.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToIndexPartial } from "../../methods/to.js";
+import { To } from "../../singletons.js";
 import { AllocateArrayBuffer } from "../../methods/arraybuffer.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -28,7 +28,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // 2. Let byteLength be ToIndex(numberLength).
-      let byteLength = ToIndexPartial(realm, length);
+      let byteLength = To.ToIndexPartial(realm, length);
 
       // 3. Return ? AllocateArrayBuffer(NewTarget, byteLength).
       return AllocateArrayBuffer(realm, NewTarget, byteLength);

--- a/src/intrinsics/ecma262/ArrayBufferPrototype.js
+++ b/src/intrinsics/ecma262/ArrayBufferPrototype.js
@@ -11,14 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, NumberValue, UndefinedValue } from "../../values/index.js";
-import {
-  Construct,
-  SpeciesConstructor,
-  IsDetachedBuffer,
-  ToInteger,
-  SameValue,
-  CopyDataBlockBytes,
-} from "../../methods/index.js";
+import { Construct, CopyDataBlockBytes, IsDetachedBuffer, SameValue, SpeciesConstructor } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -81,13 +75,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(typeof len === "number");
 
     // 6. Let relativeStart be ? ToInteger(start).
-    let relativeStart = ToInteger(realm, start);
+    let relativeStart = To.ToInteger(realm, start);
 
     // 7. If relativeStart < 0, let first be max((len + relativeStart), 0); else let first be min(relativeStart, len).
     let first = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
 
     // 8. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
-    let relativeEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let relativeEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 9. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
     let final = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);

--- a/src/intrinsics/ecma262/ArrayIteratorPrototype.js
+++ b/src/intrinsics/ecma262/ArrayIteratorPrototype.js
@@ -10,9 +10,8 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 import { NumberValue, ObjectValue, UndefinedValue, StringValue } from "../../values/index.js";
-import { ToLength } from "../../methods/to.js";
 import { Get } from "../../methods/get.js";
 import invariant from "../../invariant.js";
 
@@ -60,7 +59,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 9. Else,
       // a. Let len be ? ToLength(? Get(a, "length")).
-      len = ToLength(realm, Get(realm, a, "length"));
+      len = To.ToLength(realm, Get(realm, a, "length"));
     }
 
     // 10. If index ≥ len, then

--- a/src/intrinsics/ecma262/ArrayProto_toString.js
+++ b/src/intrinsics/ecma262/ArrayProto_toString.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToObjectPartial } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import { Get } from "../../methods/get.js";
 import { Call } from "../../methods/call.js";
 import { IsCallable } from "../../methods/is.js";
@@ -25,7 +25,7 @@ export default function(realm: Realm): NativeFunctionValue {
     0,
     context => {
       // 1. Let array be ? ToObject(this value).
-      let array = ToObjectPartial(realm, context);
+      let array = To.ToObjectPartial(realm, context);
 
       // 2. Let func be ? Get(array, "join").
       let func = Get(realm, array, "join");

--- a/src/intrinsics/ecma262/ArrayProto_values.js
+++ b/src/intrinsics/ecma262/ArrayProto_values.js
@@ -11,14 +11,13 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToObject } from "../../methods/index.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 22.1.3.30
   return new NativeFunctionValue(realm, "Array.prototype.values", "values", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Return CreateArrayIterator(O, "value").
     return Create.CreateArrayIterator(realm, O, "value");

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -14,8 +14,6 @@ import { NumberValue, StringValue, ObjectValue, UndefinedValue, NullValue, Value
 import invariant from "../../invariant.js";
 import { SameValueZeroPartial, AbstractRelationalComparison } from "../../methods/abstract.js";
 import {
-  ToLength,
-  ToObject,
   StrictEqualityComparisonPartial,
   IsCallable,
   IsConcatSpreadable,
@@ -24,15 +22,10 @@ import {
   HasProperty,
   Call,
   Invoke,
-  ToString,
-  ToStringPartial,
-  ToInteger,
-  ToNumber,
-  ToBooleanPartial,
   Get,
   HasSomeCompatibleType,
 } from "../../methods/index.js";
-import { Create, Properties } from "../../singletons.js";
+import { Create, Properties, To } from "../../singletons.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.31
@@ -44,7 +37,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.1
   obj.defineNativeMethod("concat", 1, (context, args, argCount) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let A be ? ArraySpeciesCreate(O, 0).
     let A = Create.ArraySpeciesCreate(realm, O, 0);
@@ -71,7 +64,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let k = 0;
 
         // ii. Let len be ? ToLength(? Get(E, "length")).
-        let len = ToLength(realm, Get(realm, E, "length"));
+        let len = To.ToLength(realm, Get(realm, E, "length"));
 
         // ii. If n + len > 2^53-1, throw a TypeError exception.
         if (n + len > Math.pow(2, 53) - 1) {
@@ -127,25 +120,25 @@ export default function(realm: Realm, obj: ObjectValue): void {
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION))
     obj.defineNativeMethod("copyWithin", 2, (context, [target, start, end]) => {
       // 1. Let O be ? ToObject(this value).
-      let O = ToObject(realm, context.throwIfNotConcrete());
+      let O = To.ToObject(realm, context.throwIfNotConcrete());
 
       // 2. Let len be ? ToLength(? Get(O, "length")).
-      let len = ToLength(realm, Get(realm, O, "length"));
+      let len = To.ToLength(realm, Get(realm, O, "length"));
 
       // 3. Let relativeTarget be ? ToInteger(target).
-      let relativeTarget = ToInteger(realm, target);
+      let relativeTarget = To.ToInteger(realm, target);
 
       // 4. If relativeTarget < 0, let to be max((len + relativeTarget), 0); else let to be min(relativeTarget, len).
       let to = relativeTarget < 0 ? Math.max(len + relativeTarget, 0) : Math.min(relativeTarget, len);
 
       // 5. Let relativeStart be ? ToInteger(start).
-      let relativeStart = ToInteger(realm, start);
+      let relativeStart = To.ToInteger(realm, start);
 
       // 6. If relativeStart < 0, let from be max((len + relativeStart), 0); else let from be min(relativeStart, len).
       let from = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
 
       // 7. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
-      let relativeEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+      let relativeEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
       // 8. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
       let final = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
@@ -173,10 +166,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // 12. Repeat, while count > 0
       while (count > 0) {
         // a. Let fromKey be ! ToString(from).
-        let fromKey = ToString(realm, new NumberValue(realm, from));
+        let fromKey = To.ToString(realm, new NumberValue(realm, from));
 
         // b. Let toKey be ! ToString(to).
-        let toKey = ToString(realm, new NumberValue(realm, to));
+        let toKey = To.ToString(realm, new NumberValue(realm, to));
 
         // c. Let fromPresent be ? HasProperty(O, fromKey).
         let fromPresent = HasProperty(realm, O, fromKey);
@@ -210,7 +203,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.4
   obj.defineNativeMethod("entries", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Return CreateArrayIterator(O, "key+value").
     return Create.CreateArrayIterator(realm, O, "key+value");
@@ -219,10 +212,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.5
   obj.defineNativeMethod("every", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
@@ -249,7 +242,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let kValue = Get(realm, O, Pk);
 
         // ii. Let testResult be ToBoolean(? Call(callbackfn, T, « kValue, k, O »)).
-        let testResult = ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
+        let testResult = To.ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
 
         // iii. If testResult is false, return false.
         if (!testResult) return realm.intrinsics.false;
@@ -266,19 +259,19 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.6
   obj.defineNativeMethod("fill", 1, (context, [value, start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. Let relativeStart be ? ToInteger(start).
-    let relativeStart = ToInteger(realm, start || realm.intrinsics.undefined);
+    let relativeStart = To.ToInteger(realm, start || realm.intrinsics.undefined);
 
     // 4. If relativeStart < 0, let k be max((len + relativeStart), 0); else let k be min(relativeStart, len).
     let k = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
 
     // 5. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
-    let relativeEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let relativeEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 6. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
     let final = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
@@ -302,10 +295,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.7
   obj.defineNativeMethod("filter", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
@@ -338,12 +331,12 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let kValue = Get(realm, O, Pk);
 
         // ii. Let selected be ToBoolean(? Call(callbackfn, T, « kValue, k, O »)).
-        let selected = ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
+        let selected = To.ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
 
         // iii. If selected is true, then
         if (selected) {
           // 1. Perform ? CreateDataPropertyOrThrow(A, ! ToString(to), kValue).
-          Create.CreateDataPropertyOrThrow(realm, A, ToString(realm, new NumberValue(realm, to)), kValue);
+          Create.CreateDataPropertyOrThrow(realm, A, To.ToString(realm, new NumberValue(realm, to)), kValue);
 
           // 2. Increase to by 1.
           to++;
@@ -361,10 +354,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.8
   obj.defineNativeMethod("find", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(predicate) is false, throw a TypeError exception.
     if (!IsCallable(realm, predicate)) {
@@ -386,7 +379,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let kValue = Get(realm, O, Pk);
 
       // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-      let testResult = ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
+      let testResult = To.ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
 
       // d. If testResult is true, return kValue.
       if (testResult) return kValue;
@@ -402,10 +395,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.9
   obj.defineNativeMethod("findIndex", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(predicate) is false, throw a TypeError exception.
     if (IsCallable(realm, predicate) === false) {
@@ -421,13 +414,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 6. Repeat, while k < len
     while (k < len) {
       // a. Let Pk be ! ToString(k).
-      let Pk = ToString(realm, new NumberValue(realm, k));
+      let Pk = To.ToString(realm, new NumberValue(realm, k));
 
       // b. Let kValue be ? Get(O, Pk).
       let kValue = Get(realm, O, new StringValue(realm, Pk));
 
       // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-      let testResult = ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
+      let testResult = To.ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
 
       // d. If testResult is true, return k.
       if (testResult === true) return new NumberValue(realm, k);
@@ -443,10 +436,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.10
   obj.defineNativeMethod("forEach", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
@@ -461,7 +454,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
     // 6. Repeat, while k < len
     while (k < len) {
-      // a. Let Pk be ! ToString(k).
+      // a. Let Pk be ! To.ToString(k).
       let Pk = new StringValue(realm, k + "");
 
       // b. Let kPresent be ? HasProperty(O, Pk).
@@ -488,16 +481,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION))
     obj.defineNativeMethod("includes", 1, (context, [searchElement, fromIndex]) => {
       // 1. Let O be ? ToObject(this value).
-      let O = ToObject(realm, context.throwIfNotConcrete());
+      let O = To.ToObject(realm, context.throwIfNotConcrete());
 
       // 2. Let len be ? ToLength(? Get(O, "length")).
-      let len = ToLength(realm, Get(realm, O, "length"));
+      let len = To.ToLength(realm, Get(realm, O, "length"));
 
       // 3. If len is 0, return false.
       if (len === 0) return realm.intrinsics.false;
 
       // 4. Let n be ? ToInteger(fromIndex). (If fromIndex is undefined, this step produces the value 0.)
-      let n = ToInteger(realm, fromIndex || realm.intrinsics.undefined);
+      let n = To.ToInteger(realm, fromIndex || realm.intrinsics.undefined);
 
       let k;
       // 5. If n ≥ 0, then
@@ -515,7 +508,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // 7. Repeat, while k < len
       while (k < len) {
         // a. Let elementK be the result of ? Get(O, ! ToString(k)).
-        let elementK = Get(realm, O, ToString(realm, new NumberValue(realm, k)));
+        let elementK = Get(realm, O, To.ToString(realm, new NumberValue(realm, k)));
 
         // b. If SameValueZero(searchElement, elementK) is true, return true.
         if (SameValueZeroPartial(realm, searchElement, elementK) === true) return realm.intrinsics.true;
@@ -531,16 +524,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.12
   obj.defineNativeMethod("indexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If len is 0, return -1.
     if (len === 0) return new NumberValue(realm, -1);
 
     // 4. Let n be ? ToInteger(fromIndex). (If fromIndex is undefined, this step produces the value 0.)
-    let n = fromIndex ? ToInteger(realm, fromIndex) : 0;
+    let n = fromIndex ? To.ToInteger(realm, fromIndex) : 0;
 
     // 5. If n ≥ len, return -1.
     if (n >= len) return new NumberValue(realm, -1);
@@ -587,16 +580,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.13
   obj.defineNativeMethod("join", 1, (context, [separator]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If separator is undefined, let separator be the single-element String ",".
     if (!separator || separator instanceof UndefinedValue) separator = new StringValue(realm, ",");
 
     // 4. Let sep be ? ToString(separator).
-    let sep = ToStringPartial(realm, separator);
+    let sep = To.ToStringPartial(realm, separator);
 
     // 5. If len is zero, return the empty String.
     if (len === 0) return realm.intrinsics.emptyString;
@@ -609,7 +602,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (HasSomeCompatibleType(element0, UndefinedValue, NullValue)) {
       R = "";
     } else {
-      R = ToStringPartial(realm, element0);
+      R = To.ToStringPartial(realm, element0);
     }
 
     // 8. Let k be 1.
@@ -620,7 +613,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // a. Let S be the String value produced by concatenating R and sep.
       let S: string = R + sep;
 
-      // b. Let element be ? Get(O, ! ToString(k)).
+      // b. Let element be ? Get(O, ! To.ToString(k)).
       let element = Get(realm, O, new StringValue(realm, k + ""));
 
       // c. If element is undefined or null, let next be the empty String; otherwise, let next be ? ToString(element).
@@ -628,7 +621,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       if (HasSomeCompatibleType(element, UndefinedValue, NullValue)) {
         next = "";
       } else {
-        next = ToStringPartial(realm, element);
+        next = To.ToStringPartial(realm, element);
       }
 
       // d. Let R be a String value produced by concatenating S and next.
@@ -645,7 +638,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.14
   obj.defineNativeMethod("keys", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Return CreateArrayIterator(O, "key").
     return Create.CreateArrayIterator(realm, O, "key");
@@ -654,16 +647,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.15
   obj.defineNativeMethod("lastIndexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If len is 0, return -1.
     if (len === 0) return new NumberValue(realm, -1);
 
     // 4. If argument fromIndex was passed, let n be ? ToInteger(fromIndex); else let n be len-1.
-    let n = fromIndex ? ToInteger(realm, fromIndex) : len - 1;
+    let n = fromIndex ? To.ToInteger(realm, fromIndex) : len - 1;
 
     // 5. If n ≥ 0, then
     let k;
@@ -704,10 +697,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.16
   obj.defineNativeMethod("map", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
@@ -725,7 +718,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
     // 7. Repeat, while k < len
     while (k < len) {
-      // a. Let Pk be ! ToString(k).
+      // a. Let Pk be ! To.ToString(k).
       let Pk = new StringValue(realm, k + "");
 
       // b. Let kPresent be ? HasProperty(O, Pk).
@@ -754,10 +747,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.17
   obj.defineNativeMethod("pop", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If len is zero, then
     if (len === 0) {
@@ -791,10 +784,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.18
   obj.defineNativeMethod("push", 1, (context, args, argCount) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, new StringValue(realm, "length")));
+    let len = To.ToLength(realm, Get(realm, O, new StringValue(realm, "length")));
 
     // 3. Let items be a List whose elements are, in left to right order, the arguments that were passed to realm function invocation.
     let items = argCount > 0 ? args : [];
@@ -829,10 +822,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.19
   obj.defineNativeMethod("reduce", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
@@ -916,10 +909,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.20
   obj.defineNativeMethod("reduceRight", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
@@ -1001,10 +994,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.21
   obj.defineNativeMethod("reverse", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. Let middle be floor(len/2).
     let middle = Math.floor(len / 2);
@@ -1087,10 +1080,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.22
   obj.defineNativeMethod("shift", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If len is zero, then
     if (len === 0) {
@@ -1148,19 +1141,19 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.23
   obj.defineNativeMethod("slice", 2, (context, [start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. Let relativeStart be ? ToInteger(start).
-    let relativeStart = ToInteger(realm, start);
+    let relativeStart = To.ToInteger(realm, start);
 
     // 4. If relativeStart < 0, let k be max((len + relativeStart), 0); else let k be min(relativeStart, len).
     let k = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
 
     // 5. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
-    let relativeEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let relativeEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 6. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
     let final = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
@@ -1208,10 +1201,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.24
   obj.defineNativeMethod("some", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     if (!IsCallable(realm, callbackfn)) {
@@ -1241,7 +1234,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let kValue = Get(realm, O, Pk);
 
         // ii. Let testResult be ToBoolean(? Call(callbackfn, T, « kValue, k, O »)).
-        let testResult = ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
+        let testResult = To.ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
 
         // iii. If testResult is true, return true.
         if (testResult) return realm.intrinsics.true;
@@ -1258,10 +1251,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.25
   obj.defineNativeMethod("sort", 1, (context, [comparefn]) => {
     // 1. Let obj be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(obj, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // Within this specification of the sort method, an object, obj, is said to be sparse if the following algorithm returns true:
     let isSparse = () => {
@@ -1345,7 +1338,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // 4. If the argument comparefn is not undefined, then
       if (!comparefn.mightBeUndefined()) {
         // a. Let v be ? ToNumber(? Call(comparefn, undefined, « x, y »)).
-        let v = ToNumber(realm, Call(realm, comparefn, new UndefinedValue(realm), [x, y]));
+        let v = To.ToNumber(realm, Call(realm, comparefn, new UndefinedValue(realm), [x, y]));
         // b. If v is NaN, return +0.
         if (isNaN(v)) return new NumberValue(realm, +0);
         // c. Return v.
@@ -1354,9 +1347,9 @@ export default function(realm: Realm, obj: ObjectValue): void {
         comparefn.throwIfNotConcrete();
       }
       // 5. Let xString be ? ToString(x).
-      let xString = new StringValue(realm, ToString(realm, x));
+      let xString = new StringValue(realm, To.ToString(realm, x));
       // 6. Let yString be ? ToString(y).
-      let yString = new StringValue(realm, ToString(realm, y));
+      let yString = new StringValue(realm, To.ToString(realm, y));
       // 7. Let xSmaller be the result of performing Abstract Relational Comparison xString < yString.
       let xSmaller = AbstractRelationalComparison(realm, xString, yString, true);
       // 8. If xSmaller is true, return -1.
@@ -1383,7 +1376,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       invariant(y instanceof Value, "Unexpected type");
 
       let result_ = SortCompare(x, y);
-      let numb = ToNumber(realm, result_);
+      let numb = To.ToNumber(realm, result_);
       return numb;
     };
 
@@ -1424,13 +1417,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.26
   obj.defineNativeMethod("splice", 2, (context, [start, deleteCount, ...items], argLength) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. Let relativeStart be ? ToInteger(start).
-    let relativeStart = ToInteger(realm, start);
+    let relativeStart = To.ToInteger(realm, start);
 
     // 4. If relativeStart < 0, let actualStart be max((len + relativeStart), 0); else let actualStart be min(relativeStart, len).
     let actualStart = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
@@ -1458,7 +1451,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       insertCount = argLength - 2;
 
       // b. Let dc be ? ToInteger(deleteCount).
-      let dc = ToInteger(realm, deleteCount);
+      let dc = To.ToInteger(realm, deleteCount);
 
       // c. Let actualDeleteCount be min(max(dc, 0), len - actualStart).
       actualDeleteCount = Math.min(Math.max(dc, 0), len - actualStart);
@@ -1609,10 +1602,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.27
   obj.defineNativeMethod("toLocaleString", 0, context => {
     // 1. Let array be ? ToObject(this value).
-    let array = ToObject(realm, context.throwIfNotConcrete());
+    let array = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(array, "length")).
-    let len = ToLength(realm, Get(realm, array, "length"));
+    let len = To.ToLength(realm, Get(realm, array, "length"));
 
     // 3. Let separator be the String value for the list-separator String appropriate for the host environment's
     //    current locale (this is derived in an implementation-defined way).
@@ -1632,7 +1625,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 7. Else,
       // a. Let R be ? ToString(? Invoke(firstElement, "toLocaleString")).
-      R = ToStringPartial(realm, Invoke(realm, firstElement, "toLocaleString"));
+      R = To.ToStringPartial(realm, Invoke(realm, firstElement, "toLocaleString"));
     }
 
     // 8. Let k be 1.
@@ -1653,7 +1646,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       } else {
         // d. Else,
         // i. Let R be ? ToString(? Invoke(nextElement, "toLocaleString")).
-        R = ToStringPartial(realm, Invoke(realm, nextElement, "toLocaleString"));
+        R = To.ToStringPartial(realm, Invoke(realm, nextElement, "toLocaleString"));
       }
 
       // e. Let R be a String value produced by concatenating S and R.
@@ -1673,10 +1666,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.29
   obj.defineNativeMethod("unshift", 1, (context, items, argCount) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = ToLength(realm, Get(realm, O, "length"));
+    let len = To.ToLength(realm, Get(realm, O, "length"));
 
     // 3. Let argCount be the number of actual arguments.
     argCount;

--- a/src/intrinsics/ecma262/Boolean.js
+++ b/src/intrinsics/ecma262/Boolean.js
@@ -11,14 +11,13 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, BooleanValue } from "../../values/index.js";
-import { Create } from "../../singletons.js";
-import { ToBooleanPartial } from "../../methods/to.js";
+import { Create, To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.3.1.1
   let func = new NativeFunctionValue(realm, "Boolean", "Boolean", 1, (context, [value], argCount, NewTarget) => {
     // 1. Let b be ToBoolean(value).
-    let b = new BooleanValue(realm, ToBooleanPartial(realm, value));
+    let b = new BooleanValue(realm, To.ToBooleanPartial(realm, value));
 
     // 2. If NewTarget is undefined, return b.
     if (!NewTarget) return b;

--- a/src/intrinsics/ecma262/BooleanPrototype.js
+++ b/src/intrinsics/ecma262/BooleanPrototype.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, AbstractValue, BooleanValue } from "../../values/index.js";
-import { thisBooleanValue } from "../../methods/to.js";
+import { To } from "../../singletons.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -28,7 +28,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createFromTemplate(realm, tsTemplate, StringValue, [target], tsTemplateSrc);
     }
     // 1. Let b be ? thisBooleanValue(this value).
-    let b = thisBooleanValue(realm, context);
+    let b = To.thisBooleanValue(realm, context);
 
     // 2. If b is true, return "true"; else return "false".
     return new StringValue(realm, b.value ? "true" : "false");
@@ -37,6 +37,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 19.3.3.4
   obj.defineNativeMethod("valueOf", 0, context => {
     // 1. Return ? thisBooleanValue(this value).
-    return thisBooleanValue(realm, context);
+    return To.thisBooleanValue(realm, context);
   });
 }

--- a/src/intrinsics/ecma262/DataView.js
+++ b/src/intrinsics/ecma262/DataView.js
@@ -10,9 +10,9 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ToIndexPartial, IsDetachedBuffer } from "../../methods/index.js";
+import { IsDetachedBuffer } from "../../methods/index.js";
 import { NativeFunctionValue, ObjectValue, UndefinedValue } from "../../values/index.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -40,7 +40,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // 4. Let offset be ? ToIndex(byteOffset).
-      let offset = ToIndexPartial(realm, byteOffset);
+      let offset = To.ToIndexPartial(realm, byteOffset);
 
       // 5. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
       if (IsDetachedBuffer(realm, buffer)) {
@@ -64,7 +64,7 @@ export default function(realm: Realm): NativeFunctionValue {
       } else {
         // 9. Else,
         // a. Let viewByteLength be ? ToIndex(byteLength).
-        viewByteLength = ToIndexPartial(realm, byteLength);
+        viewByteLength = To.ToIndexPartial(realm, byteLength);
 
         // b. If offset+viewByteLength > bufferByteLength, throw a RangeError exception.
         if (offset + viewByteLength > bufferByteLength) {

--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -11,8 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NativeFunctionValue, NumberValue, StringValue, ObjectValue } from "../../values/index.js";
-import { ToInteger, ToNumber, ToPrimitive } from "../../methods/to.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 import { MakeTime, MakeDate, MakeDay, TimeClip, UTC, ToDateString, thisTimeValue } from "../../methods/date.js";
 import { FatalError } from "../../errors.js";
 import invariant from "../../invariant.js";
@@ -59,30 +58,30 @@ export default function(realm: Realm): NativeFunctionValue {
       // 3. If NewTarget is not undefined, then
       if (NewTarget) {
         // a. Let y be ? ToNumber(year).
-        let y = ToNumber(realm, year);
+        let y = To.ToNumber(realm, year);
 
         // b. Let m be ? ToNumber(month).
-        let m = ToNumber(realm, month);
+        let m = To.ToNumber(realm, month);
 
         // c. If date is supplied, let dt be ? ToNumber(date); else let dt be 1.
-        let dt = argCount >= 3 ? ToNumber(realm, date) : 1;
+        let dt = argCount >= 3 ? To.ToNumber(realm, date) : 1;
 
         // d. If hours is supplied, let h be ? ToNumber(hours); else let h be 0.
-        let h = argCount >= 4 ? ToNumber(realm, hours) : 0;
+        let h = argCount >= 4 ? To.ToNumber(realm, hours) : 0;
 
         // e. If minutes is supplied, let min be ? ToNumber(minutes); else let min be 0.
-        let min = argCount >= 5 ? ToNumber(realm, minutes) : 0;
+        let min = argCount >= 5 ? To.ToNumber(realm, minutes) : 0;
 
         // f. If seconds is supplied, let s be ? ToNumber(seconds); else let s be 0.
-        let s = argCount >= 6 ? ToNumber(realm, seconds) : 0;
+        let s = argCount >= 6 ? To.ToNumber(realm, seconds) : 0;
 
         // g. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
-        let milli = argCount >= 7 ? ToNumber(realm, ms) : 0;
+        let milli = argCount >= 7 ? To.ToNumber(realm, ms) : 0;
 
         // h. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y); otherwise, let yr be y.
         let yr;
-        if (!isNaN(y) && ToInteger(realm, y) >= 0 && ToInteger(realm, y) <= 99) {
-          yr = 1900 + ToInteger(realm, new NumberValue(realm, y));
+        if (!isNaN(y) && To.ToInteger(realm, y) >= 0 && To.ToInteger(realm, y) <= 99) {
+          yr = 1900 + To.ToInteger(realm, new NumberValue(realm, y));
         } else {
           yr = y;
         }
@@ -128,7 +127,7 @@ export default function(realm: Realm): NativeFunctionValue {
         } else {
           // b. Else,
           // i. Let v be ? ToPrimitive(value)
-          let v = ToPrimitive(realm, value);
+          let v = To.ToPrimitive(realm, value);
 
           // ii. If Type(v) is String, then
           if (v instanceof StringValue) {
@@ -140,7 +139,7 @@ export default function(realm: Realm): NativeFunctionValue {
           } else {
             // iii. Else,
             // 1. Let tv be ? ToNumber(v).
-            tv = new NumberValue(realm, ToNumber(realm, v));
+            tv = new NumberValue(realm, To.ToNumber(realm, v));
           }
         }
 
@@ -209,28 +208,29 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 20.3.3.4
   func.defineNativeMethod("UTC", 7, (context, [year, month, date, hours, minutes, seconds, ms], argCount) => {
     // 1. Let y be ? ToNumber(year).
-    let y = ToNumber(realm, year);
+    let y = To.ToNumber(realm, year);
 
     // 2. Let m be ? ToNumber(month).
-    let m = argCount >= 2 ? ToNumber(realm, month) : 0;
+    let m = argCount >= 2 ? To.ToNumber(realm, month) : 0;
 
     // 3. If date is supplied, let dt be ? ToNumber(date); else let dt be 1.
-    let dt = argCount >= 3 ? ToNumber(realm, date) : 1;
+    let dt = argCount >= 3 ? To.ToNumber(realm, date) : 1;
 
     // 4. If hours is supplied, let h be ? ToNumber(hours); else let h be 0.
-    let h = argCount >= 4 ? ToNumber(realm, hours) : 0;
+    let h = argCount >= 4 ? To.ToNumber(realm, hours) : 0;
 
     // 5. If minutes is supplied, let min be ? ToNumber(minutes); else let min be 0.
-    let min = argCount >= 5 ? ToNumber(realm, minutes) : 0;
+    let min = argCount >= 5 ? To.ToNumber(realm, minutes) : 0;
 
     // 6. If seconds is supplied, let s be ? ToNumber(seconds); else let s be 0.
-    let s = argCount >= 6 ? ToNumber(realm, seconds) : 0;
+    let s = argCount >= 6 ? To.ToNumber(realm, seconds) : 0;
 
     // 7. If ms is supplied, let milli be ? ToNumber(ms); else let milli be 0.
-    let milli = argCount >= 7 ? ToNumber(realm, ms) : 0;
+    let milli = argCount >= 7 ? To.ToNumber(realm, ms) : 0;
 
     // 8. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yr be 1900+ToInteger(y); otherwise, let yr be y.
-    let yr = !isNaN(y) && ToInteger(realm, y) >= 0 && ToInteger(realm, y) <= 99 ? 1900 + ToInteger(realm, y) : y;
+    let yr =
+      !isNaN(y) && To.ToInteger(realm, y) >= 0 && To.ToInteger(realm, y) <= 99 ? 1900 + To.ToInteger(realm, y) : y;
 
     // 9. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))).
     return TimeClip(realm, MakeDate(realm, MakeDay(realm, yr, m, dt), MakeTime(realm, h, min, s, milli)));

--- a/src/intrinsics/ecma262/DatePrototype.js
+++ b/src/intrinsics/ecma262/DatePrototype.js
@@ -13,10 +13,6 @@ import type { Realm } from "../../realm.js";
 import { FatalError } from "../../errors.js";
 import { StringValue, ObjectValue, NumberValue } from "../../values/index.js";
 import {
-  ToNumber,
-  ToObject,
-  ToPrimitive,
-  ToInteger,
   Invoke,
   MakeTime,
   thisTimeValue,
@@ -37,8 +33,8 @@ import {
   MonthFromTime,
   msPerMinute,
   UTC,
-  OrdinaryToPrimitive,
 } from "../../methods/index.js";
+import { To } from "../../singletons";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -260,7 +256,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let dt be ? ToNumber(date).
-    let dt = ToNumber(realm, date);
+    let dt = To.ToNumber(realm, date);
 
     // 3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
     let newDate = MakeDate(
@@ -289,13 +285,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     t = isNaN(t) ? +0 : LocalTime(realm, t);
 
     // 3. Let y be ? ToNumber(year).
-    let y = ToNumber(realm, year);
+    let y = To.ToNumber(realm, year);
 
     // 4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be ? ToNumber(month).
-    let m = argCount >= 2 ? ToNumber(realm, month) : MonthFromTime(realm, t);
+    let m = argCount >= 2 ? To.ToNumber(realm, month) : MonthFromTime(realm, t);
 
     // 5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-    let dt = argCount >= 3 ? ToNumber(realm, date) : DateFromTime(realm, t);
+    let dt = argCount >= 3 ? To.ToNumber(realm, date) : DateFromTime(realm, t);
 
     // 6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
     let newDate = MakeDate(realm, MakeDay(realm, y, m, dt), TimeWithinDay(realm, t));
@@ -317,16 +313,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let h be ? ToNumber(hour).
-    let h = ToNumber(realm, hour);
+    let h = To.ToNumber(realm, hour);
 
     // 3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ? ToNumber(min).
-    let m = argCount >= 2 ? ToNumber(realm, min) : MinFromTime(realm, t);
+    let m = argCount >= 2 ? To.ToNumber(realm, min) : MinFromTime(realm, t);
 
     // 4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-    let s = argCount >= 3 ? ToNumber(realm, sec) : SecFromTime(realm, t);
+    let s = argCount >= 3 ? To.ToNumber(realm, sec) : SecFromTime(realm, t);
 
     // 5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-    let milli = argCount >= 4 ? ToNumber(realm, ms) : msFromTime(realm, t);
+    let milli = argCount >= 4 ? To.ToNumber(realm, ms) : msFromTime(realm, t);
 
     // 6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
     let date = MakeDate(realm, Day(realm, t), MakeTime(realm, h, m, s, milli));
@@ -348,7 +344,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let ms be ? ToNumber(ms).
-    ms = ToNumber(realm, ms);
+    ms = To.ToNumber(realm, ms);
 
     // 3. Let time be MakeTime(HourFromTime(t), MinFromTime(t), SecFromTime(t), ms).
     let time = MakeTime(realm, HourFromTime(realm, t), MinFromTime(realm, t), SecFromTime(realm, t), ms);
@@ -370,13 +366,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let m be ? ToNumber(min).
-    let m = ToNumber(realm, min);
+    let m = To.ToNumber(realm, min);
 
     // 3. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-    let s = argCount >= 2 ? ToNumber(realm, sec) : SecFromTime(realm, t);
+    let s = argCount >= 2 ? To.ToNumber(realm, sec) : SecFromTime(realm, t);
 
     // 4. If ms is not specified, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-    let milli = argCount >= 3 ? ToNumber(realm, ms) : msFromTime(realm, t);
+    let milli = argCount >= 3 ? To.ToNumber(realm, ms) : msFromTime(realm, t);
 
     // 5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
     let date = MakeDate(realm, Day(realm, t), MakeTime(realm, HourFromTime(realm, t), m, s, milli));
@@ -398,10 +394,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let m be ? ToNumber(month).
-    let m = ToNumber(realm, month);
+    let m = To.ToNumber(realm, month);
 
     // 3. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-    let dt = argCount >= 2 ? ToNumber(realm, date) : DateFromTime(realm, t);
+    let dt = argCount >= 2 ? To.ToNumber(realm, date) : DateFromTime(realm, t);
 
     // 4. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
     let newDate = MakeDate(realm, MakeDay(realm, YearFromTime(realm, t), m, dt), TimeWithinDay(realm, t));
@@ -423,10 +419,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let s be ? ToNumber(sec).
-    let s = ToNumber(realm, sec);
+    let s = To.ToNumber(realm, sec);
 
     // 3. If ms is not specified, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-    let milli = argCount >= 2 ? ToNumber(realm, ms) : msFromTime(realm, t);
+    let milli = argCount >= 2 ? To.ToNumber(realm, ms) : msFromTime(realm, t);
 
     // 4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
     let date = MakeDate(realm, Day(realm, t), MakeTime(realm, HourFromTime(realm, t), MinFromTime(realm, t), s, milli));
@@ -448,7 +444,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let t be ? ToNumber(time).
-    let t = ToNumber(realm, time);
+    let t = To.ToNumber(realm, time);
 
     // 3. Let v be TimeClip(t).
     let v = TimeClip(realm, t);
@@ -467,7 +463,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let dt be ? ToNumber(date).
-    let dt = ToNumber(realm, date);
+    let dt = To.ToNumber(realm, date);
 
     // 3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
     let newDate = MakeDate(
@@ -496,13 +492,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (isNaN(t)) t = +0;
 
     // 3. Let y be ? ToNumber(year).
-    let y = ToNumber(realm, year);
+    let y = To.ToNumber(realm, year);
 
     // 4. If month is not specified, let m be MonthFromTime(t); otherwise, let m be ? ToNumber(month).
-    let m = argCount >= 2 ? ToNumber(realm, month) : MonthFromTime(realm, t);
+    let m = argCount >= 2 ? To.ToNumber(realm, month) : MonthFromTime(realm, t);
 
     // 5. If date is not specified, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-    let dt = argCount >= 3 ? ToNumber(realm, date) : DateFromTime(realm, t);
+    let dt = argCount >= 3 ? To.ToNumber(realm, date) : DateFromTime(realm, t);
 
     // 6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
     let newDate = MakeDate(realm, MakeDay(realm, y, m, dt), TimeWithinDay(realm, t));
@@ -524,16 +520,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let h be ? ToNumber(hour).
-    let h = ToNumber(realm, hour);
+    let h = To.ToNumber(realm, hour);
 
     // 3. If min is not specified, let m be MinFromTime(t); otherwise, let m be ? ToNumber(min).
-    let m = argCount >= 2 ? ToNumber(realm, min) : MinFromTime(realm, t);
+    let m = argCount >= 2 ? To.ToNumber(realm, min) : MinFromTime(realm, t);
 
     // 4. If sec is not specified, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-    let s = argCount >= 3 ? ToNumber(realm, sec) : SecFromTime(realm, t);
+    let s = argCount >= 3 ? To.ToNumber(realm, sec) : SecFromTime(realm, t);
 
     // 5. If ms is not specified, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-    let milli = argCount >= 4 ? ToNumber(realm, ms) : msFromTime(realm, t);
+    let milli = argCount >= 4 ? To.ToNumber(realm, ms) : msFromTime(realm, t);
 
     // 6. Let newDate be MakeDate(Day(t), MakeTime(h, m, s, milli)).
     let newDate = MakeDate(realm, Day(realm, t), MakeTime(realm, h, m, s, milli));
@@ -555,7 +551,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let milli be ? ToNumber(ms).
-    let milli = ToNumber(realm, ms);
+    let milli = To.ToNumber(realm, ms);
 
     // 3. Let time be MakeTime(HourFromTime(t), MinFromTime(t), SecFromTime(t), milli).
     let time = MakeTime(realm, HourFromTime(realm, t), MinFromTime(realm, t), SecFromTime(realm, t), milli);
@@ -577,7 +573,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let m be ? ToNumber(min).
-    let m = ToNumber(realm, min);
+    let m = To.ToNumber(realm, min);
 
     // 3. If sec is not specified, let s be SecFromTime(t).
     let s;
@@ -586,7 +582,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 4. Else,
       // a. Let s be ? ToNumber(sec).
-      s = ToNumber(realm, sec);
+      s = To.ToNumber(realm, sec);
     }
 
     // 5. If ms is not specified, let milli be msFromTime(t).
@@ -596,7 +592,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 6. Else,
       // a. Let milli be ? ToNumber(ms).
-      milli = ToNumber(realm, ms);
+      milli = To.ToNumber(realm, ms);
     }
 
     // 7. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
@@ -619,7 +615,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let m be ? ToNumber(month).
-    let m = ToNumber(realm, month);
+    let m = To.ToNumber(realm, month);
 
     // 3. If date is not specified, let dt be DateFromTime(t).
     let dt;
@@ -628,7 +624,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 4. Else,
       // a. Let dt be ? ToNumber(date).
-      dt = ToNumber(realm, date);
+      dt = To.ToNumber(realm, date);
     }
 
     // 5. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
@@ -651,7 +647,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(context instanceof ObjectValue);
 
     // 2. Let s be ? ToNumber(sec).
-    let s = ToNumber(realm, sec);
+    let s = To.ToNumber(realm, sec);
 
     // 3. If ms is not specified, let milli be msFromTime(t).
     let milli;
@@ -660,7 +656,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 4. Else,
       // a. Let milli be ? ToNumber(ms).
-      milli = ToNumber(realm, ms);
+      milli = To.ToNumber(realm, ms);
     }
 
     // 5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
@@ -694,10 +690,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 20.3.4.37
   obj.defineNativeMethod("toJSON", 1, (context, [key]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let tv be ? ToPrimitive(O, hint Number).
-    let tv = ToPrimitive(realm, O, "number");
+    let tv = To.ToPrimitive(realm, O, "number");
 
     // 3. If Type(tv) is Number and tv is not finite, return null.
     if (tv instanceof NumberValue && !isFinite(tv.value)) {
@@ -788,7 +784,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       }
 
       // 6. Return ? OrdinaryToPrimitive(O, tryFirst).
-      return OrdinaryToPrimitive(realm, O, tryFirst);
+      return To.OrdinaryToPrimitive(realm, O, tryFirst);
     },
     { writable: false }
   );
@@ -815,7 +811,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     t = isNaN(t) ? +0 : LocalTime(realm, t);
 
     // 3. Let y be ? ToNumber(year).
-    let y = ToNumber(realm, year);
+    let y = To.ToNumber(realm, year);
 
     // 4. If y is NaN, set the [[DateValue]] internal slot of this Date object to NaN and return NaN.
     if (isNaN(y)) {
@@ -823,10 +819,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return realm.intrinsics.NaN;
     }
 
-    // 5. If y is not NaN and 0 ≤ ToInteger(y) ≤ 99, let yyyy be ToInteger(y) + 1900.
+    // 5. If y is not NaN and 0 ≤ To.ToInteger(y) ≤ 99, let yyyy be To.ToInteger(y) + 1900.
     let yyyy;
-    if (ToInteger(realm, y) < 99) {
-      yyyy = ToInteger(realm, y) + 1900;
+    if (To.ToInteger(realm, y) < 99) {
+      yyyy = To.ToInteger(realm, y) + 1900;
     } else {
       // 6. Else, let yyyy be y.
       yyyy = y;

--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -12,8 +12,8 @@
 import type { Realm } from "../../realm.js";
 import type { LexicalEnvironment } from "../../environment.js";
 import { ObjectValue, FunctionValue, NativeFunctionValue, StringValue } from "../../values/index.js";
-import { Get, ToStringPartial, ToStringValue } from "../../methods/index.js";
-import { Create, Properties } from "../../singletons.js";
+import { Get } from "../../methods/index.js";
+import { Create, Properties, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 import type { BabelNodeSourceLocation } from "babel-types";
 
@@ -36,7 +36,7 @@ export function describeLocation(
     }
 
     let name = callerFn.$Get("name", callerFn);
-    if (!name.mightBeUndefined()) displayName = ToStringPartial(realm, name);
+    if (!name.mightBeUndefined()) displayName = To.ToStringPartial(realm, name);
     else name.throwIfNotConcrete();
 
     if (env && env.$NewTarget) displayName = `new ${displayName}`;
@@ -68,11 +68,11 @@ function buildStack(realm: Realm, context: ObjectValue) {
   let lines = [];
   let header = "";
 
-  header += ToStringPartial(realm, Get(realm, context, "name"));
+  header += To.ToStringPartial(realm, Get(realm, context, "name"));
 
   let msg = Get(realm, context, "message");
   if (!msg.mightBeUndefined()) {
-    msg = ToStringPartial(realm, msg);
+    msg = To.ToStringPartial(realm, msg);
     if (msg) header += `: ${msg}`;
   } else {
     msg.throwIfNotConcrete();
@@ -116,7 +116,7 @@ export function build(name: string, realm: Realm, inheritError?: boolean = true)
     // 3. If message is not undefined, then
     if (!message.mightBeUndefined()) {
       // a. Let msg be ? ToString(message).
-      let msg = message.getType() === StringValue ? message : ToStringValue(realm, message);
+      let msg = message.getType() === StringValue ? message : To.ToStringValue(realm, message);
 
       // b. Let msgDesc be the PropertyDescriptor{[[Value]]: msg, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true}.
       let msgDesc = {

--- a/src/intrinsics/ecma262/ErrorPrototype.js
+++ b/src/intrinsics/ecma262/ErrorPrototype.js
@@ -11,7 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, ObjectValue, StringValue, UndefinedValue } from "../../values/index.js";
-import { ToStringPartial, Get } from "../../methods/index.js";
+import { Get } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -45,7 +46,7 @@ export function build(name: string, realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. If name is undefined, let name be "Error"; otherwise let name be ? ToString(name).
-    let nameString = nameValue instanceof UndefinedValue ? "Error" : ToStringPartial(realm, nameValue);
+    let nameString = nameValue instanceof UndefinedValue ? "Error" : To.ToStringPartial(realm, nameValue);
 
     // 5. Let msg be ? Get(O, "message").
     let msg = Get(realm, O, "message");
@@ -54,7 +55,7 @@ export function build(name: string, realm: Realm, obj: ObjectValue): void {
     }
 
     // 6. If msg is undefined, let msg be the empty String; otherwise let msg be ? ToString(msg).
-    msg = msg instanceof UndefinedValue ? "" : ToStringPartial(realm, msg);
+    msg = msg instanceof UndefinedValue ? "" : To.ToStringPartial(realm, msg);
 
     // 7. If name is the empty String, return msg.
     if (nameString === "") return new StringValue(realm, msg);

--- a/src/intrinsics/ecma262/FunctionPrototype.js
+++ b/src/intrinsics/ecma262/FunctionPrototype.js
@@ -23,8 +23,7 @@ import {
   ObjectValue,
 } from "../../values/index.js";
 import { Call } from "../../methods/call.js";
-import { ToInteger } from "../../methods/to.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 import { Get } from "../../methods/get.js";
 import { IsCallable } from "../../methods/is.js";
 import { HasOwnProperty, HasSomeCompatibleType } from "../../methods/has.js";
@@ -119,7 +118,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         // c. Else,
         targetLen = targetLen.throwIfNotConcreteNumber();
         // i. Let targetLen be ToInteger(targetLen).
-        targetLen = ToInteger(realm, targetLen);
+        targetLen = To.ToInteger(realm, targetLen);
 
         // ii. Let L be the larger of 0 and the result of targetLen minus the number of elements of args.
         L = Math.max(0, targetLen - args.length);

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -23,23 +23,11 @@ import {
   UndefinedValue,
   Value,
 } from "../../values/index.js";
-import {
-  Call,
-  EnumerableOwnProperties,
-  Get,
-  HasSomeCompatibleType,
-  IsArray,
-  IsCallable,
-  ToInteger,
-  ToLength,
-  ToNumber,
-  ToString,
-  ToStringPartial,
-} from "../../methods/index.js";
+import { Call, EnumerableOwnProperties, Get, HasSomeCompatibleType, IsArray, IsCallable } from "../../methods/index.js";
 import { InternalizeJSONProperty } from "../../methods/json.js";
 import { ValuesDomain } from "../../domains/index.js";
 import { FatalError } from "../../errors.js";
-import { Create, Properties } from "../../singletons.js";
+import { Create, Properties, To } from "../../singletons.js";
 import nativeToInterp from "../../utils/native-to-interp.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
@@ -71,7 +59,7 @@ function SerializeJSONArray(realm: Realm, value: ObjectValue, context: Context):
   let partial = [];
 
   // 6. Let len be ? ToLength(? Get(value, "length")).
-  let len = ToLength(realm, Get(realm, value, "length"));
+  let len = To.ToLength(realm, Get(realm, value, "length"));
 
   // 7. Let index be 0.
   let index = 0;
@@ -248,11 +236,11 @@ function SerializeJSONProperty(realm: Realm, key: StringValue, holder: ObjectVal
     // a. If value has a [[NumberData]] internal slot, then
     if (value.$NumberData) {
       // b. Let value be ? ToNumber(value).
-      value = new NumberValue(realm, ToNumber(realm, value));
+      value = new NumberValue(realm, To.ToNumber(realm, value));
     } else if (value.$StringData) {
       // c. Else if value has a [[StringData]] internal slot, then
       // d. Let value be ? ToString(value).
-      value = new StringValue(realm, ToString(realm, value));
+      value = new StringValue(realm, To.ToString(realm, value));
     } else if (value.$BooleanData) {
       // e. Else if value has a [[BooleanData]] internal slot, then
       // f. Let value be the value of the [[BooleanData]] internal slot of value.
@@ -276,7 +264,7 @@ function SerializeJSONProperty(realm: Realm, key: StringValue, holder: ObjectVal
   if (value instanceof NumberValue) {
     // a. If value is finite, return ! ToString(value).
     if (isFinite(value.value)) {
-      return ToString(realm, value);
+      return To.ToString(realm, value);
     } else {
       // b. Else, return "null".
       return "null";
@@ -353,9 +341,9 @@ function InternalJSONClone(realm: Realm, val: Value): Value {
     if (isArray === true) {
       clonedObj = Create.ObjectCreate(realm, realm.intrinsics.ArrayPrototype);
       let I = 0;
-      let len = ToLength(realm, Get(realm, val, "length"));
+      let len = To.ToLength(realm, Get(realm, val, "length"));
       while (I < len) {
-        let P = ToString(realm, new NumberValue(realm, I));
+        let P = To.ToString(realm, new NumberValue(realm, I));
         let newElement = Get(realm, val, P);
         if (!(newElement instanceof UndefinedValue)) {
           // TODO #1011: An abstract value that ultimately yields undefined should still be skipped
@@ -425,7 +413,7 @@ export default function(realm: Realm): ObjectValue {
           PropertyList = [];
 
           // ii. Let len be ? ToLength(? Get(replacer, "length")).
-          let len = ToLength(realm, Get(realm, replacer, "length"));
+          let len = To.ToLength(realm, Get(realm, replacer, "length"));
 
           // iii. Let k be 0.
           let k = 0;
@@ -444,12 +432,12 @@ export default function(realm: Realm): ObjectValue {
               item = v;
             } else if (v instanceof NumberValue) {
               // 4. Else if Type(v) is Number, let item be ! ToString(v).
-              item = new StringValue(realm, ToString(realm, v));
+              item = new StringValue(realm, To.ToString(realm, v));
             } else if (v instanceof ObjectValue) {
               // 5. Else if Type(v) is Object, then
               // a. If v has a [[StringData]] or [[NumberData]] internal slot, let item be ? ToString(v).
               if (v.$StringData || v.$NumberData) {
-                item = new StringValue(realm, ToString(realm, v));
+                item = new StringValue(realm, To.ToString(realm, v));
               }
             }
 
@@ -471,11 +459,11 @@ export default function(realm: Realm): ObjectValue {
       // a. If space has a [[NumberData]] internal slot, then
       if (space.$NumberData) {
         // i. Let space be ? ToNumber(space).
-        space = new NumberValue(realm, ToNumber(realm, space));
+        space = new NumberValue(realm, To.ToNumber(realm, space));
       } else if (space.$StringData) {
         // b. Else if space has a [[StringData]] internal slot, then
         // i. Let space be ? ToString(space).
-        space = new StringValue(realm, ToString(realm, space));
+        space = new StringValue(realm, To.ToString(realm, space));
       }
     }
 
@@ -483,7 +471,7 @@ export default function(realm: Realm): ObjectValue {
     // 6. If Type(space) is Number, then
     if (space instanceof NumberValue) {
       // a. Let space be min(10, ToInteger(space)).
-      space = new NumberValue(realm, Math.min(10, ToInteger(realm, space)));
+      space = new NumberValue(realm, Math.min(10, To.ToInteger(realm, space)));
 
       // b. Set gap to a String containing space occurrences of code unit 0x0020 (SPACE). This will be the empty String if space is less than 1.
       gap = Array(Math.max(0, space.value)).join(" ");
@@ -567,7 +555,7 @@ export default function(realm: Realm): ObjectValue {
       realm.rebuildNestedProperties(unfiltered, unfiltered.intrinsicName);
     } else {
       // 1. Let JText be ? ToString(text).
-      let JText = ToStringPartial(realm, text);
+      let JText = To.ToStringPartial(realm, text);
 
       // 2. Parse JText interpreted as UTF-16 encoded Unicode points (6.1.4) as a JSON text as specified in ECMA-404. Throw a SyntaxError exception if JText is not a valid JSON text as defined in that specification.
       // 3. Let scriptText be the result of concatenating "(", JText, and ");".

--- a/src/intrinsics/ecma262/Math.js
+++ b/src/intrinsics/ecma262/Math.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { StringValue, ObjectValue, NumberValue, AbstractValue } from "../../values/index.js";
-import { ToNumber, ToUint32, IsToNumberPure } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 
@@ -155,7 +155,7 @@ export default function(realm: Realm): ObjectValue {
       if (
         originalLength <= 26 &&
         args.some(arg => arg instanceof AbstractValue) &&
-        args.every(arg => IsToNumberPure(realm, arg))
+        args.every(arg => To.IsToNumberPure(realm, arg))
       ) {
         let r = buildMathTemplates.get(name);
         if (r === undefined) {
@@ -169,7 +169,7 @@ export default function(realm: Realm): ObjectValue {
 
       return new NumberValue(
         realm,
-        Math[name].apply(null, args.map((arg, i) => ToNumber(realm, arg.throwIfNotConcrete())))
+        Math[name].apply(null, args.map((arg, i) => To.ToNumber(realm, arg.throwIfNotConcrete())))
       );
     });
   }
@@ -181,15 +181,15 @@ export default function(realm: Realm): ObjectValue {
   obj.defineNativeMethod("imul", 2, (context, [x, y]) => {
     if (
       (x instanceof AbstractValue || y instanceof AbstractValue) &&
-      IsToNumberPure(realm, x) &&
-      IsToNumberPure(realm, y)
+      To.IsToNumberPure(realm, x) &&
+      To.IsToNumberPure(realm, y)
     ) {
       return AbstractValue.createFromTemplate(realm, imulTemplate, NumberValue, [x, y], imulTemplateSrc);
     }
 
     return new NumberValue(
       realm,
-      Math.imul(ToUint32(realm, x.throwIfNotConcrete()), ToUint32(realm, y.throwIfNotConcrete()))
+      Math.imul(To.ToUint32(realm, x.throwIfNotConcrete()), To.ToUint32(realm, y.throwIfNotConcrete()))
     );
   });
 

--- a/src/intrinsics/ecma262/Number.js
+++ b/src/intrinsics/ecma262/Number.js
@@ -11,8 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, NumberValue } from "../../values/index.js";
-import { ToNumber, ToInteger } from "../../methods/index.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 20.1.1
@@ -24,7 +23,7 @@ export default function(realm: Realm): NativeFunctionValue {
       n = realm.intrinsics.zero;
     } else {
       // 2. Else, let n be ? ToNumber(value).
-      n = new NumberValue(realm, ToNumber(realm, value));
+      n = new NumberValue(realm, To.ToNumber(realm, value));
     }
 
     // 3. If NewTarget is undefined, return n.
@@ -70,7 +69,7 @@ export default function(realm: Realm): NativeFunctionValue {
         return realm.intrinsics.false;
 
       // 3. Let integer be ToInteger(number).
-      let integer = ToInteger(realm, number);
+      let integer = To.ToInteger(realm, number);
 
       // 4. If integer is not equal to number, return false.
       if (integer !== number.value) return realm.intrinsics.false;
@@ -105,7 +104,7 @@ export default function(realm: Realm): NativeFunctionValue {
         return realm.intrinsics.false;
 
       // 3. Let integer be ToInteger(number).
-      let integer = ToInteger(realm, number);
+      let integer = To.ToInteger(realm, number);
 
       // 4. If integer is not equal to number, return false.
       if (integer !== number.value) return realm.intrinsics.false;

--- a/src/intrinsics/ecma262/NumberPrototype.js
+++ b/src/intrinsics/ecma262/NumberPrototype.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, UndefinedValue, AbstractValue, NumberValue } from "../../values/index.js";
-import { ToInteger, ToString, thisNumberValue } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 
@@ -22,11 +22,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 20.1.3.2
   obj.defineNativeMethod("toExponential", 1, (context, [fractionDigits]) => {
     // 1. Let x be ? thisNumberValue(this value).
-    let x = thisNumberValue(realm, context).value;
+    let x = To.thisNumberValue(realm, context).value;
 
     // 2. Let f be ? ToInteger(fractionDigits).
     fractionDigits = fractionDigits.throwIfNotConcrete();
-    let f = ToInteger(realm, fractionDigits);
+    let f = To.ToInteger(realm, fractionDigits);
 
     // 3. Assert: f is 0, when fractionDigits is undefined.
     invariant(f === 0 || !(fractionDigits instanceof UndefinedValue));
@@ -64,7 +64,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 20.1.3.3
   obj.defineNativeMethod("toFixed", 1, (context, [fractionDigits]) => {
     // 1. Let f be ToInteger(fractionDigits). (If fractionDigits is undefined, this step produces the value 0).
-    let f = ToInteger(realm, fractionDigits);
+    let f = To.ToInteger(realm, fractionDigits);
 
     // 2. If f < 0 or f > 20, throw a RangeError exception.
     if (f < 0 || f > 20) {
@@ -72,7 +72,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. Let x be this Number value.
-    let x = thisNumberValue(realm, context).value;
+    let x = To.thisNumberValue(realm, context).value;
 
     // 4. If x is NaN, return the String "NaN".
     if (isNaN(x)) return new StringValue(realm, "NaN");
@@ -85,7 +85,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
   // ECMA262 20.1.3.4
   obj.defineNativeMethod("toLocaleString", 0, context => {
-    let x = thisNumberValue(realm, context);
+    let x = To.thisNumberValue(realm, context);
     if (realm.useAbstractInterpretation) {
       // The locale is environment-dependent and may also be time-dependent
       // so do this at runtime and at this point in time
@@ -98,13 +98,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 20.1.3.5
   obj.defineNativeMethod("toPrecision", 1, (context, [precision]) => {
     // 1. Let x be ? thisNumberValue(this value).
-    let num = thisNumberValue(realm, context);
     // 2. If precision is undefined, return ! ToString(x).
+    let num = To.thisNumberValue(realm, context);
     if (precision instanceof UndefinedValue) {
-      return new StringValue(realm, ToString(realm, num));
+      return new StringValue(realm, To.ToString(realm, num));
     }
     // 3. Let p be ? ToInteger(precision).
-    let p = ToInteger(realm, precision.throwIfNotConcrete());
+    let p = To.ToInteger(realm, precision.throwIfNotConcrete());
     // 4. If x is NaN, return the String "NaN".
     let x = num.value;
     if (isNaN(x)) {
@@ -148,7 +148,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       }
     }
     // 1. Let x be ? thisNumberValue(this value).
-    let x = thisNumberValue(realm, context);
+    let x = To.thisNumberValue(realm, context);
 
     // 2. If radix is not present, let radixNumber be 10.
     // 3. Else if radix is undefined, let radixNumber be 10.
@@ -157,7 +157,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       radixNumber = 10;
     } else {
       // 4. Else let radixNumber be ? ToInteger(radix).
-      radixNumber = ToInteger(realm, radix.throwIfNotConcrete());
+      radixNumber = To.ToInteger(realm, radix.throwIfNotConcrete());
     }
 
     // 5. If radixNumber < 2 or radixNumber > 36, throw a RangeError exception.
@@ -166,7 +166,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 6. If radixNumber = 10, return ! ToString(x).
-    if (radixNumber === 10) return new StringValue(realm, ToString(realm, x));
+    if (radixNumber === 10) return new StringValue(realm, To.ToString(realm, x));
 
     // 7. Return the String representation of this Number value using the radix specified by radixNumber.
     //    Letters a-z are used for digits with values 10 through 35. The precise algorithm is
@@ -178,6 +178,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 20.1.3.7
   obj.defineNativeMethod("valueOf", 0, context => {
     // 1. Return ? thisNumberValue(this value).
-    return thisNumberValue(realm, context);
+    return To.thisNumberValue(realm, context);
   });
 }

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -22,10 +22,6 @@ import {
   SymbolValue,
 } from "../../values/index.js";
 import {
-  ToObject,
-  ToObjectPartial,
-  ToPropertyKey,
-  ToPropertyDescriptor,
   IsExtensible,
   EnumerableOwnProperties,
   GetOwnPropertyKeys,
@@ -36,7 +32,7 @@ import {
   SetIntegrityLevel,
   HasSomeCompatibleType,
 } from "../../methods/index.js";
-import { Create, Properties as Props } from "../../singletons.js";
+import { Create, Properties as Props, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -54,13 +50,13 @@ export default function(realm: Realm): NativeFunctionValue {
     }
 
     // 3. Return ToObject(value).
-    return ToObjectPartial(realm, value);
+    return To.ToObjectPartial(realm, value);
   });
 
   // ECMA262 19.1.2.1
   func.defineNativeMethod("assign", 2, (context, [target, ...sources]) => {
     // 1. Let to be ? ToObject(target).
-    let to = ToObjectPartial(realm, target);
+    let to = To.ToObjectPartial(realm, target);
     let to_must_be_partial = false;
 
     // 2. If only one argument was passed, return to.
@@ -79,7 +75,7 @@ export default function(realm: Realm): NativeFunctionValue {
       } else {
         // b. Else,
         // i. Let from be ToObject(nextSource).
-        frm = ToObjectPartial(realm, nextSource);
+        frm = To.ToObjectPartial(realm, nextSource);
         let frm_was_partial = frm.isPartialObject();
         if (frm_was_partial) {
           to_must_be_partial = true;
@@ -163,10 +159,10 @@ export default function(realm: Realm): NativeFunctionValue {
     O = O.throwIfNotObject();
 
     // 2. Let key be ? ToPropertyKey(P).
-    let key = ToPropertyKey(realm, P.throwIfNotConcrete());
+    let key = To.ToPropertyKey(realm, P.throwIfNotConcrete());
 
     // 3. Let desc be ? ToPropertyDescriptor(Attributes).
-    let desc = ToPropertyDescriptor(realm, Attributes);
+    let desc = To.ToPropertyDescriptor(realm, Attributes);
 
     // 4. Perform ? DefinePropertyOrThrow(O, key, desc).
     Props.DefinePropertyOrThrow(realm, (O: any), key, desc);
@@ -196,10 +192,10 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.1.2.6
   func.defineNativeMethod("getOwnPropertyDescriptor", 2, (context, [O, P]) => {
     // 1. Let obj be ? ToObject(O).
-    let obj = ToObjectPartial(realm, O);
+    let obj = To.ToObjectPartial(realm, O);
 
     // 2. Let key be ? ToPropertyKey(P).
-    let key = ToPropertyKey(realm, P.throwIfNotConcrete());
+    let key = To.ToPropertyKey(realm, P.throwIfNotConcrete());
 
     // 3. Let desc be ? obj.[[GetOwnProperty]](key).
     let desc = obj.$GetOwnProperty(key);
@@ -217,7 +213,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.1.2.8
   func.defineNativeMethod("getOwnPropertyDescriptors", 1, (context, [O]) => {
     // 1. Let obj be ? ToObject(O).
-    let obj = ToObject(realm, O.throwIfNotConcrete());
+    let obj = To.ToObject(realm, O.throwIfNotConcrete());
 
     // 2. Let ownKeys be ? obj.[[OwnPropertyKeys]]().
     let ownKeys = obj.$OwnPropertyKeys();
@@ -251,7 +247,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.1.2.10
   func.defineNativeMethod("getPrototypeOf", 1, (context, [O]) => {
     // 1. Let obj be ? ToObject(O).
-    let obj = ToObject(realm, O.throwIfNotConcrete());
+    let obj = To.ToObject(realm, O.throwIfNotConcrete());
 
     // 2. Return ? obj.[[GetPrototypeOf]]().
     return obj.$GetPrototypeOf();
@@ -296,7 +292,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.1.2.15
   func.defineNativeMethod("keys", 1, (context, [O]) => {
     // 1. Let obj be ? ToObject(O).
-    let obj = ToObject(realm, O.throwIfNotConcrete());
+    let obj = To.ToObject(realm, O.throwIfNotConcrete());
 
     // 2. Let nameList be ? EnumerableOwnProperties(obj, "key").
     let nameList = EnumerableOwnProperties(realm, obj, "key");
@@ -308,7 +304,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 9.1.2.16
   func.defineNativeMethod("values", 1, (context, [O]) => {
     // 1. Let obj be ? ToObject(O).
-    let obj = ToObject(realm, O.throwIfNotConcrete());
+    let obj = To.ToObject(realm, O.throwIfNotConcrete());
 
     // 2. Let nameList be ? EnumerableOwnProperties(obj, "value").
     let nameList = EnumerableOwnProperties(realm, obj, "value");
@@ -320,7 +316,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.1.2.17
   func.defineNativeMethod("entries", 1, (context, [O]) => {
     // 1. Let obj be ? ToObject(O).
-    let obj = ToObject(realm, O.throwIfNotConcrete());
+    let obj = To.ToObject(realm, O.throwIfNotConcrete());
 
     // 2. Let nameList be ? EnumerableOwnProperties(obj, "key+value").
     let nameList = EnumerableOwnProperties(realm, obj, "key+value");

--- a/src/intrinsics/ecma262/ObjectProto_toString.js
+++ b/src/intrinsics/ecma262/ObjectProto_toString.js
@@ -11,9 +11,9 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, UndefinedValue, StringValue, NullValue } from "../../values/index.js";
-import { ToObjectPartial } from "../../methods/to.js";
 import { IsArray } from "../../methods/is.js";
 import { Get } from "../../methods/get.js";
+import { To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 22.1.3.30
@@ -30,7 +30,7 @@ export default function(realm: Realm): NativeFunctionValue {
       if (context instanceof NullValue) return new StringValue(realm, "[object Null]");
 
       // 3. Let O be ToObject(this value).
-      let O = ToObjectPartial(realm, context);
+      let O = To.ToObjectPartial(realm, context);
 
       let builtinTag;
 

--- a/src/intrinsics/ecma262/ObjectPrototype.js
+++ b/src/intrinsics/ecma262/ObjectPrototype.js
@@ -11,21 +11,20 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, ObjectValue, BooleanValue, NullValue } from "../../values/index.js";
-import { ToPropertyKey, ToObject, ToObjectPartial } from "../../methods/to.js";
 import { SameValuePartial, RequireObjectCoercible } from "../../methods/abstract.js";
 import { HasOwnProperty, HasSomeCompatibleType } from "../../methods/has.js";
 import { Invoke } from "../../methods/call.js";
-import { Properties } from "../../singletons.js";
+import { Properties, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 19.1.3.2
   obj.defineNativeMethod("hasOwnProperty", 1, (context, [V]) => {
     // 1. Let P be ? ToPropertyKey(V).
-    let P = ToPropertyKey(realm, V.throwIfNotConcrete());
+    let P = To.ToPropertyKey(realm, V.throwIfNotConcrete());
 
     // 2. Let O be ? ToObject(this value).
-    let O = ToObjectPartial(realm, context);
+    let O = To.ToObjectPartial(realm, context);
 
     // 3. Return ? HasOwnProperty(O, P).
     return new BooleanValue(realm, HasOwnProperty(realm, O, P));
@@ -38,7 +37,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     V = V.throwIfNotConcreteObject();
 
     // 2. Let O be ? ToObject(this value).
-    let O = ToObjectPartial(realm, context);
+    let O = To.ToObjectPartial(realm, context);
 
     // 3. Repeat
     while (true) {
@@ -58,10 +57,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 19.1.3.4
   obj.defineNativeMethod("propertyIsEnumerable", 1, (context, [V]) => {
     // 1. Let P be ? ToPropertyKey(V).
-    let P = ToPropertyKey(realm, V.throwIfNotConcrete());
+    let P = To.ToPropertyKey(realm, V.throwIfNotConcrete());
 
     // 2. Let O be ? ToObject(this value).
-    let O = ToObjectPartial(realm, context);
+    let O = To.ToObjectPartial(realm, context);
 
     // 3. Let desc be ? O.[[GetOwnProperty]](P).
     let desc = O.$GetOwnProperty(P);
@@ -89,14 +88,14 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 19.1.3.7
   obj.defineNativeMethod("valueOf", 0, context => {
     // 1. Return ? ToObject(this value).
-    return ToObjectPartial(realm, context);
+    return To.ToObjectPartial(realm, context);
   });
 
   obj.$DefineOwnProperty("__proto__", {
     // B.2.2.1.1
     get: new NativeFunctionValue(realm, undefined, "get __proto__", 0, context => {
       // 1. Let O be ? ToObject(this value).
-      let O = ToObject(realm, context.throwIfNotConcrete());
+      let O = To.ToObject(realm, context.throwIfNotConcrete());
 
       // 2. Return ? O.[[GetPrototypeOf]]().
       return O.$GetPrototypeOf();

--- a/src/intrinsics/ecma262/Reflect.js
+++ b/src/intrinsics/ecma262/Reflect.js
@@ -11,15 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { BooleanValue, ObjectValue, NullValue } from "../../values/index.js";
-import {
-  ToPropertyDescriptor,
-  Construct,
-  ToPropertyKey,
-  IsCallable,
-  Call,
-  IsConstructor,
-} from "../../methods/index.js";
-import { Create, Properties } from "../../singletons.js";
+import { Call, Construct, IsCallable, IsConstructor } from "../../methods/index.js";
+import { Create, Properties, To } from "../../singletons.js";
 
 export default function(realm: Realm): ObjectValue {
   let obj = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "Reflect");
@@ -72,10 +65,10 @@ export default function(realm: Realm): ObjectValue {
     }
 
     // 2. Let key be ? ToPropertyKey(propertyKey).
-    let key = ToPropertyKey(realm, propertyKey);
+    let key = To.ToPropertyKey(realm, propertyKey);
 
     // 3. Let desc be ? ToPropertyDescriptor(attributes).
-    let desc = ToPropertyDescriptor(realm, attributes);
+    let desc = To.ToPropertyDescriptor(realm, attributes);
 
     // 4. Return ? target.[[DefineOwnProperty]](key, desc).
     return new BooleanValue(realm, target.$DefineOwnProperty(key, desc));
@@ -91,7 +84,7 @@ export default function(realm: Realm): ObjectValue {
     }
 
     // 2. Let key be ? ToPropertyKey(propertyKey).
-    let key = ToPropertyKey(realm, propertyKey);
+    let key = To.ToPropertyKey(realm, propertyKey);
 
     // 3. Return ? target.[[Delete]](key).
     return new BooleanValue(realm, target.$Delete(key));
@@ -107,7 +100,7 @@ export default function(realm: Realm): ObjectValue {
     }
 
     // 2. Let key be ? ToPropertyKey(propertyKey).
-    let key = ToPropertyKey(realm, propertyKey);
+    let key = To.ToPropertyKey(realm, propertyKey);
 
     // 3. If receiver is not present, then
     if (!receiver) {
@@ -129,7 +122,7 @@ export default function(realm: Realm): ObjectValue {
     }
 
     // 2. Let key be ? ToPropertyKey(propertyKey).
-    let key = ToPropertyKey(realm, propertyKey);
+    let key = To.ToPropertyKey(realm, propertyKey);
 
     // 3. Let desc be ? target.[[GetOwnProperty]](key).
     let desc = target.$GetOwnProperty(key);
@@ -160,7 +153,7 @@ export default function(realm: Realm): ObjectValue {
     }
 
     // 2. Let key be ? ToPropertyKey(propertyKey).
-    let key = ToPropertyKey(realm, propertyKey);
+    let key = To.ToPropertyKey(realm, propertyKey);
 
     // 3. Return ? target.[[HasProperty]](key).
     return new BooleanValue(realm, target.$HasProperty(key));
@@ -218,7 +211,7 @@ export default function(realm: Realm): ObjectValue {
     }
 
     // 2. Let key be ? ToPropertyKey(propertyKey).
-    let key = ToPropertyKey(realm, propertyKey);
+    let key = To.ToPropertyKey(realm, propertyKey);
 
     // 3. If receiver is not present, then
     if (!receiver) {

--- a/src/intrinsics/ecma262/RegExpPrototype.js
+++ b/src/intrinsics/ecma262/RegExpPrototype.js
@@ -24,9 +24,8 @@ import { SameValue } from "../../methods/abstract.js";
 import { Call } from "../../methods/call.js";
 import { Construct, SpeciesConstructor } from "../../methods/construct.js";
 import { Get, GetSubstitution } from "../../methods/get.js";
-import { Create, Properties } from "../../singletons.js";
+import { Create, Properties, To } from "../../singletons.js";
 import { IsCallable } from "../../methods/is.js";
-import { ToString, ToStringPartial, ToBooleanPartial, ToLength, ToInteger, ToUint32 } from "../../methods/to.js";
 import { RegExpBuiltinExec, RegExpExec, EscapeRegExpPattern, AdvanceStringIndex } from "../../methods/regexp.js";
 
 function InternalHasFlag(realm: Realm, context: Value, flag: string): Value {
@@ -84,7 +83,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 4. Let S be ? ToString(string).
-    let S = ToStringPartial(realm, string);
+    let S = To.ToStringPartial(realm, string);
 
     // 5. Return ? RegExpBuiltinExec(R, S).
     return RegExpBuiltinExec(realm, R, S);
@@ -104,31 +103,31 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let result = "";
 
     // 4. Let global be ToBoolean(? Get(R, "global")).
-    let global = ToBooleanPartial(realm, Get(realm, R, "global"));
+    let global = To.ToBooleanPartial(realm, Get(realm, R, "global"));
 
     // 5. If global is true, append "g" as the last code unit of result.
     if (global) result += "g";
 
     // 6. Let ignoreCase be ToBoolean(? Get(R, "ignoreCase")).
-    let ignoreCase = ToBooleanPartial(realm, Get(realm, R, "ignoreCase"));
+    let ignoreCase = To.ToBooleanPartial(realm, Get(realm, R, "ignoreCase"));
 
     // 7. If ignoreCase is true, append "i" as the last code unit of result.
     if (ignoreCase) result += "i";
 
     // 8. Let multiline be ToBoolean(? Get(R, "multiline")).
-    let multiline = ToBooleanPartial(realm, Get(realm, R, "multiline"));
+    let multiline = To.ToBooleanPartial(realm, Get(realm, R, "multiline"));
 
     // 9. If multiline is true, append "m" as the last code unit of result.
     if (multiline) result += "m";
 
     // 10. Let unicode be ToBoolean(? Get(R, "unicode")).
-    let unicode = ToBooleanPartial(realm, Get(realm, R, "unicode"));
+    let unicode = To.ToBooleanPartial(realm, Get(realm, R, "unicode"));
 
     // 11. If unicode is true, append "u" as the last code unit of result.
     if (unicode) result += "u";
 
     // 12. Let sticky be ToBoolean(? Get(R, "sticky")).
-    let sticky = ToBooleanPartial(realm, Get(realm, R, "sticky"));
+    let sticky = To.ToBooleanPartial(realm, Get(realm, R, "sticky"));
 
     // 13. If sticky is true, append "y" as the last code unit of result.
     if (sticky) result += "y";
@@ -158,10 +157,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. Let S be ? ToString(string).
-    let S = ToStringPartial(realm, string);
+    let S = To.ToStringPartial(realm, string);
 
     // 4. Let global be ToBoolean(? Get(rx, "global")).
-    let global = ToBooleanPartial(realm, Get(realm, rx, "global"));
+    let global = To.ToBooleanPartial(realm, Get(realm, rx, "global"));
 
     // 5. If global is false, then
     if (global === false) {
@@ -170,7 +169,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 6. Else global is true,
       // a. Let fullUnicode be ToBoolean(? Get(rx, "unicode")).
-      let fullUnicode = ToBooleanPartial(realm, Get(realm, rx, "unicode"));
+      let fullUnicode = To.ToBooleanPartial(realm, Get(realm, rx, "unicode"));
 
       // b. Perform ? Set(rx, "lastIndex", 0, true).
       Properties.Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
@@ -198,13 +197,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
         } else {
           // iii. Else result is not null,
           // 1. Let matchStr be ? ToString(? Get(result, "0")).
-          let matchStr = ToStringPartial(realm, Get(realm, result, "0"));
+          let matchStr = To.ToStringPartial(realm, Get(realm, result, "0"));
 
           // 2. Let status be CreateDataProperty(A, ! ToString(n), matchStr).
           let status = Create.CreateDataProperty(
             realm,
             A,
-            ToString(realm, new NumberValue(realm, n)),
+            To.ToString(realm, new NumberValue(realm, n)),
             new StringValue(realm, matchStr)
           );
 
@@ -214,7 +213,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
           // 4. If matchStr is the empty String, then
           if (matchStr === "") {
             // a. Let thisIndex be ? ToLength(? Get(rx, "lastIndex")).
-            let thisIndex = ToLength(realm, Get(realm, rx, "lastIndex"));
+            let thisIndex = To.ToLength(realm, Get(realm, rx, "lastIndex"));
 
             // b. Let nextIndex be AdvanceStringIndex(S, thisIndex, fullUnicode).
             let nextIndex = AdvanceStringIndex(realm, S, thisIndex, fullUnicode);
@@ -248,7 +247,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. Let S be ? ToString(string).
-    let S = ToStringPartial(realm, string);
+    let S = To.ToStringPartial(realm, string);
 
     // 4. Let lengthS be the number of code unit elements in S.
     let lengthS = S.length;
@@ -259,17 +258,17 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 6. If functionalReplace is false, then
     if (functionalReplace === false) {
       // a. Let replaceValue be ? ToString(replaceValue).
-      replaceValue = new StringValue(realm, ToStringPartial(realm, replaceValue));
+      replaceValue = new StringValue(realm, To.ToStringPartial(realm, replaceValue));
     }
 
     // 7. Let global be ToBoolean(? Get(rx, "global")).
-    let global = ToBooleanPartial(realm, Get(realm, rx, "global"));
+    let global = To.ToBooleanPartial(realm, Get(realm, rx, "global"));
 
     let fullUnicode;
     // 8. If global is true, then
     if (global === true) {
       // a. Let fullUnicode be ToBoolean(? Get(rx, "unicode")).
-      fullUnicode = ToBooleanPartial(realm, Get(realm, rx, "unicode"));
+      fullUnicode = To.ToBooleanPartial(realm, Get(realm, rx, "unicode"));
 
       // b. Perform ? Set(rx, "lastIndex", 0, true).
       Properties.Set(realm, rx, "lastIndex", realm.intrinsics.zero, true);
@@ -302,12 +301,12 @@ export default function(realm: Realm, obj: ObjectValue): void {
           invariant(fullUnicode !== undefined);
 
           // 1. Let matchStr be ? ToString(? Get(result, "0")).
-          let matchStr = ToStringPartial(realm, Get(realm, result, "0"));
+          let matchStr = To.ToStringPartial(realm, Get(realm, result, "0"));
 
           // 2. If matchStr is the empty String, then
           if (matchStr === "") {
             // a. Let thisIndex be ? ToLength(? Get(rx, "lastIndex")).
-            let thisIndex = ToLength(realm, Get(realm, rx, "lastIndex"));
+            let thisIndex = To.ToLength(realm, Get(realm, rx, "lastIndex"));
 
             // b. Let nextIndex be AdvanceStringIndex(S, thisIndex, fullUnicode).
             let nextIndex = AdvanceStringIndex(realm, S, thisIndex, fullUnicode);
@@ -328,19 +327,19 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 14. Repeat, for each result in results,
     for (let result of results) {
       // a. Let nCaptures be ? ToLength(? Get(result, "length")).
-      let nCaptures = ToLength(realm, Get(realm, result, "length"));
+      let nCaptures = To.ToLength(realm, Get(realm, result, "length"));
 
       // b. Let nCaptures be max(nCaptures - 1, 0).
       nCaptures = Math.max(nCaptures - 1, 0);
 
       // c. Let matched be ? ToString(? Get(result, "0")).
-      let matched = ToStringPartial(realm, Get(realm, result, "0"));
+      let matched = To.ToStringPartial(realm, Get(realm, result, "0"));
 
       // d. Let matchLength be the number of code units in matched.
       let matchLength = matched.length;
 
       // e. Let position be ? ToInteger(? Get(result, "index")).
-      let position = ToInteger(realm, Get(realm, result, "index"));
+      let position = To.ToInteger(realm, Get(realm, result, "index"));
 
       // f. Let position be max(min(position, lengthS), 0).
       position = Math.max(Math.min(position, lengthS), 0);
@@ -354,12 +353,12 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // i. Repeat while n ≤ nCaptures
       while (n <= nCaptures) {
         // i. Let capN be ? Get(result, ! ToString(n)).
-        let capN = Get(realm, result, ToString(realm, new NumberValue(realm, n)));
+        let capN = Get(realm, result, To.ToString(realm, new NumberValue(realm, n)));
 
         // ii. If capN is not undefined, then
         if (!capN.mightBeUndefined()) {
           // 1. Let capN be ? ToString(capN).
-          capN = ToStringPartial(realm, capN);
+          capN = To.ToStringPartial(realm, capN);
         } else {
           capN.throwIfNotConcrete();
           capN = undefined;
@@ -390,7 +389,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let replValue = Call(realm, replaceValue, realm.intrinsics.undefined, replacerArgs);
 
         // v. Let replacement be ? ToString(replValue).
-        replacement = ToStringPartial(realm, replValue);
+        replacement = To.ToStringPartial(realm, replValue);
       } else {
         // k. Else,
         invariant(replaceValue instanceof StringValue);
@@ -427,7 +426,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. Let S be ? ToString(string).
-    let S = ToStringPartial(realm, string);
+    let S = To.ToStringPartial(realm, string);
 
     // 4. Let previousLastIndex be ? Get(rx, "lastIndex").
     let previousLastIndex = Get(realm, rx, "lastIndex");
@@ -498,13 +497,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. Let S be ? ToString(string).
-    let S = ToStringPartial(realm, string);
+    let S = To.ToStringPartial(realm, string);
 
     // 4. Let C be ? SpeciesConstructor(rx, %RegExp%).
     let C = SpeciesConstructor(realm, rx, realm.intrinsics.RegExp);
 
     // 5. Let flags be ? ToString(? Get(rx, "flags")).
-    let flags = ToStringPartial(realm, Get(realm, rx, "flags"));
+    let flags = To.ToStringPartial(realm, Get(realm, rx, "flags"));
 
     let unicodeMatching;
     // 6. If flags contains "u", let unicodeMatching be true.
@@ -534,7 +533,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let lengthA = 0;
 
     // 13. If limit is undefined, let lim be 2^32-1; else let lim be ? ToUint32(limit).
-    let lim = limit instanceof UndefinedValue ? Math.pow(2, 32) - 1 : ToUint32(realm, limit.throwIfNotConcrete());
+    let lim = limit instanceof UndefinedValue ? Math.pow(2, 32) - 1 : To.ToUint32(realm, limit.throwIfNotConcrete());
 
     // 14. Let size be the number of elements in S.
     let size = S.length;
@@ -577,7 +576,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       } else {
         // d. Else z is not null,
         // i. Let e be ? ToLength(? Get(splitter, "lastIndex")).
-        let e = ToLength(realm, Get(realm, splitter, "lastIndex"));
+        let e = To.ToLength(realm, Get(realm, splitter, "lastIndex"));
 
         // ii. Let e be min(e, size).
         e = Math.min(e, size);
@@ -594,7 +593,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
           Create.CreateDataProperty(
             realm,
             A,
-            ToString(realm, new NumberValue(realm, lengthA)),
+            To.ToString(realm, new NumberValue(realm, lengthA)),
             new StringValue(realm, T)
           );
 
@@ -608,7 +607,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
           p = e;
 
           // 6. Let numberOfCaptures be ? ToLength(? Get(z, "length")).
-          let numberOfCaptures = ToLength(realm, Get(realm, z, "length"));
+          let numberOfCaptures = To.ToLength(realm, Get(realm, z, "length"));
 
           // 7. Let numberOfCaptures be max(numberOfCaptures-1, 0).
           numberOfCaptures = Math.max(numberOfCaptures - 1, 0);
@@ -619,10 +618,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
           // 9. Repeat, while i ≤ numberOfCaptures,
           while (i <= numberOfCaptures) {
             // a. Let nextCapture be ? Get(z, ! ToString(i)).
-            let nextCapture = Get(realm, z, ToString(realm, new NumberValue(realm, i)));
+            let nextCapture = Get(realm, z, To.ToString(realm, new NumberValue(realm, i)));
 
             // b. Perform ! CreateDataProperty(A, ! ToString(lengthA), nextCapture).
-            Create.CreateDataProperty(realm, A, ToString(realm, new NumberValue(realm, lengthA)), nextCapture);
+            Create.CreateDataProperty(realm, A, To.ToString(realm, new NumberValue(realm, lengthA)), nextCapture);
 
             // c. Let i be i + 1.
             i = i + 1;
@@ -644,7 +643,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let T = S.substr(p, size - p);
 
     // 21. Perform ! CreateDataProperty(A, ! ToString(lengthA), T).
-    Create.CreateDataProperty(realm, A, ToString(realm, new NumberValue(realm, lengthA)), new StringValue(realm, T));
+    Create.CreateDataProperty(realm, A, To.ToString(realm, new NumberValue(realm, lengthA)), new StringValue(realm, T));
 
     // 22. Return A.
     return A;
@@ -666,7 +665,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. Let string be ? ToString(S).
-    let string = ToStringPartial(realm, S);
+    let string = To.ToStringPartial(realm, S);
 
     // 4. Let match be ? RegExpExec(R, string).
     let match = RegExpExec(realm, R, string);
@@ -686,10 +685,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. Let pattern be ? ToString(? Get(R, "source")).
-    let pattern = ToStringPartial(realm, Get(realm, R, "source"));
+    let pattern = To.ToStringPartial(realm, Get(realm, R, "source"));
 
     // 4. Let flags be ? ToString(? Get(R, "flags")).
-    let flags = ToStringPartial(realm, Get(realm, R, "flags"));
+    let flags = To.ToStringPartial(realm, Get(realm, R, "flags"));
 
     // 5. Let result be the String value formed by concatenating "/", pattern, "/", and flags.
     let result = "/" + pattern + "/" + flags;

--- a/src/intrinsics/ecma262/String.js
+++ b/src/intrinsics/ecma262/String.js
@@ -11,19 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, NumberValue, StringValue, SymbolValue } from "../../values/index.js";
-import {
-  Get,
-  GetPrototypeFromConstructor,
-  SymbolDescriptiveString,
-  ToInteger,
-  ToLength,
-  ToNumber,
-  ToObjectPartial,
-  ToString,
-  ToStringPartial,
-  ToUint16,
-} from "../../methods/index.js";
-import { Create } from "../../singletons.js";
+import { Get, GetPrototypeFromConstructor, SymbolDescriptiveString } from "../../methods/index.js";
+import { Create, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -42,7 +31,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // b. Let s be ? ToString(value).
-      s = new StringValue(realm, ToStringPartial(realm, value));
+      s = new StringValue(realm, To.ToStringPartial(realm, value));
     }
 
     // 3. If NewTarget is undefined, return s.
@@ -72,7 +61,7 @@ export default function(realm: Realm): NativeFunctionValue {
       let next = codeUnits[nextIndex];
 
       // b. Let nextCU be ? ToUint16(next).
-      let nextCU = ToUint16(realm, next);
+      let nextCU = To.ToUint16(realm, next);
 
       // c. Append nextCU to the end of elements.
       elements.push(nextCU);
@@ -106,13 +95,13 @@ export default function(realm: Realm): NativeFunctionValue {
         let next = codePoints[nextIndex];
 
         // b. Let nextCP be ? ToNumber(next).
-        let nextCP = ToNumber(realm, next);
+        let nextCP = To.ToNumber(realm, next);
 
         // c. If SameValue(nextCP, ToInteger(nextCP)) is false, throw a RangeError exception.
-        if (nextCP !== ToInteger(realm, nextCP)) {
+        if (nextCP !== To.ToInteger(realm, nextCP)) {
           throw realm.createErrorThrowCompletion(
             realm.intrinsics.RangeError,
-            "SameValue(nextCP, ToInteger(nextCP)) is false"
+            "SameValue(nextCP, To.ToInteger(nextCP)) is false"
           );
         }
 
@@ -120,7 +109,7 @@ export default function(realm: Realm): NativeFunctionValue {
         if (nextCP < 0 || nextCP > 0x10ffff) {
           throw realm.createErrorThrowCompletion(
             realm.intrinsics.RangeError,
-            "SameValue(nextCP, ToInteger(nextCP)) is false"
+            "SameValue(nextCP, To.ToInteger(nextCP)) is false"
           );
         }
 
@@ -146,13 +135,13 @@ export default function(realm: Realm): NativeFunctionValue {
       let numberOfSubstitutions = substitutions.length;
 
       // 3. Let cooked be ? ToObject(template).
-      let cooked = ToObjectPartial(realm, template);
+      let cooked = To.ToObjectPartial(realm, template);
 
       // 4. Let raw be ? ToObject(? Get(cooked, "raw")).
-      let raw = ToObjectPartial(realm, Get(realm, cooked, "raw"));
+      let raw = To.ToObjectPartial(realm, Get(realm, cooked, "raw"));
 
       // 5. Let literalSegments be ? ToLength(? Get(raw, "length")).
-      let literalSegments = ToLength(realm, Get(realm, raw, "length"));
+      let literalSegments = To.ToLength(realm, Get(realm, raw, "length"));
 
       // 6. If literalSegments ≤ 0, return the empty string.
       if (literalSegments <= 0) return realm.intrinsics.emptyString;
@@ -166,10 +155,10 @@ export default function(realm: Realm): NativeFunctionValue {
       // 9. Repeat
       while (true) {
         // a. Let nextKey be ! ToString(nextIndex).
-        let nextKey = ToString(realm, new NumberValue(realm, nextIndex));
+        let nextKey = To.ToString(realm, new NumberValue(realm, nextIndex));
 
         // b. Let nextSeg be ? ToString(? Get(raw, nextKey)).
-        let nextSeg = ToStringPartial(realm, Get(realm, raw, nextKey));
+        let nextSeg = To.ToStringPartial(realm, Get(realm, raw, nextKey));
 
         // c. Append in order the code unit elements of nextSeg to the end of stringElements.
         stringElements = stringElements + nextSeg;
@@ -188,7 +177,7 @@ export default function(realm: Realm): NativeFunctionValue {
           next = realm.intrinsics.emptyString;
 
         // g. Let nextSub be ? ToString(next).
-        let nextSub = ToStringPartial(realm, next);
+        let nextSub = To.ToStringPartial(realm, next);
 
         // h. Append in order the code unit elements of nextSub to the end of stringElements.
         stringElements = stringElements + nextSub;

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -15,17 +15,8 @@ import { AbstractValue, UndefinedValue, NumberValue, ObjectValue, StringValue, N
 import { IsCallable, IsRegExp } from "../../methods/is.js";
 import { GetMethod, GetSubstitution } from "../../methods/get.js";
 import { Call, Invoke } from "../../methods/call.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 import { RegExpCreate } from "../../methods/regexp.js";
-import {
-  ToString,
-  ToStringPartial,
-  thisStringValue,
-  ToInteger,
-  ToUint32,
-  ToNumber,
-  ToLength,
-} from "../../methods/to.js";
 import { SplitMatch, RequireObjectCoercible } from "../../methods/abstract.js";
 import { HasSomeCompatibleType } from "../../methods/has.js";
 import invariant from "../../invariant.js";
@@ -49,10 +40,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let position be ? ToInteger(pos).
-    let position = ToInteger(realm, pos);
+    let position = To.ToInteger(realm, pos);
 
     // 4. Let size be the number of elements in S.
     let size = S.length;
@@ -70,10 +61,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let position be ? ToInteger(pos).
-    let position = ToInteger(realm, pos);
+    let position = To.ToInteger(realm, pos);
 
     // 4. Let size be the number of elements in S.
     let size = S.length;
@@ -93,10 +84,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. Let position be ? ToInteger(pos).
-      let position = ToInteger(realm, pos);
+      let position = To.ToInteger(realm, pos);
 
       // 4. Let size be the number of elements in S.
       let size = S.length;
@@ -118,7 +109,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let args be a List whose elements are the arguments passed to this function.
     args = argCount === 0 ? [] : args;
@@ -132,7 +123,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let next = args.shift();
 
       // b. Let nextString be ? ToString(next).
-      let nextString = ToStringPartial(realm, next);
+      let nextString = To.ToStringPartial(realm, next);
 
       // c. Let R be the String value consisting of the code units of the previous value of R followed by the code units of nextString.
       R = R + nextString;
@@ -149,7 +140,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. Let isRegExp be ? IsRegExp(searchString).
       let isRegExp = IsRegExp(realm, searchString);
@@ -160,7 +151,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       }
 
       // 5. Let searchStr be ? ToString(searchString).
-      let searchStr = ToStringPartial(realm, searchString);
+      let searchStr = To.ToStringPartial(realm, searchString);
 
       // 6. Let len be the number of elements in S.
       let len = S.length;
@@ -170,7 +161,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       if (!endPosition || endPosition instanceof UndefinedValue) {
         pos = len;
       } else {
-        pos = ToInteger(realm, endPosition.throwIfNotConcrete());
+        pos = To.ToInteger(realm, endPosition.throwIfNotConcrete());
       }
 
       // 8. Let end be min(max(pos, 0), len).
@@ -200,7 +191,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. Let isRegExp be ? IsRegExp(searchString).
       let isRegExp = IsRegExp(realm, searchString);
@@ -211,10 +202,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       }
 
       // 5. Let searchStr be ? ToString(searchString).
-      let searchStr = ToStringPartial(realm, searchString);
+      let searchStr = To.ToStringPartial(realm, searchString);
 
       // 6. Let pos be ? ToInteger(position). (If position is undefined, this step produces the value 0.)
-      let pos = ToInteger(realm, position || realm.intrinsics.undefined);
+      let pos = To.ToInteger(realm, position || realm.intrinsics.undefined);
 
       // 7. Let len be the number of elements in S.
       let len = S.length;
@@ -251,13 +242,13 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let searchStr be ? ToString(searchString).
-    let searchStr = ToStringPartial(realm, searchString);
+    let searchStr = To.ToStringPartial(realm, searchString);
 
     // 4. Let pos be ? ToInteger(position). (If position is undefined, this step produces the value 0.)
-    let pos = position ? ToInteger(realm, position) : 0;
+    let pos = position ? To.ToInteger(realm, position) : 0;
 
     // 5. Let len be the number of elements in S.
     // 6. Let start be min(max(pos, 0), len).
@@ -275,20 +266,20 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let searchStr be ? ToString(searchString).
-    let searchStr = ToStringPartial(realm, searchString);
+    let searchStr = To.ToStringPartial(realm, searchString);
 
     // 4. Let numPos be ? ToNumber(position). (If position is undefined, this step produces the value NaN.)
-    let numPos = ToNumber(realm, position || realm.intrinsics.undefined);
+    let numPos = To.ToNumber(realm, position || realm.intrinsics.undefined);
 
     // 5. If numPos is NaN, let pos be +∞; otherwise, let pos be ToInteger(numPos).
     let pos;
     if (isNaN(numPos)) {
       pos = Infinity;
     } else {
-      pos = ToInteger(realm, numPos);
+      pos = To.ToInteger(realm, numPos);
     }
 
     // 6. Let len be the number of elements in S.
@@ -307,10 +298,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let That be ? ToString(that).
-    let That = ToStringPartial(realm, that);
+    let That = To.ToStringPartial(realm, that);
 
     return new NumberValue(realm, S.localeCompare(That));
   });
@@ -334,7 +325,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     }
 
     // 3. Let S be ? ToString(O).
-    let S = new StringValue(realm, ToStringPartial(realm, O));
+    let S = new StringValue(realm, To.ToStringPartial(realm, O));
 
     // 4. Let rx be ? RegExpCreate(regexp, undefined).
     let rx = RegExpCreate(realm, regexp, undefined);
@@ -350,13 +341,13 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. If form is not provided or form is undefined, let form be "NFC".
       if (!form || form instanceof UndefinedValue) form = new StringValue(realm, "NFC");
 
       // 4. Let f be ? ToString(form).
-      let f = ToStringPartial(realm, form);
+      let f = To.ToStringPartial(realm, form);
 
       // 5. If f is not one of "NFC", "NFD", "NFKC", or "NFKD", throw a RangeError exception.
       if (f !== "NFC" && f !== "NFD" && f !== "NFKC" && f !== "NFKD") {
@@ -376,10 +367,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. Let intMaxLength be ? ToLength(maxLength).
-      let intMaxLength = ToLength(realm, maxLength);
+      let intMaxLength = To.ToLength(realm, maxLength);
 
       // 4. Let stringLength be the number of elements in S.
       let stringLength = S.length;
@@ -392,7 +383,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       if (!fillString || fillString instanceof UndefinedValue) filler = " ";
       else
         // 7. Else, let filler be ? ToString(fillString).
-        filler = ToStringPartial(realm, fillString);
+        filler = To.ToStringPartial(realm, fillString);
 
       // 8. If filler is the empty String, return S.
       if (filler === "") return new StringValue(realm, S);
@@ -414,10 +405,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. Let intMaxLength be ? ToLength(maxLength).
-      let intMaxLength = ToLength(realm, maxLength);
+      let intMaxLength = To.ToLength(realm, maxLength);
 
       // 4. Let stringLength be the number of elements in S.
       let stringLength = S.length;
@@ -430,7 +421,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       if (!fillString || fillString instanceof UndefinedValue) filler = " ";
       else
         // 7. Else, let filler be ? ToString(fillString).
-        filler = ToStringPartial(realm, fillString);
+        filler = To.ToStringPartial(realm, fillString);
 
       // 8. If filler is the empty String, return S.
       if (filler === "") return new StringValue(realm, S);
@@ -452,10 +443,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. Let n be ? ToInteger(count).
-      let n = ToInteger(realm, count);
+      let n = To.ToInteger(realm, count);
 
       // 4. If n < 0, throw a RangeError exception.
       if (n < 0) {
@@ -495,10 +486,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     }
 
     // 3. Let string be ? ToString(O).
-    let string = ToString(realm, O.throwIfNotConcrete());
+    let string = To.ToString(realm, O.throwIfNotConcrete());
 
     // 4. Let searchString be ? ToString(searchValue).
-    let searchString = ToStringPartial(realm, searchValue);
+    let searchString = To.ToStringPartial(realm, searchValue);
 
     // 5. Let functionalReplace be IsCallable(replaceValue).
     let functionalReplace = IsCallable(realm, replaceValue);
@@ -507,7 +498,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     // 6. If functionalReplace is false, then
     if (functionalReplace === false) {
       // a. Let replaceValue be ? ToString(replaceValue).
-      replaceValueString = ToStringPartial(realm, replaceValue);
+      replaceValueString = To.ToStringPartial(realm, replaceValue);
     }
 
     // 7. Search string for the first occurrence of searchString and
@@ -530,7 +521,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       ]);
 
       // b. Let replStr be ? ToString(replValue).
-      replStr = ToStringPartial(realm, replValue);
+      replStr = To.ToStringPartial(realm, replValue);
     } else {
       // 9. Else,
       // a. Let captures be an empty List.
@@ -538,7 +529,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
 
       // b. Let replStr be GetSubstitution(matched, string, pos, captures, replaceValue).
       invariant(typeof replaceValueString === "string");
-      replStr = ToString(realm, GetSubstitution(realm, matched, string, pos, captures, replaceValueString));
+      replStr = To.ToString(realm, GetSubstitution(realm, matched, string, pos, captures, replaceValueString));
     }
 
     // 10. Let tailPos be pos + the number of code units in matched.
@@ -571,7 +562,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     }
 
     // 3. Let string be ? ToString(O).
-    let string = ToStringPartial(realm, O);
+    let string = To.ToStringPartial(realm, O);
 
     // 4. Let rx be ? RegExpCreate(regexp, undefined).
     let rx = RegExpCreate(realm, regexp, undefined);
@@ -590,16 +581,16 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     }
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let len be the number of elements in S.
     let len = S.length;
 
     // 4. Let intStart be ? ToInteger(start).
-    let intStart = ToInteger(realm, start);
+    let intStart = To.ToInteger(realm, start);
 
     // 5. If end is undefined, let intEnd be len; else let intEnd be ? ToInteger(end).
-    let intEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let intEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 6. If intStart < 0, let from be max(len + intStart, 0); otherwise let from be min(intStart, len).
     let from = intStart < 0 ? Math.max(len + intStart, 0) : Math.min(intStart, len);
@@ -642,7 +633,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     }
 
     // 3. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 4. Let A be ArrayCreate(0).
     let A = Create.ArrayCreate(realm, 0);
@@ -652,7 +643,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
 
     // 6. If limit is undefined, let lim be 232-1; else let lim be ? ToUint32(limit).
     let lim =
-      !limit || limit instanceof UndefinedValue ? Math.pow(2, 32) - 1 : ToUint32(realm, limit.throwIfNotConcrete());
+      !limit || limit instanceof UndefinedValue ? Math.pow(2, 32) - 1 : To.ToUint32(realm, limit.throwIfNotConcrete());
 
     // 7. Let s be the number of elements in S.
     let s = S.length;
@@ -661,7 +652,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let p = 0;
 
     // 9. Let R be ? ToString(separator).
-    let R = ToStringPartial(realm, separator);
+    let R = To.ToStringPartial(realm, separator);
 
     // 10. If lim = 0, return A.
     if (lim === 0) return A;
@@ -745,7 +736,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       let O = RequireObjectCoercible(realm, context);
 
       // 2. Let S be ? ToString(O).
-      let S = ToString(realm, O.throwIfNotConcrete());
+      let S = To.ToString(realm, O.throwIfNotConcrete());
 
       // 3. Let isRegExp be ? IsRegExp(searchString).
       let isRegExp = IsRegExp(realm, searchString);
@@ -756,10 +747,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       }
 
       // 5. Let searchStr be ? ToString(searchString).
-      let searchStr = ToStringPartial(realm, searchString);
+      let searchStr = To.ToStringPartial(realm, searchString);
 
       // 6. Let pos be ? ToInteger(position). (If position is undefined, this step produces the value 0.)
-      let pos = ToInteger(realm, position || realm.intrinsics.undefined);
+      let pos = To.ToInteger(realm, position || realm.intrinsics.undefined);
 
       // 7. Let len be the number of elements in S.
       let len = S.length;
@@ -786,16 +777,16 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let len be the number of elements in S.
     let len = S.length;
 
     // 4. Let intStart be ? ToInteger(start).
-    let intStart = ToInteger(realm, start);
+    let intStart = To.ToInteger(realm, start);
 
     // 5. If end is undefined, let intEnd be len; else let intEnd be ? ToInteger(end).
-    let intEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let intEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 6. Let finalStart be min(max(intStart, 0), len).
     let finalStart = Math.min(Math.max(intStart, 0), len);
@@ -819,7 +810,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ToString(O)
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     if (realm.isCompatibleWith(realm.MOBILE_JSC_VERSION)) {
       locales = undefined;
@@ -862,7 +853,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
       return target;
     }
     // 1. Return ? thisStringValue(this value).
-    return thisStringValue(realm, context);
+    return To.thisStringValue(realm, context);
   });
 
   // ECMA262 21.1.3.24
@@ -876,7 +867,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Let T be a String value that is a copy of S with both leading and trailing white space removed. The definition of white space is the union of WhiteSpace and LineTerminator. When determining whether a Unicode code point is in Unicode general category “Zs”, code unit sequences are interpreted as UTF-16 encoded code point sequences as specified in 6.1.4.
     let T = S.trim();
@@ -888,7 +879,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
   // ECMA262 21.1.3.26
   obj.defineNativeMethod("valueOf", 0, context => {
     // 1. Return ? thisStringValue(this value).
-    return thisStringValue(realm, context);
+    return To.thisStringValue(realm, context);
   });
 
   // ECMA262 21.1.3.27
@@ -897,7 +888,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ? ToString(O).
-    let S = ToString(realm, O.throwIfNotConcrete());
+    let S = To.ToString(realm, O.throwIfNotConcrete());
 
     // 3. Return CreateStringIterator(S).
     return Create.CreateStringIterator(realm, new StringValue(realm, S));
@@ -909,12 +900,12 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     // 2. Let S be ToString(O).
-    let S = ToStringPartial(realm, O);
+    let S = To.ToStringPartial(realm, O);
 
     // 3. ReturnIfAbrupt(S).
 
     // 4. Let intStart be ToInteger(start).
-    let intStart = ToInteger(realm, start);
+    let intStart = To.ToInteger(realm, start);
 
     // 5. ReturnIfAbrupt(intStart).
 
@@ -923,7 +914,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     if (!length || length instanceof UndefinedValue) {
       end = Infinity;
     } else {
-      end = ToInteger(realm, length.throwIfNotConcrete());
+      end = To.ToInteger(realm, length.throwIfNotConcrete());
     }
 
     // 7. ReturnIfAbrupt(end).

--- a/src/intrinsics/ecma262/Symbol.js
+++ b/src/intrinsics/ecma262/Symbol.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NativeFunctionValue, StringValue, SymbolValue, UndefinedValue } from "../../values/index.js";
-import { ToStringPartial } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import { SameValue } from "../../methods/abstract.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -30,7 +30,7 @@ export default function(realm: Realm): NativeFunctionValue {
       descString = description;
     } else {
       // 3. Else, let descString be ? ToString(description).
-      descString = ToStringPartial(realm, description);
+      descString = To.ToStringPartial(realm, description);
       descString = new StringValue(realm, descString);
     }
     // 4. Return a new unique Symbol value whose [[Description]] value is descString.
@@ -40,7 +40,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.4.2.1
   func.defineNativeMethod("for", 1, (context, [key]) => {
     // 1. Let stringKey be ? ToString(key).
-    let stringKey = ToStringPartial(realm, key);
+    let stringKey = To.ToStringPartial(realm, key);
     stringKey = new StringValue(realm, stringKey);
 
     // 2. For each element e of the GlobalSymbolRegistry List,

--- a/src/intrinsics/ecma262/TypedArray.js
+++ b/src/intrinsics/ecma262/TypedArray.js
@@ -21,9 +21,8 @@ import {
   TypedArrayCreate,
 } from "../../methods/typedarray.js";
 import { SpeciesConstructor } from "../../methods/construct.js";
-import { ToIndexPartial, ToLength, ToString, ToObjectPartial } from "../../methods/to.js";
 import { Get, GetMethod } from "../../methods/get.js";
-import { Properties } from "../../singletons.js";
+import { Properties, To } from "../../singletons.js";
 import { IterableToList } from "../../methods/iterator.js";
 import { IsDetachedBuffer, IsConstructor, IsCallable } from "../../methods/is.js";
 import { Call } from "../../methods/call.js";
@@ -91,7 +90,7 @@ export default function(realm: Realm): NativeFunctionValue {
       // e. Repeat, while k < len
       while (k < len) {
         // i. Let Pk be ! ToString(k).
-        let Pk = ToString(realm, new NumberValue(realm, k));
+        let Pk = To.ToString(realm, new NumberValue(realm, k));
 
         // ii. Let kValue be the first element of values and remove that element from values.
         let kValue = values.shift();
@@ -123,10 +122,10 @@ export default function(realm: Realm): NativeFunctionValue {
     // 8. NOTE: source is not an Iterable so assume it is already an array-like object.
 
     // 9. Let arrayLike be ! ToObject(source).
-    let arrayLike = ToObjectPartial(realm, source);
+    let arrayLike = To.ToObjectPartial(realm, source);
 
     // 10. Let len be ? ToLength(? Get(arrayLike, "length")).
-    let len = ToLength(realm, Get(realm, arrayLike, "length"));
+    let len = To.ToLength(realm, Get(realm, arrayLike, "length"));
 
     // 11. Let targetObj be ? TypedArrayCreate(C, « len »).
     let targetObj = TypedArrayCreate(realm, C, [new NumberValue(realm, len)]);
@@ -137,7 +136,7 @@ export default function(realm: Realm): NativeFunctionValue {
     // 13. Repeat, while k < len
     while (k < len) {
       // a. Let Pk be ! ToString(k).
-      let Pk = ToString(realm, new NumberValue(realm, k));
+      let Pk = To.ToString(realm, new NumberValue(realm, k));
 
       // b. Let kValue be ? Get(arrayLike, Pk).
       let kValue = Get(realm, arrayLike, Pk);
@@ -192,7 +191,7 @@ export default function(realm: Realm): NativeFunctionValue {
       let kValue = items[k];
 
       // b. Let Pk be ! ToString(k).
-      let Pk = ToString(realm, new NumberValue(realm, k));
+      let Pk = To.ToString(realm, new NumberValue(realm, k));
 
       // c. Perform ? Set(newObj, Pk, kValue, true).
       Properties.Set(realm, newObj, Pk, kValue, true);
@@ -268,7 +267,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
       }
 
       // 3. Let elementLength be ? ToIndex(length).
-      let elementLength = ToIndexPartial(realm, length);
+      let elementLength = To.ToIndexPartial(realm, length);
 
       // 4. Let constructorName be the String value of the Constructor Name value specified in Table 50 for this TypedArray constructor.
       let constructorName = getConstructorName(type);
@@ -434,7 +433,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
         // e. Repeat, while k < len
         while (k < len) {
           // i. Let Pk be ! ToString(k).
-          let Pk = new StringValue(realm, ToString(realm, new NumberValue(realm, k)));
+          let Pk = new StringValue(realm, To.ToString(realm, new NumberValue(realm, k)));
 
           // ii. Let kValue be the first element of values and remove that element from values.
           let kValue = values.shift();
@@ -459,7 +458,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
       let arrayLike = object;
 
       // 9. Let len be ? ToLength(? Get(arrayLike, "length")).
-      let len = ToLength(realm, Get(realm, arrayLike, "length"));
+      let len = To.ToLength(realm, Get(realm, arrayLike, "length"));
 
       // 10. Perform ? AllocateTypedArrayBuffer(O, len).
       AllocateTypedArrayBuffer(realm, O, len);
@@ -470,7 +469,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
       // 12. Repeat, while k < len
       while (k < len) {
         // a. Let Pk be ! ToString(k).
-        let Pk = new StringValue(realm, ToString(realm, new NumberValue(realm, k)));
+        let Pk = new StringValue(realm, To.ToString(realm, new NumberValue(realm, k)));
 
         // b. Let kValue be ? Get(arrayLike, Pk).
         let kValue = Get(realm, arrayLike, Pk);
@@ -512,7 +511,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
       let elementSize = ArrayElementSize[constructorName];
 
       // 7. Let offset be ? ToIndex(byteOffset).
-      let offset = ToIndexPartial(realm, byteOffset);
+      let offset = To.ToIndexPartial(realm, byteOffset);
 
       // 8. If offset modulo elementSize ≠ 0, throw a RangeError exception.
       if (offset % elementSize !== 0) {
@@ -548,7 +547,7 @@ export function build(realm: Realm, type: ElementType): NativeFunctionValue {
       } else {
         // 12. Else,
         // a. Let newLength be ? ToIndex(length).
-        let newLength = ToIndexPartial(realm, length);
+        let newLength = To.ToIndexPartial(realm, length);
 
         // b. Let newByteLength be newLength × elementSize.
         newByteLength = newLength * elementSize;

--- a/src/intrinsics/ecma262/TypedArrayProto_values.js
+++ b/src/intrinsics/ecma262/TypedArrayProto_values.js
@@ -11,15 +11,14 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToObject } from "../../methods/index.js";
-import { Create } from "../../singletons.js";
+import { Create, To } from "../../singletons.js";
 import { ValidateTypedArray } from "../../methods/typedarray.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 22.1.3.30
   return new NativeFunctionValue(realm, "Array.prototype.values", "values", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -13,16 +13,6 @@ import type { Realm } from "../../realm.js";
 import type { ElementType } from "../../types.js";
 import { ElementSize } from "../../types.js";
 import { ObjectValue, StringValue, NumberValue, UndefinedValue, NullValue } from "../../values/index.js";
-import {
-  ToInteger,
-  ToString,
-  ToStringPartial,
-  ToBooleanPartial,
-  ToObject,
-  ToObjectPartial,
-  ToLength,
-  ToNumber,
-} from "../../methods/to.js";
 import { Call, Invoke } from "../../methods/call.js";
 import { Get } from "../../methods/get.js";
 import { HasProperty, HasSomeCompatibleType } from "../../methods/has.js";
@@ -37,7 +27,7 @@ import {
 } from "../../methods/typedarray.js";
 import { SetValueInBuffer, GetValueFromBuffer, CloneArrayBuffer } from "../../methods/arraybuffer.js";
 import { SameValue, SameValueZeroPartial, StrictEqualityComparisonPartial } from "../../methods/abstract.js";
-import { Create, Properties } from "../../singletons.js";
+import { Create, Properties, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
@@ -144,7 +134,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.5
   obj.defineNativeMethod("copyWithin", 2, (context, [target, start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -154,19 +144,19 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(typeof len === "number");
 
     // 4. Let relativeTarget be ? ToInteger(target).
-    let relativeTarget = ToInteger(realm, target);
+    let relativeTarget = To.ToInteger(realm, target);
 
     // 5. If relativeTarget < 0, let to be max((len + relativeTarget), 0); else let to be min(relativeTarget, len).
     let to = relativeTarget < 0 ? Math.max(len + relativeTarget, 0) : Math.min(relativeTarget, len);
 
     // 6. Let relativeStart be ? ToInteger(start).
-    let relativeStart = ToInteger(realm, start);
+    let relativeStart = To.ToInteger(realm, start);
 
     // 7. If relativeStart < 0, let from be max((len + relativeStart), 0); else let from be min(relativeStart, len).
     let from = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
 
     // 8. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
-    let relativeEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let relativeEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 9. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
     let final = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
@@ -194,10 +184,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 13. Repeat, while count > 0
     while (count > 0) {
       // a. Let fromKey be ! ToString(from).
-      let fromKey = ToString(realm, new NumberValue(realm, from));
+      let fromKey = To.ToString(realm, new NumberValue(realm, from));
 
       // b. Let toKey be ! ToString(to).
-      let toKey = ToString(realm, new NumberValue(realm, to));
+      let toKey = To.ToString(realm, new NumberValue(realm, to));
 
       // c. Let fromPresent be ? HasProperty(O, fromKey).
       let fromPresent = HasProperty(realm, O, fromKey);
@@ -244,7 +234,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.7
   obj.defineNativeMethod("every", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -278,7 +268,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let kValue = Get(realm, O, Pk);
 
         // ii. Let testResult be ToBoolean(? Call(callbackfn, T, « kValue, k, O »)).
-        let testResult = ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
+        let testResult = To.ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
 
         // iii. If testResult is false, return false.
         if (!testResult) return realm.intrinsics.false;
@@ -295,7 +285,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.8
   obj.defineNativeMethod("fill", 1, (context, [value, start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -305,13 +295,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(typeof len === "number");
 
     // 4. Let relativeStart be ? ToInteger(start).
-    let relativeStart = ToInteger(realm, start || realm.intrinsics.undefined);
+    let relativeStart = To.ToInteger(realm, start || realm.intrinsics.undefined);
 
     // 5. If relativeStart < 0, let k be max((len + relativeStart), 0); else let k be min(relativeStart, len).
     let k = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
 
     // 6. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
-    let relativeEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let relativeEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 7. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
     let final = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
@@ -365,13 +355,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 9. Repeat, while k < len
     while (k < len) {
       // a. Let Pk be ! ToString(k).
-      let Pk = ToString(realm, new NumberValue(realm, k));
+      let Pk = To.ToString(realm, new NumberValue(realm, k));
 
       // b. Let kValue be ? Get(O, Pk).
       let kValue = Get(realm, O, Pk);
 
       // c. Let selected be ToBoolean(? Call(callbackfn, T, « kValue, k, O »)).
-      let selected = ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
+      let selected = To.ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
 
       // d. If selected is true, then
       if (selected === true) {
@@ -395,7 +385,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 12. For each element e of kept
     for (let e of kept) {
       // a. Perform ! Set(A, ! ToString(n), e, true).
-      Properties.Set(realm, A, new StringValue(realm, ToString(realm, new NumberValue(realm, n))), e, true);
+      Properties.Set(realm, A, new StringValue(realm, To.ToString(realm, new NumberValue(realm, n))), e, true);
 
       // b. Increment n by 1.
       n = n + 1;
@@ -408,7 +398,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.10
   obj.defineNativeMethod("find", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -437,7 +427,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let kValue = Get(realm, O, Pk);
 
       // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-      let testResult = ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
+      let testResult = To.ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
 
       // d. If testResult is true, return kValue.
       if (testResult) return kValue;
@@ -453,7 +443,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.11
   obj.defineNativeMethod("findIndex", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -476,13 +466,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 7. Repeat, while k < len
     while (k < len) {
       // a. Let Pk be ! ToString(k).
-      let Pk = ToString(realm, new NumberValue(realm, k));
+      let Pk = To.ToString(realm, new NumberValue(realm, k));
 
       // b. Let kValue be ? Get(O, Pk).
       let kValue = Get(realm, O, new StringValue(realm, Pk));
 
       // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
-      let testResult = ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
+      let testResult = To.ToBooleanPartial(realm, Call(realm, predicate, T, [kValue, new NumberValue(realm, k), O]));
 
       // d. If testResult is true, return k.
       if (testResult === true) return new NumberValue(realm, k);
@@ -498,7 +488,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.12
   obj.defineNativeMethod("forEach", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -546,7 +536,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.14
   obj.defineNativeMethod("includes", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -559,7 +549,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (len === 0) return realm.intrinsics.false;
 
     // 5. Let n be ? ToInteger(fromIndex). (If fromIndex is undefined, this step produces the value 0.)
-    let n = ToInteger(realm, fromIndex || realm.intrinsics.undefined);
+    let n = To.ToInteger(realm, fromIndex || realm.intrinsics.undefined);
 
     let k;
     // 6. If n ≥ 0, then
@@ -577,7 +567,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 8. Repeat, while k < len
     while (k < len) {
       // a. Let elementK be the result of ? Get(O, ! ToString(k)).
-      let elementK = Get(realm, O, ToString(realm, new NumberValue(realm, k)));
+      let elementK = Get(realm, O, To.ToString(realm, new NumberValue(realm, k)));
 
       // b. If SameValueZero(searchElement, elementK) is true, return true.
       if (SameValueZeroPartial(realm, searchElement, elementK) === true) return realm.intrinsics.true;
@@ -593,7 +583,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.14
   obj.defineNativeMethod("indexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -606,7 +596,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (len === 0) return new NumberValue(realm, -1);
 
     // 5. Let n be ? ToInteger(fromIndex). (If fromIndex is undefined, this step produces the value 0.)
-    let n = fromIndex ? ToInteger(realm, fromIndex) : 0;
+    let n = fromIndex ? To.ToInteger(realm, fromIndex) : 0;
 
     // 6. If n ≥ len, return -1.
     if (n >= len) return new NumberValue(realm, -1);
@@ -653,7 +643,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.15
   obj.defineNativeMethod("join", 1, (context, [separator]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -666,7 +656,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (!separator || separator instanceof UndefinedValue) separator = new StringValue(realm, ",");
 
     // 5. Let sep be ? ToString(separator).
-    let sep = ToStringPartial(realm, separator);
+    let sep = To.ToStringPartial(realm, separator);
 
     // 6. If len is zero, return the empty String.
     if (len === 0) return realm.intrinsics.emptyString;
@@ -679,7 +669,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (HasSomeCompatibleType(element0, UndefinedValue, NullValue)) {
       R = "";
     } else {
-      R = ToStringPartial(realm, element0);
+      R = To.ToStringPartial(realm, element0);
     }
 
     // 9. Let k be 1.
@@ -698,7 +688,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       if (HasSomeCompatibleType(element, UndefinedValue, NullValue)) {
         next = "";
       } else {
-        next = ToStringPartial(realm, element);
+        next = To.ToStringPartial(realm, element);
       }
 
       // d. Let R be a String value produced by concatenating S and next.
@@ -728,7 +718,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.17
   obj.defineNativeMethod("lastIndexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -741,7 +731,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (len === 0) return new NumberValue(realm, -1);
 
     // 5. If argument fromIndex was passed, let n be ? ToInteger(fromIndex); else let n be len-1.
-    let n = fromIndex ? ToInteger(realm, fromIndex) : len - 1;
+    let n = fromIndex ? To.ToInteger(realm, fromIndex) : len - 1;
 
     // 6. If n ≥ 0, then
     let k;
@@ -845,7 +835,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 8. Repeat, while k < len
     while (k < len) {
       // a. Let Pk be ! ToString(k).
-      let Pk = ToString(realm, new NumberValue(realm, k));
+      let Pk = To.ToString(realm, new NumberValue(realm, k));
 
       // b. Let kValue be ? Get(O, Pk).
       let kValue = Get(realm, O, Pk);
@@ -867,7 +857,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.20
   obj.defineNativeMethod("reduce", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -958,7 +948,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.21
   obj.defineNativeMethod("reduceRight", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -1047,7 +1037,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.21
   obj.defineNativeMethod("reverse", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -1162,7 +1152,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       invariant(target.$ViewedArrayBuffer, "target has a [[ViewedArrayBuffer]] internal slot");
 
       // 6. Let targetOffset be ? ToInteger(offset).
-      let targetOffset = ToInteger(realm, offset || realm.intrinsics.undefined);
+      let targetOffset = To.ToInteger(realm, offset || realm.intrinsics.undefined);
 
       // 7. If targetOffset < 0, throw a RangeError exception.
       if (targetOffset < 0) {
@@ -1197,10 +1187,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
       invariant(typeof targetByteOffset === "number");
 
       // 15. Let src be ? ToObject(array).
-      let src = ToObjectPartial(realm, array);
+      let src = To.ToObjectPartial(realm, array);
 
       // 16. Let srcLength be ? ToLength(? Get(src, "length")).
-      let srcLength = ToLength(realm, Get(realm, src, "length"));
+      let srcLength = To.ToLength(realm, Get(realm, src, "length"));
 
       // 17. If srcLength + targetOffset > targetLength, throw a RangeError exception.
       if (srcLength + targetOffset > targetLength) {
@@ -1219,10 +1209,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // 21. Repeat, while targetByteIndex < limit
       while (targetByteIndex < limit) {
         // a. Let Pk be ! ToString(k).
-        let Pk = ToString(realm, new NumberValue(realm, k));
+        let Pk = To.ToString(realm, new NumberValue(realm, k));
 
         // b. Let kNumber be ? ToNumber(? Get(src, Pk)).
-        let kNumber = ToNumber(realm, Get(realm, src, Pk));
+        let kNumber = To.ToNumber(realm, Get(realm, src, Pk));
 
         // c. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
         if (IsDetachedBuffer(realm, targetBuffer) === true) {
@@ -1267,7 +1257,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       invariant(target.$ViewedArrayBuffer);
 
       // 6. Let targetOffset be ? ToInteger(offset).
-      let targetOffset = ToInteger(realm, offset || realm.intrinsics.undefined);
+      let targetOffset = To.ToInteger(realm, offset || realm.intrinsics.undefined);
 
       // 7. If targetOffset < 0, throw a RangeError exception.
       if (targetOffset < 0) {
@@ -1409,13 +1399,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(typeof len === "number");
 
     // 4. Let relativeStart be ? ToInteger(start).
-    let relativeStart = ToInteger(realm, start);
+    let relativeStart = To.ToInteger(realm, start);
 
     // 5. If relativeStart < 0, let k be max((len + relativeStart), 0); else let k be min(relativeStart, len).
     let k = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
 
     // 6. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToInteger(end).
-    let relativeEnd = !end || end instanceof UndefinedValue ? len : ToInteger(realm, end.throwIfNotConcrete());
+    let relativeEnd = !end || end instanceof UndefinedValue ? len : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 7. If relativeEnd < 0, let final be max((len + relativeEnd), 0); else let final be min(relativeEnd, len).
     let final = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
@@ -1448,13 +1438,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // b. Repeat, while k < final
       while (k < final) {
         // i. Let Pk be ! ToString(k).
-        let Pk = ToString(realm, new NumberValue(realm, k));
+        let Pk = To.ToString(realm, new NumberValue(realm, k));
 
         // ii. Let kValue be ? Get(O, Pk).
         let kValue = Get(realm, O, Pk);
 
         // iii. Perform ! Set(A, ! ToString(n), kValue).
-        Properties.Set(realm, A, ToString(realm, new NumberValue(realm, n)), kValue, true);
+        Properties.Set(realm, A, To.ToString(realm, new NumberValue(realm, n)), kValue, true);
 
         // iv. Increase k by 1.
         k += 1;
@@ -1519,7 +1509,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.25
   obj.defineNativeMethod("some", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
@@ -1556,7 +1546,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         let kValue = Get(realm, O, Pk);
 
         // ii. Let testResult be ToBoolean(? Call(callbackfn, T, « kValue, k, O »)).
-        let testResult = ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
+        let testResult = To.ToBooleanPartial(realm, Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]));
 
         // iii. If testResult is true, return true.
         if (testResult) return realm.intrinsics.true;
@@ -1573,7 +1563,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.26
   obj.defineNativeMethod("sort", 1, (context, [comparefn]) => {
     // 1. Let obj be the this value.
-    let O = ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Let buffer be ? ValidateTypedArray(obj).
     let buffer = ValidateTypedArray(realm, O);
@@ -1643,7 +1633,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       invariant(y instanceof NumberValue, "Unexpected type");
 
       let result_ = SortCompare(x, y);
-      let numb = ToNumber(realm, result_);
+      let numb = To.ToNumber(realm, result_);
       return numb;
     };
 
@@ -1694,13 +1684,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
     invariant(typeof srcLength === "number");
 
     // 7. Let relativeBegin be ? ToInteger(begin).
-    let relativeBegin = ToInteger(realm, begin);
+    let relativeBegin = To.ToInteger(realm, begin);
 
     // 8. If relativeBegin < 0, let beginIndex be max((srcLength + relativeBegin), 0); else let beginIndex be min(relativeBegin, srcLength).
     let beginIndex = relativeBegin < 0 ? Math.max(srcLength + relativeBegin, 0) : Math.min(relativeBegin, srcLength);
 
     // 9. If end is undefined, let relativeEnd be srcLength; else, let relativeEnd be ? ToInteger(end).
-    let relativeEnd = !end || end instanceof UndefinedValue ? srcLength : ToInteger(realm, end.throwIfNotConcrete());
+    let relativeEnd = !end || end instanceof UndefinedValue ? srcLength : To.ToInteger(realm, end.throwIfNotConcrete());
 
     // 10. If relativeEnd < 0, let endIndex be max((srcLength + relativeEnd), 0); else let endIndex be min(relativeEnd, srcLength).
     let endIndex = relativeEnd < 0 ? Math.max(srcLength + relativeEnd, 0) : Math.min(relativeEnd, srcLength);
@@ -1732,7 +1722,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.28
   obj.defineNativeMethod("toLocaleString", 0, context => {
     // 1. Let array be ? ToObject(this value).
-    let array = ToObject(realm, context.throwIfNotConcrete());
+    let array = To.ToObject(realm, context.throwIfNotConcrete());
 
     // 2. Perform ? ValidateTypedArray(array).
     ValidateTypedArray(realm, array);
@@ -1758,7 +1748,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     } else {
       // 8. Else,
       // a. Let R be ? ToString(? Invoke(firstElement, "toLocaleString")).
-      R = ToStringPartial(realm, Invoke(realm, firstElement, "toLocaleString"));
+      R = To.ToStringPartial(realm, Invoke(realm, firstElement, "toLocaleString"));
     }
 
     // 9. Let k be 1.
@@ -1779,7 +1769,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       } else {
         // d. Else,
         // i. Let R be ? ToString(? Invoke(nextElement, "toLocaleString")).
-        R = ToStringPartial(realm, Invoke(realm, nextElement, "toLocaleString"));
+        R = To.ToStringPartial(realm, Invoke(realm, nextElement, "toLocaleString"));
       }
 
       // e. Let R be a String value produced by concatenating S and R.

--- a/src/intrinsics/ecma262/decodeURI.js
+++ b/src/intrinsics/ecma262/decodeURI.js
@@ -11,8 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToString } from "../../methods/index.js";
 import { StringValue } from "../../values/index.js";
+import { To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.6.2
@@ -22,7 +22,7 @@ export default function(realm: Realm): NativeFunctionValue {
 
     encodedURI = encodedURI.throwIfNotConcrete();
     // 1. Let uriString be ? ToString(encodedURI).
-    let uriString = ToString(realm, encodedURI);
+    let uriString = To.ToString(realm, encodedURI);
     // 2. Let reservedURISet be a String containing one instance of each code unit valid in uriReserved plus "#".
     // 3. Return ? Decode(uriString, reservedURISet).
     try {

--- a/src/intrinsics/ecma262/decodeURIComponent.js
+++ b/src/intrinsics/ecma262/decodeURIComponent.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToString } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import { StringValue } from "../../values/index.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -23,7 +23,7 @@ export default function(realm: Realm): NativeFunctionValue {
     encodedURIComponent = encodedURIComponent.throwIfNotConcrete();
 
     // 1. Let componentString be ? ToString(uri).
-    let componentString = ToString(realm, encodedURIComponent);
+    let componentString = To.ToString(realm, encodedURIComponent);
 
     // 2. Let reservedURIComponentSet be the empty String.
     // 3. Return ? Encode(componentString, unescapedURIComponentSet).

--- a/src/intrinsics/ecma262/encodeURI.js
+++ b/src/intrinsics/ecma262/encodeURI.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToString } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import { StringValue } from "../../values/index.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -22,7 +22,7 @@ export default function(realm: Realm): NativeFunctionValue {
 
     uri = uri.throwIfNotConcrete();
     // 1. Let uriString be ? ToString(uri).
-    let uriString = ToString(realm, uri);
+    let uriString = To.ToString(realm, uri);
     // 2. Let unescapedURISet be a String containing one instance of each code unit valid in uriReserved and uriUnescaped plus "#".
     // 3. Return ? Encode(uriString, unescapedURISet).
     try {

--- a/src/intrinsics/ecma262/encodeURIComponent.js
+++ b/src/intrinsics/ecma262/encodeURIComponent.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToString } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import { StringValue } from "../../values/index.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -23,7 +23,7 @@ export default function(realm: Realm): NativeFunctionValue {
     uriComponent = uriComponent.throwIfNotConcrete();
 
     // 1. Let componentString be ? ToString(uri).
-    let componentString = ToString(realm, uriComponent);
+    let componentString = To.ToString(realm, uriComponent);
 
     // 2. Let unescapedURIComponentSet be a String containing one instance of each code unit valid in uriUnescaped.
     // 3. Return ? Encode(componentString, unescapedURIComponentSet).

--- a/src/intrinsics/ecma262/isFinite.js
+++ b/src/intrinsics/ecma262/isFinite.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToNumber } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.2
@@ -22,7 +22,7 @@ export default function(realm: Realm): NativeFunctionValue {
     1,
     (context, [number]) => {
       // 1. Let num be ? ToNumber(number).
-      let num = ToNumber(realm, number);
+      let num = To.ToNumber(realm, number);
 
       // 2. If num is NaN, +∞, or -∞, return false.
       if (isNaN(num) || num === +Infinity || num === -Infinity) return realm.intrinsics.false;

--- a/src/intrinsics/ecma262/isNaN.js
+++ b/src/intrinsics/ecma262/isNaN.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { ToNumber } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.3
@@ -22,7 +22,7 @@ export default function(realm: Realm): NativeFunctionValue {
     1,
     (context, [number]) => {
       // 1. Let num be ? ToNumber(number).
-      let num = ToNumber(realm, number);
+      let num = To.ToNumber(realm, number);
 
       // 2. If num is NaN, return true.
       if (isNaN(num)) return realm.intrinsics.true;

--- a/src/intrinsics/ecma262/parseFloat.js
+++ b/src/intrinsics/ecma262/parseFloat.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { NumberValue } from "../../values/index.js";
-import { ToStringPartial } from "../../methods/to.js";
+import { To } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.4
@@ -25,7 +25,7 @@ export default function(realm: Realm): NativeFunctionValue {
       if (!string) return realm.intrinsics.NaN;
 
       // 1. Let inputString be ? ToString(string).
-      let inputString = ToStringPartial(realm, string);
+      let inputString = To.ToStringPartial(realm, string);
 
       return new NumberValue(realm, parseFloat(inputString));
     },

--- a/src/intrinsics/ecma262/parseInt.js
+++ b/src/intrinsics/ecma262/parseInt.js
@@ -12,7 +12,7 @@
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
 import { NumberValue } from "../../values/index.js";
-import { ToStringPartial, ToInt32 } from "../../methods/to.js";
+import { To } from "../../singletons.js";
 
 function ToDigit(ch: string): number | void {
   if (ch >= "0" && ch <= "9") {
@@ -33,7 +33,7 @@ export default function(realm: Realm): NativeFunctionValue {
     2,
     (context, [string, radix]) => {
       // 1. Let inputString be ? ToString(string).
-      let inputString = ToStringPartial(realm, string);
+      let inputString = To.ToStringPartial(realm, string);
 
       // 2. Let S be a newly created substring of inputString consisting of the first code unit that is not a StrWhiteSpaceChar and all code units following that code unit. (In other words, remove leading white space.) If inputString does not contain any such code unit, let S be the empty string.
       let S = inputString.trim();
@@ -48,7 +48,7 @@ export default function(realm: Realm): NativeFunctionValue {
       if (S !== "" && (S.charAt(0) === "-" || S.charAt(0) === "+")) S = S.substr(1);
 
       // 6. Let R be ? ToInt32(radix).
-      let R = ToInt32(realm, radix);
+      let R = To.ToInt32(realm, radix);
 
       // 7. Let stripPrefix be true.
       let stripPrefix = true;

--- a/src/intrinsics/node/buffer.js
+++ b/src/intrinsics/node/buffer.js
@@ -13,9 +13,8 @@ import invariant from "../../invariant.js";
 import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NumberValue, NativeFunctionValue, ObjectValue, StringValue } from "../../values/index.js";
-import { ToInteger } from "../../methods/index.js";
 import { getNodeBufferFromTypedArray } from "./utils.js";
-import { Properties } from "../../singletons.js";
+import { Properties, To } from "../../singletons.js";
 
 declare var process: any;
 
@@ -66,7 +65,7 @@ export default function(realm: Realm): ObjectValue {
       let utf8Slice = new NativeFunctionValue(realm, "Buffer.prototype.utf8Slice", "utf8Slice", 0, (context, args) => {
         invariant(context instanceof ObjectValue);
         let self = getNodeBufferFromTypedArray(realm, context);
-        let decodedArgs = args.map((arg, i) => ToInteger(realm, arg));
+        let decodedArgs = args.map((arg, i) => To.ToInteger(realm, arg));
         let utf8String = nativeBufferPrototype.utf8Slice.apply(self, decodedArgs);
         return new StringValue(realm, utf8String);
       });
@@ -81,7 +80,7 @@ export default function(realm: Realm): ObjectValue {
             invariant(arg instanceof ObjectValue);
             return getNodeBufferFromTypedArray(realm, arg);
           } else {
-            return ToInteger(realm, arg);
+            return To.ToInteger(realm, arg);
           }
         });
         let bytesCopied = nativeBufferPrototype.copy.apply(self, decodedArgs);

--- a/src/intrinsics/node/contextify.js
+++ b/src/intrinsics/node/contextify.js
@@ -22,8 +22,8 @@ import {
   StringValue,
   UndefinedValue,
 } from "../../values/index.js";
-import { Get, GetFunctionRealm, ToBoolean, ToInteger, ToString } from "../../methods/index.js";
-import { Properties } from "../../singletons.js";
+import { Get, GetFunctionRealm } from "../../methods/index.js";
+import { Properties, To } from "../../singletons.js";
 import parse from "../../utils/parse.js";
 import type { BabelNodeFile } from "babel-types";
 
@@ -99,7 +99,7 @@ export default function(realm: Realm): ObjectValue {
     }
 
     invariant(args[0] instanceof ConcreteValue);
-    let code = ToString(realm, args[0]);
+    let code = To.ToString(realm, args[0]);
 
     let options = args[1];
     let filename = getFilenameArg(options);
@@ -245,7 +245,7 @@ export default function(realm: Realm): ObjectValue {
     if (value instanceof UndefinedValue) {
       return -1;
     }
-    let timeout = ToInteger(realm, value);
+    let timeout = To.ToInteger(realm, value);
 
     if (timeout <= 0) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "timeout must be a positive number");
@@ -267,7 +267,7 @@ export default function(realm: Realm): ObjectValue {
     if (value instanceof UndefinedValue) {
       return true;
     }
-    return ToBoolean(realm, value);
+    return To.ToBoolean(realm, value);
   }
 
   function getFilenameArg(options: Value): string {
@@ -287,7 +287,7 @@ export default function(realm: Realm): ObjectValue {
     if (value instanceof UndefinedValue) {
       return defaultFilename;
     }
-    return ToString(realm, value);
+    return To.ToString(realm, value);
   }
 
   function getCachedData(options: Value): Uint8Array {
@@ -328,7 +328,7 @@ export default function(realm: Realm): ObjectValue {
     }
     let value = Get(realm, options, "lineOffset");
     invariant(value instanceof ConcreteValue);
-    return value instanceof UndefinedValue ? defaultLineOffset : ToInteger(realm, value);
+    return value instanceof UndefinedValue ? defaultLineOffset : To.ToInteger(realm, value);
   }
 
   function getColumnOffsetArg(options: Value): number {
@@ -338,7 +338,7 @@ export default function(realm: Realm): ObjectValue {
     }
     let value = Get(realm, options, "columnOffset");
     invariant(value instanceof ConcreteValue);
-    return value instanceof UndefinedValue ? defaultColumnOffset : ToInteger(realm, value);
+    return value instanceof UndefinedValue ? defaultColumnOffset : To.ToInteger(realm, value);
   }
 
   function evalMachine(self: Value, timeout: number, displayErrors: boolean, breakOnSigint: boolean): Value {

--- a/src/intrinsics/node/fs.js
+++ b/src/intrinsics/node/fs.js
@@ -12,11 +12,10 @@
 import invariant from "../../invariant.js";
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NumberValue, ObjectValue, StringValue } from "../../values/index.js";
-import { ToString, ToNumber } from "../../methods/index.js";
 import { ValuesDomain } from "../../domains/index.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import { getNodeBufferFromTypedArray } from "./utils.js";
-import { Properties } from "../../singletons.js";
+import { Properties, To } from "../../singletons.js";
 
 declare var process: any;
 
@@ -31,11 +30,11 @@ export default function(realm: Realm): ObjectValue {
     return realm.intrinsics.undefined;
   });
   obj.defineNativeMethod("internalModuleStat", 0, (context, args) => {
-    const fileName = ToString(realm, args[0]);
+    const fileName = To.ToString(realm, args[0]);
     return new NumberValue(realm, nativeFS.internalModuleStat(fileName));
   });
   obj.defineNativeMethod("lstat", 0, (context, args) => {
-    const path = ToString(realm, args[0]);
+    const path = To.ToString(realm, args[0]);
     invariant(args[1] instanceof ObjectValue);
     const buffer = getNodeBufferFromTypedArray(realm, args[1]);
     const float64buffer = new Float64Array(buffer.buffer);
@@ -43,7 +42,7 @@ export default function(realm: Realm): ObjectValue {
     return args[1];
   });
   obj.defineNativeMethod("fstat", 0, (context, args) => {
-    const fd = ToNumber(realm, args[0]);
+    const fd = To.ToNumber(realm, args[0]);
     invariant(args[1] instanceof ObjectValue);
     const buffer = getNodeBufferFromTypedArray(realm, args[1]);
     const float64buffer = new Float64Array(buffer.buffer);
@@ -51,29 +50,29 @@ export default function(realm: Realm): ObjectValue {
     return args[1];
   });
   obj.defineNativeMethod("open", 0, (context, args) => {
-    const path = ToString(realm, args[0]);
-    const flags = ToNumber(realm, args[1]);
-    const mode = ToNumber(realm, args[2]);
+    const path = To.ToString(realm, args[0]);
+    const flags = To.ToNumber(realm, args[1]);
+    const mode = To.ToNumber(realm, args[2]);
     const fd = nativeFS.open(path, flags, mode);
     return new NumberValue(realm, fd);
   });
   obj.defineNativeMethod("close", 0, (context, args) => {
-    const fd = ToNumber(realm, args[0]);
+    const fd = To.ToNumber(realm, args[0]);
     nativeFS.close(fd);
     return realm.intrinsics.undefined;
   });
   obj.defineNativeMethod("read", 0, (context, args) => {
-    const fd = ToNumber(realm, args[0]);
+    const fd = To.ToNumber(realm, args[0]);
     invariant(args[1] instanceof ObjectValue);
     const buffer = getNodeBufferFromTypedArray(realm, args[1]);
-    const offset = ToNumber(realm, args[2]);
-    const length = ToNumber(realm, args[3]);
-    const position = args[4] === realm.intrinsics.undefined ? undefined : ToNumber(realm, args[4]);
+    const offset = To.ToNumber(realm, args[2]);
+    const length = To.ToNumber(realm, args[3]);
+    const position = args[4] === realm.intrinsics.undefined ? undefined : To.ToNumber(realm, args[4]);
     const bytesRead = nativeFS.read(fd, buffer, offset, length, position);
     return new NumberValue(realm, bytesRead);
   });
   obj.defineNativeMethod("internalModuleReadFile", 0, (context, args) => {
-    const path = ToString(realm, args[0]);
+    const path = To.ToString(realm, args[0]);
     const result = nativeFS.internalModuleReadFile(path);
     if (result === undefined) {
       return realm.intrinsics.undefined;

--- a/src/intrinsics/node/process.js
+++ b/src/intrinsics/node/process.js
@@ -23,9 +23,9 @@ import {
   ObjectValue,
   StringValue,
 } from "../../values/index.js";
-import { Get, ToString, ToInteger, ToBoolean } from "../../methods/index.js";
+import { Get } from "../../methods/index.js";
 import { ValuesDomain } from "../../domains/index.js";
-import { Properties } from "../../singletons.js";
+import { Properties, To } from "../../singletons.js";
 import buildExpressionTemplate from "../../utils/builder.js";
 import initializeBuffer from "./buffer.js";
 import initializeContextify from "./contextify.js";
@@ -67,9 +67,9 @@ function initializeTTYWrap(realm) {
     0,
     (context, args, argCount, NewTarget) => {
       invariant(args[0] instanceof ConcreteValue);
-      let fd = ToInteger(realm, args[0]);
+      let fd = To.ToInteger(realm, args[0]);
       invariant(args[1] instanceof ConcreteValue);
-      let value = ToBoolean(realm, args[1]);
+      let value = To.ToBoolean(realm, args[1]);
 
       invariant(NewTarget, "TTY must be called as a constructor.");
 
@@ -120,7 +120,7 @@ function initializeTTYWrap(realm) {
   });
 
   obj.defineNativeMethod("guessHandleType", 0, (context, args) => {
-    let fd = ToInteger(realm, args[0]);
+    let fd = To.ToInteger(realm, args[0]);
     return new StringValue(realm, nativeTTYWrap.guessHandleType(fd));
     // TODO: Make this abstract so that changing the pipe at runtime is
     // possible. Currently this causes an introspection error.
@@ -141,7 +141,7 @@ function initializeTTYWrap(realm) {
   });
 
   obj.defineNativeMethod("isTTY", 0, (context, args) => {
-    let fd = ToInteger(realm, args[0]);
+    let fd = To.ToInteger(realm, args[0]);
     const isTTYtemplateSrc = `(process.binding('tty_wrap').isTTY(${fd}))`;
     const isTTYtemplate = buildExpressionTemplate(isTTYtemplateSrc);
     let val = AbstractValue.createFromTemplate(realm, isTTYtemplate, BooleanValue, [], isTTYtemplateSrc);
@@ -363,7 +363,7 @@ export default function(realm: Realm, processArgv: Array<string>): ObjectValue {
   let obj = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "process");
   obj.defineNativeMethod("binding", 1, (context, args) => {
     let arg0 = args.length < 1 ? realm.intrinsics.undefined : args[0];
-    let module = ToString(realm, arg0);
+    let module = To.ToString(realm, arg0);
     // TODO: Add the module to the moduleLoadList but don't track that
     // as a side-effect.
     switch (module) {

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -21,7 +21,7 @@ import {
   Value,
   ECMAScriptSourceFunctionValue,
 } from "../../values/index.js";
-import { ToStringPartial } from "../../methods/index.js";
+import { To } from "../../singletons.js";
 import { ValuesDomain } from "../../domains/index.js";
 import * as t from "babel-types";
 import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
@@ -286,13 +286,13 @@ export default function(realm: Realm): void {
           let generator = realm.generator;
           invariant(generator);
 
-          let key = ToStringPartial(realm, propertyName);
+          let key = To.ToStringPartial(realm, propertyName);
           let propertyIdentifier = generator.getAsPropertyNameExpression(key);
           let computed = !t.isIdentifier(propertyIdentifier);
           let condition = ([objectNode, valueNode]) =>
             t.binaryExpression("!==", t.memberExpression(objectNode, propertyIdentifier, computed), valueNode);
           if (invariantOptions) {
-            let invariantOptionString = ToStringPartial(realm, invariantOptions);
+            let invariantOptionString = To.ToStringPartial(realm, invariantOptions);
             switch (invariantOptionString) {
               case "VALUE_DEFINED_INVARIANT":
                 condition = ([objectNode, valueNode]) =>

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -20,9 +20,9 @@ import {
   UndefinedValue,
 } from "../../values/index.js";
 import buildExpressionTemplate from "../../utils/builder.js";
-import { describeLocation } from "../ecma262/Error.js";
-import { ToStringPartial } from "../../methods/index.js";
 import { ValuesDomain } from "../../domains/index.js";
+import { describeLocation } from "../ecma262/Error.js";
+import { To } from "../../singletons.js";
 import AbstractObjectValue from "../../values/AbstractObjectValue";
 
 const throwTemplateSrc = "(function(){throw new global.Error('abstract value defined at ' + A);})()";
@@ -41,7 +41,7 @@ export function parseTypeNameOrTemplate(
     }
     return { type, template: undefined };
   } else if (typeNameOrTemplate instanceof StringValue) {
-    let typeNameString = ToStringPartial(realm, typeNameOrTemplate);
+    let typeNameString = To.ToStringPartial(realm, typeNameOrTemplate);
     let type = Value.getTypeFromName(typeNameString);
     if (type === undefined) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown typeNameOrTemplate");
@@ -69,7 +69,7 @@ export function createAbstract(
   let { type, template } = parseTypeNameOrTemplate(realm, typeNameOrTemplate);
 
   let result;
-  let nameString = name ? ToStringPartial(realm, name) : "";
+  let nameString = name ? To.ToStringPartial(realm, name) : "";
   if (nameString === "") {
     let locString;
     for (let executionContext of realm.contextStack.slice().reverse()) {

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -26,12 +26,12 @@ import {
   ConcreteValue,
   AbstractValue,
 } from "../values/index.js";
-import { ToPrimitive, ToNumber, ToBooleanPartial } from "./to.js";
 import { Call } from "./call.js";
 import { IsCallable } from "./is.js";
 import { Completion, ReturnCompletion, ThrowCompletion } from "../completions.js";
 import { GetMethod, Get } from "./get.js";
 import { HasCompatibleType } from "./has.js";
+import { To } from "../singletons.js";
 import type { BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -100,17 +100,17 @@ export function AbstractRelationalComparison(
   // 1. If the LeftFirst flag is true, then
   if (LeftFirst) {
     // a. Let px be ? ToPrimitive(x, hint Number).
-    px = ToPrimitive(realm, x, "number");
+    px = To.ToPrimitive(realm, x, "number");
 
     // b. Let py be ? ToPrimitive(y, hint Number).
-    py = ToPrimitive(realm, y, "number");
+    py = To.ToPrimitive(realm, y, "number");
   } else {
     // 2. Else the order of evaluation needs to be reversed to preserve left to right evaluation
     // a. Let py be ? ToPrimitive(y, hint Number).
-    py = ToPrimitive(realm, y, "number");
+    py = To.ToPrimitive(realm, y, "number");
 
     // b. Let px be ? ToPrimitive(x, hint Number).
-    px = ToPrimitive(realm, x, "number");
+    px = To.ToPrimitive(realm, x, "number");
   }
 
   // 3. If both px and py are Strings, then
@@ -138,10 +138,10 @@ export function AbstractRelationalComparison(
   } else {
     // 4. Else,
     // a. Let nx be ? ToNumber(px). Because px and py are primitive values evaluation order is not important.
-    let nx = ToNumber(realm, px);
+    let nx = To.ToNumber(realm, px);
 
     // b. Let ny be ? ToNumber(py).
-    let ny = ToNumber(realm, py);
+    let ny = To.ToNumber(realm, py);
 
     // c. If nx is NaN, return undefined.
     if (isNaN(nx)) return realm.intrinsics.undefined;
@@ -199,32 +199,32 @@ export function AbstractEqualityComparison(realm: Realm, x: ConcreteValue, y: Co
 
   // 4. If Type(x) is Number and Type(y) is String, return the result of the comparison x == ToNumber(y).
   if (x instanceof NumberValue && y instanceof StringValue) {
-    return AbstractEqualityComparison(realm, x, new NumberValue(realm, ToNumber(realm, y)));
+    return AbstractEqualityComparison(realm, x, new NumberValue(realm, To.ToNumber(realm, y)));
   }
 
   // 5. If Type(x) is String and Type(y) is Number, return the result of the comparison ToNumber(x) == y.
   if (x instanceof StringValue && y instanceof NumberValue) {
-    return AbstractEqualityComparison(realm, new NumberValue(realm, ToNumber(realm, x)), y);
+    return AbstractEqualityComparison(realm, new NumberValue(realm, To.ToNumber(realm, x)), y);
   }
 
   // 6. If Type(x) is Boolean, return the result of the comparison ToNumber(x) == y.
   if (x instanceof BooleanValue) {
-    return AbstractEqualityComparison(realm, new NumberValue(realm, ToNumber(realm, x)), y);
+    return AbstractEqualityComparison(realm, new NumberValue(realm, To.ToNumber(realm, x)), y);
   }
 
   // 7. If Type(y) is Boolean, return the result of the comparison x == ToNumber(y).
   if (y instanceof BooleanValue) {
-    return AbstractEqualityComparison(realm, x, new NumberValue(realm, ToNumber(realm, y)));
+    return AbstractEqualityComparison(realm, x, new NumberValue(realm, To.ToNumber(realm, y)));
   }
 
   // 8. If Type(x) is either String, Number, or Symbol and Type(y) is Object, return the result of the comparison x == ToPrimitive(y).
   if ((x instanceof StringValue || x instanceof NumberValue || x instanceof SymbolValue) && y instanceof ObjectValue) {
-    return AbstractEqualityComparison(realm, x, ToPrimitive(realm, y));
+    return AbstractEqualityComparison(realm, x, To.ToPrimitive(realm, y));
   }
 
   // 9. If Type(x) is Object and Type(y) is either String, Number, or Symbol, return the result of the comparison ToPrimitive(x) == y.
   if (x instanceof ObjectValue && (y instanceof StringValue || y instanceof NumberValue || y instanceof SymbolValue)) {
-    return AbstractEqualityComparison(realm, ToPrimitive(realm, x), y);
+    return AbstractEqualityComparison(realm, To.ToPrimitive(realm, x), y);
   }
 
   // 10. Return false.
@@ -420,7 +420,7 @@ export function InstanceofOperator(realm: Realm, O: Value, C: Value): boolean {
   // 3. If instOfHandler is not undefined, then
   if (!(instOfHandler instanceof UndefinedValue)) {
     // a. Return ToBoolean(? Call(instOfHandler, C, « O »)).
-    return ToBooleanPartial(realm, Call(realm, instOfHandler, C, [O]));
+    return To.ToBooleanPartial(realm, Call(realm, instOfHandler, C, [O]));
   }
 
   // 4. If IsCallable(C) is false, throw a TypeError exception.

--- a/src/methods/arraybuffer.js
+++ b/src/methods/arraybuffer.js
@@ -14,9 +14,8 @@ import type { DataBlock, ElementType } from "../types.js";
 import { Value, ObjectValue, NumberValue, EmptyValue, NullValue, UndefinedValue } from "../values/index.js";
 import { SpeciesConstructor } from "../methods/construct.js";
 import { IsConstructor } from "../methods/index.js";
-import { ToIndexPartial, ToBooleanPartial, ToNumber, ElementConv } from "./to.js";
 import { IsDetachedBuffer } from "../methods/is.js";
-import { Create, Properties } from "../singletons.js";
+import { Create, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import { ElementSize } from "../types.js";
 
@@ -158,10 +157,10 @@ export function GetViewValue(
   invariant(view.$ViewedArrayBuffer);
 
   // 4. Let getIndex be ? ToIndex(requestIndex).
-  let getIndex = ToIndexPartial(realm, requestIndex);
+  let getIndex = To.ToIndexPartial(realm, requestIndex);
 
   // 5. Let littleEndian be ToBoolean(isLittleEndian).
-  let littleEndian = ToBooleanPartial(realm, isLittleEndian);
+  let littleEndian = To.ToBooleanPartial(realm, isLittleEndian);
 
   // 6. Let buffer be view.[[ViewedArrayBuffer]].
   let buffer = view.$ViewedArrayBuffer;
@@ -301,13 +300,13 @@ export function SetViewValue(
   invariant(view.$ViewedArrayBuffer);
 
   // 4. Let getIndex be ? ToIndex(requestIndex).
-  let getIndex = ToIndexPartial(realm, requestIndex);
+  let getIndex = To.ToIndexPartial(realm, requestIndex);
 
   // 5. Let numberValue be ? ToNumber(value).
-  let numberValue = ToNumber(realm, value);
+  let numberValue = To.ToNumber(realm, value);
 
   // 6. Let littleEndian be ToBoolean(isLittleEndian).
-  let littleEndian = ToBooleanPartial(realm, isLittleEndian);
+  let littleEndian = To.ToBooleanPartial(realm, isLittleEndian);
 
   // 7. Let buffer be view.[[ViewedArrayBuffer]].
   let buffer = view.$ViewedArrayBuffer;
@@ -446,7 +445,7 @@ export function SetValueInBuffer(
     let n = ElementSize[type];
 
     // b. Let convOp be the abstract operation named in the Conversion Operation column in Table 50 for Element Type type.
-    let convOp = ElementConv[type];
+    let convOp = To.ElementConv[type];
 
     // c. Let intValue be convOp(value).
     let intValue = convOp(realm, value);

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -25,15 +25,7 @@ import {
   AbstractObjectValue,
   AbstractValue,
 } from "../values/index.js";
-import {
-  GetIterator,
-  HasSomeCompatibleType,
-  IsCallable,
-  IsPropertyKey,
-  IteratorStep,
-  IteratorValue,
-  ToObjectPartial,
-} from "./index.js";
+import { GetIterator, HasSomeCompatibleType, IsCallable, IsPropertyKey, IteratorStep, IteratorValue } from "./index.js";
 import { GeneratorStart } from "../methods/generator.js";
 import {
   ReturnCompletion,
@@ -43,7 +35,7 @@ import {
 } from "../completions.js";
 import { GetTemplateObject, GetV, GetThisValue } from "../methods/get.js";
 import { construct_empty_effects } from "../realm.js";
-import { Create, Environment, Functions, Join } from "../singletons.js";
+import { Create, Environment, Functions, Join, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeExpression, BabelNodeSpreadElement, BabelNodeTemplateLiteral } from "babel-types";
 import * as t from "babel-types";
@@ -279,7 +271,7 @@ export function OrdinaryCallBindThis(
     } else {
       //  b. Else,
       // i. Let thisValue be ! ToObject(thisArgument).
-      thisValue = ToObjectPartial(calleeRealm, thisArgument);
+      thisValue = To.ToObjectPartial(calleeRealm, thisArgument);
 
       // ii. NOTE ToObject produces wrapper objects using calleeRealm.
     }

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -30,10 +30,9 @@ import {
 import { GetPrototypeFromConstructor } from "./get.js";
 import { IsConstructor, IsPropertyKey, IsArray } from "./is.js";
 import { Type, SameValue, RequireObjectCoercible } from "./abstract.js";
-import { ToStringPartial, ToLength } from "./to.js";
 import { Get, GetFunctionRealm } from "./get.js";
 import { Construct, MakeConstructor } from "./construct.js";
-import { Functions, Properties } from "../singletons.js";
+import { Functions, Properties, To } from "../singletons.js";
 import IsStrict from "../utils/strict.js";
 import invariant from "../invariant.js";
 import parse from "../utils/parse.js";
@@ -85,7 +84,7 @@ export class CreateImplementation {
     let str = RequireObjectCoercible(realm, string);
 
     // 2. Let S be ? ToString(str).
-    let S = ToStringPartial(realm, str);
+    let S = To.ToStringPartial(realm, str);
 
     // 3. Let p1 be the String value that is the concatenation of "<" and tag.
     let p1 = `<${tag}`;
@@ -93,7 +92,7 @@ export class CreateImplementation {
     // 4. If attribute is not the empty String, then
     if (attribute) {
       // a. Let V be ? ToString(value).
-      let V = ToStringPartial(realm, value);
+      let V = To.ToStringPartial(realm, value);
 
       // b. Let escapedV be the String value that is the same as V except that each occurrence of the code unit
       //    0x0022 (QUOTATION MARK) in V has been replaced with the six code unit sequence "&quot;".
@@ -651,7 +650,7 @@ export class CreateImplementation {
     }
 
     // 3. Let len be ? ToLength(? Get(obj, "length")).
-    let len = ToLength(realm, Get(realm, obj, "length"));
+    let len = To.ToLength(realm, Get(realm, obj, "length"));
 
     // 4. Let list be a new empty List.
     let list: Array<Value> = [];
@@ -732,7 +731,7 @@ export class CreateImplementation {
       let firstArg = args[0];
 
       // b. Let P be ? ToString(firstArg).
-      P = ToStringPartial(realm, firstArg);
+      P = To.ToStringPartial(realm, firstArg);
 
       // c. Let k be 1.
       let k = 1;
@@ -743,7 +742,7 @@ export class CreateImplementation {
         let nextArg = args[k];
 
         // ii. Let nextArgString be ? ToString(nextArg).
-        let nextArgString = ToStringPartial(realm, nextArg);
+        let nextArgString = To.ToStringPartial(realm, nextArg);
 
         // iii. Let P be the result of concatenating the previous value of P, the String "," (a comma), and nextArgString.
         P = P + "," + nextArgString;
@@ -757,7 +756,7 @@ export class CreateImplementation {
     }
 
     // 9. Let bodyText be ? ToString(bodyText).
-    bodyText = ToStringPartial(realm, bodyText);
+    bodyText = To.ToStringPartial(realm, bodyText);
 
     // 10. Let parameters be the result of parsing P, interpreted as UTF-16 encoded Unicode text as described in 6.1.4, using parameterGoal as the goal symbol. Throw a SyntaxError exception if the parse fails.
     // 11. Let body be the result of parsing bodyText, interpreted as UTF-16 encoded Unicode text as described in 6.1.4, using goal as the goal symbol. Throw a SyntaxError exception if the parse fails.

--- a/src/methods/date.js
+++ b/src/methods/date.js
@@ -11,7 +11,7 @@
 
 import { NumberValue, Value, ObjectValue } from "../values/index.js";
 import type { Realm } from "../realm.js";
-import { ToInteger } from "./to.js";
+import { To } from "../singletons.js";
 import invariant from "../invariant.js";
 
 // Constants
@@ -198,16 +198,16 @@ export function MakeTime(realm: Realm, hour: number, min: number, sec: number, m
   if (!isFinite(hour) || !isFinite(min) || !isFinite(sec) || !isFinite(ms)) return NaN;
 
   // 2. Let h be ToInteger(hour).
-  let h = ToInteger(realm, new NumberValue(realm, hour));
+  let h = To.ToInteger(realm, new NumberValue(realm, hour));
 
   // 3. Let m be ToInteger(min).
-  let m = ToInteger(realm, new NumberValue(realm, min));
+  let m = To.ToInteger(realm, new NumberValue(realm, min));
 
   // 4. Let s be ToInteger(sec).
-  let s = ToInteger(realm, new NumberValue(realm, sec));
+  let s = To.ToInteger(realm, new NumberValue(realm, sec));
 
   // 5. Let milli be ToInteger(ms).
-  let milli = ToInteger(realm, new NumberValue(realm, ms));
+  let milli = To.ToInteger(realm, new NumberValue(realm, ms));
 
   // 6. Let t be h * msPerHour + m * msPerMinute + s * msPerSecond + milli, performing the arithmetic
   //    according to IEEE 754-2008 rules (that is, as if using the ECMAScript operators * and +).
@@ -223,13 +223,13 @@ export function MakeDay(realm: Realm, year: number, month: number, date: number)
   if (!isFinite(year) || !isFinite(month) || !isFinite(date)) return NaN;
 
   // 2. Let y be ToInteger(year).
-  let y = ToInteger(realm, new NumberValue(realm, year));
+  let y = To.ToInteger(realm, new NumberValue(realm, year));
 
   // 3. Let m be ToInteger(month).
-  let m = ToInteger(realm, new NumberValue(realm, month));
+  let m = To.ToInteger(realm, new NumberValue(realm, month));
 
   // 4. Let dt be ToInteger(date).
-  let dt = ToInteger(realm, new NumberValue(realm, date));
+  let dt = To.ToInteger(realm, new NumberValue(realm, date));
 
   // 5. Let ym be y + floor(m / 12).
   let ym = y + Math.floor(m / 12);
@@ -287,7 +287,7 @@ export function TimeClip(realm: Realm, time: number | Value): NumberValue {
   }
 
   // 3. Let clippedTime be ToInteger(time).
-  let clippedTime = ToInteger(realm, new NumberValue(realm, time));
+  let clippedTime = To.ToInteger(realm, new NumberValue(realm, time));
 
   // 4. If clippedTime is -0, let clippedTime be +0.
   if (Object.is(clippedTime, -0)) clippedTime = +0;

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -41,7 +41,6 @@ import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   GetV,
   GetThisValue,
-  ToObjectPartial,
   RequireObjectCoercible,
   HasSomeCompatibleType,
   GetIterator,
@@ -51,7 +50,7 @@ import {
   IsAnonymousFunctionDefinition,
   HasOwnProperty,
 } from "./index.js";
-import { Create, Functions, Properties } from "../singletons.js";
+import { Create, Functions, Properties, To } from "../singletons.js";
 import type {
   BabelNode,
   BabelNodeVariableDeclaration,
@@ -133,8 +132,8 @@ export class EnvironmentImplementation {
         // i. Assert: In this case, base will never be null or undefined.
         invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
 
-        // ii. Let base be ToObject(base).
-        base = ToObjectPartial(realm, base);
+        // ii. Let base be To.ToObject(base).
+        base = To.ToObjectPartial(realm, base);
       }
       invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
 
@@ -863,7 +862,7 @@ export class EnvironmentImplementation {
           throw e;
         }
 
-        // f. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
+        // f. Let status be CreateDataProperty(A, ! To.ToString(n), nextValue).
         let status = Create.CreateDataProperty(realm, A, n.toString(), nextValue);
 
         // g. Assert: status is true.
@@ -929,7 +928,7 @@ export class EnvironmentImplementation {
           throw e;
         }
 
-        // f. Let status be CreateDataProperty(A, ! ToString(n), nextValue).
+        // f. Let status be CreateDataProperty(A, ! To.ToString(n), nextValue).
         let status = Create.CreateDataProperty(realm, A, n.toString(), nextValue);
 
         // g. Assert: status is true.

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -28,7 +28,6 @@ import {
 import { Reference } from "../environment.js";
 import { FatalError } from "../errors.js";
 import { SetIntegrityLevel } from "./integrity.js";
-import { ToString } from "./to.js";
 import {
   Call,
   HasSomeCompatibleType,
@@ -36,9 +35,8 @@ import {
   IsCallable,
   IsDataDescriptor,
   IsPropertyKey,
-  ToObjectPartial,
 } from "./index.js";
-import { Create, Environment, Join, Path } from "../singletons.js";
+import { Create, Environment, Join, Path, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeTemplateLiteral } from "babel-types";
 
@@ -367,7 +365,7 @@ export function GetV(realm: Realm, V: Value, P: PropertyKeyValue): Value {
   invariant(IsPropertyKey(realm, P), "Not a valid property key");
 
   // 2. Let O be ? ToObject(V).
-  let O = ToObjectPartial(realm, V);
+  let O = To.ToObjectPartial(realm, V);
 
   // 3. Return ? O.[[Get]](P, V).
   return O.$Get(P, V);
@@ -457,7 +455,7 @@ export function GetTemplateObject(realm: Realm, templateLiteral: BabelNodeTempla
   // 10. Repeat while index < count
   while (index < count) {
     // a. Let prop be ! ToString(index).
-    let prop = ToString(realm, new NumberValue(realm, index));
+    let prop = To.ToString(realm, new NumberValue(realm, index));
 
     // b. Let cookedValue be the String value cookedStrings[index].
     let cookedValue = new StringValue(realm, cookedStrings[index]);

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -9,7 +9,6 @@
 
 /* @flow */
 
-export * from "./to.js";
 export * from "./abstract.js";
 export * from "./call.js";
 export * from "./construct.js";

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -13,7 +13,6 @@ import { FatalError } from "../errors.js";
 import type { PropertyKeyValue } from "../types.js";
 import type { Realm } from "../realm.js";
 import type { Descriptor } from "../types.js";
-import { ToBooleanPartial, ToUint32, ToString } from "./to.js";
 import { Get } from "./get.js";
 import {
   FunctionValue,
@@ -27,6 +26,7 @@ import {
   AbstractValue,
   AbstractObjectValue,
 } from "../values/index.js";
+import { To } from "../singletons.js";
 import { Value } from "../values/index.js";
 import invariant from "../invariant.js";
 import { HasName, HasCompatibleType } from "./has.js";
@@ -43,7 +43,7 @@ export function IsConcatSpreadable(realm: Realm, O: Value): boolean {
   let spreadable = Get(realm, O, realm.intrinsics.SymbolIsConcatSpreadable);
 
   // 3. If spreadable is not undefined, return ToBoolean(spreadable).
-  if (!spreadable.mightBeUndefined()) return ToBooleanPartial(realm, spreadable);
+  if (!spreadable.mightBeUndefined()) return To.ToBooleanPartial(realm, spreadable);
   spreadable.throwIfNotConcrete();
 
   // 4. Return ? IsArray(O).
@@ -205,7 +205,7 @@ export function IsRegExp(realm: Realm, argument: Value): boolean {
   let isRegExp = Get(realm, argument, realm.intrinsics.SymbolMatch);
 
   // 3. If isRegExp is not undefined, return ToBoolean(isRegExp).
-  if (isRegExp !== undefined) return ToBooleanPartial(realm, isRegExp) === true;
+  if (isRegExp !== undefined) return To.ToBooleanPartial(realm, isRegExp) === true;
 
   // 4. If argument has a [[RegExpMatcher]] internal slot, return true.
   if (argument.$RegExpMatcher) return true;
@@ -312,8 +312,8 @@ export function IsArrayIndex(realm: Realm, P: PropertyKeyValue): boolean {
     return false;
   }
 
-  let i = ToUint32(realm, new StringValue(realm, key));
-  return i !== Math.pow(2, 32) - 1 && ToString(realm, new NumberValue(realm, i)) === key;
+  let i = To.ToUint32(realm, new StringValue(realm, key));
+  return i !== Math.pow(2, 32) - 1 && To.ToString(realm, new NumberValue(realm, i)) === key;
 }
 
 // ECMA262 25.4.1.6

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -13,11 +13,11 @@ import type { Realm } from "../realm.js";
 import type { CallableObjectValue } from "../types.js";
 import { Completion, AbruptCompletion, ThrowCompletion } from "../completions.js";
 import { NativeFunctionValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "../values/index.js";
-import { Call, Get, GetMethod, Invoke, ToBooleanPartial } from "./index.js";
+import { Call, Get, GetMethod, Invoke } from "./index.js";
 import invariant from "../invariant.js";
 import type { IterationKind } from "../types.js";
 import { SameValue } from "./abstract.js";
-import { Create } from "../singletons.js";
+import { Create, To } from "../singletons.js";
 
 // ECMA262 7.4.1
 export function GetIterator(realm: Realm, obj: Value = realm.intrinsics.undefined, method?: Value): ObjectValue {
@@ -69,7 +69,7 @@ export function IteratorComplete(realm: Realm, iterResult: ObjectValue): boolean
   invariant(iterResult instanceof ObjectValue, "expected obj");
 
   // 2. Return ToBoolean(? Get(iterResult, "done")).
-  return ToBooleanPartial(realm, Get(realm, iterResult, "done"));
+  return To.ToBooleanPartial(realm, Get(realm, iterResult, "done"));
 }
 
 // ECMA262 7.4.2

--- a/src/methods/json.js
+++ b/src/methods/json.js
@@ -11,11 +11,10 @@
 
 import type { Realm } from "../realm.js";
 import { Value, ObjectValue, NumberValue, UndefinedValue, StringValue } from "../values/index.js";
-import { Create } from "../singletons.js";
+import { Create, To } from "../singletons.js";
 import { Get } from "../methods/get.js";
 import { Call } from "../methods/call.js";
 import { IsArray } from "../methods/is.js";
-import { ToLength, ToString } from "../methods/to.js";
 import { EnumerableOwnProperties } from "../methods/own.js";
 import type { PropertyKeyValue } from "../types.js";
 import invariant from "../invariant.js";
@@ -40,24 +39,24 @@ export function InternalizeJSONProperty(
       let I = 0;
 
       // ii. Let len be ? ToLength(? Get(val, "length")).
-      let len = ToLength(realm, Get(realm, val, "length"));
+      let len = To.ToLength(realm, Get(realm, val, "length"));
 
       // iii. Repeat while I < len,
       while (I < len) {
         // 1. Let newElement be ? InternalizeJSONProperty(val, ! ToString(I)).
-        let newElement = InternalizeJSONProperty(realm, reviver, val, ToString(realm, new NumberValue(realm, I)));
+        let newElement = InternalizeJSONProperty(realm, reviver, val, To.ToString(realm, new NumberValue(realm, I)));
 
         // 2. If newElement is undefined, then
         if (newElement instanceof UndefinedValue) {
           // a. Perform ? val.[[Delete]](! ToString(I)).
-          val.$Delete(ToString(realm, new NumberValue(realm, I)));
+          val.$Delete(To.ToString(realm, new NumberValue(realm, I)));
         } else {
           // 3. Else,
           // a. Perform ? CreateDataProperty(val, ! ToString(I), newElement).
           Create.CreateDataProperty(
             realm,
             val,
-            ToString(realm, new NumberValue(realm, I)),
+            To.ToString(realm, new NumberValue(realm, I)),
             newElement.throwIfNotConcrete()
           );
 

--- a/src/methods/own.js
+++ b/src/methods/own.js
@@ -11,16 +11,16 @@
 
 import type { PropertyKeyValue } from "../types.js";
 import type { Realm } from "../realm.js";
-import { Get, ToObject, IsArrayIndex } from "./index.js";
+import { Get, IsArrayIndex } from "./index.js";
 import { StringValue, ObjectValue, Value, ArrayValue } from "../values/index.js";
-import { Create, Properties } from "../singletons.js";
+import { Create, Properties, To } from "../singletons.js";
 
 import invariant from "../invariant.js";
 
 // ECMA262 19.1.2.8.1
 export function GetOwnPropertyKeys(realm: Realm, O: Value, Type: Function): ArrayValue {
   // 1. Let obj be ? ToObject(O).
-  let obj = ToObject(realm, O.throwIfNotConcrete());
+  let obj = To.ToObject(realm, O.throwIfNotConcrete());
 
   // 2. Let keys be ? obj.[[OwnPropertyKeys]]().
   let keys = obj.$OwnPropertyKeys();

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -45,16 +45,10 @@ import {
   MakeConstructor,
   SameValue,
   SameValuePartial,
-  ToBooleanPartial,
-  ToNumber,
-  ToObject,
-  ToObjectPartial,
-  ToPropertyDescriptor,
-  ToUint32,
 } from "../methods/index.js";
 import { type BabelNodeObjectMethod, type BabelNodeClassMethod, isValidIdentifier } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
-import { Create, Environment, Functions, Join, Path } from "../singletons.js";
+import { Create, Environment, Functions, Join, Path, To } from "../singletons.js";
 import IsStrict from "../utils/strict.js";
 import * as t from "babel-types";
 
@@ -279,7 +273,7 @@ export class PropertiesImplementation {
       // return or throw completion
       if (completion instanceof AbruptCompletion) throw completion;
       invariant(completion instanceof Value);
-      return ToBooleanPartial(realm, completion);
+      return To.ToBooleanPartial(realm, completion);
     }
 
     return OrdinarySetHelper();
@@ -774,7 +768,7 @@ export class PropertiesImplementation {
     invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue);
 
     // 2. Let props be ? ToObject(Properties).
-    let props = ToObject(realm, Properties.throwIfNotConcrete());
+    let props = To.ToObject(realm, Properties.throwIfNotConcrete());
 
     // 3. Let keys be ? props.[[OwnPropertyKeys]]().
     let keys = props.$OwnPropertyKeys();
@@ -795,7 +789,7 @@ export class PropertiesImplementation {
         let descObj = Get(realm, props, nextKey);
 
         // ii. Let desc be ? ToPropertyDescriptor(descObj).
-        let desc = ToPropertyDescriptor(realm, descObj);
+        let desc = To.ToPropertyDescriptor(realm, descObj);
 
         // iii. Append the pair (a two element List) consisting of nextKey and desc to the end of descriptors.
         descriptors.push([nextKey, desc]);
@@ -902,7 +896,7 @@ export class PropertiesImplementation {
         invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
 
         // ii. Set base to ToObject(base).
-        base = ToObjectPartial(realm, base);
+        base = To.ToObjectPartial(realm, base);
       }
       invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
 
@@ -943,10 +937,10 @@ export class PropertiesImplementation {
     let newLenDesc = Object.assign({}, Desc);
 
     // 3. Let newLen be ? ToUint32(Desc.[[Value]]).
-    let newLen = ToUint32(realm, DescValue);
+    let newLen = To.ToUint32(realm, DescValue);
 
     // 4. Let numberLen be ? ToNumber(Desc.[[Value]]).
-    let numberLen = ToNumber(realm, DescValue);
+    let numberLen = To.ToNumber(realm, DescValue);
 
     // 5. If newLen ≠ numberLen, throw a RangeError exception.
     if (newLen !== numberLen) {

--- a/src/methods/regexp.js
+++ b/src/methods/regexp.js
@@ -12,12 +12,11 @@
 import type { Realm } from "../realm.js";
 import invariant from "../invariant.js";
 import { NullValue, NumberValue, ObjectValue, StringValue, UndefinedValue, Value } from "../values/index.js";
-import { ToString, ToStringPartial, ToLength } from "./to.js";
 import { Get } from "./get.js";
 import { IsCallable } from "./is.js";
 import { Call } from "./call.js";
 import { HasCompatibleType, HasSomeCompatibleType } from "./has.js";
-import { Create, Properties } from "../singletons.js";
+import { Create, Properties, To } from "../singletons.js";
 
 // ECMA262 21.2.3.2.3
 export function RegExpCreate(realm: Realm, P: ?Value, F: ?Value): ObjectValue {
@@ -61,7 +60,7 @@ export function RegExpInitialize(realm: Realm, obj: ObjectValue, pattern: ?Value
     P = "";
   } else {
     // 2. Else, let P be ? ToString(pattern).
-    P = ToStringPartial(realm, pattern);
+    P = To.ToStringPartial(realm, pattern);
   }
 
   // 3. If flags is undefined, let F be the empty String.
@@ -70,7 +69,7 @@ export function RegExpInitialize(realm: Realm, obj: ObjectValue, pattern: ?Value
     F = "";
   } else {
     // 4. Else, let F be ? ToString(flags).
-    F = ToStringPartial(realm, flags);
+    F = To.ToStringPartial(realm, flags);
   }
 
   // 5. If F contains any code unit other than "g", "i", "m", "u", or "y" or if it contains the same code unit more than once, throw a SyntaxError exception.
@@ -197,7 +196,7 @@ export function RegExpBuiltinExec(realm: Realm, R: ObjectValue, S: string): Obje
   let length = S.length;
 
   // 4. Let lastIndex be ? ToLength(? Get(R, "lastIndex")).
-  let lastIndex = ToLength(realm, Get(realm, R, "lastIndex"));
+  let lastIndex = To.ToLength(realm, Get(realm, R, "lastIndex"));
 
   // 5. Let flags be R.[[OriginalFlags]].
   let flags = R.$OriginalFlags;
@@ -327,7 +326,7 @@ export function RegExpBuiltinExec(realm: Realm, R: ObjectValue, S: string): Obje
     }
 
     // e. Perform ! CreateDataProperty(A, ! ToString(i), capturedValue).
-    Create.CreateDataProperty(realm, A, ToString(realm, new NumberValue(realm, i)), capturedValue);
+    Create.CreateDataProperty(realm, A, To.ToString(realm, new NumberValue(realm, i)), capturedValue);
   }
 
   // 25. Return A.

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -34,743 +34,754 @@ import {
 } from "../values/index.js";
 import invariant from "../invariant.js";
 
-export const ElementConv = {
-  Int8: ToInt8,
-  Int16: ToInt16,
-  Int32: ToInt32,
-  Uint8: ToUint8,
-  Uint16: ToUint16,
-  Uint32: ToUint32,
-  Uint8Clamped: ToUint8Clamp,
+type ElementConvType = {
+  Int8: (Realm, numberOrValue) => number,
+  Int16: (Realm, numberOrValue) => number,
+  Int32: (Realm, numberOrValue) => number,
+  Uint8: (Realm, numberOrValue) => number,
+  Uint16: (Realm, numberOrValue) => number,
+  Uint32: (Realm, numberOrValue) => number,
+  Uint8Clamped: (Realm, numberOrValue) => number,
 };
-
 type numberOrValue = number | Value;
 
 function modulo(x: number, y: number): number {
   return x < 0 ? x % y + y : x % y;
 }
 
-// ECMA262 7.1.5
-export function ToInt32(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-  if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
-
-  // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
-  let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
-
-  // 4. Let int16bit be int modulo 2^32.
-  let int32bit = modulo(int, Math.pow(2, 32));
-
-  // 5. If int32bit ≥ 2^31, return int32bit - 2^32; otherwise return int32bit.
-  return int32bit >= Math.pow(2, 31) ? int32bit - Math.pow(2, 32) : int32bit;
-}
-
-// ECMA262 7.1.6
-export function ToUint32(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-  if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
-
-  // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
-  let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
-
-  // 4. Let int16bit be int modulo 2^32.
-  let int32bit = modulo(int, Math.pow(2, 32));
-
-  // 5. Return int32bit.
-  return int32bit;
-}
-
-// ECMA262 7.1.7
-export function ToInt16(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-  if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
-
-  // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
-  let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
-
-  // 4. Let int16bit be int modulo 2^16.
-  let int16bit = modulo(int, Math.pow(2, 16));
-
-  // 5. If int16bit ≥ 2^15, return int16bit - 2^16; otherwise return int16bit.
-  return int16bit >= Math.pow(2, 15) ? int16bit - Math.pow(2, 16) : int16bit;
-}
-
-// ECMA262 7.1.8
-export function ToUint16(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-  if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
-
-  // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
-  let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
-
-  // 4. Let int16bit be int modulo 2^16.
-  let int16bit = modulo(int, Math.pow(2, 16));
-
-  // 5. Return int16bit.
-  return int16bit;
-}
-
-// ECMA262 7.1.9
-export function ToInt8(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-  if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
-
-  // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
-  let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
-
-  // 4. Let int8bit be int modulo 2^8.
-  let int8bit = modulo(int, Math.pow(2, 8));
-
-  // 5. If int8bit ≥ 2^7, return int8bit - 2^8; otherwise return int8bit.
-  return int8bit >= Math.pow(2, 7) ? int8bit - Math.pow(2, 8) : int8bit;
-}
-
-// ECMA262 7.1.10
-export function ToUint8(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-  if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
-
-  // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
-  let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
-
-  // 4. Let int8bit be int modulo 2^8.
-  let int8bit = modulo(int, Math.pow(2, 8));
-
-  // 5. Return int8bit.
-  return int8bit;
-}
-
-// ECMA262 7.1.11
-export function ToUint8Clamp(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, return +0.
-  if (isNaN(number)) return +0;
-
-  // 3. If number ≤ 0, return +0.
-  if (number <= 0) return +0;
-
-  // 4. If number ≥ 255, return 255.
-  if (number >= 255) return 255;
-
-  // 5. Let f be floor(number).
-  let f = Math.floor(number);
-
-  // 6. If f + 0.5 < number, return f + 1.
-  if (f + 0.5 < number) return f + 1;
-
-  // 7. If number < f + 0.5, return f.
-  if (number < f + 0.5) return f;
-
-  // 8. If f is odd, return f + 1.
-  if (f % 2 === 1) return f + 1;
-
-  // 9. Return f.
-  return f;
-}
-
-// ECMA262 19.3.3.1
-export function thisBooleanValue(realm: Realm, value: Value): BooleanValue {
-  // 1. If Type(value) is Boolean, return value.
-  if (value instanceof BooleanValue) return value;
-
-  // 2. If Type(value) is Object and value has a [[BooleanData]] internal slot, then
-  if (value instanceof ObjectValue && value.$BooleanData) {
-    const booleanData = value.$BooleanData.throwIfNotConcreteBoolean();
-    // a. Assert: value's [[BooleanData]] internal slot is a Boolean value.
-    invariant(booleanData instanceof BooleanValue, "expected boolean data internal slot to be a boolean value");
-
-    // b. Return the value of value's [[BooleanData]] internal slot.
-    return booleanData;
+export class ToImplementation {
+  constructor() {
+    this.ElementConv = {
+      Int8: this.ToInt8.bind(this),
+      Int16: this.ToInt16.bind(this),
+      Int32: this.ToInt32.bind(this),
+      Uint8: this.ToUint8.bind(this),
+      Uint16: this.ToUint16.bind(this),
+      Uint32: this.ToUint32.bind(this),
+      Uint8Clamped: this.ToUint8Clamp.bind(this),
+    };
   }
 
-  value.throwIfNotConcrete();
+  ElementConv: ElementConvType;
 
-  // 3. Throw a TypeError exception.
-  throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-}
+  // ECMA262 7.1.5
+  ToInt32(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
 
-// ECMA262 20.1.3
-export function thisNumberValue(realm: Realm, value: Value): NumberValue {
-  // 1. If Type(value) is Number, return value.
-  if (value instanceof NumberValue) return value;
+    // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
+    if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
 
-  // 2. If Type(value) is Object and value has a [[NumberData]] internal slot, then
-  if (value instanceof ObjectValue && value.$NumberData) {
-    const numberData = value.$NumberData.throwIfNotConcreteNumber();
-    // a. Assert: value's [[NumberData]] internal slot is a Number value.
-    invariant(numberData instanceof NumberValue, "expected number data internal slot to be a number value");
+    // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
+    let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
 
-    // b. Return the value of value's [[NumberData]] internal slot.
-    return numberData;
+    // 4. Let int16bit be int modulo 2^32.
+    let int32bit = modulo(int, Math.pow(2, 32));
+
+    // 5. If int32bit ≥ 2^31, return int32bit - 2^32; otherwise return int32bit.
+    return int32bit >= Math.pow(2, 31) ? int32bit - Math.pow(2, 32) : int32bit;
   }
 
-  value = value.throwIfNotConcrete();
+  // ECMA262 7.1.6
+  ToUint32(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
 
-  // 3. Throw a TypeError exception.
-  throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-}
+    // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
+    if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
 
-// ECMA262 21.1.3
-export function thisStringValue(realm: Realm, value: Value): StringValue {
-  // 1. If Type(value) is String, return value.
-  if (value instanceof StringValue) return value;
+    // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
+    let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
 
-  // 2. If Type(value) is Object and value has a [[StringData]] internal slot, then
-  if (value instanceof ObjectValue && value.$StringData) {
-    const stringData = value.$StringData.throwIfNotConcreteString();
-    // a. Assert: value's [[StringData]] internal slot is a String value.
-    invariant(stringData instanceof StringValue, "expected string data internal slot to be a string value");
+    // 4. Let int16bit be int modulo 2^32.
+    let int32bit = modulo(int, Math.pow(2, 32));
 
-    // b. Return the value of value's [[StringData]] internal slot.
-    return stringData;
+    // 5. Return int32bit.
+    return int32bit;
   }
 
-  value = value.throwIfNotConcrete();
+  // ECMA262 7.1.7
+  ToInt16(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
 
-  // 3. Throw a TypeError exception.
-  throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-}
+    // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
+    if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
 
-// ECMA262 6.2.4.5
-export function ToPropertyDescriptor(realm: Realm, Obj: Value): Descriptor {
-  Obj = Obj.throwIfNotConcrete();
+    // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
+    let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
 
-  // 1. If Type(Obj) is not Object, throw a TypeError exception.
-  if (!(Obj instanceof ObjectValue)) {
+    // 4. Let int16bit be int modulo 2^16.
+    let int16bit = modulo(int, Math.pow(2, 16));
+
+    // 5. If int16bit ≥ 2^15, return int16bit - 2^16; otherwise return int16bit.
+    return int16bit >= Math.pow(2, 15) ? int16bit - Math.pow(2, 16) : int16bit;
+  }
+
+  // ECMA262 7.1.8
+  ToUint16(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
+
+    // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
+    if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
+
+    // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
+    let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
+
+    // 4. Let int16bit be int modulo 2^16.
+    let int16bit = modulo(int, Math.pow(2, 16));
+
+    // 5. Return int16bit.
+    return int16bit;
+  }
+
+  // ECMA262 7.1.9
+  ToInt8(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
+
+    // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
+    if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
+
+    // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
+    let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
+
+    // 4. Let int8bit be int modulo 2^8.
+    let int8bit = modulo(int, Math.pow(2, 8));
+
+    // 5. If int8bit ≥ 2^7, return int8bit - 2^8; otherwise return int8bit.
+    return int8bit >= Math.pow(2, 7) ? int8bit - Math.pow(2, 8) : int8bit;
+  }
+
+  // ECMA262 7.1.10
+  ToUint8(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
+
+    // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
+    if (isNaN(number) || number === 0 || !isFinite(number)) return +0;
+
+    // 3. Let int be the mathematical value that is the same sign as number and whose magnitude is floor(abs(number)).
+    let int = number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
+
+    // 4. Let int8bit be int modulo 2^8.
+    let int8bit = modulo(int, Math.pow(2, 8));
+
+    // 5. Return int8bit.
+    return int8bit;
+  }
+
+  // ECMA262 7.1.11
+  ToUint8Clamp(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
+
+    // 2. If number is NaN, return +0.
+    if (isNaN(number)) return +0;
+
+    // 3. If number ≤ 0, return +0.
+    if (number <= 0) return +0;
+
+    // 4. If number ≥ 255, return 255.
+    if (number >= 255) return 255;
+
+    // 5. Let f be floor(number).
+    let f = Math.floor(number);
+
+    // 6. If f + 0.5 < number, return f + 1.
+    if (f + 0.5 < number) return f + 1;
+
+    // 7. If number < f + 0.5, return f.
+    if (number < f + 0.5) return f;
+
+    // 8. If f is odd, return f + 1.
+    if (f % 2 === 1) return f + 1;
+
+    // 9. Return f.
+    return f;
+  }
+
+  // ECMA262 19.3.3.1
+  thisBooleanValue(realm: Realm, value: Value): BooleanValue {
+    // 1. If Type(value) is Boolean, return value.
+    if (value instanceof BooleanValue) return value;
+
+    // 2. If Type(value) is Object and value has a [[BooleanData]] internal slot, then
+    if (value instanceof ObjectValue && value.$BooleanData) {
+      const booleanData = value.$BooleanData.throwIfNotConcreteBoolean();
+      // a. Assert: value's [[BooleanData]] internal slot is a Boolean value.
+      invariant(booleanData instanceof BooleanValue, "expected boolean data internal slot to be a boolean value");
+
+      // b. Return the value of value's [[BooleanData]] internal slot.
+      return booleanData;
+    }
+
+    value.throwIfNotConcrete();
+
+    // 3. Throw a TypeError exception.
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
   }
 
-  // 2. Let desc be a new Property Descriptor that initially has no fields.
-  let desc: Descriptor = {};
+  // ECMA262 20.1.3
+  thisNumberValue(realm: Realm, value: Value): NumberValue {
+    // 1. If Type(value) is Number, return value.
+    if (value instanceof NumberValue) return value;
 
-  // 3. Let hasEnumerable be ? HasProperty(Obj, "enumerable").
-  let hasEnumerable = HasProperty(realm, Obj, "enumerable");
+    // 2. If Type(value) is Object and value has a [[NumberData]] internal slot, then
+    if (value instanceof ObjectValue && value.$NumberData) {
+      const numberData = value.$NumberData.throwIfNotConcreteNumber();
+      // a. Assert: value's [[NumberData]] internal slot is a Number value.
+      invariant(numberData instanceof NumberValue, "expected number data internal slot to be a number value");
 
-  // 4. If hasEnumerable is true, then
-  if (hasEnumerable === true) {
-    // a. Let enum be ToBoolean(? Get(Obj, "enumerable")).
-    let enu = ToBooleanPartial(realm, Get(realm, Obj, "enumerable"));
+      // b. Return the value of value's [[NumberData]] internal slot.
+      return numberData;
+    }
 
-    // b. Set the [[Enumerable]] field of desc to enum.
-    desc.enumerable = enu === true;
+    value = value.throwIfNotConcrete();
+
+    // 3. Throw a TypeError exception.
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
   }
 
-  // 5. Let hasConfigurable be ? HasProperty(Obj, "configurable").
-  let hasConfigurable = HasProperty(realm, Obj, "configurable");
+  // ECMA262 21.1.3
+  thisStringValue(realm: Realm, value: Value): StringValue {
+    // 1. If Type(value) is String, return value.
+    if (value instanceof StringValue) return value;
 
-  // 6. If hasConfigurable is true, then
-  if (hasConfigurable === true) {
-    // a. Let conf be ToBoolean(? Get(Obj, "configurable")).
-    let conf = ToBooleanPartial(realm, Get(realm, Obj, "configurable"));
+    // 2. If Type(value) is Object and value has a [[StringData]] internal slot, then
+    if (value instanceof ObjectValue && value.$StringData) {
+      const stringData = value.$StringData.throwIfNotConcreteString();
+      // a. Assert: value's [[StringData]] internal slot is a String value.
+      invariant(stringData instanceof StringValue, "expected string data internal slot to be a string value");
 
-    // b. Set the [[Configurable]] field of desc to conf.
-    desc.configurable = conf === true;
+      // b. Return the value of value's [[StringData]] internal slot.
+      return stringData;
+    }
+
+    value = value.throwIfNotConcrete();
+
+    // 3. Throw a TypeError exception.
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
   }
 
-  // 7. Let hasValue be ? HasProperty(Obj, "value").
-  let hasValue = HasProperty(realm, Obj, "value");
+  // ECMA262 6.2.4.5
+  ToPropertyDescriptor(realm: Realm, Obj: Value): Descriptor {
+    Obj = Obj.throwIfNotConcrete();
 
-  // 8. If hasValue is true, then
-  if (hasValue === true) {
-    // a. Let value be ? Get(Obj, "value").
-    let value = Get(realm, Obj, "value");
-
-    // b. Set the [[Value]] field of desc to value.
-    desc.value = value;
-  }
-
-  // 9. Let hasWritable be ? HasProperty(Obj, "writable").
-  let hasWritable = HasProperty(realm, Obj, "writable");
-
-  // 10. If hasWritable is true, then
-  if (hasWritable === true) {
-    // a. Let writable be ToBoolean(? Get(Obj, "writable")).
-    let writable = ToBooleanPartial(realm, Get(realm, Obj, "writable"));
-
-    // b. Set the [[Writable]] field of desc to writable.
-    desc.writable = writable === true;
-  }
-
-  // 11. Let hasGet be ? HasProperty(Obj, "get").
-  let hasGet = HasProperty(realm, Obj, "get");
-
-  // 12. If hasGet is true, then
-  if (hasGet === true) {
-    // a. Let getter be ? Get(Obj, "get").
-    let getter = Get(realm, Obj, "get");
-
-    // b. If IsCallable(getter) is false and getter is not undefined, throw a TypeError exception.
-    if (IsCallable(realm, getter) === false && !getter.mightBeUndefined()) {
+    // 1. If Type(Obj) is not Object, throw a TypeError exception.
+    if (!(Obj instanceof ObjectValue)) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
     }
-    getter.throwIfNotConcrete();
 
-    // c. Set the [[Get]] field of desc to getter.
-    desc.get = ((getter: any): CallableObjectValue | UndefinedValue);
-  }
+    // 2. Let desc be a new Property Descriptor that initially has no fields.
+    let desc: Descriptor = {};
 
-  // 13. Let hasSet be ? HasProperty(Obj, "set").
-  let hasSet = HasProperty(realm, Obj, "set");
+    // 3. Let hasEnumerable be ? HasProperty(Obj, "enumerable").
+    let hasEnumerable = HasProperty(realm, Obj, "enumerable");
 
-  // 14. If hasSet is true, then
-  if (hasSet === true) {
-    // a. Let setter be ? Get(Obj, "set").
-    let setter = Get(realm, Obj, "set");
+    // 4. If hasEnumerable is true, then
+    if (hasEnumerable === true) {
+      // a. Let enum be ToBoolean(? Get(Obj, "enumerable")).
+      let enu = this.ToBooleanPartial(realm, Get(realm, Obj, "enumerable"));
 
-    // b. If IsCallable(setter) is false and setter is not undefined, throw a TypeError exception.
-    if (IsCallable(realm, setter) === false && !setter.mightBeUndefined()) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-    }
-    setter.throwIfNotConcrete();
-
-    // c. Set the [[Set]] field of desc to setter.
-    desc.set = ((setter: any): CallableObjectValue | UndefinedValue);
-  }
-
-  // 15. If either desc.[[Get]] or desc.[[Set]] is present, then
-  if (desc.get || desc.set) {
-    // a. If either desc.[[Value]] or desc.[[Writable]] is present, throw a TypeError exception.
-    if ("value" in desc || "writable" in desc) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-    }
-  }
-
-  // 16. Return desc.
-  return desc;
-}
-
-// ECMA262 7.1.13
-export function ToObject(realm: Realm, arg: ConcreteValue): ObjectValue {
-  if (arg instanceof UndefinedValue) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  } else if (arg instanceof NullValue) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  } else if (arg instanceof BooleanValue) {
-    let obj = new ObjectValue(realm, realm.intrinsics.BooleanPrototype);
-    obj.$BooleanData = arg;
-    return obj;
-  } else if (arg instanceof NumberValue) {
-    let obj = new ObjectValue(realm, realm.intrinsics.NumberPrototype);
-    obj.$NumberData = arg;
-    return obj;
-  } else if (arg instanceof StringValue) {
-    let obj = Create.StringCreate(realm, arg, realm.intrinsics.StringPrototype);
-    return obj;
-  } else if (arg instanceof SymbolValue) {
-    let obj = new ObjectValue(realm, realm.intrinsics.SymbolPrototype);
-    obj.$SymbolData = arg;
-    return obj;
-  } else if (arg instanceof ObjectValue) {
-    return arg;
-  }
-  invariant(false);
-}
-
-function WrapAbstractInObject(realm: Realm, arg: AbstractValue): ObjectValue {
-  let obj;
-  switch (arg.types.getType()) {
-    case NumberValue:
-      obj = new ObjectValue(realm, realm.intrinsics.NumberPrototype);
-      obj.$NumberData = arg;
-      break;
-
-    case StringValue:
-      obj = new ObjectValue(realm, realm.intrinsics.StringPrototype);
-      obj.$StringData = arg;
-      break;
-
-    case BooleanValue:
-      obj = new ObjectValue(realm, realm.intrinsics.BooleanPrototype);
-      obj.$BooleanData = arg;
-      break;
-
-    case SymbolValue:
-      obj = new ObjectValue(realm, realm.intrinsics.SymbolPrototype);
-      obj.$SymbolData = arg;
-      break;
-
-    case UndefinedValue:
-    case NullValue:
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-
-    default:
-      obj = arg.throwIfNotConcreteObject();
-      break;
-  }
-  return obj;
-}
-
-export function ToObjectPartial(realm: Realm, arg: Value): ObjectValue | AbstractObjectValue {
-  if (arg instanceof AbstractObjectValue) return arg;
-  if (arg instanceof AbstractValue) {
-    return WrapAbstractInObject(realm, arg);
-  }
-  arg = arg.throwIfNotConcrete();
-  return ToObject(realm, arg);
-}
-
-// ECMA262 7.1.15
-export function ToLength(realm: Realm, argument: numberOrValue): number {
-  // Let len be ? ToInteger(argument).
-  let len = ToInteger(realm, argument);
-
-  // If len ≤ +0, return +0.
-  if (len <= 0) return +0;
-
-  // If len is +∞, return 2^53-1.
-  if (len === +Infinity) return Math.pow(2, 53) - 1;
-
-  // Return min(len, 2^53-1).
-  return Math.min(len, Math.pow(2, 53) - 1);
-}
-
-// ECMA262 7.1.4
-export function ToInteger(realm: Realm, argument: numberOrValue): number {
-  // 1. Let number be ? ToNumber(argument).
-  let number = ToNumber(realm, argument);
-
-  // 2. If number is NaN, return +0.
-  if (isNaN(number)) return +0;
-
-  // 3. If number is +0, -0, +∞, or -∞, return number.
-  if (!isFinite(number) || number === 0) return number;
-
-  // 4. Return the number value that is the same sign as number and whose magnitude is floor(abs(number)).
-  return number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
-}
-
-// ECMA262 7.1.17
-export function ToIndex(realm: Realm, value: number | ConcreteValue): number {
-  let index;
-  // 1. If value is undefined, then
-  if (value instanceof UndefinedValue) {
-    // a. Let index be 0.
-    index = 0;
-  } else {
-    // 2. Else,
-    // a. Let integerIndex be ? ToInteger(value).
-    let integerIndex = ToInteger(realm, value);
-
-    // b. If integerIndex < 0, throw a RangeError exception.
-    if (integerIndex < 0) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "integerIndex < 0");
+      // b. Set the [[Enumerable]] field of desc to enum.
+      desc.enumerable = enu === true;
     }
 
-    // c. Let index be ! ToLength(integerIndex).
-    index = ToLength(realm, integerIndex);
+    // 5. Let hasConfigurable be ? HasProperty(Obj, "configurable").
+    let hasConfigurable = HasProperty(realm, Obj, "configurable");
 
-    // d. If SameValueZero(integerIndex, index) is false, throw a RangeError exception.
-    if (SameValueZero(realm, new NumberValue(realm, integerIndex), new NumberValue(realm, index)) === false) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "integerIndex < 0");
-    }
-  }
-  // 3. Return index.
-  return index;
-}
+    // 6. If hasConfigurable is true, then
+    if (hasConfigurable === true) {
+      // a. Let conf be ToBoolean(? Get(Obj, "configurable")).
+      let conf = this.ToBooleanPartial(realm, Get(realm, Obj, "configurable"));
 
-export function ToIndexPartial(realm: Realm, value: numberOrValue): number {
-  return ToIndex(realm, typeof value === "number" ? value : value.throwIfNotConcrete());
-}
-
-// ECMA262 7.1.3
-export function ToNumber(realm: Realm, val: numberOrValue): number {
-  if (typeof val === "number") {
-    return val;
-  } else if (val instanceof AbstractValue) {
-    AbstractValue.reportIntrospectionError(val);
-    throw new FatalError();
-  } else if (val instanceof UndefinedValue) {
-    return NaN;
-  } else if (val instanceof NullValue) {
-    return +0;
-  } else if (val instanceof ObjectValue) {
-    let prim = ToPrimitive(realm, val, "number");
-    return ToNumber(realm, prim);
-  } else if (val instanceof BooleanValue) {
-    if (val.value === true) {
-      return 1;
-    } else {
-      // `val.value === false`
-      return 0;
-    }
-  } else if (val instanceof NumberValue) {
-    return val.value;
-  } else if (val instanceof StringValue) {
-    return Number(val.value);
-  } else if (val instanceof SymbolValue) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  } else {
-    invariant(false, "unexpected type of value");
-  }
-}
-
-export function IsToNumberPure(realm: Realm, val: numberOrValue): boolean {
-  if (val instanceof Value) {
-    if (IsToPrimitivePure(realm, val)) {
-      let type = val.getType();
-      return type !== SymbolValue && type !== PrimitiveValue && type !== Value;
-    }
-    return false;
-  }
-  return true;
-}
-
-// ECMA262 7.1.1
-export function ToPrimitive(
-  realm: Realm,
-  input: ConcreteValue,
-  hint?: "default" | "string" | "number"
-): PrimitiveValue {
-  return ToPrimitiveOrAbstract(realm, input, hint).throwIfNotConcretePrimitive();
-}
-
-export function ToPrimitiveOrAbstract(
-  realm: Realm,
-  input: ConcreteValue,
-  hint?: "default" | "string" | "number"
-): AbstractValue | PrimitiveValue {
-  if (input instanceof PrimitiveValue) {
-    return input;
-  }
-
-  // When Type(input) is Object, the following steps are taken
-  invariant(input instanceof ObjectValue, "expected an object");
-
-  // 1. If PreferredType was not passed, let hint be "default".
-  hint = hint || "default";
-
-  // Following two steps are redundant since we just pass string hints.
-  // 2. Else if PreferredType is hint String, let hint be "string".
-  // 3. Else PreferredType is hint Number, let hint be "number".
-
-  // 4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
-  let exoticToPrim = GetMethod(realm, input, realm.intrinsics.SymbolToPrimitive);
-
-  // 5. If exoticToPrim is not undefined, then
-  if (!(exoticToPrim instanceof UndefinedValue)) {
-    // a. Let result be ? Call(exoticToPrim, input, « hint »).
-    let result = Call(realm, exoticToPrim, input, [new StringValue(realm, hint)]);
-
-    // b. If Type(result) is not Object, return result.
-    if (!(result instanceof ObjectValue)) {
-      invariant(result instanceof PrimitiveValue);
-      return result;
+      // b. Set the [[Configurable]] field of desc to conf.
+      desc.configurable = conf === true;
     }
 
-    // c. Throw a TypeError exception.
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  }
+    // 7. Let hasValue be ? HasProperty(Obj, "value").
+    let hasValue = HasProperty(realm, Obj, "value");
 
-  // 6. If hint is "default", let hint be "number".
-  if (hint === "default") hint = "number";
+    // 8. If hasValue is true, then
+    if (hasValue === true) {
+      // a. Let value be ? Get(Obj, "value").
+      let value = Get(realm, Obj, "value");
 
-  // 7. Return ? OrdinaryToPrimitive(input, hint).
-  return OrdinaryToPrimitiveOrAbstract(realm, input, hint);
-}
+      // b. Set the [[Value]] field of desc to value.
+      desc.value = value;
+    }
 
-// Returns result type of ToPrimitive if it is pure (terminates, does not throw exception, does not read or write heap), otherwise undefined.
-export function GetToPrimitivePureResultType(realm: Realm, input: Value): void | typeof Value {
-  let type = input.getType();
-  if (input instanceof PrimitiveValue) return type;
-  if (input instanceof AbstractValue && Value.isTypeCompatibleWith(type, PrimitiveValue)) return type;
-  return undefined;
-}
+    // 9. Let hasWritable be ? HasProperty(Obj, "writable").
+    let hasWritable = HasProperty(realm, Obj, "writable");
 
-export function IsToPrimitivePure(realm: Realm, input: Value) {
-  return GetToPrimitivePureResultType(realm, input) !== undefined;
-}
+    // 10. If hasWritable is true, then
+    if (hasWritable === true) {
+      // a. Let writable be ToBoolean(? Get(Obj, "writable")).
+      let writable = this.ToBooleanPartial(realm, Get(realm, Obj, "writable"));
 
-// ECMA262 7.1.1
-export function OrdinaryToPrimitive(realm: Realm, input: ObjectValue, hint: "string" | "number"): PrimitiveValue {
-  return OrdinaryToPrimitiveOrAbstract(realm, input, hint).throwIfNotConcretePrimitive();
-}
+      // b. Set the [[Writable]] field of desc to writable.
+      desc.writable = writable === true;
+    }
 
-export function OrdinaryToPrimitiveOrAbstract(
-  realm: Realm,
-  input: ObjectValue,
-  hint: "string" | "number"
-): AbstractValue | PrimitiveValue {
-  let methodNames;
+    // 11. Let hasGet be ? HasProperty(Obj, "get").
+    let hasGet = HasProperty(realm, Obj, "get");
 
-  // 1. Assert: Type(O) is Object.
-  invariant(input instanceof ObjectValue, "Expected object");
+    // 12. If hasGet is true, then
+    if (hasGet === true) {
+      // a. Let getter be ? Get(Obj, "get").
+      let getter = Get(realm, Obj, "get");
 
-  // 2. Assert: Type(hint) is String and its value is either "string" or "number".
-  invariant(hint === "string" || hint === "number", "Expected string or number hint");
+      // b. If IsCallable(getter) is false and getter is not undefined, throw a TypeError exception.
+      if (IsCallable(realm, getter) === false && !getter.mightBeUndefined()) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+      }
+      getter.throwIfNotConcrete();
 
-  // 3. If hint is "string", then
-  if (hint === "string") {
-    // a. Let methodNames be « "toString", "valueOf" ».
-    methodNames = ["toString", "valueOf"];
-  } else {
-    // 4. Else,
-    // a. Let methodNames be « "valueOf", "toString" ».
-    methodNames = ["valueOf", "toString"];
-  }
+      // c. Set the [[Get]] field of desc to getter.
+      desc.get = ((getter: any): CallableObjectValue | UndefinedValue);
+    }
 
-  // 5. For each name in methodNames in List order, do
-  for (let name of methodNames) {
-    // a. Let method be ? Get(O, name).
-    let method = Get(realm, input, new StringValue(realm, name));
+    // 13. Let hasSet be ? HasProperty(Obj, "set").
+    let hasSet = HasProperty(realm, Obj, "set");
 
-    // b. If IsCallable(method) is true, then
-    if (IsCallable(realm, method)) {
-      // i. Let result be ? Call(method, O).
-      let result = Call(realm, method, input);
-      let resultType = result.getType();
+    // 14. If hasSet is true, then
+    if (hasSet === true) {
+      // a. Let setter be ? Get(Obj, "set").
+      let setter = Get(realm, Obj, "set");
 
-      // ii. If Type(result) is not Object, return result.
-      if (Value.isTypeCompatibleWith(resultType, PrimitiveValue)) {
-        invariant(result instanceof AbstractValue || result instanceof PrimitiveValue);
-        return result;
+      // b. If IsCallable(setter) is false and setter is not undefined, throw a TypeError exception.
+      if (IsCallable(realm, setter) === false && !setter.mightBeUndefined()) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+      }
+      setter.throwIfNotConcrete();
+
+      // c. Set the [[Set]] field of desc to setter.
+      desc.set = ((setter: any): CallableObjectValue | UndefinedValue);
+    }
+
+    // 15. If either desc.[[Get]] or desc.[[Set]] is present, then
+    if (desc.get || desc.set) {
+      // a. If either desc.[[Value]] or desc.[[Writable]] is present, throw a TypeError exception.
+      if ("value" in desc || "writable" in desc) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
       }
     }
+
+    // 16. Return desc.
+    return desc;
   }
 
-  // 6. Throw a TypeError exception.
-  throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "can't turn to primitive");
-}
-
-// ECMA262 7.1.12
-export function ToString(realm: Realm, val: string | ConcreteValue): string {
-  if (typeof val === "string") {
-    return val;
-  } else if (val instanceof StringValue) {
-    return val.value;
-  } else if (val instanceof NumberValue) {
-    return val.value + "";
-  } else if (val instanceof UndefinedValue) {
-    return "undefined";
-  } else if (val instanceof NullValue) {
-    return "null";
-  } else if (val instanceof SymbolValue) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  } else if (val instanceof BooleanValue) {
-    return val.value ? "true" : "false";
-  } else if (val instanceof ObjectValue) {
-    let primValue = ToPrimitive(realm, val, "string");
-    return ToString(realm, primValue);
-  } else {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to string");
+  // ECMA262 7.1.13
+  ToObject(realm: Realm, arg: ConcreteValue): ObjectValue {
+    if (arg instanceof UndefinedValue) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    } else if (arg instanceof NullValue) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    } else if (arg instanceof BooleanValue) {
+      let obj = new ObjectValue(realm, realm.intrinsics.BooleanPrototype);
+      obj.$BooleanData = arg;
+      return obj;
+    } else if (arg instanceof NumberValue) {
+      let obj = new ObjectValue(realm, realm.intrinsics.NumberPrototype);
+      obj.$NumberData = arg;
+      return obj;
+    } else if (arg instanceof StringValue) {
+      let obj = Create.StringCreate(realm, arg, realm.intrinsics.StringPrototype);
+      return obj;
+    } else if (arg instanceof SymbolValue) {
+      let obj = new ObjectValue(realm, realm.intrinsics.SymbolPrototype);
+      obj.$SymbolData = arg;
+      return obj;
+    } else if (arg instanceof ObjectValue) {
+      return arg;
+    }
+    invariant(false);
   }
-}
 
-export function ToStringPartial(realm: Realm, val: string | Value): string {
-  return ToString(realm, typeof val === "string" ? val : val.throwIfNotConcrete());
-}
+  _WrapAbstractInObject(realm: Realm, arg: AbstractValue): ObjectValue {
+    let obj;
+    switch (arg.types.getType()) {
+      case NumberValue:
+        obj = new ObjectValue(realm, realm.intrinsics.NumberPrototype);
+        obj.$NumberData = arg;
+        break;
 
-export function ToStringValue(realm: Realm, val: Value): Value {
-  if (val.getType() === StringValue) return val;
-  let str;
-  if (typeof val === "string") {
-    str = val;
-  } else if (val instanceof NumberValue) {
-    str = val.value + "";
-  } else if (val instanceof UndefinedValue) {
-    str = "undefined";
-  } else if (val instanceof NullValue) {
-    str = "null";
-  } else if (val instanceof SymbolValue) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-  } else if (val instanceof BooleanValue) {
-    str = val.value ? "true" : "false";
-  } else if (val instanceof ObjectValue) {
-    let primValue = ToPrimitiveOrAbstract(realm, val, "string");
-    if (primValue.getType() === StringValue) return primValue;
-    str = ToStringPartial(realm, primValue);
-  } else {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to string");
+      case StringValue:
+        obj = new ObjectValue(realm, realm.intrinsics.StringPrototype);
+        obj.$StringData = arg;
+        break;
+
+      case BooleanValue:
+        obj = new ObjectValue(realm, realm.intrinsics.BooleanPrototype);
+        obj.$BooleanData = arg;
+        break;
+
+      case SymbolValue:
+        obj = new ObjectValue(realm, realm.intrinsics.SymbolPrototype);
+        obj.$SymbolData = arg;
+        break;
+
+      case UndefinedValue:
+      case NullValue:
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+
+      default:
+        obj = arg.throwIfNotConcreteObject();
+        break;
+    }
+    return obj;
   }
-  return new StringValue(realm, str);
-}
 
-// ECMA262 7.1.2
-export function ToBoolean(realm: Realm, val: ConcreteValue): boolean {
-  if (val instanceof BooleanValue) {
-    return val.value;
-  } else if (val instanceof UndefinedValue) {
-    return false;
-  } else if (val instanceof NullValue) {
-    return false;
-  } else if (val instanceof NumberValue) {
-    return val.value !== 0 && !isNaN(val.value);
-  } else if (val instanceof StringValue) {
-    return val.value.length > 0;
-  } else if (val instanceof ObjectValue) {
+  ToObjectPartial(realm: Realm, arg: Value): ObjectValue | AbstractObjectValue {
+    if (arg instanceof AbstractObjectValue) return arg;
+    if (arg instanceof AbstractValue) {
+      return this._WrapAbstractInObject(realm, arg);
+    }
+    arg = arg.throwIfNotConcrete();
+    return this.ToObject(realm, arg);
+  }
+
+  // ECMA262 7.1.15
+  ToLength(realm: Realm, argument: numberOrValue): number {
+    // Let len be ? ToInteger(argument).
+    let len = this.ToInteger(realm, argument);
+
+    // If len ≤ +0, return +0.
+    if (len <= 0) return +0;
+
+    // If len is +∞, return 2^53-1.
+    if (len === +Infinity) return Math.pow(2, 53) - 1;
+
+    // Return min(len, 2^53-1).
+    return Math.min(len, Math.pow(2, 53) - 1);
+  }
+
+  // ECMA262 7.1.4
+  ToInteger(realm: Realm, argument: numberOrValue): number {
+    // 1. Let number be ? ToNumber(argument).
+    let number = this.ToNumber(realm, argument);
+
+    // 2. If number is NaN, return +0.
+    if (isNaN(number)) return +0;
+
+    // 3. If number is +0, -0, +∞, or -∞, return number.
+    if (!isFinite(number) || number === 0) return number;
+
+    // 4. Return the number value that is the same sign as number and whose magnitude is floor(abs(number)).
+    return number < 0 ? -Math.floor(Math.abs(number)) : Math.floor(Math.abs(number));
+  }
+
+  // ECMA262 7.1.17
+  ToIndex(realm: Realm, value: number | ConcreteValue): number {
+    let index;
+    // 1. If value is undefined, then
+    if (value instanceof UndefinedValue) {
+      // a. Let index be 0.
+      index = 0;
+    } else {
+      // 2. Else,
+      // a. Let integerIndex be ? ToInteger(value).
+      let integerIndex = this.ToInteger(realm, value);
+
+      // b. If integerIndex < 0, throw a RangeError exception.
+      if (integerIndex < 0) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "integerIndex < 0");
+      }
+
+      // c. Let index be ! ToLength(integerIndex).
+      index = this.ToLength(realm, integerIndex);
+
+      // d. If SameValueZero(integerIndex, index) is false, throw a RangeError exception.
+      if (SameValueZero(realm, new NumberValue(realm, integerIndex), new NumberValue(realm, index)) === false) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.RangeError, "integerIndex < 0");
+      }
+    }
+    // 3. Return index.
+    return index;
+  }
+
+  ToIndexPartial(realm: Realm, value: numberOrValue): number {
+    return this.ToIndex(realm, typeof value === "number" ? value : value.throwIfNotConcrete());
+  }
+
+  // ECMA262 7.1.3
+  ToNumber(realm: Realm, val: numberOrValue): number {
+    if (typeof val === "number") {
+      return val;
+    } else if (val instanceof AbstractValue) {
+      AbstractValue.reportIntrospectionError(val);
+      throw new FatalError();
+    } else if (val instanceof UndefinedValue) {
+      return NaN;
+    } else if (val instanceof NullValue) {
+      return +0;
+    } else if (val instanceof ObjectValue) {
+      let prim = this.ToPrimitive(realm, val, "number");
+      return this.ToNumber(realm, prim);
+    } else if (val instanceof BooleanValue) {
+      if (val.value === true) {
+        return 1;
+      } else {
+        // `val.value === false`
+        return 0;
+      }
+    } else if (val instanceof NumberValue) {
+      return val.value;
+    } else if (val instanceof StringValue) {
+      return Number(val.value);
+    } else if (val instanceof SymbolValue) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    } else {
+      invariant(false, "unexpected type of value");
+    }
+  }
+
+  IsToNumberPure(realm: Realm, val: numberOrValue): boolean {
+    if (val instanceof Value) {
+      if (this.IsToPrimitivePure(realm, val)) {
+        let type = val.getType();
+        return type !== SymbolValue && type !== PrimitiveValue && type !== Value;
+      }
+      return false;
+    }
     return true;
-  } else if (val instanceof SymbolValue) {
-    return true;
-  } else {
-    invariant(!(val instanceof AbstractValue));
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to a boolean");
-  }
-}
-
-export function ToBooleanPartial(realm: Realm, val: Value): boolean {
-  if (!val.mightNotBeObject()) return true;
-  return ToBoolean(realm, val.throwIfNotConcrete());
-}
-
-// ECMA262 7.1.14
-export function ToPropertyKey(realm: Realm, arg: ConcreteValue): SymbolValue | string /* but not StringValue */ {
-  // 1. Let key be ? ToPrimitive(argument, hint String).
-  let key = ToPrimitive(realm, arg, "string");
-
-  // 2. If Type(key) is Symbol, then
-  if (key instanceof SymbolValue) {
-    // a. Return key.
-    return key;
   }
 
-  // 3. Return ! ToString(key).
-  return ToString(realm, key);
-}
+  // ECMA262 7.1.1
+  ToPrimitive(realm: Realm, input: ConcreteValue, hint?: "default" | "string" | "number"): PrimitiveValue {
+    return this.ToPrimitiveOrAbstract(realm, input, hint).throwIfNotConcretePrimitive();
+  }
 
-export function ToPropertyKeyPartial(
-  realm: Realm,
-  arg: Value
-): AbstractValue | SymbolValue | string /* but not StringValue */ {
-  if (arg instanceof ConcreteValue) return ToPropertyKey(realm, arg);
-  if (arg.mightNotBeString()) arg.throwIfNotConcrete();
-  invariant(arg instanceof AbstractValue);
-  return arg;
-}
+  ToPrimitiveOrAbstract(
+    realm: Realm,
+    input: ConcreteValue,
+    hint?: "default" | "string" | "number"
+  ): AbstractValue | PrimitiveValue {
+    if (input instanceof PrimitiveValue) {
+      return input;
+    }
 
-// ECMA262 7.1.16
-export function CanonicalNumericIndexString(realm: Realm, argument: StringValue): number | void {
-  // 1. Assert: Type(argument) is String.
-  invariant(argument instanceof StringValue);
+    // When Type(input) is Object, the following steps are taken
+    invariant(input instanceof ObjectValue, "expected an object");
 
-  // 2. If argument is "-0", return −0.
-  if (argument.value === "-0") return -0;
+    // 1. If PreferredType was not passed, let hint be "default".
+    hint = hint || "default";
 
-  // 3. Let n be ToNumber(argument).
-  let n = ToNumber(realm, argument);
+    // Following two steps are redundant since we just pass string hints.
+    // 2. Else if PreferredType is hint String, let hint be "string".
+    // 3. Else PreferredType is hint Number, let hint be "number".
 
-  // 4. If SameValue(ToString(n), argument) is false, return undefined.
-  if (SameValue(realm, new StringValue(realm, ToString(realm, new NumberValue(realm, n))), argument) === false)
+    // 4. Let exoticToPrim be ? GetMethod(input, @@toPrimitive).
+    let exoticToPrim = GetMethod(realm, input, realm.intrinsics.SymbolToPrimitive);
+
+    // 5. If exoticToPrim is not undefined, then
+    if (!(exoticToPrim instanceof UndefinedValue)) {
+      // a. Let result be ? Call(exoticToPrim, input, « hint »).
+      let result = Call(realm, exoticToPrim, input, [new StringValue(realm, hint)]);
+
+      // b. If Type(result) is not Object, return result.
+      if (!(result instanceof ObjectValue)) {
+        invariant(result instanceof PrimitiveValue);
+        return result;
+      }
+
+      // c. Throw a TypeError exception.
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    }
+
+    // 6. If hint is "default", let hint be "number".
+    if (hint === "default") hint = "number";
+
+    // 7. Return ? OrdinaryToPrimitive(input, hint).
+    return this.OrdinaryToPrimitiveOrAbstract(realm, input, hint);
+  }
+
+  // Returns result type of ToPrimitive if it is pure (terminates, does not throw exception, does not read or write heap), otherwise undefined.
+  GetToPrimitivePureResultType(realm: Realm, input: Value): void | typeof Value {
+    let type = input.getType();
+    if (input instanceof PrimitiveValue) return type;
+    if (input instanceof AbstractValue && Value.isTypeCompatibleWith(type, PrimitiveValue)) return type;
     return undefined;
+  }
 
-  // 5. Return n.
-  return n;
+  IsToPrimitivePure(realm: Realm, input: Value) {
+    return this.GetToPrimitivePureResultType(realm, input) !== undefined;
+  }
+
+  // ECMA262 7.1.1
+  OrdinaryToPrimitive(realm: Realm, input: ObjectValue, hint: "string" | "number"): PrimitiveValue {
+    return this.OrdinaryToPrimitiveOrAbstract(realm, input, hint).throwIfNotConcretePrimitive();
+  }
+
+  OrdinaryToPrimitiveOrAbstract(
+    realm: Realm,
+    input: ObjectValue,
+    hint: "string" | "number"
+  ): AbstractValue | PrimitiveValue {
+    let methodNames;
+
+    // 1. Assert: Type(O) is Object.
+    invariant(input instanceof ObjectValue, "Expected object");
+
+    // 2. Assert: Type(hint) is String and its value is either "string" or "number".
+    invariant(hint === "string" || hint === "number", "Expected string or number hint");
+
+    // 3. If hint is "string", then
+    if (hint === "string") {
+      // a. Let methodNames be « "toString", "valueOf" ».
+      methodNames = ["toString", "valueOf"];
+    } else {
+      // 4. Else,
+      // a. Let methodNames be « "valueOf", "toString" ».
+      methodNames = ["valueOf", "toString"];
+    }
+
+    // 5. For each name in methodNames in List order, do
+    for (let name of methodNames) {
+      // a. Let method be ? Get(O, name).
+      let method = Get(realm, input, new StringValue(realm, name));
+
+      // b. If IsCallable(method) is true, then
+      if (IsCallable(realm, method)) {
+        // i. Let result be ? Call(method, O).
+        let result = Call(realm, method, input);
+        let resultType = result.getType();
+
+        // ii. If Type(result) is not Object, return result.
+        if (Value.isTypeCompatibleWith(resultType, PrimitiveValue)) {
+          invariant(result instanceof AbstractValue || result instanceof PrimitiveValue);
+          return result;
+        }
+      }
+    }
+
+    // 6. Throw a TypeError exception.
+    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "can't turn to primitive");
+  }
+
+  // ECMA262 7.1.12
+  ToString(realm: Realm, val: string | ConcreteValue): string {
+    if (typeof val === "string") {
+      return val;
+    } else if (val instanceof StringValue) {
+      return val.value;
+    } else if (val instanceof NumberValue) {
+      return val.value + "";
+    } else if (val instanceof UndefinedValue) {
+      return "undefined";
+    } else if (val instanceof NullValue) {
+      return "null";
+    } else if (val instanceof SymbolValue) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    } else if (val instanceof BooleanValue) {
+      return val.value ? "true" : "false";
+    } else if (val instanceof ObjectValue) {
+      let primValue = this.ToPrimitive(realm, val, "string");
+      return this.ToString(realm, primValue);
+    } else {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to string");
+    }
+  }
+
+  ToStringPartial(realm: Realm, val: string | Value): string {
+    return this.ToString(realm, typeof val === "string" ? val : val.throwIfNotConcrete());
+  }
+
+  ToStringValue(realm: Realm, val: Value): Value {
+    if (val.getType() === StringValue) return val;
+    let str;
+    if (typeof val === "string") {
+      str = val;
+    } else if (val instanceof NumberValue) {
+      str = val.value + "";
+    } else if (val instanceof UndefinedValue) {
+      str = "undefined";
+    } else if (val instanceof NullValue) {
+      str = "null";
+    } else if (val instanceof SymbolValue) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    } else if (val instanceof BooleanValue) {
+      str = val.value ? "true" : "false";
+    } else if (val instanceof ObjectValue) {
+      let primValue = this.ToPrimitiveOrAbstract(realm, val, "string");
+      if (primValue.getType() === StringValue) return primValue;
+      str = this.ToStringPartial(realm, primValue);
+    } else {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to string");
+    }
+    return new StringValue(realm, str);
+  }
+
+  // ECMA262 7.1.2
+  ToBoolean(realm: Realm, val: ConcreteValue): boolean {
+    if (val instanceof BooleanValue) {
+      return val.value;
+    } else if (val instanceof UndefinedValue) {
+      return false;
+    } else if (val instanceof NullValue) {
+      return false;
+    } else if (val instanceof NumberValue) {
+      return val.value !== 0 && !isNaN(val.value);
+    } else if (val instanceof StringValue) {
+      return val.value.length > 0;
+    } else if (val instanceof ObjectValue) {
+      return true;
+    } else if (val instanceof SymbolValue) {
+      return true;
+    } else {
+      invariant(!(val instanceof AbstractValue));
+      throw realm.createErrorThrowCompletion(
+        realm.intrinsics.TypeError,
+        "unknown value type, can't coerce to a boolean"
+      );
+    }
+  }
+
+  ToBooleanPartial(realm: Realm, val: Value): boolean {
+    if (!val.mightNotBeObject()) return true;
+    return this.ToBoolean(realm, val.throwIfNotConcrete());
+  }
+
+  // ECMA262 7.1.14
+  ToPropertyKey(realm: Realm, arg: ConcreteValue): SymbolValue | string /* but not StringValue */ {
+    // 1. Let key be ? ToPrimitive(argument, hint String).
+    let key = this.ToPrimitive(realm, arg, "string");
+
+    // 2. If Type(key) is Symbol, then
+    if (key instanceof SymbolValue) {
+      // a. Return key.
+      return key;
+    }
+
+    // 3. Return ! ToString(key).
+    return this.ToString(realm, key);
+  }
+
+  ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */ {
+    if (arg instanceof ConcreteValue) return this.ToPropertyKey(realm, arg);
+    if (arg.mightNotBeString()) arg.throwIfNotConcrete();
+    invariant(arg instanceof AbstractValue);
+    return arg;
+  }
+
+  // ECMA262 7.1.16
+  CanonicalNumericIndexString(realm: Realm, argument: StringValue): number | void {
+    // 1. Assert: Type(argument) is String.
+    invariant(argument instanceof StringValue);
+
+    // 2. If argument is "-0", return −0.
+    if (argument.value === "-0") return -0;
+
+    // 3. Let n be ToNumber(argument).
+    let n = this.ToNumber(realm, argument);
+
+    // 4. If SameValue(ToString(n), argument) is false, return undefined.
+    if (SameValue(realm, new StringValue(realm, this.ToString(realm, new NumberValue(realm, n))), argument) === false)
+      return undefined;
+
+    // 5. Return n.
+    return n;
+  }
 }

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -25,7 +25,7 @@ import { AllocateArrayBuffer } from "../methods/arraybuffer.js";
 import { IsDetachedBuffer, IsInteger } from "../methods/is.js";
 import { GetValueFromBuffer, SetValueInBuffer } from "../methods/arraybuffer.js";
 import { Construct, SpeciesConstructor } from "../methods/construct.js";
-import { ToNumber } from "../methods/to.js";
+import { To } from "../singletons.js";
 import invariant from "../invariant.js";
 
 export const ArrayElementSize = {
@@ -159,7 +159,7 @@ export function IntegerIndexedElementSet(realm: Realm, O: ObjectValue, index: nu
   );
 
   // 3. Let numValue be ? ToNumber(value).
-  let numValue = ToNumber(realm, value);
+  let numValue = To.ToNumber(realm, value);
 
   // 4. Let buffer be O.[[ViewedArrayBuffer]].
   let buffer = O.$ViewedArrayBuffer;

--- a/src/realm.js
+++ b/src/realm.js
@@ -27,13 +27,13 @@ import {
 } from "./values/index.js";
 import { LexicalEnvironment, Reference, GlobalEnvironmentRecord } from "./environment.js";
 import type { Binding } from "./environment.js";
-import { cloneDescriptor, Construct, ToString } from "./methods/index.js";
+import { cloneDescriptor, Construct } from "./methods/index.js";
 import { Completion, ThrowCompletion, AbruptCompletion, PossiblyNormalCompletion } from "./completions.js";
 import type { Compatibility, RealmOptions } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
 import { Generator, PreludeGenerator } from "./utils/generator.js";
-import { Environment, Functions, Join, Properties } from "./singletons.js";
+import { Environment, Functions, Join, Properties, To } from "./singletons.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
 import * as t from "babel-types";
 
@@ -615,7 +615,7 @@ export class Realm {
       let res = "";
       while (values.length) {
         let next = values.shift();
-        let nextString = ToString(realm, next);
+        let nextString = To.ToString(realm, next);
         res += nextString;
       }
       return res;

--- a/src/repl-cli.js
+++ b/src/repl-cli.js
@@ -12,9 +12,10 @@
 import { Realm, ExecutionContext } from "./realm.js";
 import { FatalError } from "./errors.js";
 import { Get } from "./methods/index.js";
-import { ToStringPartial, InstanceofOperator } from "./methods/index.js";
+import { InstanceofOperator } from "./methods/index.js";
 import { AbruptCompletion, ThrowCompletion } from "./completions.js";
 import { Value, ObjectValue } from "./values/index.js";
+import { To } from "./singletons.js";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
 import repl from "repl";
@@ -31,10 +32,10 @@ function serialize(realm: Realm, res: Value | AbruptCompletion): any {
     try {
       let value = res.value;
       if (value instanceof ObjectValue && InstanceofOperator(realm, value, realm.intrinsics.Error)) {
-        err = new FatalError(ToStringPartial(realm, Get(realm, value, "message")));
-        err.stack = ToStringPartial(realm, Get(realm, value, "stack"));
+        err = new FatalError(To.ToStringPartial(realm, Get(realm, value, "message")));
+        err.stack = To.ToStringPartial(realm, Get(realm, value, "stack"));
       } else {
-        err = new FatalError(ToStringPartial(realm, value));
+        err = new FatalError(To.ToStringPartial(realm, value));
       }
     } finally {
       realm.popContext(context);

--- a/src/serializer/LoggingTracer.js
+++ b/src/serializer/LoggingTracer.js
@@ -12,7 +12,7 @@
 import { Reference } from "../environment.js";
 import { Realm, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
-import { ToStringPartial, Get } from "../methods/index.js";
+import { Get } from "../methods/index.js";
 import { ThrowCompletion, AbruptCompletion } from "../completions.js";
 import {
   FunctionValue,
@@ -25,6 +25,7 @@ import {
   ObjectValue,
   AbstractValue,
 } from "../values/index.js";
+import { To } from "../singletons.js";
 import invariant from "../invariant.js";
 
 function describeValue(realm: Realm, v: Value): string {
@@ -32,7 +33,7 @@ function describeValue(realm: Realm, v: Value): string {
   if (v instanceof UndefinedValue) return "undefined";
   if (v instanceof NullValue) return "null";
   if (v instanceof StringValue) return `"${v.value}"`; // TODO: proper escaping
-  if (v instanceof FunctionValue) return ToStringPartial(realm, Get(realm, v, "name")) || "(anonymous function)";
+  if (v instanceof FunctionValue) return To.ToStringPartial(realm, Get(realm, v, "name")) || "(anonymous function)";
   if (v instanceof ObjectValue) return "(some object)";
   if (v instanceof AbstractValue) return "(some abstract value)";
   invariant(false);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -11,7 +11,7 @@
 
 import { Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding } from "../types.js";
-import { ToLength, IsArray, Get, IsAccessorDescriptor } from "../methods/index.js";
+import { IsArray, Get, IsAccessorDescriptor } from "../methods/index.js";
 import {
   ArrayValue,
   BoundFunctionValue,
@@ -65,6 +65,7 @@ import { voidExpression, emptyExpression, constructorExpression, protoExpression
 import { Emitter } from "./Emitter.js";
 import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js";
 import { commonAncestorOf, getSuggestedArrayLiteralLength } from "./utils.js";
+import { To } from "../singletons.js";
 
 function commentStatement(text: string) {
   let s = t.emptyStatement();
@@ -814,7 +815,7 @@ export class ResidualHeapSerializer {
     // 1. array length is abstract.
     // 2. array length is concrete, but different from number of index properties
     //  we put into initialization list.
-    if (lenProperty instanceof AbstractValue || ToLength(realm, lenProperty) !== numberOfIndexProperties) {
+    if (lenProperty instanceof AbstractValue || To.ToLength(realm, lenProperty) !== numberOfIndexProperties) {
       this.emitter.emitNowOrAfterWaitingForDependencies([val], () => {
         this._assignProperty(
           () => t.memberExpression(this.getSerializeObjectIdentifier(val), t.identifier("length")),

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -13,7 +13,7 @@ import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../enviro
 import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding, ObjectKind } from "../types.js";
-import { ToLength, HashSet, IsArray, Get } from "../methods/index.js";
+import { HashSet, IsArray, Get } from "../methods/index.js";
 import {
   BoundFunctionValue,
   ProxyValue,
@@ -46,7 +46,7 @@ import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
 import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
 import { getSuggestedArrayLiteralLength } from "./utils.js";
-import { Environment } from "../singletons.js";
+import { Environment, To } from "../singletons.js";
 
 export type Scope = FunctionValue | Generator;
 
@@ -251,7 +251,7 @@ export class ResidualHeapVisitor {
     let lenProperty = Get(realm, val, "length");
     if (
       lenProperty instanceof AbstractValue ||
-      ToLength(realm, lenProperty) !== getSuggestedArrayLiteralLength(realm, val)
+      To.ToLength(realm, lenProperty) !== getSuggestedArrayLiteralLength(realm, val)
     ) {
       this.visitValue(lenProperty);
     }

--- a/src/serializer/logger.js
+++ b/src/serializer/logger.js
@@ -11,9 +11,10 @@
 
 import { Realm, ExecutionContext } from "../realm.js";
 import { FatalError } from "../errors.js";
-import { ToStringPartial, Get, InstanceofOperator } from "../methods/index.js";
+import { Get, InstanceofOperator } from "../methods/index.js";
 import { Completion, ThrowCompletion } from "../completions.js";
 import { ObjectValue, StringValue, Value } from "../values/index.js";
+import { To } from "../singletons.js";
 import invariant from "../invariant.js";
 
 export class Logger {
@@ -88,9 +89,13 @@ export class Logger {
       let object = ((value: any): ObjectValue);
       try {
         let err = new FatalError(
-          this.tryQuery(() => ToStringPartial(realm, Get(realm, object, "message")), "(unknown message)", false)
+          this.tryQuery(() => To.ToStringPartial(realm, Get(realm, object, "message")), "(unknown message)", false)
         );
-        err.stack = this.tryQuery(() => ToStringPartial(realm, Get(realm, object, "stack")), "(unknown stack)", false);
+        err.stack = this.tryQuery(
+          () => To.ToStringPartial(realm, Get(realm, object, "stack")),
+          "(unknown stack)",
+          false
+        );
         console.error(err.message);
         console.error(err.stack);
         if (this.internalDebug && res instanceof ThrowCompletion) console.error(res.nativeStack);
@@ -108,7 +113,7 @@ export class Logger {
       }
     } else {
       try {
-        value = ToStringPartial(realm, value);
+        value = To.ToStringPartial(realm, value);
       } catch (err) {
         value = err.message;
       }

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -16,6 +16,7 @@ import type {
   JoinType,
   PathType,
   PropertiesType,
+  ToType,
   WidenType,
 } from "./types.js";
 
@@ -25,6 +26,7 @@ export let Functions: FunctionType = (null: any);
 export let Join: JoinType = (null: any);
 export let Path: PathType = (null: any);
 export let Properties: PropertiesType = (null: any);
+export let To: ToType = (null: any);
 export let Widen: WidenType = (null: any);
 
 export function setCreate(singleton: CreateType) {
@@ -49,6 +51,10 @@ export function setPath(singleton: PathType) {
 
 export function setProperties(singleton: PropertiesType) {
   Properties = singleton;
+}
+
+export function setTo(singleton: ToType) {
+  To = singleton;
 }
 
 export function setWiden(singleton: WidenType) {

--- a/src/types.js
+++ b/src/types.js
@@ -14,6 +14,7 @@ import type {
   AbstractValue,
   ArrayValue,
   BooleanValue,
+  ConcreteValue,
   ECMAScriptFunctionValue,
   ECMAScriptSourceFunctionValue,
   EmptyValue,
@@ -21,11 +22,12 @@ import type {
   NativeFunctionValue,
   NullValue,
   NumberValue,
+  PrimitiveValue,
   StringValue,
   SymbolValue,
   UndefinedValue,
-  Value,
 } from "./values/index.js";
+import { Value } from "./values/index.js";
 import {
   AbruptCompletion,
   Completion,
@@ -870,4 +872,117 @@ export type WidenType = {
   // then we have reached a fixed point and no further calls to widen are needed. e1/e2 represent a general
   // summary of the loop, regardless of how many iterations will be performed at runtime.
   equalsEffects(e1: Effects, e2: Effects): boolean,
+};
+
+export type numberOrValue = number | Value;
+
+export type ElementConvType = {
+  Int8: (Realm, numberOrValue) => number,
+  Int16: (Realm, numberOrValue) => number,
+  Int32: (Realm, numberOrValue) => number,
+  Uint8: (Realm, numberOrValue) => number,
+  Uint16: (Realm, numberOrValue) => number,
+  Uint32: (Realm, numberOrValue) => number,
+  Uint8Clamped: (Realm, numberOrValue) => number,
+};
+
+export type ToType = {
+  ElementConv: ElementConvType,
+
+  // ECMA262 7.1.5
+  ToInt32(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.6
+  ToUint32(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.7
+  ToInt16(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.8
+  ToUint16(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.9
+  ToInt8(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.10
+  ToUint8(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.11
+  ToUint8Clamp(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 19.3.3.1
+  thisBooleanValue(realm: Realm, value: Value): BooleanValue,
+
+  // ECMA262 20.1.3
+  thisNumberValue(realm: Realm, value: Value): NumberValue,
+
+  // ECMA262 21.1.3
+  thisStringValue(realm: Realm, value: Value): StringValue,
+
+  // ECMA262 6.2.4.5
+  ToPropertyDescriptor(realm: Realm, Obj: Value): Descriptor,
+
+  // ECMA262 7.1.13
+  ToObject(realm: Realm, arg: ConcreteValue): ObjectValue,
+
+  ToObjectPartial(realm: Realm, arg: Value): ObjectValue | AbstractObjectValue,
+
+  // ECMA262 7.1.15
+  ToLength(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.4
+  ToInteger(realm: Realm, argument: numberOrValue): number,
+
+  // ECMA262 7.1.17
+  ToIndex(realm: Realm, value: number | ConcreteValue): number,
+
+  ToIndexPartial(realm: Realm, value: numberOrValue): number,
+
+  // ECMA262 7.1.3
+  ToNumber(realm: Realm, val: numberOrValue): number,
+
+  IsToNumberPure(realm: Realm, val: numberOrValue): boolean,
+
+  // ECMA262 7.1.1
+  ToPrimitive(realm: Realm, input: ConcreteValue, hint?: "default" | "string" | "number"): PrimitiveValue,
+
+  ToPrimitiveOrAbstract(
+    realm: Realm,
+    input: ConcreteValue,
+    hint?: "default" | "string" | "number"
+  ): AbstractValue | PrimitiveValue,
+
+  // Returns result type of ToPrimitive if it is pure (terminates, does not throw exception, does not read or write heap), otherwise undefined.
+  GetToPrimitivePureResultType(realm: Realm, input: Value): void | typeof Value,
+
+  IsToPrimitivePure(realm: Realm, input: Value): boolean,
+
+  // ECMA262 7.1.1
+  OrdinaryToPrimitive(realm: Realm, input: ObjectValue, hint: "string" | "number"): PrimitiveValue,
+
+  OrdinaryToPrimitiveOrAbstract(
+    realm: Realm,
+    input: ObjectValue,
+    hint: "string" | "number"
+  ): AbstractValue | PrimitiveValue,
+
+  // ECMA262 7.1.12
+  ToString(realm: Realm, val: string | ConcreteValue): string,
+
+  ToStringPartial(realm: Realm, val: string | Value): string,
+
+  ToStringValue(realm: Realm, val: Value): Value,
+
+  // ECMA262 7.1.2
+  ToBoolean(realm: Realm, val: ConcreteValue): boolean,
+
+  ToBooleanPartial(realm: Realm, val: Value): boolean,
+
+  // ECMA262 7.1.14
+  ToPropertyKey(realm: Realm, arg: ConcreteValue): SymbolValue | string /* but not StringValue */,
+
+  ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */,
+
+  // ECMA262 7.1.16
+  CanonicalNumericIndexString(realm: Realm, argument: StringValue): number | void,
 };

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -13,10 +13,9 @@ import type { BabelNodeSourceLocation } from "babel-types";
 import { FatalError } from "../errors.js";
 import { ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
-import { ToBoolean } from "../methods/index.js";
 import { Realm } from "../realm.js";
 import { AbstractValue, BooleanValue, ConcreteValue, Value } from "../values/index.js";
-import { Path } from "../singletons.js";
+import { Path, To } from "../singletons.js";
 
 export default function simplifyAndRefineAbstractValue(
   realm: Realm,
@@ -192,10 +191,10 @@ function simplifyEquality(realm: Realm, equality: AbstractValue): Value {
 
 function makeBoolean(realm: Realm, value: Value, loc: ?BabelNodeSourceLocation = undefined): Value {
   if (value.getType() === BooleanValue) return value;
-  if (value instanceof ConcreteValue) return new BooleanValue(realm, ToBoolean(realm, value));
+  if (value instanceof ConcreteValue) return new BooleanValue(realm, To.ToBoolean(realm, value));
   invariant(value instanceof AbstractValue);
   let v = AbstractValue.createFromUnaryOp(realm, "!", value, true, value.expressionLocation);
-  if (v instanceof ConcreteValue) return new BooleanValue(realm, !ToBoolean(realm, v));
+  if (v instanceof ConcreteValue) return new BooleanValue(realm, !To.ToBoolean(realm, v));
   invariant(v instanceof AbstractValue);
   return AbstractValue.createFromUnaryOp(realm, "!", v, true, loc || value.expressionLocation);
 }

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -13,8 +13,7 @@ import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor, ObjectKind } from "../types.js";
 import { ObjectValue, StringValue, NumberValue, Value } from "./index.js";
 import { IsAccessorDescriptor, IsPropertyKey, IsArrayIndex } from "../methods/is.js";
-import { ToUint32 } from "../methods/to.js";
-import { Properties } from "../singletons.js";
+import { Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 
 export default class ArrayValue extends ObjectValue {
@@ -63,7 +62,7 @@ export default class ArrayValue extends ObjectValue {
       oldLen = oldLen.value;
 
       // d. Let index be ! ToUint32(P).
-      let index = ToUint32(this.$Realm, typeof P === "string" ? new StringValue(this.$Realm, P) : P);
+      let index = To.ToUint32(this.$Realm, typeof P === "string" ? new StringValue(this.$Realm, P) : P);
 
       // e. If index ≥ oldLen and oldLenDesc.[[Writable]] is false, return false.
       if (index >= oldLen && oldLenDesc.writable === false) return false;

--- a/src/values/IntegerIndexedExotic.js
+++ b/src/values/IntegerIndexedExotic.js
@@ -12,12 +12,11 @@
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
 import { ObjectValue, NumberValue, StringValue, Value, UndefinedValue } from "../values/index.js";
-import { CanonicalNumericIndexString, ToString } from "../methods/to.js";
 import { IsInteger, IsArrayIndex, IsAccessorDescriptor, IsDetachedBuffer, IsPropertyKey } from "../methods/is.js";
 import { OrdinaryGet } from "../methods/get.js";
 import { OrdinaryHasProperty } from "../methods/has.js";
 import { IntegerIndexedElementSet, IntegerIndexedElementGet } from "../methods/typedarray.js";
-import { Properties } from "../singletons.js";
+import { Properties, To } from "../singletons.js";
 import invariant from "../invariant";
 
 export default class IntegerIndexedExotic extends ObjectValue {
@@ -38,7 +37,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     // 3. If Type(P) is String, then
     if (typeof P === "string" || P instanceof StringValue) {
       // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-      let numericIndex = CanonicalNumericIndexString(
+      let numericIndex = To.CanonicalNumericIndexString(
         this.$Realm,
         typeof P === "string" ? new StringValue(this.$Realm, P) : P
       );
@@ -77,7 +76,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     // 3. If Type(P) is String, then
     if (typeof P === "string" || P instanceof StringValue) {
       // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-      let numericIndex = CanonicalNumericIndexString(
+      let numericIndex = To.CanonicalNumericIndexString(
         this.$Realm,
         typeof P === "string" ? new StringValue(this.$Realm, P) : P
       );
@@ -131,7 +130,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     // 3. If Type(P) is String, then
     if (typeof P === "string" || P instanceof StringValue) {
       // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-      let numericIndex = CanonicalNumericIndexString(
+      let numericIndex = To.CanonicalNumericIndexString(
         this.$Realm,
         typeof P === "string" ? new StringValue(this.$Realm, P) : P
       );
@@ -195,7 +194,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     // 2. If Type(P) is String, then
     if (typeof P === "string" || P instanceof StringValue) {
       // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-      let numericIndex = CanonicalNumericIndexString(
+      let numericIndex = To.CanonicalNumericIndexString(
         this.$Realm,
         typeof P === "string" ? new StringValue(this.$Realm, P) : P
       );
@@ -221,7 +220,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     // 2. If Type(P) is String, then
     if (typeof P === "string" || P instanceof StringValue) {
       // a. Let numericIndex be ! CanonicalNumericIndexString(P).
-      let numericIndex = CanonicalNumericIndexString(
+      let numericIndex = To.CanonicalNumericIndexString(
         this.$Realm,
         typeof P === "string" ? new StringValue(this.$Realm, P) : P
       );
@@ -260,7 +259,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     // 4. For each integer i starting with 0 such that i < len, in ascending order,
     for (let i = 0; i < len; ++i) {
       // a. Add ! ToString(i) as the last element of keys.
-      keys.push(new StringValue(this.$Realm, ToString(this.$Realm, new NumberValue(this.$Realm, i))));
+      keys.push(new StringValue(this.$Realm, To.ToString(this.$Realm, new NumberValue(this.$Realm, i))));
     }
 
     // 5. For each own property key P of O such that Type(P) is String and P is not an integer index, in ascending chronological order of property creation

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -13,11 +13,10 @@ import { Realm } from "../realm.js";
 import { Value, SymbolValue, NullValue, ObjectValue, UndefinedValue, StringValue } from "./index.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
 import invariant from "../invariant.js";
-import { ToBooleanPartial, ToPropertyDescriptor } from "../methods/to.js";
 import { SameValue, SameValuePartial, SamePropertyKey } from "../methods/abstract.js";
 import { GetMethod } from "../methods/get.js";
 import { IsExtensible, IsPropertyKey, IsDataDescriptor, IsAccessorDescriptor } from "../methods/is.js";
-import { Create, Properties } from "../singletons.js";
+import { Create, Properties, To } from "../singletons.js";
 import { Call } from "../methods/call.js";
 
 function FindPropertyKey(realm: Realm, keys: Array<PropertyKeyValue>, key: PropertyKeyValue): number {
@@ -139,7 +138,7 @@ export default class ProxyValue extends ObjectValue {
     }
 
     // 8. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, V »)).
-    let booleanTrapResult = ToBooleanPartial(realm, Call(realm, trap, handler, [target, V]));
+    let booleanTrapResult = To.ToBooleanPartial(realm, Call(realm, trap, handler, [target, V]));
 
     // 9. If booleanTrapResult is false, return false.
     if (!booleanTrapResult) return false;
@@ -191,7 +190,7 @@ export default class ProxyValue extends ObjectValue {
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target »)).
-    let booleanTrapResult = ToBooleanPartial(realm, Call(realm, trap, handler, [target]));
+    let booleanTrapResult = To.ToBooleanPartial(realm, Call(realm, trap, handler, [target]));
 
     // 8. Let targetResult be ? target.[[IsExtensible]]().
     invariant(target instanceof ObjectValue);
@@ -235,7 +234,7 @@ export default class ProxyValue extends ObjectValue {
     }
 
     // 7. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target »)).
-    let booleanTrapResult = ToBooleanPartial(realm, Call(realm, trap, handler, [target]));
+    let booleanTrapResult = To.ToBooleanPartial(realm, Call(realm, trap, handler, [target]));
 
     // 8. If booleanTrapResult is true, then
     if (booleanTrapResult) {
@@ -325,7 +324,7 @@ export default class ProxyValue extends ObjectValue {
     let extensibleTarget = IsExtensible(realm, target);
 
     // 13. Let resultDesc be ? ToPropertyDescriptor(trapResultObj).
-    let resultDesc = ToPropertyDescriptor(realm, trapResultObj);
+    let resultDesc = To.ToPropertyDescriptor(realm, trapResultObj);
 
     // 14. Call CompletePropertyDescriptor(resultDesc).
     Properties.CompletePropertyDescriptor(realm, resultDesc);
@@ -386,7 +385,7 @@ export default class ProxyValue extends ObjectValue {
     let descObj = Properties.FromPropertyDescriptor(realm, Desc);
 
     // 9. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P, descObj »)).
-    let booleanTrapResult = ToBooleanPartial(
+    let booleanTrapResult = To.ToBooleanPartial(
       realm,
       Call(realm, trap, handler, [target, typeof P === "string" ? new StringValue(realm, P) : P, descObj])
     );
@@ -472,7 +471,7 @@ export default class ProxyValue extends ObjectValue {
     }
 
     // 8. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P »)).
-    let booleanTrapResult = ToBooleanPartial(
+    let booleanTrapResult = To.ToBooleanPartial(
       realm,
       Call(realm, trap, handler, [target, typeof P === "string" ? new StringValue(realm, P) : P])
     );
@@ -609,7 +608,7 @@ export default class ProxyValue extends ObjectValue {
     }
 
     // 8. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P, V, Receiver »)).
-    let booleanTrapResult = ToBooleanPartial(
+    let booleanTrapResult = To.ToBooleanPartial(
       realm,
       Call(realm, trap, handler, [target, typeof P === "string" ? new StringValue(realm, P) : P, V, Receiver])
     );
@@ -680,7 +679,7 @@ export default class ProxyValue extends ObjectValue {
     }
 
     // 8. Let booleanTrapResult be ToBoolean(? Call(trap, handler, « target, P »)).
-    let booleanTrapResult = ToBooleanPartial(
+    let booleanTrapResult = To.ToBooleanPartial(
       realm,
       Call(realm, trap, handler, [target, typeof P === "string" ? new StringValue(realm, P) : P])
     );

--- a/src/values/StringExotic.js
+++ b/src/values/StringExotic.js
@@ -12,10 +12,8 @@
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
 import { ObjectValue, NumberValue, StringValue } from "../values/index.js";
-import { CanonicalNumericIndexString } from "../methods/to.js";
 import { IsInteger, IsArrayIndex } from "../methods/is.js";
-import { ToString, ToInteger } from "../methods/to.js";
-import { Properties } from "../singletons.js";
+import { Properties, To } from "../singletons.js";
 import invariant from "../invariant";
 
 export default class StringExotic extends ObjectValue {
@@ -40,7 +38,10 @@ export default class StringExotic extends ObjectValue {
     if (typeof P !== "string" && !(P instanceof StringValue)) return undefined;
 
     // 5. Let index be ! CanonicalNumericIndexString(P).
-    let index = CanonicalNumericIndexString(this.$Realm, typeof P === "string" ? new StringValue(this.$Realm, P) : P);
+    let index = To.CanonicalNumericIndexString(
+      this.$Realm,
+      typeof P === "string" ? new StringValue(this.$Realm, P) : P
+    );
 
     // 6. If index is undefined, return undefined.
     if (index === undefined || index === null) return undefined;
@@ -90,7 +91,7 @@ export default class StringExotic extends ObjectValue {
     // 4. For each integer i starting with 0 such that i < len, in ascending order,
     for (let i = 0; i < len; ++i) {
       // a. Add ! ToString(i) as the last element of keys.
-      keys.push(new StringValue(this.$Realm, ToString(this.$Realm, new NumberValue(this.$Realm, i))));
+      keys.push(new StringValue(this.$Realm, To.ToString(this.$Realm, new NumberValue(this.$Realm, i))));
     }
 
     // 5. For each own property key P of O such that P is an integer index and ToInteger(P) ≥ len, in ascending numeric index order,
@@ -98,7 +99,7 @@ export default class StringExotic extends ObjectValue {
     for (let key of properties
       .filter(x => IsArrayIndex(this.$Realm, x))
       .map(x => parseInt(x, 10))
-      .filter(x => ToInteger(this.$Realm, x) >= len)
+      .filter(x => To.ToInteger(this.$Realm, x) >= len)
       .sort((x, y) => x - y)) {
       // i. Add P as the last element of keys.
       keys.push(new StringValue(this.$Realm, key + ""));


### PR DESCRIPTION
Move the implementations of the to methods behind an interface so that we can reduce the Flow cycle length (as well as avoiding increasing it when a planned future request adds a new import to to.js).

This is a mechanical refactor with no new functionality.