### PR TITLE
Prepend additional functions prelude *after* splicing in function declarations

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -548,14 +548,6 @@ export class ResidualFunctions {
       prelude.unshift(this.referentializer.createCapturedScopesArrayInitialization(referentializationScope));
     }
 
-    for (let [additionalFunction, body] of additionalFunctionPreludes.entries()) {
-      invariant(additionalFunction);
-      let prelude = ((body: any): Array<BabelNodeStatement>);
-      let additionalBody = rewrittenAdditionalFunctions.get(additionalFunction);
-      invariant(additionalBody);
-      additionalBody.unshift(...prelude);
-    }
-
     for (let instance of this.functionInstances.reverse()) {
       let functionBody = functionBodies.get(instance);
       if (functionBody !== undefined) {
@@ -568,6 +560,14 @@ export class ResidualFunctions {
           ([insertionPoint.index, 0]: Array<any>).concat((functionBody: Array<any>))
         );
       }
+    }
+
+    for (let [additionalFunction, body] of additionalFunctionPreludes.entries()) {
+      invariant(additionalFunction);
+      let prelude = ((body: any): Array<BabelNodeStatement>);
+      let additionalBody = rewrittenAdditionalFunctions.get(additionalFunction);
+      invariant(additionalBody);
+      additionalBody.unshift(...prelude);
     }
 
     // Inject initializer code for indexed vars into functions (for delay initializations)

--- a/test/serializer/additional-functions/prelude-ordering.js
+++ b/test/serializer/additional-functions/prelude-ordering.js
@@ -1,0 +1,8 @@
+// additional functions
+// simple closures
+function additional1() {
+    var obj = {x: 42};
+    return function() { let ret = obj; obj = {}; return ret; }
+}
+function additional2() {}
+inspect = function() { return additional1()().x; }


### PR DESCRIPTION
Release notes: none

This addresses the --simpleClosures case mentioned in #1238 (but not the other case where we delay closure scope creation).

Prepend additional functions prelude *after* splicing in function declarations,
otherwise the ordering of the insertions is messed up.
Adding regression test.