### PR TITLE
Deal with loops where early iterations do not assign to a property

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -338,10 +338,6 @@ export class PropertiesImplementation {
 
           // iii. Let valueDesc be the PropertyDescriptor{[[Value]]: V}.
           let valueDesc = { value: V };
-          if (weakDeletion) {
-            valueDesc = existingDescriptor;
-            valueDesc.value = V;
-          }
 
           // iv. Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
           if (weakDeletion || existingDescValue.mightHaveBeenDeleted()) {
@@ -350,6 +346,8 @@ export class PropertiesImplementation {
             // and that redefining the property with valueDesc will not change the
             // attributes of the property, so we delete it to make things nice for $DefineOwnProperty.
             Receiver.$Delete(P);
+            valueDesc = existingDescriptor;
+            valueDesc.value = V;
           }
           return Receiver.$DefineOwnProperty(P, valueDesc);
         } else {

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -616,6 +616,7 @@ export default class AbstractValue extends Value {
     let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;
     let result = new Constructor(realm, types, values, hash, args, buildFunction);
     result.kind = "widened property";
+    result.mightBeEmpty = resultTemplate.mightBeEmpty;
     result.expressionLocation = resultTemplate.expressionLocation;
     return result;
   }
@@ -628,6 +629,7 @@ export default class AbstractValue extends Value {
     let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;
     let result = new Constructor(realm, types, values, hash, []);
     result.kind = "widened";
+    result.mightBeEmpty = value1.mightHaveBeenDeleted() || value2.mightHaveBeenDeleted();
     result.expressionLocation = value1.expressionLocation;
     return result;
   }

--- a/test/serializer/abstract/DoWhile6a.js
+++ b/test/serializer/abstract/DoWhile6a.js
@@ -1,0 +1,9 @@
+let n = global.__abstract ? __abstract("number", "1") : 1;
+let i = 0;
+let ob = { j: 0 };
+do {
+  i++;
+  if (i > 1) ob.j = i;
+} while (i < n);
+
+inspect = function() { return i + " " + ob.j; }

--- a/test/serializer/abstract/DoWhile6b.js
+++ b/test/serializer/abstract/DoWhile6b.js
@@ -1,0 +1,10 @@
+let n = global.__abstract ? __abstract("number", "1") : 1;
+let i = 0;
+let ob = { };
+do {
+  i++;
+  if (i > 1) ob.j = i;
+} while (i < n);
+let k = ob.j;
+
+inspect = function() { return k + " " + JSON.stringify(Reflect.ownKeys(ob)); }


### PR DESCRIPTION
Release note: none

This is the first among a number of step to deal with the gnarly edge cases that arise because a property can be absent (empty) rather than just undefined.

