### PR TITLE
Handle legacy React.createClass component bail outs

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -25,7 +25,7 @@ import {
   AbstractObjectValue,
 } from "../values/index.js";
 import { ReactStatistics, type ReactSerializerState } from "../serializer/types.js";
-import { isReactElement, valueIsClassComponent, mapOverArrayValue } from "./utils";
+import { isReactElement, valueIsClassComponent, mapOverArrayValue, valueIsLegacyCreateClassComponent } from "./utils";
 import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
@@ -153,8 +153,10 @@ export class Reconciler {
     let value;
     let childContext = context;
 
-    // first we check if it's a class component
-    if (valueIsClassComponent(this.realm, componentType)) {
+    // first we check if it's a legacy class component
+    if (valueIsLegacyCreateClassComponent(this.realm, componentType)) {
+      throw new ExpectedBailOut("components created with create-react-class are not supported");
+    } else if (valueIsClassComponent(this.realm, componentType)) {
       // We first need to know what type of class component we're dealing with.
       // A "simple" class component is defined as:
       //

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -82,7 +82,7 @@ export function isReactComponent(name: string) {
   return name.length > 0 && name[0] === name[0].toUpperCase();
 }
 
-export function valueIsClassComponent(realm: Realm, value: Value) {
+export function valueIsClassComponent(realm: Realm, value: Value): boolean {
   if (!(value instanceof FunctionValue)) {
     return false;
   }
@@ -91,6 +91,18 @@ export function valueIsClassComponent(realm: Realm, value: Value) {
     if (prototype instanceof ObjectValue) {
       return prototype.properties.has("isReactComponent");
     }
+  }
+  return false;
+}
+
+export function valueIsLegacyCreateClassComponent(realm: Realm, value: Value): boolean {
+  if (!(value instanceof FunctionValue)) {
+    return false;
+  }
+  let prototype = Get(realm, value, "prototype");
+
+  if (prototype instanceof ObjectValue) {
+    return prototype.properties.has("__reactAutoBindPairs");
   }
   return false;
 }


### PR DESCRIPTION
Release notes: none

This adds detection support for the legacy `React.createClass`/`create-react-class` API so that we can safely bail out.