### PR TITLE
fix #1239 - Command-line based syntax errors now print location

### DIFF
--- a/scripts/test-std-in.sh
+++ b/scripts/test-std-in.sh
@@ -1,22 +1,26 @@
 # Prepack test input
-cat ./test/std-in/StdIn.js | node ./bin/prepack.js --out StdIn-test.js
+cat ./test/std-in/StdIn.js | node ./bin/prepack.js --out StdIn-test.js > /dev/null
 # Run the resulting program and check it for expected output
-node ./StdIn-test.js | grep "Hello world from std-in!" > /dev/null
+node ./StdIn-test.js | grep "Hello world from std-in" > /dev/null
 if [[ $? -ne 0 ]]; then
+    echo "Stdin test failed: cat ./test/std-in/StdIn.js | node ./bin/prepack.js --out StdIn-test.js returned an error"
     exit 1
 fi
 rm ./StdIn-test.js
 
 # Prepack test empty input and check if it logs correct msg
-echo "" | node ./bin/prepack.js --out StdIn-test.js | grep "No source code to prepack" > /dev/null
-if [[ $? -ne 1 ]]; then
+# we swap stdout and stderr to inspect the errors using 2>&1 1>/dev/null
+(echo "" | node ./bin/prepack.js --out StdIn-test.js 2>&1 1>/dev/null ) | grep "Prepack returned empty code." > /dev/null
+if [[ $? -ne 0 ]]; then
+     echo "Stdin test failed: echo "" | node ./bin/prepack.js --out StdIn-test.js didn't return the expected error"
     exit 1
 fi
 
 # Prepack test input and check if it exits with signal 1
-cat ./test/std-in/StdInError.js | node ./bin/prepack.js --out StdInError-test.js 2> /dev/null
-if [[ $? -ne 1 ]]; then
+(echo "{}()" | node ./bin/prepack.js --out StdInError-test.js  2>&1 1>/dev/null ) | grep "Syntax error in stdin: Unexpected token (1:3)" > /dev/null
+if [[ $? -ne 0 ]]; then
+    echo "Stdin test failed: cat ./test/std-in/StdInError.js | node ./bin/prepack.js --out StdInError-test.js didn't return the expected error"
     # If the test failed, rerun and show the output
-    cat ./test/std-in/StdInError.js | node ./bin/prepack.js --out StdInError-test.js
+    echo "{}()" | node ./bin/prepack.js --out StdInError-test.js
     exit 1
 fi

--- a/scripts/test-std-in.sh
+++ b/scripts/test-std-in.sh
@@ -17,7 +17,7 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Prepack test input and check if it exits with signal 1
-(echo "{}()" | node ./bin/prepack.js --out StdInError-test.js  2>&1 1>/dev/null ) | grep "Syntax error in stdin: Unexpected token (1:3)" > /dev/null
+(echo "{}()" | node ./bin/prepack.js --out StdInError-test.js  2>&1 1>/dev/null ) | grep "In stdin:(1:4) FatalError PP1004: Syntax error: Unexpected token (1:3)" > /dev/null
 if [[ $? -ne 0 ]]; then
     echo "Stdin test failed: cat ./test/std-in/StdInError.js | node ./bin/prepack.js --out StdInError-test.js didn't return the expected error"
     # If the test failed, rerun and show the output

--- a/src/environment.js
+++ b/src/environment.js
@@ -1061,10 +1061,14 @@ export class LexicalEnvironment {
           let error = e.value;
           if (error instanceof ObjectValue) {
             let message = error.$Get("message", error);
-            // syntax errors happen on one given position, so start position = end position
-            const location = { source: source.filePath, start: e.location, end: e.location };
             message.value = `Syntax error: ${message.value}`;
-            let diagnostic = new CompilerDiagnostic(message.value, location, "PP1004", "FatalError");
+            e.location.source = source.filePath;
+            // the position is not located properly on the type
+            // syntax errors happen on one given position, so start position = end position
+            const position: BabelNodePosition = e.location;
+            e.location.start = position;
+            e.location.end = position;
+            let diagnostic = new CompilerDiagnostic(message.value, e.location, "PP1004", "FatalError");
             this.realm.handleError(diagnostic);
             throw new FatalError(message.value);
           }

--- a/src/environment.js
+++ b/src/environment.js
@@ -1061,22 +1061,10 @@ export class LexicalEnvironment {
           let error = e.value;
           if (error instanceof ObjectValue) {
             let message = error.$Get("message", error);
-            // a nicer error message for parse errors.
-            let sourceMessage;
-            e.location.source = source.filePath;
-            switch (e.location.source) {
-              case "":
-                sourceMessage = "unknown source";
-                break;
-              case "no-filename-specified":
-                sourceMessage = "stdin";
-                break;
-              default:
-                sourceMessage = `input file ${e.location.source}`;
-                break;
-            }
-            message.value = `Syntax error in ${sourceMessage}: ${message.value}`;
-            let diagnostic = new CompilerDiagnostic(message.value, e.location, "PP1004", "FatalError");
+            // syntax errors happen on one given position, so start position = end position
+            const location = { source: source.filePath, start: e.location, end: e.location };
+            message.value = `Syntax error: ${message.value}`;
+            let diagnostic = new CompilerDiagnostic(message.value, location, "PP1004", "FatalError");
             this.realm.handleError(diagnostic);
             throw new FatalError(message.value);
           }

--- a/src/environment.js
+++ b/src/environment.js
@@ -1063,11 +1063,10 @@ export class LexicalEnvironment {
             let message = error.$Get("message", error);
             message.value = `Syntax error: ${message.value}`;
             e.location.source = source.filePath;
-            // the position is not located properly on the type
+            // the position was not located properly on the
             // syntax errors happen on one given position, so start position = end position
-            const position: BabelNodePosition = e.location;
-            e.location.start = position;
-            e.location.end = position;
+            e.location.start = { line: e.location.line, column: e.location.column };
+            e.location.end = { line: e.location.line, column: e.location.column };
             let diagnostic = new CompilerDiagnostic(message.value, e.location, "PP1004", "FatalError");
             this.realm.handleError(diagnostic);
             throw new FatalError(message.value);

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -248,7 +248,8 @@ function run(
             sourceMessage = "In stdin";
             break;
           default:
-            sourceMessage = `In input file ${loc.source}`;
+            // flow made me do this || ""
+            sourceMessage = `In input file ${loc.source || ""}`;
             break;
         }
 
@@ -285,14 +286,13 @@ function run(
             sourceMessage = "In stdin";
             break;
           default:
-            sourceMessage = `In input file ${loc.source}`;
+            sourceMessage = `In input file ${loc.source || ""}`;
             break;
         }
         console.error(
           `${sourceMessage || ""}:(${loc.start.line}:${loc.start.column +
             1}) ${error.severity} ${error.errorCode}: ${error.message}` +
             ` (https://github.com/facebook/prepack/wiki/${error.errorCode})`
-
         );
       }
       if (foundFatal) process.exit(1);

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -42,13 +42,7 @@ export function prepackStdin(options: PrepackOptions = defaultOptions, callback:
       let serialized;
       try {
         serialized = prepackSources(
-          [
-            {
-              filePath: filename,
-              fileContents: code,
-              sourceMapContents: sourceMap,
-            },
-          ],
+          [{ filePath: filename, fileContents: code, sourceMapContents: sourceMap }],
           options
         );
       } catch (err) {
@@ -84,13 +78,7 @@ export function prepackFile(
       let serialized;
       try {
         serialized = prepackSources(
-          [
-            {
-              filePath: filename,
-              fileContents: code,
-              sourceMapContents: sourceMap,
-            },
-          ],
+          [{ filePath: filename, fileContents: code, sourceMapContents: sourceMap }],
           options
         );
       } catch (err) {
@@ -119,11 +107,7 @@ export function prepackFileSync(filenames: Array<string>, options: PrepackOption
     } catch (_e) {
       if (options.inputSourceMapFilename) console.warn(`No sourcemap found at ${sourceMapFilename}.`);
     }
-    return {
-      filePath: filename,
-      fileContents: code,
-      sourceMapContents: sourceMap,
-    };
+    return { filePath: filename, fileContents: code, sourceMapContents: sourceMap };
   });
   let debugChannel;
   if (options.debugInFilePath && options.debugOutFilePath) {

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -34,14 +34,21 @@ export function prepackStdin(options: PrepackOptions = defaultOptions, callback:
   process.stdin.on("data", function(code) {
     fs.readFile(sourceMapFilename, "utf8", function(mapErr, sourceMap) {
       if (mapErr) {
-        console.warn(`No sourcemap found at ${sourceMapFilename}.`);
+        //if no sourcemap was provided we silently ignore
+        if (sourceMapFilename !== "") console.warn(`No sourcemap found at ${sourceMapFilename}.`);
         sourceMap = "";
       }
       let filename = "no-filename-specified";
       let serialized;
       try {
         serialized = prepackSources(
-          [{ filePath: filename, fileContents: code, sourceMapContents: sourceMap }],
+          [
+            {
+              filePath: filename,
+              fileContents: code,
+              sourceMapContents: sourceMap,
+            },
+          ],
           options
         );
       } catch (err) {
@@ -77,7 +84,13 @@ export function prepackFile(
       let serialized;
       try {
         serialized = prepackSources(
-          [{ filePath: filename, fileContents: code, sourceMapContents: sourceMap }],
+          [
+            {
+              filePath: filename,
+              fileContents: code,
+              sourceMapContents: sourceMap,
+            },
+          ],
           options
         );
       } catch (err) {
@@ -106,7 +119,11 @@ export function prepackFileSync(filenames: Array<string>, options: PrepackOption
     } catch (_e) {
       if (options.inputSourceMapFilename) console.warn(`No sourcemap found at ${sourceMapFilename}.`);
     }
-    return { filePath: filename, fileContents: code, sourceMapContents: sourceMap };
+    return {
+      filePath: filename,
+      fileContents: code,
+      sourceMapContents: sourceMap,
+    };
   });
   let debugChannel;
   if (options.debugInFilePath && options.debugOutFilePath) {

--- a/test/error-handler/syntaxError.js
+++ b/test/error-handler/syntaxError.js
@@ -1,4 +1,4 @@
 // recover-from-errors
-// expected errors: [{"location":{"line":4,"column":3,"source":"test/error-handler/syntaxError.js"},"severity":"FatalError","errorCode":"PP1004","callStack":"Error\n    "}]
+// expected errors: [{"location":{"source":"test/error-handler/syntaxError.js","start":{"line":4,"column":3},"end":{"line":4,"column":3}},"severity":"FatalError","errorCode":"PP1004","callStack":"Error\n    "}]
 
 if x then y

--- a/test/error-handler/syntaxError.js
+++ b/test/error-handler/syntaxError.js
@@ -1,4 +1,4 @@
 // recover-from-errors
-// expected errors: [{"location":{"source":"test/error-handler/syntaxError.js","start":{"line":4,"column":3},"end":{"line":4,"column":3}},"severity":"FatalError","errorCode":"PP1004","callStack":"Error\n    "}]
+// expected errors: [{"location":{"line":4,"column":3,"source":"test/error-handler/syntaxError.js","start":{"line":4,"column":3},"end":{"line":4,"column":3}},"severity":"FatalError","errorCode":"PP1004","callStack":"Error\n    "}]
 
 if x then y

--- a/test/error-handler/syntaxError.js
+++ b/test/error-handler/syntaxError.js
@@ -1,3 +1,4 @@
-// expected errors: [{"location":{"line":3,"column":3,"source":"test/error-handler/syntaxError.js"},"severity":"FatalError","errorCode":"PP1004","callStack":"Error\n    "}]
+// recover-from-errors
+// expected errors: [{"location":{"line":4,"column":3,"source":"test/error-handler/syntaxError.js"},"severity":"FatalError","errorCode":"PP1004","callStack":"Error\n    "}]
 
 if x then y

--- a/test/std-in/StdIn.js
+++ b/test/std-in/StdIn.js
@@ -1,8 +1,9 @@
+// @flow
 function hello() {
-  return 'Hello';
+  return "Hello";
 }
 function world() {
-  return 'world';
+  return "world";
 }
-let greeting = hello() + ' ' + world();
-console.log(greeting + ' from std-in!');
+let greeting = hello() + " " + world();
+console.log(greeting + " from std-in");

--- a/test/std-in/StdInError.js
+++ b/test/std-in/StdInError.js
@@ -1,8 +1,0 @@
-function hello() {
-  return 'Hello';
-}
-function world() {
-  return 'world';
-// SyntaxError: Unexpected token
-let greeting = hello() + ' ' + world();
-console.log(greeting + ' from std-in!');


### PR DESCRIPTION
Hi all!

I took the path to implement a custom errorHandler, to be more aligned with the rest of the code, but it may be a mistake.

I reached that point.
```bash
echo "(){}" | yarn prepack
yarn prepack v0.27.5
$ node lib/prepack-cli.js
Unexpected token (1:1) found in stdin
Error: A fatal error occurred while prepacking.
+ (full stack trace)
error Command failed with exit code 1.
```

and when srcmapIn is given but not existing:
```bash
 echo "(){}" | yarn prepack -- --srcmapIn notExisting
yarn prepack v0.27.5
$ node lib/prepack-cli.js "--srcmapIn" "notExisting"
No sourcemap found at notExisting.
Unexpected token (1:1) found in stdin
+ (stack trace)
```
Finally when using files with syntax error:
```bash
yarn prepack ../notepad/test.js
yarn prepack v0.27.5
$ node lib/prepack-cli.js "../notepad/test.js"
Unexpected token (1:3) found in input file ../notepad/test.js
+ (stack trace)
```