### PR TITLE
Enable the debugger

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -198,7 +198,6 @@ function run(
       additionalFunctions: additionalFunctions,
       lazyObjectsRuntime: lazyObjectsRuntime,
       heapGraphFilePath: heapGraphFilePath,
-      enableDebugger: false, //always turn off debugger until debugger is fully built
       debugInFilePath: debugInFilePath,
       debugOutFilePath: debugOutFilePath,
     },

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -109,8 +109,7 @@ export function prepackFileSync(filenames: Array<string>, options: PrepackOption
     return { filePath: filename, fileContents: code, sourceMapContents: sourceMap };
   });
   let debugChannel;
-  //flag to hide the debugger for now
-  if (options.enableDebugger && options.debugInFilePath && options.debugOutFilePath) {
+  if (options.debugInFilePath && options.debugOutFilePath) {
     let debugOptions = getDebuggerOptions(options);
     let ioWrapper = new FileIOWrapper(false, debugOptions.inFilePath, debugOptions.outFilePath);
     debugChannel = new DebugChannel(ioWrapper);

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -46,7 +46,6 @@ export type PrepackOptions = {|
   trace?: boolean,
   uniqueSuffix?: string,
   maxStackDepth?: number,
-  enableDebugger?: boolean,
   debugInFilePath?: string,
   debugOutFilePath?: string,
 |};


### PR DESCRIPTION
Release note: Debugger is available!
Summary:
- remove the flag that hides the debugger
- to check whether to invoke the debugger:
    - inFilePath and outFilePath are specified when starting prepack (check in prepack-node.js)
    - if so, DebugChannel will read from inFile to see if debugger is attached

Test Plan:
- invoked debugger from CLI and Nuclide
- started prepack without invoking debugger