### PR TITLE
Fix #1023 remove global.__annotate as it is not used anymore

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -220,14 +220,6 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
-  // TODO #1023: Remove this property. It's just here as some existing internal test cases assume that the __annotate property is exists and is readable.
-  global.$DefineOwnProperty("__annotate", {
-    value: realm.intrinsics.undefined,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
-
   // Internal helper function for tests.
   // __isAbstract(value) checks if a given value is abstract.
   global.$DefineOwnProperty("__isAbstract", {


### PR DESCRIPTION
Hi all,

- I ran the Unit Tests on master of the public repo with and without __annotate, I couldn't see any difference.
- I rollbacked to c2bec2e when @NTillmann committed " Get rid of __annotate concept" and couldn't find any reference to "__annotate".

Maybe @hermanventer meant __annotate was still used inside Facebook tests?

