### PR TITLE
Add missing postProcessValue() for heap traversal

### DIFF
--- a/src/serializer/ResidualHeapRefCounter.js
+++ b/src/serializer/ResidualHeapRefCounter.js
@@ -87,4 +87,10 @@ export class ResidualHeapRefCounter extends ResidualHeapVisitor {
     invariant(this._path.length > 0);
     this._path.pop();
   }
+
+  // Override.
+  visitRoots(): void {
+    super.visitRoots();
+    invariant(this._path.length === 0, "Path should be balanced empty after traversal.");
+  }
 }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -495,6 +495,7 @@ export class ResidualHeapVisitor {
     if (val instanceof AbstractValue) {
       let equivalentValue = this.equivalenceSet.add(val);
       if (this.preProcessValue(equivalentValue)) this.visitAbstractValue(equivalentValue);
+      this.postProcessValue(equivalentValue);
       return (equivalentValue: any);
     }
     this.visitValue(val);


### PR DESCRIPTION
Release Note: none

Found this bug during working on another feature. Every preProcessValue() should be paired with a postProcessValue(). Also add an invariant to check the stack balance.