### PR TITLE
ReactElement tweaks and fixes

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -37,12 +37,16 @@ export function isReactElement(val: Value): boolean {
   if (val instanceof ObjectValue && val.properties.has("$$typeof")) {
     let realm = val.$Realm;
     let $$typeof = Get(realm, val, "$$typeof");
-    if ($$typeof instanceof SymbolValue) {
+    let globalObject = realm.$GlobalObject;
+    let globalSymbolValue = Get(realm, globalObject, "Symbol");
+
+    if (globalSymbolValue === realm.intrinsics.undefined) {
+      if ($$typeof instanceof NumberValue) {
+        return $$typeof.value === 0xeac7;
+      }
+    } else if ($$typeof instanceof SymbolValue) {
       let symbolFromRegistry = realm.globalSymbolRegistry.find(e => e.$Symbol === $$typeof);
       return symbolFromRegistry !== undefined && symbolFromRegistry.$Key === "react.element";
-    }
-    if (realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && $$typeof instanceof NumberValue) {
-      return $$typeof.value === 0xeac7;
     }
   }
   return false;

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -41,6 +41,9 @@ export function isReactElement(val: Value): boolean {
       let symbolFromRegistry = realm.globalSymbolRegistry.find(e => e.$Symbol === $$typeof);
       return symbolFromRegistry !== undefined && symbolFromRegistry.$Key === "react.element";
     }
+    if (realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && $$typeof instanceof NumberValue) {
+      return $$typeof.value === 0xeac7;
+    }
   }
   return false;
 }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -135,10 +135,13 @@ export class ResidualHeapVisitor {
 
     // visit properties
     for (let [propertyBindingKey, propertyBindingValue] of obj.properties) {
-      // we don't want to the $$typeof or _owner properties
+      // we don't want to the $$typeof or _owner/_store properties
       // as this is contained within the JSXElement, otherwise
       // they we be need to be emitted during serialization
-      if (kind === "ReactElement" && (propertyBindingKey === "$$typeof" || propertyBindingKey === "_owner")) {
+      if (
+        kind === "ReactElement" &&
+        (propertyBindingKey === "$$typeof" || propertyBindingKey === "_owner" || propertyBindingKey === "_store")
+      ) {
         continue;
       }
       invariant(propertyBindingValue);


### PR DESCRIPTION
After testing this in JS environments that don't support `Symbol`, React falls back to using `0xeac7`.

```js
const REACT_ELEMENT_TYPE = hasSymbol ? Symbol["for"]("react.element") : 0xeac7;
```

This adds detection for this.

I've also excluded `_store` from being visited on ReactElement. This was picked up when evaluated DEV React bundles (where `_store` is set on the object).