### PR TITLE
Introduce Prepack heap objects graph

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -43,6 +43,7 @@ export type SerializerOptions = {
   inlineExpressions?: boolean,
   simpleClosures?: boolean,
   trace?: boolean,
+  heapGraph?: boolean,
 };
 
 export type PartialEvaluatorOptions = {

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -18,6 +18,7 @@ import type { BabelNodeSourceLocation } from "babel-types";
 import fs from "fs";
 import v8 from "v8";
 import { version } from "../package.json";
+import invariant from "./invariant";
 
 // Prepack helper
 declare var __residual: any;
@@ -56,6 +57,7 @@ function run(
     --residual               Produces the residual program that results after constant folding.
     --profile                Enables console logging of profile information of different phases of prepack.
     --statsFile              The name of the output file where statistics will be written to.
+    --heapGraphFile          The name of the output file where heap graph will be written to.
     --inlineExpressions      When generating code, tells prepack to avoid naming expressions when they are only used once,
                              and instead inline them where they are used.
     --simpleClosures         When generating code, tells prepack to not defer initializing closures
@@ -75,6 +77,7 @@ function run(
   let timeout: number;
   let additionalFunctions: Array<string>;
   let lazyObjectsRuntime: string;
+  let heapGraphFile: string;
   let debugInFilePath: string;
   let debugOutFilePath: string;
   let flags = {
@@ -156,9 +159,12 @@ function run(
         case "lazyObjectsRuntime":
           lazyObjectsRuntime = args.shift();
           break;
+        case "heapGraphFile":
+          heapGraphFile = args.shift();
+          break;
         case "help":
           console.log(
-            "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --maxStackDepth depthValue ] [ --timeout seconds ] [ --additionalFunctions fnc1,fnc2,... ] [ --lazyObjectsRuntime lazyObjectsRuntimeName]" +
+            "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --maxStackDepth depthValue ] [ --timeout seconds ] [ --additionalFunctions fnc1,fnc2,... ] [ --lazyObjectsRuntime lazyObjectsRuntimeName] [ -- heapGraphFile heapGraphFile]" +
               Object.keys(flags).map(s => "[ --" + s + "]").join(" ") +
               "\n" +
               HELP_STR
@@ -191,6 +197,7 @@ function run(
       timeout: timeout,
       additionalFunctions: additionalFunctions,
       lazyObjectsRuntime: lazyObjectsRuntime,
+      heapGraphFile: heapGraphFile,
       enableDebugger: false, //always turn off debugger until debugger is fully built
       debugInFilePath: debugInFilePath,
       debugOutFilePath: debugOutFilePath,
@@ -280,6 +287,10 @@ function run(
       }
       if (outputSourceMap) {
         fs.writeFileSync(outputSourceMap, serialized.map ? JSON.stringify(serialized.map) : "");
+      }
+      if (heapGraphFile) {
+        invariant(serialized.heapGraph);
+        fs.writeFileSync(heapGraphFile, serialized.heapGraph);
       }
     }
   }

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -57,7 +57,7 @@ function run(
     --residual               Produces the residual program that results after constant folding.
     --profile                Enables console logging of profile information of different phases of prepack.
     --statsFile              The name of the output file where statistics will be written to.
-    --heapGraphFile          The name of the output file where heap graph will be written to.
+    --heapGraphFilePath      The name of the output file where heap graph will be written to.
     --inlineExpressions      When generating code, tells prepack to avoid naming expressions when they are only used once,
                              and instead inline them where they are used.
     --simpleClosures         When generating code, tells prepack to not defer initializing closures
@@ -77,7 +77,7 @@ function run(
   let timeout: number;
   let additionalFunctions: Array<string>;
   let lazyObjectsRuntime: string;
-  let heapGraphFile: string;
+  let heapGraphFilePath: string;
   let debugInFilePath: string;
   let debugOutFilePath: string;
   let flags = {
@@ -159,12 +159,12 @@ function run(
         case "lazyObjectsRuntime":
           lazyObjectsRuntime = args.shift();
           break;
-        case "heapGraphFile":
-          heapGraphFile = args.shift();
+        case "heapGraphFilePath":
+          heapGraphFilePath = args.shift();
           break;
         case "help":
           console.log(
-            "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --maxStackDepth depthValue ] [ --timeout seconds ] [ --additionalFunctions fnc1,fnc2,... ] [ --lazyObjectsRuntime lazyObjectsRuntimeName] [ -- heapGraphFile heapGraphFile]" +
+            "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --maxStackDepth depthValue ] [ --timeout seconds ] [ --additionalFunctions fnc1,fnc2,... ] [ --lazyObjectsRuntime lazyObjectsRuntimeName] [ --heapGraphFilePath heapGraphFilePath]" +
               Object.keys(flags).map(s => "[ --" + s + "]").join(" ") +
               "\n" +
               HELP_STR
@@ -197,7 +197,7 @@ function run(
       timeout: timeout,
       additionalFunctions: additionalFunctions,
       lazyObjectsRuntime: lazyObjectsRuntime,
-      heapGraphFile: heapGraphFile,
+      heapGraphFilePath: heapGraphFilePath,
       enableDebugger: false, //always turn off debugger until debugger is fully built
       debugInFilePath: debugInFilePath,
       debugOutFilePath: debugOutFilePath,
@@ -288,9 +288,9 @@ function run(
       if (outputSourceMap) {
         fs.writeFileSync(outputSourceMap, serialized.map ? JSON.stringify(serialized.map) : "");
       }
-      if (heapGraphFile) {
+      if (heapGraphFilePath) {
         invariant(serialized.heapGraph);
-        fs.writeFileSync(heapGraphFile, serialized.heapGraph);
+        fs.writeFileSync(heapGraphFilePath, serialized.heapGraph);
       }
     }
   }

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -20,16 +20,14 @@ import { prepackSources } from "./prepack-standalone.js";
 import { type SourceMap } from "./types.js";
 import { DebugChannel } from "./debugger/server/channel/DebugChannel.js";
 import { FileIOWrapper } from "./debugger/common/channel/FileIOWrapper.js";
+import type { SerializedResult } from "./serializer/types.js";
 
 import fs from "fs";
 
 export * from "./prepack-node-environment";
 export * from "./prepack-standalone";
 
-export function prepackStdin(
-  options: PrepackOptions = defaultOptions,
-  callback: (any, ?{ code: string, map?: SourceMap }) => void
-) {
+export function prepackStdin(options: PrepackOptions = defaultOptions, callback: (any, ?SerializedResult) => void) {
   let sourceMapFilename = options.inputSourceMapFilename || "";
   process.stdin.setEncoding("utf8");
   process.stdin.resume();

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -18,6 +18,7 @@ export type PrepackOptions = {|
   additionalGlobals?: Realm => void,
   additionalFunctions?: Array<string>,
   lazyObjectsRuntime?: string,
+  heapGraphFile?: string,
   compatibility?: Compatibility,
   debugNames?: boolean,
   delayInitializations?: boolean,
@@ -83,6 +84,7 @@ export function getRealmOptions({
 export function getSerializerOptions({
   additionalFunctions,
   lazyObjectsRuntime,
+  heapGraphFile,
   delayInitializations = false,
   delayUnsupportedRequires = false,
   internalDebug = false,
@@ -107,6 +109,7 @@ export function getSerializerOptions({
     inlineExpressions,
     simpleClosures,
     trace,
+    heapGraph: !!heapGraphFile,
   };
   if (additionalFunctions) result.additionalFunctions = additionalFunctions;
   if (lazyObjectsRuntime !== undefined) {

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -18,7 +18,7 @@ export type PrepackOptions = {|
   additionalGlobals?: Realm => void,
   additionalFunctions?: Array<string>,
   lazyObjectsRuntime?: string,
-  heapGraphFile?: string,
+  heapGraphFilePath?: string,
   compatibility?: Compatibility,
   debugNames?: boolean,
   delayInitializations?: boolean,
@@ -84,7 +84,7 @@ export function getRealmOptions({
 export function getSerializerOptions({
   additionalFunctions,
   lazyObjectsRuntime,
-  heapGraphFile,
+  heapGraphFilePath,
   delayInitializations = false,
   delayUnsupportedRequires = false,
   internalDebug = false,
@@ -109,7 +109,7 @@ export function getSerializerOptions({
     inlineExpressions,
     simpleClosures,
     trace,
-    heapGraph: !!heapGraphFile,
+    heapGraph: !!heapGraphFilePath,
   };
   if (additionalFunctions) result.additionalFunctions = additionalFunctions;
   if (lazyObjectsRuntime !== undefined) {

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -17,7 +17,6 @@ import initializeGlobals from "./globals.js";
 import * as t from "babel-types";
 import { getRealmOptions, getSerializerOptions } from "./prepack-options";
 import { FatalError } from "./errors.js";
-import { SerializerStatistics, TimingStatistics } from "./serializer/types.js";
 import type { SourceFile } from "./types.js";
 import { AbruptCompletion } from "./completions.js";
 import type { PrepackOptions } from "./prepack-options";
@@ -26,6 +25,7 @@ import type { BabelNodeFile, BabelNodeProgram } from "babel-types";
 import invariant from "./invariant.js";
 import { version } from "../package.json";
 import type { DebugChannel } from "./debugger/server/channel/DebugChannel.js";
+import type { SerializedResult } from "./serializer/types.js";
 
 // IMPORTANT: This function is now deprecated and will go away in a future release.
 // Please use FatalError instead.
@@ -42,7 +42,7 @@ export function prepackSources(
   sources: Array<SourceFile>,
   options: PrepackOptions = defaultOptions,
   debugChannel: DebugChannel | void = undefined
-): { code: string, map?: SourceMap, statistics?: SerializerStatistics, timingStats?: TimingStatistics } {
+): SerializedResult {
   let realmOptions = getRealmOptions(options);
   realmOptions.errorHandler = options.errorHandler;
   let realm = construct_realm(realmOptions, debugChannel);
@@ -91,7 +91,7 @@ export function prepackString(
   code: string,
   sourceMap: string,
   options: PrepackOptions = defaultOptions
-): { code: string, map?: SourceMap, statistics?: SerializerStatistics, timingStats?: TimingStatistics } {
+): SerializedResult {
   return prepackSources([{ filePath: filename, fileContents: code, sourceMapContents: sourceMap }], options);
 }
 

--- a/src/serializer/ResidualHeapGraphGenerator.js
+++ b/src/serializer/ResidualHeapGraphGenerator.js
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { Logger } from "./logger.js";
+import type { Modules } from "./modules.js";
+import type { Realm } from "../realm.js";
+import type { Effects } from "../realm.js";
+import type { ObjectRefCount } from "./types.js";
+
+import invariant from "../invariant.js";
+import {
+  Value,
+  EmptyValue,
+  FunctionValue,
+  AbstractValue,
+  SymbolValue,
+  ProxyValue,
+  ObjectValue,
+} from "../values/index.js";
+import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
+import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
+
+type Edge = {
+  fromId: number,
+  toId: number,
+};
+
+/**
+ * Generate a visualizable objects graph for Prepack heap.
+ */
+export class ResidualHeapGraphGenerator extends ResidualHeapVisitor {
+  constructor(
+    realm: Realm,
+    logger: Logger,
+    modules: Modules,
+    additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
+    valueToEdgeRecord: Map<Value, ObjectRefCount>
+  ) {
+    super(realm, logger, modules, additionalFunctionValuesAndEffects);
+    this._valueToEdgeRecord = valueToEdgeRecord;
+    this._visitedValues = new Set();
+    this._valueIds = new Map();
+    this._idSeed = 0;
+    this._ancestors = [];
+    this._edges = [];
+  }
+
+  _valueToEdgeRecord: Map<Value, ObjectRefCount>;
+  _valueIds: Map<Value, number>;
+  _idSeed: number;
+  _visitedValues: Set<Value>;
+  _ancestors: Array<Value>;
+  _edges: Array<Edge>;
+
+  // Override.
+  preProcessValue(val: Value): boolean {
+    if (this._shouldIgnore(val)) {
+      return true;
+    }
+    this._updateEdge(val);
+
+    if (this._visitedValues.has(val)) {
+      return false; // Already visited.
+    }
+    this._visitedValues.add(val);
+    return true;
+  }
+
+  // Override.
+  postProcessValue(val: Value): void {
+    if (this._shouldIgnore(val)) {
+      return;
+    }
+    invariant(this._ancestors.length > 0);
+    this._ancestors.pop();
+  }
+
+  _getValueId(val: Value): number {
+    let id = this._valueIds.get(val);
+    if (!id) {
+      this._valueIds.set(val, ++this._idSeed);
+      id = this._idSeed;
+    }
+    return id;
+  }
+
+  _shouldIgnore(val: Value): boolean {
+    return val instanceof EmptyValue || val.isIntrinsic() || ResidualHeapInspector.isLeaf(val);
+  }
+
+  _updateEdge(val: Value) {
+    if (this._ancestors.length > 0) {
+      const parent = this._ancestors[this._ancestors.length - 1];
+      this._edges.push({ fromId: this._getValueId(parent), toId: this._getValueId(val) });
+    }
+    this._ancestors.push(val);
+  }
+
+  _getValueLabel(val: Value): string {
+    // TODO: add object identifier in label.
+    // TODO: does not use ref count yet, figure out how to best visualize it later.
+    return val.__originalName || "";
+  }
+
+  _generateDotGraph(nodes: Set<Value>, edges: Array<Edge>): string {
+    let content = "digraph{\n";
+
+    for (const val of nodes) {
+      const nodeId = this._getValueId(val);
+      content += `  node${nodeId} [shape=${this._getValueShape(val)} label=${this._getValueLabel(val)}];\n`;
+    }
+
+    for (const edge of edges) {
+      content += `  node${edge.fromId} -> node${edge.toId};\n`;
+    }
+    content += "}";
+    return content;
+  }
+
+  // TODO: find a way to comment the meaning of shape => value mapping in final graph language.
+  _getValueShape(val: Value): string {
+    let shape = null;
+    if (val instanceof FunctionValue) {
+      shape = "circle";
+    } else if (val instanceof AbstractValue) {
+      shape = "star";
+    } else if (val instanceof ProxyValue) {
+      shape = "house";
+    } else if (val instanceof SymbolValue) {
+      shape = "diamond";
+    } else if (val instanceof ObjectValue) {
+      shape = "box";
+    } else {
+      shape = "tripleoctagon";
+    }
+    return shape;
+  }
+
+  generateResult(): string {
+    return this._generateDotGraph(this._visitedValues, this._edges);
+  }
+}

--- a/src/serializer/ResidualHeapRefCounter.js
+++ b/src/serializer/ResidualHeapRefCounter.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { Logger } from "./logger.js";
+import type { Modules } from "./modules.js";
+import type { Realm, Effects } from "../realm.js";
+import type { ObjectRefCount } from "./types.js";
+
+import invariant from "../invariant.js";
+import { Value, EmptyValue, FunctionValue } from "../values/index.js";
+import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
+import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
+
+/**
+ * Record residual heap object's incoming and outgoing reference counts.
+ */
+export class ResidualHeapRefCounter extends ResidualHeapVisitor {
+  constructor(
+    realm: Realm,
+    logger: Logger,
+    modules: Modules,
+    additionalFunctionValuesAndEffects: Map<FunctionValue, Effects>
+  ) {
+    super(realm, logger, modules, additionalFunctionValuesAndEffects);
+    this._valueToEdgeRecord = new Map();
+    this._ancestors = [];
+  }
+
+  _valueToEdgeRecord: Map<Value, ObjectRefCount>;
+  _ancestors: Array<Value>;
+
+  getResult(): Map<Value, ObjectRefCount> {
+    return this._valueToEdgeRecord;
+  }
+
+  _shouldIgnore(val: Value): boolean {
+    return val instanceof EmptyValue || val.isIntrinsic() || ResidualHeapInspector.isLeaf(val);
+  }
+
+  preProcessValue(val: Value): boolean {
+    if (this._shouldIgnore(val)) {
+      return false;
+    }
+
+    if (this._ancestors.length > 0) {
+      this._updateParentOutgoingEdgeCount();
+    }
+    this._ancestors.push(val);
+
+    return this._updateValueIncomingEdgeCount(val);
+  }
+
+  _updateParentOutgoingEdgeCount() {
+    const parent = this._ancestors[this._ancestors.length - 1];
+    const edgeRecord = this._valueToEdgeRecord.get(parent);
+    invariant(edgeRecord);
+    ++edgeRecord.outGoing;
+  }
+
+  _updateValueIncomingEdgeCount(val: Value): boolean {
+    let edgeRecord = this._valueToEdgeRecord.get(val);
+    if (edgeRecord === undefined) {
+      this._valueToEdgeRecord.set(val, {
+        inComing: 1,
+        outGoing: 0,
+      });
+      return true;
+    } else {
+      ++edgeRecord.inComing;
+      return false; // visited node, skip its children.
+    }
+  }
+
+  // Override.
+  postProcessValue(val: Value) {
+    if (this._shouldIgnore(val)) {
+      return;
+    }
+    invariant(this._ancestors.length > 0);
+    this._ancestors.pop();
+  }
+}

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -15,13 +15,12 @@ import type { SourceFile } from "../types.js";
 import { AbruptCompletion } from "../completions.js";
 import { Generator } from "../utils/generator.js";
 import generate from "babel-generator";
-import type SourceMap from "babel-generator";
 import traverseFast from "../utils/traverse-fast.js";
 import { stripFlowTypeAnnotations } from "../flow/utils.js";
 import invariant from "../invariant.js";
 import type { SerializerOptions } from "../options.js";
 import { TimingStatistics, SerializerStatistics, ReactStatistics } from "./types.js";
-import type { ReactSerializerState } from "./types.js";
+import type { ReactSerializerState, SerializedResult } from "./types.js";
 import { Functions } from "./functions.js";
 import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
@@ -31,6 +30,8 @@ import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js";
 import { LazyObjectsSerializer } from "./LazyObjectsSerializer.js";
 import * as t from "babel-types";
+import { ResidualHeapRefCounter } from "./ResidualHeapRefCounter";
+import { ResidualHeapGraphGenerator } from "./ResidualHeapGraphGenerator";
 
 export class Serializer {
   constructor(realm: Realm, serializerOptions: SerializerOptions = {}) {
@@ -94,15 +95,7 @@ export class Serializer {
     return code;
   }
 
-  init(
-    sources: Array<SourceFile>,
-    sourceMaps?: boolean = false
-  ): void | {
-    code: string,
-    map: void | SourceMap,
-    statistics?: SerializerStatistics,
-    timingStats?: TimingStatistics,
-  } {
+  init(sources: Array<SourceFile>, sourceMaps?: boolean = false): void | SerializedResult {
     // Phase 1: Let's interpret.
     let timingStats = this.options.profile ? new TimingStatistics() : undefined;
     if (timingStats !== undefined) {
@@ -140,6 +133,27 @@ export class Serializer {
     residualHeapVisitor.visitRoots();
     if (this.logger.hasErrors()) return undefined;
     if (timingStats !== undefined) timingStats.deepTraversalTime = Date.now() - timingStats.deepTraversalTime;
+
+    let heapGraph;
+    if (this.options.heapGraph) {
+      const heapRefCounter = new ResidualHeapRefCounter(
+        this.realm,
+        this.logger,
+        this.modules,
+        additionalFunctionValuesAndEffects
+      );
+      heapRefCounter.visitRoots();
+
+      const heapGraphGenerator = new ResidualHeapGraphGenerator(
+        this.realm,
+        this.logger,
+        this.modules,
+        additionalFunctionValuesAndEffects,
+        heapRefCounter.getResult()
+      );
+      heapGraphGenerator.visitRoots();
+      heapGraph = heapGraphGenerator.generateResult();
+    }
 
     // Phase 2: Let's serialize the heap and generate code.
     // Serialize for the first time in order to gather reference counts
@@ -206,6 +220,7 @@ export class Serializer {
       reactStatistics,
       statistics: residualHeapSerializer.statistics,
       timingStats: timingStats,
+      heapGraph,
     };
   }
 }

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -191,7 +191,7 @@ export type ReactSerializerState = {
 
 export type ObjectRefCount = {
   inComing: number, // The number of objects that references this object.
-  outGoing: number, // The number of children that are referenced by this object.
+  outGoing: number, // The number of objects that are referenced by this object.
 };
 
 export type SerializedResult = {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -188,3 +188,16 @@ export type LocationService = {
 export type ReactSerializerState = {
   usedReactElementKeys: Set<string>,
 };
+
+export type ObjectRefCount = {
+  inComing: number, // The number of objects that references this object.
+  outGoing: number, // The number of children that are referenced by this object.
+};
+
+export type SerializedResult = {
+  code: string,
+  map: void | SourceMap,
+  statistics?: SerializerStatistics,
+  timingStats?: TimingStatistics,
+  heapGraph?: string,
+};


### PR DESCRIPTION
Release note: introduce Prepack heap objects graph.

This is the first PR to introduce prepack heap objects graph. The visualization is basic now(no coloring, legend for the nodes) and we need to figure out how best show the ref count. 

I would like to land this first so that @JWZ2018 can start integrate this into REPL website.

Later I am going to add the final identifier name into the node label.