### PR TITLE
Compute a fixed point for do-while

### DIFF
--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -58,6 +58,19 @@ export default class ValuesDomain {
 
   _elements: void | Set<ConcreteValue>;
 
+  contains(x: ValuesDomain): boolean {
+    let elems = this._elements;
+    let xelems = x._elements;
+    if (elems === xelems) return true;
+    if (elems === undefined) return true;
+    if (xelems === undefined) return false;
+    if (elems.size < xelems.size) return false;
+    for (let e of xelems) {
+      if (!elems.has(e)) return false;
+    }
+    return true;
+  }
+
   isTop() {
     return this._elements === undefined;
   }

--- a/src/environment.js
+++ b/src/environment.js
@@ -93,6 +93,8 @@ export type Binding = {
   environment: EnvironmentRecord,
   name: string,
   isGlobal: boolean,
+  // bindings that are assigned to inside loops with abstract termination conditions need temporal locations
+  phiNode?: AbstractValue,
 };
 
 // ECMA262 8.1.1.1

--- a/src/evaluators/DoWhileStatement.js
+++ b/src/evaluators/DoWhileStatement.js
@@ -11,7 +11,8 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { Value } from "../values/index.js";
+import { FatalError } from "../errors.js";
+import { AbstractValue, Value } from "../values/index.js";
 import { EmptyValue } from "../values/index.js";
 import { UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
@@ -33,34 +34,67 @@ export default function(
   let V = realm.intrinsics.undefined;
 
   // 2. Repeat
-  while (true) {
-    // a. Let stmt be the result of evaluating Statement.
-    let stmt = env.evaluateCompletion(body, strictCode);
-    invariant(stmt instanceof Value || stmt instanceof AbruptCompletion);
+  let resultOrDiagnostic = realm.evaluateWithUndoForDiagnostic(() => {
+    while (true) {
+      // a. Let stmt be the result of evaluating Statement.
+      let stmt = env.evaluateCompletion(body, strictCode);
+      //todo: check if stmt is a PossiblyNormalCompletion and defer to fixpoint computation below
+      invariant(stmt instanceof Value || stmt instanceof AbruptCompletion);
 
-    // b. If LoopContinues(stmt, labelSet) is false, return Completion(UpdateEmpty(stmt, V)).
-    if (LoopContinues(realm, stmt, labelSet) === false) {
-      invariant(stmt instanceof AbruptCompletion);
-      // ECMA262 13.1.7
-      if (stmt instanceof BreakCompletion) {
-        if (!stmt.target) return (UpdateEmpty(realm, stmt, V): any).value;
+      // b. If LoopContinues(stmt, labelSet) is false, return Completion(UpdateEmpty(stmt, V)).
+      if (LoopContinues(realm, stmt, labelSet) === false) {
+        invariant(stmt instanceof AbruptCompletion);
+        // ECMA262 13.1.7
+        if (stmt instanceof BreakCompletion) {
+          if (!stmt.target) return (UpdateEmpty(realm, stmt, V): any).value;
+        }
+        throw UpdateEmpty(realm, stmt, V);
       }
-      throw UpdateEmpty(realm, stmt, V);
+
+      // c. If stmt.[[Value]] is not empty, let V be stmt.[[Value]].
+      let resultValue = InternalGetResultValue(realm, stmt);
+      if (!(resultValue instanceof EmptyValue)) V = resultValue;
+
+      // d. Let exprRef be the result of evaluating Expression.
+      let exprRef = env.evaluate(test, strictCode);
+
+      // e. Let exprValue be ? GetValue(exprRef).
+      let exprValue = Environment.GetConditionValue(realm, exprRef);
+
+      // f. If ToBoolean(exprValue) is false, return NormalCompletion(V).
+      if (To.ToBooleanPartial(realm, exprValue) === false) return V;
     }
+    invariant(false);
+  });
+  if (resultOrDiagnostic instanceof Value) return resultOrDiagnostic;
 
-    // c. If stmt.[[Value]] is not empty, let V be stmt.[[Value]].
-    let resultValue = InternalGetResultValue(realm, stmt);
-    if (!(resultValue instanceof EmptyValue)) V = resultValue;
-
-    // d. Let exprRef be the result of evaluating Expression.
+  // If we get here then unrolling the loop did not work, possibly because the value of the loop condition is not known,
+  // so instead try to compute a fixpoint for it
+  let ftest = () => {
     let exprRef = env.evaluate(test, strictCode);
-
-    // e. Let exprValue be ? GetValue(exprRef).
+    return Environment.GetConditionValue(realm, exprRef);
+  };
+  let fbody = () => env.evaluateCompletion(body, strictCode);
+  let effects = realm.evaluateForFixpointEffects(ftest, fbody);
+  if (effects !== undefined) {
+    let [outsideEffects, insideEffects] = effects;
+    let [rval] = outsideEffects;
+    let [, bodyGenerator] = insideEffects;
+    realm.applyEffects(outsideEffects);
+    let exprRef = env.evaluate(test, strictCode);
     let exprValue = Environment.GetValue(realm, exprRef);
-
-    // f. If ToBoolean(exprValue) is false, return NormalCompletion(V).
-    if (To.ToBooleanPartial(realm, exprValue) === false) return V;
+    invariant(exprValue instanceof AbstractValue);
+    let cond = bodyGenerator.derive(exprValue.types, exprValue.values, [exprValue], ([n]) => n, {
+      skipInvariant: true,
+    });
+    let generator = realm.generator;
+    invariant(generator !== undefined);
+    generator.emitDoWhileStatement(cond, bodyGenerator);
+    invariant(rval instanceof Value, "todo: handle loops that throw exceptions or return");
+    return rval;
   }
 
-  invariant(false);
+  // If we get here the fixpoint computation failed as well. Report the diagnostic from the unrolling and throw.
+  realm.handleError(resultOrDiagnostic);
+  throw new FatalError();
 }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -33,6 +33,10 @@ import {
   Value,
 } from "../values/index.js";
 import invariant from "../invariant.js";
+import buildExpressionTemplate from "../utils/builder.js";
+
+const tsTemplateSrc = "(A).toString()";
+const tsTemplate = buildExpressionTemplate(tsTemplateSrc);
 
 type ElementConvType = {
   Int8: (Realm, numberOrValue) => number,
@@ -761,7 +765,12 @@ export class ToImplementation {
 
   ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */ {
     if (arg instanceof ConcreteValue) return this.ToPropertyKey(realm, arg);
-    if (arg.mightNotBeString()) arg.throwIfNotConcrete();
+    if (arg.mightNotBeString()) {
+      if (!arg.mightNotBeNumber()) {
+        return AbstractValue.createFromTemplate(realm, tsTemplate, StringValue, [arg], tsTemplateSrc);
+      }
+      arg.throwIfNotConcrete();
+    }
     invariant(arg instanceof AbstractValue);
     return arg;
   }

--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -21,6 +21,7 @@ import { Generator } from "../utils/generator.js";
 import { AbstractValue, ObjectValue, Value } from "../values/index.js";
 
 import invariant from "../invariant.js";
+import * as t from "babel-types";
 
 export class WidenImplementation {
   _widenArrays(
@@ -92,15 +93,14 @@ export class WidenImplementation {
       invariant(val instanceof Value);
       return val;
     }
-    if (result1 instanceof PossiblyNormalCompletion && result2 instanceof PossiblyNormalCompletion) {
+    if (result1 instanceof PossiblyNormalCompletion || result2 instanceof PossiblyNormalCompletion) {
       //todo: #1174 figure out how to deal with loops that have embedded conditional exits
       // widen join pathConditions
       // widen normal result and Effects
       // use abrupt part of result2, depend stability to make this safe. See below.
       throw new FatalError();
     }
-    // todo: #1174 figure out what a stable result is and how to check it
-    invariant(false, "widening should happen only after result type has stablized");
+    invariant(false);
   }
 
   widenMaps<K, V>(m1: Map<K, void | V>, m2: Map<K, void | V>, widen: (K, void | V, void | V) => V): Map<K, void | V> {
@@ -120,7 +120,25 @@ export class WidenImplementation {
 
   widenBindings(realm: Realm, m1: Bindings, m2: Bindings): Bindings {
     let widen = (b: Binding, v1: void | Value, v2: void | Value) => {
-      let result = this.widenValues(realm, v1 || b.value, v2 || b.value);
+      invariant(v2 !== undefined); // Local variables are not going to get deleted as a result of widening
+      let result = this.widenValues(realm, v1 || b.value, v2);
+      if (result instanceof AbstractValue && result.kind === "widening") {
+        let phiNode = b.phiNode;
+        if (phiNode === undefined) {
+          // Create a temporal location for binding
+          let generator = realm.generator;
+          invariant(generator !== undefined);
+          phiNode = generator.derive(result.types, result.values, [v1 || realm.intrinsics.undefined], ([n]) => n, {
+            skipInvariant: true,
+          });
+          b.phiNode = phiNode;
+        }
+        // Let the widened value be a reference to the phiNode of the binding
+        invariant(phiNode.intrinsicName !== undefined);
+        let phiName = phiNode.intrinsicName;
+        result.intrinsicName = phiName;
+        result._buildNode = args => t.identifier(phiName);
+      }
       invariant(result instanceof Value);
       return result;
     };
@@ -216,67 +234,69 @@ export class WidenImplementation {
     }
   }
 
-  // If e2 is the result of a loop iteration starting with effects e1 and it has the same elements as e1,
+  // If e2 is the result of a loop iteration starting with effects e1 and it has a subset of elements of e1,
   // then we have reached a fixed point and no further calls to widen are needed. e1/e2 represent a general
   // summary of the loop, regardless of how many iterations will be performed at runtime.
-  equalsEffects(e1: Effects, e2: Effects): boolean {
+  containsEffects(e1: Effects, e2: Effects): boolean {
     let [result1, , bindings1, properties1] = e1;
     let [result2, , bindings2, properties2] = e2;
 
-    if (!this.equalsResults(result1, result2)) return false;
-    if (!this.equalsBindings(bindings1, bindings2)) return false;
-    if (!this.equalsPropertyBindings(properties1, properties2)) return false;
+    if (!this.containsResults(result1, result2)) return false;
+    if (!this.containsBindings(bindings1, bindings2)) return false;
+    if (!this.containsPropertyBindings(properties1, properties2)) return false;
     return true;
   }
 
-  equalsResults(result1: EvaluationResult, result2: EvaluationResult): boolean {
-    if (result1 instanceof Value && result2 instanceof Value) return result1.equals(result2);
+  containsResults(result1: EvaluationResult, result2: EvaluationResult): boolean {
+    if (result1 instanceof Value && result2 instanceof Value) return this._containsValues(result1, result2);
     return false;
   }
 
-  equalsMap<K, V>(m1: Map<K, void | V>, m2: Map<K, void | V>, f: (void | V, void | V) => boolean): boolean {
-    m1.forEach((val1, key, map1) => {
-      let val2 = m2.get(key);
-      if (val2 === undefined || !f(val2, val1)) return false;
-    });
-    m2.forEach((val2, key, map2) => {
-      if (!m1.has(key)) return false;
-    });
+  containsMap<K, V>(m1: Map<K, void | V>, m2: Map<K, void | V>, f: (void | V, void | V) => boolean): boolean {
+    for (const [key1, val1] of m1.entries()) {
+      if (val1 === undefined) continue; // deleted
+      let val2 = m2.get(key1);
+      if (val2 === undefined) continue; // A key that disappears has been widened away into the unknown key
+      if (!f(val2, val1)) return false;
+    }
+    for (const key2 of m2.keys()) {
+      if (!m1.has(key2)) return false;
+    }
     return true;
   }
 
-  equalsBindings(m1: Bindings, m2: Bindings): boolean {
-    let equalsBinding = (v1: void | Value, v2: void | Value) => {
-      if (v1 === undefined || v2 === undefined || !v1.equals(v2)) return false;
+  containsBindings(m1: Bindings, m2: Bindings): boolean {
+    let containsBinding = (v1: void | Value, v2: void | Value) => {
+      if (v1 === undefined || v2 === undefined || !this._containsValues(v1, v2)) return false;
       return true;
     };
-    return this.equalsMap(m1, m2, equalsBinding);
+    return this.containsMap(m1, m2, containsBinding);
   }
 
-  equalsPropertyBindings(m1: PropertyBindings, m2: PropertyBindings): boolean {
+  containsPropertyBindings(m1: PropertyBindings, m2: PropertyBindings): boolean {
     let equalsPropertyBinding = (d1: void | Descriptor, d2: void | Descriptor) => {
       if (d1 === undefined || d2 === undefined) return false;
       let [v1, v2] = [d1.value, d2.value];
       if (v1 === undefined) return v2 === undefined;
-      if (v1 instanceof Value && v2 instanceof Value && !v1.equals(v2)) return false;
+      if (v1 instanceof Value && v2 instanceof Value && !this._containsValues(v1, v2)) return false;
       if (Array.isArray(v1) && Array.isArray(v2)) {
-        return this._equalsArray(((v1: any): Array<Value>), ((v2: any): Array<Value>));
+        return this._containsArray(((v1: any): Array<Value>), ((v2: any): Array<Value>));
       }
       return false;
     };
-    return this.equalsMap(m1, m2, equalsPropertyBinding);
+    return this.containsMap(m1, m2, equalsPropertyBinding);
   }
 
-  _equalsArray(
+  _containsArray(
     v1: void | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
     v2: void | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
   ): boolean {
     let e = (v1 && v1[0]) || (v2 && v2[0]);
-    if (e instanceof Value) return this._equalsArraysOfValue((v1: any), (v2: any));
-    else return this._equalsArrayOfsMapEntries((v1: any), (v2: any));
+    if (e instanceof Value) return this._containsArraysOfValue((v1: any), (v2: any));
+    else return this._containsArrayOfsMapEntries((v1: any), (v2: any));
   }
 
-  _equalsArraysOfValue(
+  _containsArraysOfValue(
     realm: Realm,
     a1: void | Array<{ $Key: void | Value, $Value: void | Value }>,
     a2: void | Array<{ $Key: void | Value, $Value: void | Value }>
@@ -290,7 +310,7 @@ export class WidenImplementation {
         if (key2 !== undefined) return false;
       } else {
         if (key1 instanceof Value && key2 instanceof Value && key1.equals(key2)) {
-          if (val1 instanceof Value && val2 instanceof Value && val1.equals(val2)) continue;
+          if (val1 instanceof Value && val2 instanceof Value && this._containsValues(val1, val2)) continue;
         }
         return false;
       }
@@ -298,12 +318,20 @@ export class WidenImplementation {
     return true;
   }
 
-  _equalsArrayOfsMapEntries(realm: Realm, a1: void | Array<Value>, a2: void | Array<Value>): boolean {
+  _containsArrayOfsMapEntries(realm: Realm, a1: void | Array<Value>, a2: void | Array<Value>): boolean {
     let n = Math.max((a1 && a1.length) || 0, (a2 && a2.length) || 0);
     for (let i = 0; i < n; i++) {
       let [val1, val2] = [a1 && a1[i], a2 && a2[i]];
-      if (val1 instanceof Value && val2 instanceof Value && !val1.equals(val2)) return false;
+      if (val1 instanceof Value && val2 instanceof Value && !this._containsValues(val1, val2)) return false;
     }
     return false;
+  }
+
+  _containsValues(val1: Value, val2: Value) {
+    if (val1 instanceof AbstractValue && val2 instanceof AbstractValue) {
+      if (val1.getType() !== val2.getType()) return false;
+      return val1.values.contains(val2.values);
+    }
+    return val1.equals(val2);
   }
 }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -650,6 +650,13 @@ export class ResidualHeapSerializer {
 
   serializeValue(val: Value, referenceOnly?: boolean, bindingType?: BabelVariableKind): BabelNodeExpression {
     invariant(!val.refuseSerialization);
+    if (val instanceof AbstractValue && val.kind === "widening") {
+      this.serializedValues.add(val);
+      let name = val.intrinsicName;
+      invariant(name !== undefined);
+      return t.identifier(name);
+    }
+
     let scopes = this.residualValues.get(val);
     invariant(scopes !== undefined);
 

--- a/src/types.js
+++ b/src/types.js
@@ -868,10 +868,10 @@ export type WidenType = {
     v2: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
   ): Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
 
-  // If e2 is the result of a loop iteration starting with effects e1 and it has the same elements as e1,
+  // If e2 is the result of a loop iteration starting with effects e1 and it has a subset of elements of e1,
   // then we have reached a fixed point and no further calls to widen are needed. e1/e2 represent a general
   // summary of the loop, regardless of how many iterations will be performed at runtime.
-  equalsEffects(e1: Effects, e2: Effects): boolean,
+  containsEffects(e1: Effects, e2: Effects): boolean,
 };
 
 export type numberOrValue = number | Value;

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -197,6 +197,21 @@ export class Generator {
     );
   }
 
+  // test must be a temporal value, which means that it must have a defined intrinsicName
+  emitDoWhileStatement(test: AbstractValue, body: Generator) {
+    this._addEntry({
+      args: [],
+      buildNode: function([], context: SerializationContext) {
+        let testId = test.intrinsicName;
+        invariant(testId !== undefined);
+        let statements = context.serializeGenerator(body);
+        let block = t.blockStatement(statements);
+        return t.doWhileStatement(t.identifier(testId), block);
+      },
+      dependencies: [body],
+    });
+  }
+
   emitInvariant(
     args: Array<Value>,
     violationConditionFn: (Array<BabelNodeExpression>) => BabelNodeExpression,

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -607,7 +607,7 @@ export default class AbstractValue extends Value {
   static createFromWidening(realm: Realm, value1: Value, value2: Value): AbstractValue {
     // todo: #1174 look at kind and figure out much narrower widenings
     let types = TypesDomain.joinValues(value1, value2);
-    let values = ValuesDomain.joinValues(realm, value1, value2);
+    let values = ValuesDomain.topVal;
     let [hash] = hashCall("widening");
     let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;
     let result = new Constructor(realm, types, values, hash, []);

--- a/test/serializer/abstract/DoWhile.js
+++ b/test/serializer/abstract/DoWhile.js
@@ -1,0 +1,9 @@
+let n = global.__abstract ? __abstract("number", "10") : 10;
+let i = 0;
+let j;
+do {
+  i++;
+  j = 0;
+} while (i < n);
+
+inspect = function() { return i + " " + j; }

--- a/test/serializer/abstract/DoWhile1.js
+++ b/test/serializer/abstract/DoWhile1.js
@@ -1,0 +1,13 @@
+let n = global.__abstract ? __abstract("number", "10") : 10;
+let i = 0;
+let j;
+let k = 10;
+do {
+  i++;
+  if (i > 1) {
+    j = 2;
+    k = i + 3;
+  }
+} while (i < n);
+
+inspect = function() { return i + " " + j + " " + k; }

--- a/test/serializer/abstract/DoWhile2.js
+++ b/test/serializer/abstract/DoWhile2.js
@@ -1,0 +1,10 @@
+// throws introspection error
+let n = global.__abstract ? __abstract("number", "10") : 10;
+let o = {};
+let i = 0;
+do {
+  i++;
+  if (i > 5) throw "oopsie";
+} while (i < n);
+
+inspect = function() { return i; }

--- a/test/serializer/abstract/DoWhile2a.js
+++ b/test/serializer/abstract/DoWhile2a.js
@@ -1,0 +1,9 @@
+let n = global.__abstract ? __abstract("number", "10") : 10;
+let o = {};
+let i = 0;
+do {
+  i++;
+  throw "oopsie";
+} while (i < n);
+
+inspect = function() { return i; }

--- a/test/serializer/abstract/DoWhile3.js
+++ b/test/serializer/abstract/DoWhile3.js
@@ -1,0 +1,15 @@
+let n = global.__abstract ? __abstract("number", "10") : 10;
+let i = 0;
+do {
+  i++;
+  break;
+} while (i < n);
+xyz: do {
+  i++;
+  break xyz;
+} while (i < n);
+do { 5; } while (false);
+do { } while (false);
+do { i++; } while (i < 12);
+
+inspect = function() { return i; }

--- a/test/serializer/abstract/DoWhile4.js
+++ b/test/serializer/abstract/DoWhile4.js
@@ -1,0 +1,9 @@
+// throws introspection error
+let n = global.__abstract ? __abstract("number", "10") : 10;
+let i = 0;
+do {
+  i++;
+  if (i > 5) break;
+} while (i < n);
+
+inspect = function() { return i; }

--- a/test/serializer/abstract/DoWhile5.js
+++ b/test/serializer/abstract/DoWhile5.js
@@ -1,0 +1,11 @@
+let n = global.__abstract ? __abstract("number", "10") : 10;
+let i = 0;
+let j;
+let k;
+do {
+  j = i;
+  i++;
+  k = i + 2;
+} while (i < n);
+
+inspect = function() { return i + " " + j + " " + k; }


### PR DESCRIPTION
Release note: Handle do-while loops with abstract bounds, for loop bodies only involving locals.

Issue: #1174 

This adds a simple fixed point computation for do-while loops only. Currently only loops that updated only local variables and that have no abrupt exits are supported.

This is deliberately as minimal as possible to make review easier. Given the complexity of this feature, thoughtful review would be great.