### PR TITLE
Remove build changes for debugger

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,26 +1,10 @@
 {
-  "env": {
-    "development": {
-      "presets": [
-        "env",
-        "react"
-      ],
-      "plugins": [
-        "transform-class-properties",
-        "transform-object-rest-spread"
-      ]
-    },
-    "debugger": {
-      "presets": [["env", {
-          "targets": {
-            "node": "current"
-          }
-        }],
-      "react"],
-      "plugins": [
-        "transform-class-properties",
-        "transform-object-rest-spread"
-      ]
-    }
-  }
+  "presets": [
+    "env",
+    "react"
+  ],
+  "plugins": [
+    "transform-class-properties",
+    "transform-object-rest-spread"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "browser": "lib/prepack-standalone.js",
   "scripts": {
     "build": "babel src --out-dir lib --source-maps && yarn build-bundle",
-    "build-debugger": "BABEL_ENV=debugger babel src/debugger --out-dir lib/debugger --source-maps",
     "build-scripts": "babel scripts --out-dir lib --source-maps",
     "build-bundle": "webpack",
     "watch": "babel src scripts --out-dir lib --watch --source-maps",


### PR DESCRIPTION
Release note: none
Summary:
After recent refactorings in Nuclide, we don't need to build the debugger differently anymore. We can use our transpiled code directly into Nuclide.
This undoes #1240 

Test Plan:
- `yarn build`
- recopy adapter into Nuclide and check it still works