### PR TITLE
fatal error when missing a context in InternalConstruct

### DIFF
--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -196,7 +196,7 @@ function InternalConstruct(
   invariant(newTarget instanceof ObjectValue, "expected object");
 
   if (!realm.hasRunningContext()) {
-    invariant(realm.useAbstractInterpretation)
+    invariant(realm.useAbstractInterpretation);
     throw new FatalError("no running context");
   }
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -11,6 +11,7 @@
 
 import type { LexicalEnvironment } from "../environment.js";
 import type { PropertyKeyValue, FunctionBodyAstNode } from "../types.js";
+import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { ECMAScriptFunctionValue } from "../values/index.js";
 import {
@@ -193,6 +194,11 @@ function InternalConstruct(
 
   // 2. Assert: Type(newTarget) is Object.
   invariant(newTarget instanceof ObjectValue, "expected object");
+
+  if (!realm.hasRunningContext()) {
+    invariant(realm.useAbstractInterpretation)
+    throw new FatalError("no running context");
+  }
 
   // 3. Let callerContext be the running execution context.
   let callerContext = realm.getRunningContext();

--- a/src/realm.js
+++ b/src/realm.js
@@ -302,6 +302,10 @@ export class Realm {
     }
   }
 
+  hasRunningContext(): boolean {
+    return this.contextStack.length !== 0;
+  }
+
   getRunningContext(): ExecutionContext {
     let context = this.contextStack[this.contextStack.length - 1];
     invariant(context, "There's no running execution context");


### PR DESCRIPTION
The serializer is optimistically running code that can fail with a runtime error, without first setting up a context. When this fails, throw an error instead of asserting. 