### PR TITLE
Make additional function capture more precise

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -347,7 +347,7 @@ function runTest(name, code, options, args) {
       console.error(err.stack);
     }
     return false;
-  } else if (code.includes("// Copies of ")) {
+  } else if (code.includes("// Copies of ") && !options.simpleClosures) {
     let marker = "// Copies of ";
     let searchStart = code.indexOf(marker);
     let searchEnd = code.indexOf(":", searchStart);
@@ -361,7 +361,7 @@ function runTest(name, code, options, args) {
       }
       let regex = new RegExp(value, "gi");
       let matches = serialized.code.match(regex);
-      if (!options.simpleClosures && (!matches || matches.length !== count)) {
+      if (!matches || matches.length !== count) {
         console.error(
           chalk.red(`Wrong number of occurrances of ${value} got ${matches ? matches.length : 0} instead of ${count}`)
         );

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -312,6 +312,7 @@ function runTest(name, code, options, args) {
       if (err instanceof FatalError) return true;
       console.error("Test should have caused introspection error, but instead caused a different internal error!");
       console.error(err);
+      console.error(err.stack);
     }
     return false;
   } else if (code.includes("// cannot serialize")) {
@@ -321,6 +322,8 @@ function runTest(name, code, options, args) {
       if (err instanceof FatalError) {
         return true;
       }
+      console.error(err);
+      console.error(err.stack);
     }
     console.error(chalk.red("Test should have caused error during serialization!"));
     return false;
@@ -341,6 +344,7 @@ function runTest(name, code, options, args) {
       console.error(serialized.code);
     } catch (err) {
       console.error(err);
+      console.error(err.stack);
     }
     return false;
   } else if (code.includes("// Copies of ")) {
@@ -357,7 +361,7 @@ function runTest(name, code, options, args) {
       }
       let regex = new RegExp(value, "gi");
       let matches = serialized.code.match(regex);
-      if (!matches || matches.length !== count) {
+      if (!options.simpleClosures && (!matches || matches.length !== count)) {
         console.error(
           chalk.red(`Wrong number of occurrances of ${value} got ${matches ? matches.length : 0} instead of ${count}`)
         );
@@ -365,6 +369,7 @@ function runTest(name, code, options, args) {
       }
     } catch (err) {
       console.error(err);
+      console.error(err.stack);
       return false;
     }
     return true;
@@ -391,6 +396,7 @@ function runTest(name, code, options, args) {
     let unique = 27277;
     let oldUniqueSuffix = "";
     let expectedCode = code;
+    let actualStack;
     if (compileJSXWithBabel) {
       expectedCode = transformWithBabel(expectedCode, ["transform-react-jsx"]);
     }
@@ -425,6 +431,7 @@ function runTest(name, code, options, args) {
           if (found !== positive) {
             console.error(chalk.red(`Output ${positive ? "does not contain" : "contains"} forbidden string: ${value}`));
             markersIssue = true;
+            console.error(newCode);
           }
         }
         if (markersIssue) break;
@@ -446,6 +453,7 @@ function runTest(name, code, options, args) {
         } catch (e) {
           // always compare strings.
           actual = "" + e;
+          actualStack = e.stack;
         }
         if (expected !== actual) {
           console.error(chalk.red("Output mismatch!"));
@@ -455,7 +463,7 @@ function runTest(name, code, options, args) {
           break;
         }
         // Test the number of clone functions generated with the inital prepack call
-        if (i === 0 && functionCloneCountMatch) {
+        if (i === 0 && functionCloneCountMatch && !options.simpleClosures) {
           let functionCount = parseInt(functionCloneCountMatch[1], 10);
           if (serialized.statistics && functionCount !== serialized.statistics.functionClones) {
             console.error(
@@ -488,6 +496,7 @@ function runTest(name, code, options, args) {
       }
     } catch (err) {
       console.error(err);
+      console.error(err.stack);
     }
     console.log(chalk.underline("original code"));
     console.log(code);
@@ -499,6 +508,7 @@ function runTest(name, code, options, args) {
     }
     console.log(chalk.underline("output of inspect() on last generated code iteration"));
     console.log(actual);
+    if (actualStack) console.log(actualStack);
     return false;
   }
 }
@@ -545,16 +555,21 @@ function run(args) {
       test.name.includes("additional-functions") ||
       test.name.includes("react");
 
-    for (let [delayInitializations, inlineExpressions, lazyObjectsRuntime] of [
-      [false, false, undefined],
-      [true, true, undefined],
-      [false, false, args.lazyObjectsRuntime],
-    ]) {
+    const fastPermutations = [[false, false, undefined, false]];
+    const fullPermutations = [
+      [false, false, undefined, false],
+      [false, false, undefined, true],
+      [false, true, undefined, true],
+      [true, true, undefined, false],
+      [false, false, args.lazyObjectsRuntime, false],
+    ];
+    const flagPermutations = args.fast ? fastPermutations : fullPermutations;
+    for (let [delayInitializations, inlineExpressions, lazyObjectsRuntime, simpleClosures] of flagPermutations) {
       if ((skipLazyObjects || args.noLazySupport) && lazyObjectsRuntime) {
         continue;
       }
       total++;
-      let options = { delayInitializations, inlineExpressions, lazyObjectsRuntime };
+      let options = { delayInitializations, inlineExpressions, lazyObjectsRuntime, simpleClosures };
       if (runTest(test.name, test.file, options, args)) passed++;
       else failed++;
     }
@@ -573,6 +588,7 @@ class ProgramArgs {
   es5: boolean;
   lazyObjectsRuntime: string;
   noLazySupport: boolean;
+  fast: boolean;
   constructor(
     debugNames: boolean,
     verbose: boolean,
@@ -580,7 +596,8 @@ class ProgramArgs {
     outOfProcessRuntime: string,
     es5: boolean,
     lazyObjectsRuntime: string,
-    noLazySupport: boolean
+    noLazySupport: boolean,
+    fast: boolean
   ) {
     this.debugNames = debugNames;
     this.verbose = verbose;
@@ -589,6 +606,7 @@ class ProgramArgs {
     this.es5 = es5;
     this.lazyObjectsRuntime = lazyObjectsRuntime;
     this.noLazySupport = noLazySupport;
+    this.fast = fast;
   }
 }
 
@@ -634,7 +652,7 @@ class ArgsParseError {
 function argsParse(): ProgramArgs {
   let parsedArgs = minimist(process.argv.slice(2), {
     string: ["filter", "outOfProcessRuntime"],
-    boolean: ["debugNames", "verbose", "es5"],
+    boolean: ["debugNames", "verbose", "es5", "fast"],
     default: {
       debugNames: false,
       verbose: false,
@@ -644,6 +662,7 @@ function argsParse(): ProgramArgs {
       // to run tests. If not a seperate node context used.
       lazyObjectsRuntime: LAZY_OBJECTS_RUNTIME_NAME,
       noLazySupport: false,
+      fast: false,
     },
   });
   if (typeof parsedArgs.debugNames !== "boolean") {
@@ -654,6 +673,9 @@ function argsParse(): ProgramArgs {
   }
   if (typeof parsedArgs.es5 !== "boolean") {
     throw new ArgsParseError("es5 must be a boolean (either --es5 or not)");
+  }
+  if (typeof parsedArgs.fast !== "boolean") {
+    throw new ArgsParseError("fast must be a boolean (either --fast or not)");
   }
   if (typeof parsedArgs.filter !== "string") {
     throw new ArgsParseError(
@@ -676,7 +698,8 @@ function argsParse(): ProgramArgs {
     parsedArgs.outOfProcessRuntime,
     parsedArgs.es5,
     parsedArgs.lazyObjectsRuntime,
-    parsedArgs.noLazySupport
+    parsedArgs.noLazySupport,
+    parsedArgs.fast
   );
   return programArgs;
 }

--- a/src/options.js
+++ b/src/options.js
@@ -12,7 +12,7 @@
 import type { ErrorHandler } from "./errors.js";
 
 export type Compatibility = "browser" | "jsc-600-1-4-17" | "node-source-maps" | "node-cli" | "react-mocks";
-export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "node-source-maps", "node-cli"];
+export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "node-source-maps", "node-cli", "react-mocks"];
 export type ReactOutputTypes = "create-element" | "jsx";
 
 export type RealmOptions = {

--- a/src/realm.js
+++ b/src/realm.js
@@ -184,6 +184,7 @@ export class Realm {
     this.globalSymbolRegistry = [];
     this.activeLexicalEnvironments = new Set();
     this._abstractValuesDefined = new Set(); // A set of nameStrings to ensure abstract values have unique names
+    this.debugNames = opts.debugNames;
   }
 
   start: number;
@@ -191,6 +192,7 @@ export class Realm {
   isStrict: boolean;
   useAbstractInterpretation: boolean;
   trackLeaks: boolean;
+  debugNames: void | boolean;
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -86,6 +86,7 @@ export class ResidualFunctions {
       if (!additionalFunctionValueInfos.has(instance.functionValue)) this.addFunctionInstance(instance);
     }
     this.additionalFunctionValueNestedFunctions = additionalFunctionValueNestedFunctions;
+    this.simpleClosures = !!options.simpleClosures;
   }
 
   realm: Realm;
@@ -105,6 +106,7 @@ export class ResidualFunctions {
   additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>;
   additionalFunctionValueNestedFunctions: Set<FunctionValue>;
   referentializer: Referentializer;
+  simpleClosures: boolean;
 
   addFunctionInstance(instance: FunctionInstance) {
     this.functionInstances.push(instance);
@@ -133,7 +135,7 @@ export class ResidualFunctions {
     let functionInfo = this.residualFunctionInfos.get(funcBody);
     invariant(functionInfo);
     let { usesArguments } = functionInfo;
-    return !shouldInlineFunction() && instances.length > 1 && !usesArguments;
+    return !shouldInlineFunction() && instances.length > 1 && !usesArguments && !this.simpleClosures;
   }
 
   // Note: this function takes linear time. Please do not call it inside loop.
@@ -152,7 +154,7 @@ export class ResidualFunctions {
       invariant(instances.length > 0);
 
       let factoryId;
-      const suffix = instances[0].functionValue.__originalName || "";
+      const suffix = instances[0].functionValue.__originalName || this.realm.debugNames ? "factoryFunction" : "";
       if (this._shouldUseFactoryFunction(functionBody, instances)) {
         // Rewritten function should never use factory function.
         invariant(!this._hasRewrittenFunctionInstance(rewrittenAdditionalFunctions, instances));
@@ -503,7 +505,8 @@ export class ResidualFunctions {
             usesThis ||
             hasFunctionArg ||
             (firstUsage !== undefined && !firstUsage.isNotEarlierThan(insertionPoint)) ||
-            this.functionPrototypes.get(functionValue) !== undefined
+            this.functionPrototypes.get(functionValue) !== undefined ||
+            this.simpleClosures
           ) {
             let callArgs: Array<BabelNodeExpression | BabelNodeSpreadElement> = [t.thisExpression()];
             for (let flatArg of flatArgs) callArgs.push(flatArg);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1070,7 +1070,6 @@ export class ResidualHeapSerializer {
     for (let [boundName, residualBinding] of residualBindings) {
       let referencedValues = [];
       let serializeBindingFunc;
-      invariant(residualBinding);
       if (!residualBinding.declarativeEnvironmentRecord) {
         serializeBindingFunc = () => this._serializeGlobalBinding(boundName, residualBinding);
       } else {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1070,6 +1070,7 @@ export class ResidualHeapSerializer {
     for (let [boundName, residualBinding] of residualBindings) {
       let referencedValues = [];
       let serializeBindingFunc;
+      invariant(residualBinding);
       if (!residualBinding.declarativeEnvironmentRecord) {
         serializeBindingFunc = () => this._serializeGlobalBinding(boundName, residualBinding);
       } else {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -46,7 +46,7 @@ import { ClosureRefVisitor } from "./visitors.js";
 import { Logger } from "./logger.js";
 import { Modules } from "./modules.js";
 import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
-import { getSuggestedArrayLiteralLength } from "./utils.js";
+import { commonAncestorOf, getSuggestedArrayLiteralLength, getOrDefault } from "./utils.js";
 import { Environment, To } from "../singletons.js";
 import { isReactElement, valueIsReactLibraryObject } from "../react/utils.js";
 import { canHoistReactElement } from "../react/hoisting.js";
@@ -88,6 +88,8 @@ export class ResidualHeapVisitor {
     this.equivalenceSet = new HashSet();
     this.reactElementEquivalenceSet = new ReactElementSet(realm, this.equivalenceSet);
     this.additionalFunctionValueInfos = new Map();
+    this.inAdditionalFunction = false;
+    this.reVisitSet = new Set();
   }
 
   realm: Realm;
@@ -112,6 +114,14 @@ export class ResidualHeapVisitor {
   equivalenceSet: HashSet<AbstractValue>;
   shouldVisitReactLibrary: boolean;
   reactElementEquivalenceSet: ReactElementSet;
+
+  // We only want to add to reVisitSet when we're in an additional function
+  inAdditionalFunction: boolean;
+  // Tracks objects + functions that were visited from inside additional functions that need to be serialized in a
+  // parent scope of the additional function (e.g. functions/objects only used from additional functions that were
+  // declared outside the additional function need to be serialized in the additional function's parent scope for
+  // identity to work).
+  reVisitSet: Set<ObjectValue>;
 
   _withScope(scope: Scope, f: () => void) {
     let oldScope = this.scope;
@@ -237,26 +247,6 @@ export class ResidualHeapVisitor {
     if (desc.set !== undefined) this.visitValue(desc.set);
   }
 
-  visitDeclarativeEnvironmentRecordBinding(r: DeclarativeEnvironmentRecord, n: string): ResidualFunctionBinding {
-    let residualFunctionBindings = this.declarativeEnvironmentRecordsBindings.get(r);
-    if (!residualFunctionBindings) {
-      residualFunctionBindings = new Map();
-      this.declarativeEnvironmentRecordsBindings.set(r, residualFunctionBindings);
-    }
-    let residualFunctionBinding = residualFunctionBindings.get(n);
-    if (!residualFunctionBinding) {
-      let realm = this.realm;
-      let binding = r.bindings[n];
-      invariant(!binding.deletable);
-      let value = (binding.initialized && binding.value) || realm.intrinsics.undefined;
-      residualFunctionBinding = { value, modified: false, declarativeEnvironmentRecord: r };
-      residualFunctionBindings.set(n, residualFunctionBinding);
-    }
-    invariant(residualFunctionBinding.value !== undefined);
-    residualFunctionBinding.value = this.visitEquivalentValue(residualFunctionBinding.value);
-    return residualFunctionBinding;
-  }
-
   visitValueArray(val: ObjectValue): void {
     this.visitObjectProperties(val);
     const realm = this.realm;
@@ -312,7 +302,8 @@ export class ResidualHeapVisitor {
     }
   }
 
-  visitValueFunction(val: FunctionValue): void {
+  visitValueFunction(val: FunctionValue, parentScope: Scope): void {
+    if (this.inAdditionalFunction) this.reVisitSet.add(val);
     this.visitObjectProperties(val);
 
     if (val instanceof BoundFunctionValue) {
@@ -327,11 +318,16 @@ export class ResidualHeapVisitor {
     invariant(val instanceof ECMAScriptSourceFunctionValue);
     invariant(val.constructor === ECMAScriptSourceFunctionValue);
     let formalParameters = val.$FormalParameters;
-    invariant(formalParameters != null);
     let code = val.$ECMAScriptCode;
-    invariant(code != null);
 
     let functionInfo = this.functionInfos.get(code);
+    let residualFunctionBindings = new Map();
+    this.functionInstances.set(val, {
+      residualFunctionBindings,
+      initializationStatements: [],
+      functionValue: val,
+      scopeInstances: new Map(),
+    });
 
     if (!functionInfo) {
       functionInfo = {
@@ -340,8 +336,6 @@ export class ResidualHeapVisitor {
         usesArguments: false,
         usesThis: false,
       };
-      this.functionInfos.set(code, functionInfo);
-
       let state = {
         tryQuery: this.logger.tryQuery.bind(this.logger),
         val,
@@ -355,6 +349,7 @@ export class ResidualHeapVisitor {
         null,
         state
       );
+      this.functionInfos.set(code, functionInfo);
 
       if (val.isResidual && functionInfo.unbound.size) {
         if (!val.isUnsafeResidual) {
@@ -369,47 +364,81 @@ export class ResidualHeapVisitor {
       }
     }
 
-    let residualFunctionBindings = new Map();
-    this._withScope(val, () => {
-      invariant(functionInfo);
-      for (let innerName of functionInfo.unbound) {
-        let residualFunctionBinding;
-        let doesNotMatter = true;
-        let reference = this.logger.tryQuery(
-          () => Environment.ResolveBinding(this.realm, innerName, doesNotMatter, val.$Environment),
-          undefined,
-          false /* The only reason `ResolveBinding` might fail is because the global object is partial. But in that case, we know that we are dealing with the common scope. */
-        );
-        if (
-          reference === undefined ||
-          Environment.IsUnresolvableReference(this.realm, reference) ||
-          reference.base instanceof GlobalEnvironmentRecord
-        ) {
-          residualFunctionBinding = this.visitGlobalBinding(innerName);
-        } else {
-          invariant(!Environment.IsUnresolvableReference(this.realm, reference));
-          let referencedBase = reference.base;
-          let referencedName: string = (reference.referencedName: any);
-          if (typeof referencedName !== "string") {
-            throw new FatalError("TODO: do not know how to visit reference with symbol");
-          }
-          invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
-          residualFunctionBinding = this.visitDeclarativeEnvironmentRecordBinding(referencedBase, referencedName);
+    let additionalFunctionEffects = this.additionalFunctionValuesAndEffects.get(val);
+    if (additionalFunctionEffects) {
+      this._visitAdditionalFunction(val, additionalFunctionEffects, parentScope);
+    } else {
+      this._withScope(val, () => {
+        invariant(functionInfo);
+        for (let innerName of functionInfo.unbound) {
+          let residualBinding = this.visitBinding(val, innerName);
+          invariant(residualBinding !== undefined);
+          residualFunctionBindings.set(innerName, residualBinding);
+          if (functionInfo.modified.has(innerName)) residualBinding.modified = true;
         }
-        residualFunctionBindings.set(innerName, residualFunctionBinding);
-        if (functionInfo.modified.has(innerName)) residualFunctionBinding.modified = true;
-      }
-    });
+      });
+    }
+  }
 
-    this.functionInstances.set(val, {
-      residualFunctionBindings,
-      initializationStatements: [],
-      functionValue: val,
-      scopeInstances: new Map(),
-    });
+  // Visits a binding, if createBinding is true, will always return a ResidualFunctionBinding
+  // otherwise visits + returns the binding only if one already exists.
+  visitBinding(val: FunctionValue, name: string, createBinding: boolean = true): ResidualFunctionBinding | void {
+    let residualFunctionBinding;
+    let doesNotMatter = true;
+    let reference = this.logger.tryQuery(
+      () => Environment.ResolveBinding(this.realm, name, doesNotMatter, val.$Environment),
+      undefined,
+      false /* The only reason `ResolveBinding` might fail is because the global object is partial. But in that case, we know that we are dealing with the common scope. */
+    );
+    let getFromMap = createBinding ? getOrDefault : (map, key, defaultFn) => map.get(key);
+    if (
+      reference === undefined ||
+      Environment.IsUnresolvableReference(this.realm, reference) ||
+      reference.base instanceof GlobalEnvironmentRecord
+    ) {
+      // Global Binding
+      residualFunctionBinding = getFromMap(
+        this.globalBindings,
+        name,
+        () =>
+          ({
+            value: this.realm.getGlobalLetBinding(name),
+            modified: true,
+            declarativeEnvironmentRecord: null,
+          }: ResidualFunctionBinding)
+      );
+    } else {
+      // DeclarativeEnvironmentRecord binding
+      invariant(!Environment.IsUnresolvableReference(this.realm, reference));
+      let referencedBase = reference.base;
+      let referencedName: string = (reference.referencedName: any);
+      if (typeof referencedName !== "string") {
+        throw new FatalError("TODO: do not know how to visit reference with symbol");
+      }
+      invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
+      let residualFunctionBindings = getOrDefault(
+        this.declarativeEnvironmentRecordsBindings,
+        referencedBase,
+        () => new Map()
+      );
+      residualFunctionBinding = getFromMap(residualFunctionBindings, referencedName, (): ResidualFunctionBinding => {
+        invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
+        let binding = referencedBase.bindings[referencedName];
+        invariant(!binding.deletable);
+        return {
+          value: (binding.initialized && binding.value) || this.realm.intrinsics.undefined,
+          modified: false,
+          declarativeEnvironmentRecord: referencedBase,
+        };
+      });
+    }
+    if (residualFunctionBinding && residualFunctionBinding.value)
+      residualFunctionBinding.value = this.visitEquivalentValue(residualFunctionBinding.value);
+    return residualFunctionBinding;
   }
 
   visitValueObject(val: ObjectValue): void {
+    if (this.inAdditionalFunction) this.reVisitSet.add(val);
     let kind = val.getKind();
     this.visitObjectProperties(val, kind);
 
@@ -546,9 +575,10 @@ export class ResidualHeapVisitor {
       if (this.preProcessValue(val)) this.visitValueProxy(val);
     } else if (val instanceof FunctionValue) {
       // Function declarations should get hoisted in common scope so that instances only get allocated once
+      let parentScope = this.scope;
       this._withScope(this.commonScope, () => {
         invariant(val instanceof FunctionValue);
-        if (this.preProcessValue(val)) this.visitValueFunction(val);
+        if (this.preProcessValue(val)) this.visitValueFunction(val, parentScope);
       });
     } else if (val instanceof SymbolValue) {
       if (this.preProcessValue(val)) this.visitValueSymbol(val);
@@ -567,17 +597,6 @@ export class ResidualHeapVisitor {
       }
     }
     this.postProcessValue(val);
-  }
-
-  visitGlobalBinding(key: string): ResidualFunctionBinding {
-    let binding = this.globalBindings.get(key);
-    if (!binding) {
-      let value = this.realm.getGlobalLetBinding(key);
-      binding = ({ value, modified: true, declarativeEnvironmentRecord: null }: ResidualFunctionBinding);
-      this.globalBindings.set(key, binding);
-    }
-    if (binding.value) binding.value = this.visitEquivalentValue(binding.value);
-    return binding;
   }
 
   createGeneratorVisitCallbacks(generator: Generator, commonScope: Scope): VisitEntryCallbacks {
@@ -604,8 +623,32 @@ export class ResidualHeapVisitor {
     });
   }
 
-  visitAdditionalFunctionEffects() {
-    for (let [functionValue, { effects }] of this.additionalFunctionValuesAndEffects.entries()) {
+  _visitAdditionalFunction(
+    functionValue: FunctionValue,
+    additionalEffects: AdditionalFunctionEffects,
+    parentScope: Scope
+  ) {
+    // Get Instance + Info
+    invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
+    let code = functionValue.$ECMAScriptCode;
+    let functionInfo = this.functionInfos.get(code);
+    invariant(functionInfo !== undefined);
+    let funcInstance = this.functionInstances.get(functionValue);
+    invariant(funcInstance !== undefined);
+
+    // Set Visitor state
+    // Allows us to emit function declarations etc. inside of this additional
+    // function instead of adding them at global scope
+    let prevCommonScope = this.commonScope;
+    this.commonScope = functionValue;
+    let oldReactElementEquivalenceSet = this.reactElementEquivalenceSet;
+    this.reactElementEquivalenceSet = new ReactElementSet(this.realm, this.equivalenceSet);
+    this.inAdditionalFunction = true;
+    let prevReVisit = this.reVisitSet;
+    this.reVisitSet = new Set();
+
+    let _visitAdditionalFunctionEffects = () => {
+      let { effects } = additionalEffects;
       let [
         result,
         generator,
@@ -633,11 +676,6 @@ export class ResidualHeapVisitor {
         modifiedProperties,
         createdObjects,
       ]);
-      // Allows us to emit function declarations etc. inside of this additional
-      // function instead of adding them at global scope
-      this.commonScope = functionValue;
-      let oldReactElementEquivalenceSet = this.reactElementEquivalenceSet;
-      this.reactElementEquivalenceSet = new ReactElementSet(this.realm, this.equivalenceSet);
       let modifiedBindingInfo = new Map();
       let visitPropertiesAndBindings = () => {
         for (let propertyBinding of modifiedProperties.keys()) {
@@ -649,44 +687,40 @@ export class ResidualHeapVisitor {
           this.visitObjectProperty(binding);
         }
         // Handing of ModifiedBindings
-        for (let additionalBinding of modifiedBindings.keys()) {
-          //let modifiedBinding: Binding = ((additionalBinding: any): Binding);
+        for (let [additionalBinding, previousValue] of modifiedBindings) {
           let modifiedBinding = additionalBinding;
           let residualBinding;
-          if (modifiedBinding.isGlobal) {
-            residualBinding = this.globalBindings.get(modifiedBinding.name);
-          } else {
-            let containingEnv = modifiedBinding.environment;
-            invariant(containingEnv instanceof DeclarativeEnvironmentRecord);
-            let bindMap = this.declarativeEnvironmentRecordsBindings.get(containingEnv);
-            if (bindMap) residualBinding = bindMap.get(modifiedBinding.name);
-          }
-          // Only visit it if there is already a binding (no binding means that
-          // the additional function created the binding)
-          if (residualBinding && modifiedBinding.value !== residualBinding.value) {
-            let newValue = modifiedBinding.value;
-            invariant(newValue);
-            this.visitValue(newValue);
-            residualBinding.modified = true;
-            // This should be enforced by checkThatFunctionsAreIndependent
-            invariant(
-              !residualBinding.additionalFunctionOverridesValue,
-              "We should only have one additional function value modifying any given residual binding"
-            );
-            residualBinding.additionalFunctionOverridesValue = true;
-            modifiedBindingInfo.set(modifiedBinding, residualBinding);
-          }
+          this._withScope(functionValue, () => {
+            // Also visit the original value of the binding
+            residualBinding = this.visitBinding(functionValue, modifiedBinding.name);
+            invariant(residualBinding !== undefined);
+            // Fixup the binding to have the correct value
+            // No previousValue means this is a binding for a nested function
+            if (previousValue && previousValue.value)
+              residualBinding.value = this.visitEquivalentValue(previousValue.value);
+            invariant(functionInfo !== undefined);
+            if (functionInfo.modified.has(modifiedBinding.name)) residualBinding.modified;
+          });
+          invariant(residualBinding !== undefined);
+          invariant(funcInstance !== undefined);
+          funcInstance.residualFunctionBindings.set(modifiedBinding.name, residualBinding);
+          let newValue = modifiedBinding.value;
+          invariant(newValue);
+          this.visitValue(newValue);
+          residualBinding.modified = true;
+          // This should be enforced by checkThatFunctionsAreIndependent
+          invariant(
+            !residualBinding.additionalFunctionOverridesValue,
+            "We should only have one additional function value modifying any given residual binding"
+          );
+          if (previousValue && previousValue.value) residualBinding.additionalFunctionOverridesValue = functionValue;
+          modifiedBindingInfo.set(modifiedBinding, residualBinding);
         }
         invariant(result instanceof Value);
         if (!(result instanceof UndefinedValue)) this.visitValue(result);
       };
-      invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
-      let code = functionValue.$ECMAScriptCode;
-      invariant(code != null);
-      let functionInfo = this.functionInfos.get(code);
-      invariant(functionInfo);
-      let funcInstance = this.functionInstances.get(functionValue);
-      invariant(funcInstance);
+      invariant(funcInstance !== undefined);
+      invariant(functionInfo !== undefined);
       this.additionalFunctionValueInfos.set(functionValue, {
         functionValue,
         captures: functionInfo.unbound,
@@ -695,10 +729,53 @@ export class ResidualHeapVisitor {
       });
       this.visitGenerator(generator);
       this._withScope(generator, visitPropertiesAndBindings);
+
+      // Remove any modifications to CreatedObjects -- these are fine being serialized inside the additional function
+      this.reVisitSet = new Set([...this.reVisitSet].filter(x => !createdObjects.has(x)));
+
       this.realm.restoreBindings(modifiedBindings);
       this.realm.restoreProperties(modifiedProperties);
-      this.reactElementEquivalenceSet = oldReactElementEquivalenceSet;
+      return this.realm.intrinsics.undefined;
+    };
+    this.realm.evaluateAndRevertInGlobalEnv(_visitAdditionalFunctionEffects);
+
+    // Cleanup
+    this.commonScope = prevCommonScope;
+    this.reactElementEquivalenceSet = oldReactElementEquivalenceSet;
+    this._withScope(
+      parentScope,
+      // Re-visit any bindings corresponding to unbound values or values closed over from outside additional function
+      // they're serialized in the correct scope
+      () => {
+        invariant(functionInfo !== undefined);
+        invariant(funcInstance !== undefined);
+        for (let value of this.reVisitSet) {
+          // Populate old reVisitSet because we switched them out
+          prevReVisit.add(value);
+          this.visitValue(value);
+        }
+        for (let innerName of functionInfo.unbound) {
+          let residualBinding = this.visitBinding(functionValue, innerName, false);
+          if (residualBinding) {
+            residualBinding.modified = true;
+            funcInstance.residualFunctionBindings.set(innerName, residualBinding);
+          }
+        }
+        this.reVisitSet = prevReVisit;
+      }
+    );
+    this.inAdditionalFunction = false;
+  }
+
+  visitRoots(): void {
+    let generator = this.realm.generator;
+    invariant(generator);
+    this.visitGenerator(generator);
+    for (let moduleValue of this.modules.initializedModules.values()) this.visitValue(moduleValue);
+    if (this.realm.react.enabled && this.shouldVisitReactLibrary) {
+      this._visitReactLibrary();
     }
+
     // Do a fixpoint over all pure generator entries to make sure that we visit
     // arguments of only BodyEntries that are required by some other residual value
     let oldDelayedEntries = [];
@@ -712,17 +789,18 @@ export class ResidualHeapVisitor {
         });
       }
     }
-    return this.realm.intrinsics.undefined;
-  }
 
-  visitRoots(): void {
-    let generator = this.realm.generator;
-    invariant(generator);
-    this.visitGenerator(generator);
-    for (let moduleValue of this.modules.initializedModules.values()) this.visitValue(moduleValue);
-    this.realm.evaluateAndRevertInGlobalEnv(this.visitAdditionalFunctionEffects.bind(this));
-    if (this.realm.react.enabled && this.shouldVisitReactLibrary) {
-      this._visitReactLibrary();
+    // Artificially add reVisitSet to generators so that they can get serialized in parent scopes of additionalFunctions
+    // if necessary.
+    for (let value of this.reVisitSet) {
+      let scopes = this.values.get(value);
+      invariant(scopes);
+      scopes = [...scopes];
+      let generators = scopes.filter(x => x instanceof Generator);
+      invariant(generators.length > 0);
+      let commonAncestor = scopes.reduce((x, y) => commonAncestorOf(x, y), generators[0]);
+      invariant(commonAncestor instanceof Generator); // every scope is either the root, or a descendant
+      commonAncestor.appendDependencies([value]);
     }
   }
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -61,6 +61,7 @@ export type GeneratorBuildNodeFunction = (Array<BabelNodeExpression>, Serializat
 export type GeneratorEntry = {
   declared?: AbstractValue,
   args: Array<Value>,
+  // If we're just trying to add roots for the serializer to notice, we don't need a buildNode.
   buildNode?: GeneratorBuildNodeFunction,
   dependencies?: Array<Generator>,
   isPure?: boolean,
@@ -122,7 +123,7 @@ export class Generator {
   }
 
   // Will force the array of Values to be serialized but not emit anything for a buildNode
-  appendDependencies(values: Array<Value>) {
+  appendRoots(values: Array<Value>) {
     this._addEntry({
       args: values,
     });

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -61,7 +61,7 @@ export type GeneratorBuildNodeFunction = (Array<BabelNodeExpression>, Serializat
 export type GeneratorEntry = {
   declared?: AbstractValue,
   args: Array<Value>,
-  buildNode: GeneratorBuildNodeFunction,
+  buildNode?: GeneratorBuildNodeFunction,
   dependencies?: Array<Generator>,
   isPure?: boolean,
 };
@@ -119,6 +119,13 @@ export class Generator {
 
   empty() {
     return this._entries.length === 0;
+  }
+
+  // Will force the array of Values to be serialized but not emit anything for a buildNode
+  appendDependencies(values: Array<Value>) {
+    this._addEntry({
+      args: values,
+    });
   }
 
   emitGlobalDeclaration(key: string, value: Value) {
@@ -395,7 +402,7 @@ export class Generator {
     for (let entry of this._entries) {
       if (!entry.isPure || !entry.declared || !context.canOmit(entry.declared)) {
         let nodes = entry.args.map((boundArg, i) => context.serializeValue(boundArg));
-        context.emit(entry.buildNode(nodes, context));
+        if (entry.buildNode) context.emit(entry.buildNode(nodes, context));
         if (entry.declared !== undefined) context.declare(entry.declared);
       }
     }

--- a/test/serializer/additional-functions/func-nesting.js
+++ b/test/serializer/additional-functions/func-nesting.js
@@ -1,0 +1,39 @@
+// additional functions
+inspect = undefined;
+(function(){
+  var Super = 
+    function Super() {
+      this.prop = "bar";
+    };
+var ES5Class = (function (superclass) {
+  function Foo() {
+    superclass.apply(this, arguments);
+    this.state = "hello";
+  }
+
+	if ( superclass ) {
+    Foo.__proto__ = superclass;
+  }
+  Foo.prototype = Object.create( superclass && superclass.prototype );
+  Foo.prototype.constructor = Foo;
+	Foo.prototype.method = function() { return " world"; };
+
+	return Foo;
+}(Super));
+
+function additional1() {
+	return new ES5Class();
+}
+function additional2() {
+}
+global.additional1 = additional1;
+global.additional2 = additional2;
+
+inspect = function inspect() {
+  let c1 = additional1();
+	let c2 = additional1();
+  additional2();
+
+  return 'START' + c1 + ' ' + (c1.prototype === c2.prototype) + ' ' + (c1.method === c2.method);
+}
+}());

--- a/test/serializer/additional-functions/precise_captures.js
+++ b/test/serializer/additional-functions/precise_captures.js
@@ -1,0 +1,17 @@
+(function() {
+function Bar() {
+  return 123;
+}
+
+function Foo() {
+  return Bar();
+}
+
+if (global.__registerAdditionalFunctionToPrepack) __registerAdditionalFunctionToPrepack(Foo);
+
+global.Foo = Foo;
+
+inspect = function() {
+	return Foo();
+}
+}());

--- a/test/serializer/additional-functions/return-value-simple.js
+++ b/test/serializer/additional-functions/return-value-simple.js
@@ -6,6 +6,7 @@ global.z = 100;
 
 function additional1() {
   let x = 5;
+  var q = 5;
   return 23;
 }
 

--- a/test/serializer/basic/CircularFuncs.js
+++ b/test/serializer/basic/CircularFuncs.js
@@ -1,0 +1,32 @@
+// serialized function clone count: 0
+function f (x) {
+  var valueA = 0;
+  var valueB = 1;
+  var valueC = 2;
+
+  function a() { // no inline
+    valueA++;
+    return b();
+  }
+
+  function b() { // no inline
+    valueA++;
+    valueB++;
+    return c();
+  }
+
+  function c() {
+    if (valueA % 3) a();
+    x ? valueC++ : valueC += 2;
+    return valueA * valueB * valueC;
+  }
+
+  return a;
+}
+
+var s = f(true);
+var r = f(false);
+
+inspect = function() {
+  return s() + ' ' + r();
+}


### PR DESCRIPTION
This PR attempts to resolve issue #1140 #1093 making additional functions capture precisely the values the rewritten additional function will need. 

This is accomplished by visiting the additional function's effects when we encounter a `visitValueFunction` corresponding to that additional function. 

All values that need to be serialized in the parent scope of the additional function:
1. Object/Function captures that are
a. from the additional function or nested functions 
b. not in CreatedObjects (i.e. created in a parent scope)
2. additional function's captures that will be used by rewritten function
These are re-visited from the function's parent scope to make sure that we record the scopes for the bindings correctly.

`reVisitSet` ensures that Objects/Functions that need to be in a parent scope get placed in the correct parent scope by appending them to the common generator (where `_getTarget` would emit them). The other reason for this is that while serializing additional functions, they don't have access to previous generators/bodies. 

Other changes:
- `test-runner.js` now tests simpleClosures option. This makes test-serializer take a long time so 
- there is now a `--fast` option as well that runs each test only once.
- `test-runner.js` also has more error output giving actual stacktraces.
- added tests
- moved specialized binding functions into `visitBinding`
- add `react-mocks` compatibility option to CLI to be able to debug `test-react` with cli
