### PR TITLE
Fix: Test output percentage should round down instead of up

### DIFF
--- a/scripts/generate-sourcemaps-test.js
+++ b/scripts/generate-sourcemaps-test.js
@@ -114,7 +114,7 @@ function run() {
     else failed++;
   }
 
-  console.log("Generated:", `${passed}/${total}`, (Math.round(passed / total * 100) || 0) + "%");
+  console.log("Generated:", `${passed}/${total}`, (Math.floor(passed / total * 100) || 0) + "%");
   return failed === 0;
 }
 

--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -124,7 +124,7 @@ function run() {
     else failed++;
   }
 
-  console.log("Passed:", `${passed}/${total}`, (Math.round(passed / total * 100) || 0) + "%");
+  console.log("Passed:", `${passed}/${total}`, (Math.floor(passed / total * 100) || 0) + "%");
   return failed === 0;
 }
 

--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -125,7 +125,7 @@ function run() {
     else failed++;
   }
 
-  console.log("Passed:", `${passed}/${total}`, (Math.round(passed / total * 100) || 0) + "%");
+  console.log("Passed:", `${passed}/${total}`, (Math.floor(passed / total * 100) || 0) + "%");
   return failed === 0;
 }
 

--- a/scripts/test-residual.js
+++ b/scripts/test-residual.js
@@ -176,7 +176,7 @@ function run() {
     else failed++;
   }
 
-  console.log("Passed:", `${passed}/${total}`, (Math.round(passed / total * 100) || 0) + "%");
+  console.log("Passed:", `${passed}/${total}`, (Math.floor(passed / total * 100) || 0) + "%");
   return failed === 0;
 }
 

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -556,7 +556,7 @@ function run(args) {
     }
   }
 
-  console.log("Passed:", `${passed}/${total}`, (Math.round(passed / total * 100) || 0) + "%");
+  console.log("Passed:", `${passed}/${total}`, (Math.floor(passed / total * 100) || 0) + "%");
   return failed === 0;
 }
 


### PR DESCRIPTION
Release notes: Percentage output of passing tests (passed tests / total tests) should be rounded down instead of up.

From an example I encountered earlier, when we had number of tests passed = 1157 and total tests = 1159, we would display, "Passed: 1157/1159 100%". We should instead display "Passed: 1157/1159 99%"