### PR TITLE
Remove getSerializeObjectIdentifierOptional from ResidualHeapValueIdentifier

### DIFF
--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -184,15 +184,6 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       : super.getSerializeObjectIdentifier(val);
   }
 
-  // Override default behavior.
-  // Inside lazy objects callback, the lazy object identifier needs to be replaced with the
-  // parameter passed from the runtime.
-  getSerializeObjectIdentifierOptional(val: Value): void | BabelNodeIdentifier {
-    return val instanceof ObjectValue && this._isEmittingIntoLazyObjectInitializerBody(val)
-      ? this._callbackLazyObjectParam
-      : super.getSerializeObjectIdentifierOptional(val);
-  }
-
   // Override default serializer with lazy mode.
   serializeValueRawObject(obj: ObjectValue): BabelNodeExpression {
     this._lazyObjectInitializers.set(obj, this._serializeLazyObjectInitializer(obj));

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -341,7 +341,6 @@ export class ResidualFunctions {
         for (let instance of instancesToSplice) {
           let { functionValue, residualFunctionBindings, scopeInstances } = instance;
           let id = this.locationService.getLocation(functionValue);
-          invariant(id !== undefined);
           let funcParams = params.slice();
           let funcNode = t.functionExpression(
             null,
@@ -471,7 +470,6 @@ export class ResidualFunctions {
         for (let instance of normalInstances) {
           let { functionValue, residualFunctionBindings, insertionPoint } = instance;
           let functionId = this.locationService.getLocation(functionValue);
-          invariant(functionId !== undefined);
           let flatArgs: Array<BabelNodeExpression> = factoryNames.map(name => {
             let residualBinding = residualFunctionBindings.get(name);
             invariant(residualBinding);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -115,6 +115,7 @@ export class ResidualHeapSerializer {
     this.functionNameGenerator = this.preludeGenerator.createNameGenerator("$f_");
     this.requireReturns = new Map();
     this.serializedValues = new Set();
+    this._serializedValueWithIdentifiers = new Set();
     this.additionalFunctionValueNestedFunctions = new Set();
     this.residualFunctions = new ResidualFunctions(
       this.realm,
@@ -122,7 +123,7 @@ export class ResidualHeapSerializer {
       this.modules,
       this.requireReturns,
       {
-        getLocation: value => this.getSerializeObjectIdentifierOptional(value),
+        getLocation: value => this.getSerializeObjectIdentifier(value),
         createLocation: () => {
           let location = t.identifier(this.valueNameGenerator.generate("initialized"));
           this.currentFunctionBody.entries.push(t.variableDeclaration("var", [t.variableDeclarator(location)]));
@@ -184,6 +185,7 @@ export class ResidualHeapSerializer {
   residualFunctionInstances: Map<FunctionValue, FunctionInstance>;
   residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>;
   serializedValues: Set<Value>;
+  _serializedValueWithIdentifiers: Set<Value>;
   residualFunctions: ResidualFunctions;
   _options: SerializerOptions;
   referencedDeclaredValues: Set<AbstractValue>;
@@ -398,11 +400,6 @@ export class ResidualHeapSerializer {
   // Overridable.
   getSerializeObjectIdentifier(val: Value) {
     return this.residualHeapValueIdentifiers.getIdentifierAndIncrementReferenceCount(val);
-  }
-
-  // Overridable.
-  getSerializeObjectIdentifierOptional(val: Value) {
-    return this.residualHeapValueIdentifiers.getIdentifierAndIncrementReferenceCountOptional(val);
   }
 
   _emitProperty(
@@ -643,9 +640,8 @@ export class ResidualHeapSerializer {
     let scopes = this.residualValues.get(val);
     invariant(scopes !== undefined);
 
-    let ref = this.getSerializeObjectIdentifierOptional(val);
-    if (ref) {
-      return ref;
+    if (this._serializedValueWithIdentifiers.has(val)) {
+      return this.getSerializeObjectIdentifier(val);
     }
 
     this.serializedValues.add(val);
@@ -654,6 +650,7 @@ export class ResidualHeapSerializer {
       invariant(res !== undefined);
       return res;
     }
+    this._serializedValueWithIdentifiers.add(val);
 
     let target = this._getTarget(val, scopes);
 

--- a/src/serializer/ResidualHeapValueIdentifiers.js
+++ b/src/serializer/ResidualHeapValueIdentifiers.js
@@ -55,16 +55,9 @@ export class ResidualHeapValueIdentifiers {
   }
 
   getIdentifierAndIncrementReferenceCount(val: Value): BabelNodeIdentifier {
-    let id = this.getIdentifierAndIncrementReferenceCountOptional(val);
-    invariant(id !== undefined, "Value Id cannot be null or undefined");
-    return id;
-  }
-
-  getIdentifierAndIncrementReferenceCountOptional(val: Value): void | BabelNodeIdentifier {
+    this.incrementReferenceCount(val);
     let id = this.refs.get(val);
-    if (id !== undefined) {
-      this.incrementReferenceCount(val);
-    }
+    invariant(id !== undefined, "Value Id cannot be null or undefined");
     return id;
   }
 

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -180,7 +180,7 @@ export class SerializerStatistics {
 }
 
 export type LocationService = {
-  getLocation: Value => void | BabelNodeIdentifier,
+  getLocation: Value => BabelNodeIdentifier,
   createLocation: () => BabelNodeIdentifier,
 };
 


### PR DESCRIPTION
Release Note: N/A

getSerializeObjectIdentifierOptional() relies on the internal identifier map to check if a value has been serialized and with identifier. I am going to change this assumption in later PR so refactor the code to remove this API. 
Introduce new _serializedValueWithIdentifiers data structure to serve getSerializeObjectIdentifierOptional() API purpose. 
