### PR TITLE
Fixing ordering issue with simple-closures.

### DIFF
--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -179,6 +179,7 @@ export class Referentializer {
             }
 
             if (this._options.simpleClosures) {
+              // When simpleClosures is enabled, then space for captured mutable bindings is allocated upfront.
               let serializedBindingId = t.identifier(this._referentializedNameGenerator.generate(name));
               let serializedValue = residualBinding.serializedValue;
               invariant(serializedValue);
@@ -186,6 +187,7 @@ export class Referentializer {
               instance.initializationStatements.push(declar);
               residualBinding.serializedValue = serializedBindingId;
             } else {
+              // When simpleClosures is not enabled, then space for captured mutable bindings is allocated lazily.
               let scope = this._getSerializedBindingScopeInstance(residualBinding);
               let capturedScope = "__captured" + scope.name;
               // Save the serialized value for initialization at the top of

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -234,6 +234,13 @@ export class ResidualFunctions {
 
     let defineFunction = (instance, funcId, funcNode) => {
       let { functionValue } = instance;
+
+      if (instance.initializationStatements.length > 0) {
+        // always add initialization statements to insertion point
+        let initializationBody = getFunctionBody(instance);
+        Array.prototype.push.apply(initializationBody, instance.initializationStatements);
+      }
+
       let body;
       if (t.isFunctionExpression(funcNode)) {
         funcNodes.set(functionValue, ((funcNode: any): BabelNodeFunctionExpression));
@@ -242,7 +249,7 @@ export class ResidualFunctions {
         invariant(t.isCallExpression(funcNode)); // .bind call
         body = getFunctionBody(instance);
       }
-      for (let s of instance.initializationStatements) body.push(s);
+
       body.push(t.variableDeclaration("var", [t.variableDeclarator(funcId, funcNode)]));
       let prototypeId = this.functionPrototypes.get(functionValue);
       if (prototypeId !== undefined) {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -601,7 +601,7 @@ export class ResidualHeapSerializer {
         ).length;
       }
 
-      if (numAdditionalFunctionReferences > 0 || !this._options.delayInitializations) {
+      if (numAdditionalFunctionReferences > 0 || !this._options.delayInitializations || this._options.simpleClosures) {
         // We can just emit it into the current function body.
         return {
           body: this.currentFunctionBody,

--- a/test/serializer/basic/SimpleClosures2.js
+++ b/test/serializer/basic/SimpleClosures2.js
@@ -1,0 +1,7 @@
+// does not contain:__scope
+// simple closures
+(function() {
+    var obj = { x: 42 };
+    let f = function() { let ret = obj; obj = undefined; return ret; };
+    inspect = function() { return f().x + (f() === undefined); }
+})();


### PR DESCRIPTION
Release notes: none
Towards closing #1226.
Add regression test case.

Note that simple-closures doesn't work together with delay-initializations,
so delay-initializations now gets silently disabled when needed.