### PR TITLE
Autogenerate debug files

### DIFF
--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -21,7 +21,6 @@ import type {
   PrepackLaunchArguments,
 } from "./../common/types.js";
 import { DebuggerConstants } from "./../common/DebuggerConstants.js";
-import path from "path";
 
 /* An implementation of an debugger adapter adhering to the VSCode Debug protocol
  * The adapter is responsible for communication between the UI and Prepack
@@ -38,6 +37,17 @@ class PrepackDebugSession extends DebugSession {
   }
   _clientID: void | string;
   _adapterChannel: AdapterChannel;
+
+  _generateDebugFilePath(direction: "in" | "out") {
+    let time = Date.now();
+    let filePath = "/tmp/";
+    if (direction === "in") {
+      filePath += `prepack-debug-engine2adapter-${time}.txt`;
+    } else {
+      filePath += `prepack-debug-adapter2engine-${time}.txt`;
+    }
+    return filePath;
+  }
 
   _registerMessageCallbacks() {
     this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_READY_RESPONSE, (response: DebuggerResponse) => {
@@ -98,8 +108,8 @@ class PrepackDebugSession extends DebugSession {
 
   // Override
   launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-    let inFilePath = path.join(__dirname, "../common/", args.debugInFilePath);
-    let outFilePath = path.join(__dirname, "../common/", args.debugOutFilePath);
+    let inFilePath = this._generateDebugFilePath("in");
+    let outFilePath = this._generateDebugFilePath("out");
     // set up the communication channel
     this._adapterChannel = new AdapterChannel(inFilePath, outFilePath);
     this._registerMessageCallbacks();

--- a/src/debugger/common/types.js
+++ b/src/debugger/common/types.js
@@ -158,8 +158,6 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
   sourceFile: string,
   prepackRuntime: string,
   prepackArguments: Array<string>,
-  debugInFilePath: string,
-  debugOutFilePath: string,
 }
 
 export type SteppingType = "Step Into" | "Step Over";

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -21,8 +21,6 @@ export type DebuggerCLIArguments = {
   prepackRuntime: string,
   sourceFile: string,
   prepackArguments: Array<string>,
-  debugInFilePath: string,
-  debugOutFilePath: string,
 };
 
 //separator for messages according to the protocol
@@ -39,8 +37,6 @@ export class UISession {
     this._prepackRuntime = args.prepackRuntime;
     this._sourceFile = args.sourceFile;
     this._prepackArguments = args.prepackArguments;
-    this._inFilePath = args.debugInFilePath;
-    this._outFilePath = args.debugOutFilePath;
     this._sequenceNum = 1;
     this._invalidCount = 0;
     this._dataHandler = new DataHandler();
@@ -51,10 +47,6 @@ export class UISession {
   _proc: Process;
   //path to the debug adapter
   _adapterPath: string;
-  // path to debugger input file
-  _inFilePath: string;
-  // path to debugger output file
-  _outFilePath: string;
   // the child (i.e. adapter) process
   _adapterProcess: child_process.ChildProcess;
 
@@ -177,8 +169,6 @@ export class UISession {
       prepackRuntime: this._prepackRuntime,
       sourceFile: this._sourceFile,
       prepackArguments: this._prepackArguments,
-      debugInFilePath: this._inFilePath,
-      debugOutFilePath: this._outFilePath,
     };
     this._sendLaunchRequest(launchArgs);
   }

--- a/src/debugger/mock-ui/debugger-cli.js
+++ b/src/debugger/mock-ui/debugger-cli.js
@@ -31,8 +31,6 @@ function readCLIArguments(process, console): DebuggerCLIArguments {
   let prepackRuntime = "";
   let prepackArguments = [];
   let sourceFile = "";
-  let debugInFilePath = "";
-  let debugOutFilePath = "";
 
   let args = Array.from(process.argv);
   args.splice(0, 2);
@@ -52,23 +50,12 @@ function readCLIArguments(process, console): DebuggerCLIArguments {
       prepackArguments = args.shift().split(" ");
     } else if (arg === "sourceFile") {
       sourceFile = args.shift();
-    } else if (arg === "debugInFilePath") {
-      debugInFilePath = args.shift();
-    } else if (arg === "debugOutFilePath") {
-      debugOutFilePath = args.shift();
     } else {
       console.error("Unknown argument: " + arg);
       process.exit(1);
     }
   }
-  if (debugInFilePath.length === 0) {
-    console.error("No debugger input file path provided!");
-    process.exit(1);
-  }
-  if (debugOutFilePath.length === 0) {
-    console.error("No debugger output file path provided!");
-    process.exit(1);
-  }
+
   if (adapterPath.length === 0) {
     console.error("No path to the debug adapter provided!");
     process.exit(1);
@@ -85,8 +72,6 @@ function readCLIArguments(process, console): DebuggerCLIArguments {
     prepackRuntime: prepackRuntime,
     prepackArguments: prepackArguments,
     sourceFile: sourceFile,
-    debugInFilePath: debugInFilePath,
-    debugOutFilePath: debugOutFilePath,
   };
   return result;
 }


### PR DESCRIPTION
Release note: none
Summary:
- autogenerate the debugger communication files in the /tmp/ directory
- remove user input debug files in CLI

Test Plan:
- start up debugger in CLI, verify communication channels behave as before
- make the corresponding changes in Nuclide, verify the same