### PR TITLE
Remove sending stopped event on debugger entry

### DIFF
--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -51,6 +51,7 @@ class PrepackDebugSession extends DebugSession {
 
   _registerMessageCallbacks() {
     this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_READY_RESPONSE, (response: DebuggerResponse) => {
+      // Not all clients expect a StoppedEvent on entry. Only send for the ones which expect it
       if (this._clientID === DebuggerConstants.CLI_CLIENTID) {
         this.sendEvent(new StoppedEvent("entry", DebuggerConstants.PREPACK_THREAD_ID));
       }

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -50,12 +50,6 @@ class PrepackDebugSession extends DebugSession {
   }
 
   _registerMessageCallbacks() {
-    this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_READY_RESPONSE, (response: DebuggerResponse) => {
-      // Not all clients expect a StoppedEvent on entry. Only send for the ones which expect it
-      if (this._clientID === DebuggerConstants.CLI_CLIENTID) {
-        this.sendEvent(new StoppedEvent("entry", DebuggerConstants.PREPACK_THREAD_ID));
-      }
-    });
     this._adapterChannel.registerChannelEvent(DebugMessage.STOPPED_RESPONSE, (response: DebuggerResponse) => {
       let result = response.result;
       invariant(result.kind === "stopped");

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -51,7 +51,9 @@ class PrepackDebugSession extends DebugSession {
 
   _registerMessageCallbacks() {
     this._adapterChannel.registerChannelEvent(DebugMessage.PREPACK_READY_RESPONSE, (response: DebuggerResponse) => {
-      this.sendEvent(new StoppedEvent("entry", DebuggerConstants.PREPACK_THREAD_ID));
+      if (this._clientID === DebuggerConstants.CLI_CLIENTID) {
+        this.sendEvent(new StoppedEvent("entry", DebuggerConstants.PREPACK_THREAD_ID));
+      }
     });
     this._adapterChannel.registerChannelEvent(DebugMessage.STOPPED_RESPONSE, (response: DebuggerResponse) => {
       let result = response.result;

--- a/src/debugger/adapter/channel/AdapterChannel.js
+++ b/src/debugger/adapter/channel/AdapterChannel.js
@@ -42,9 +42,7 @@ export class AdapterChannel {
 
   _processPrepackMessage(message: string) {
     let dbgResponse = this._marshaller.unmarshallResponse(message);
-    if (dbgResponse.result.kind === "ready") {
-      this._eventEmitter.emit(DebugMessage.PREPACK_READY_RESPONSE, dbgResponse);
-    } else if (dbgResponse.result.kind === "breakpoint-add") {
+    if (dbgResponse.result.kind === "breakpoint-add") {
       this._eventEmitter.emit(DebugMessage.BREAKPOINT_ADD_ACKNOWLEDGE, dbgResponse.id, dbgResponse);
     } else if (dbgResponse.result.kind === "stopped") {
       this._eventEmitter.emit(DebugMessage.STOPPED_RESPONSE, dbgResponse);

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -124,18 +124,7 @@ export class UISession {
     } else if (event.event === "stopped") {
       this._prepackWaiting = true;
       if (event.body) {
-        if (event.body.reason === "entry") {
-          this._uiOutput("Prepack is ready");
-          this._prepackLaunched = true;
-          // start reading requests from the user
-          this._reader.question("(dbg) ", (input: string) => {
-            this._dispatch(input);
-          });
-        } else if (event.body.reason.startsWith("breakpoint")) {
-          this._uiOutput("Prepack stopped on: " + event.body.reason);
-        } else {
-          this._uiOutput(event.body.reason);
-        }
+        this._uiOutput(event.body.reason);
       }
     }
   }
@@ -143,6 +132,8 @@ export class UISession {
   _processResponse(response: DebugProtocol.Response) {
     if (response.command === "initialize") {
       this._processInitializeResponse(((response: any): DebugProtocol.InitializeResponse));
+    } else if (response.command === "launch") {
+      this._processLaunchResponse(((response: any): DebugProtocol.LaunchResponse));
     } else if (response.command === "threads") {
       this._processThreadsResponse(((response: any): DebugProtocol.ThreadsResponse));
     } else if (response.command === "stackTrace") {
@@ -171,6 +162,16 @@ export class UISession {
       prepackArguments: this._prepackArguments,
     };
     this._sendLaunchRequest(launchArgs);
+  }
+
+  _processLaunchResponse(response: DebugProtocol.LaunchResponse) {
+    this._uiOutput("Prepack is ready");
+    this._prepackLaunched = true;
+    this._prepackWaiting = true;
+    // start reading requests from the user
+    this._reader.question("(dbg) ", (input: string) => {
+      this._dispatch(input);
+    });
   }
 
   _processStackTraceResponse(response: DebugProtocol.StackTraceResponse) {


### PR DESCRIPTION
Release note: none
Summary:
- Nuclide does not expect the first stop event from the debug adapters
- caused a bug where the state information is not shown on the first stop in Nuclide
- Remove sending a stopped event on entry

Test Plan:
- checked that CLI still behaves as before
- updated adapter code in Nuclide and confirmed that first stop now shows state info