### PR TITLE
Deal with explicit property deletions inside abstract loops

### DIFF
--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -297,7 +297,7 @@ export class WidenImplementation {
       if (val1 === undefined) continue; // deleted
       let val2 = m2.get(key1);
       if (val2 === undefined) continue; // A key that disappears has been widened away into the unknown key
-      if (!f(val2, val1)) return false;
+      if (!f(val1, val2)) return false;
     }
     for (const key2 of m2.keys()) {
       if (!m1.has(key2)) return false;

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -245,7 +245,7 @@ export default class AbstractValue extends Value {
   mightBeNull(): boolean {
     let valueType = this.getType();
     if (valueType === NullValue) return true;
-    if (valueType !== Value) return false;
+    if (valueType !== PrimitiveValue && valueType !== Value) return false;
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(NullValue);
   }
@@ -253,23 +253,23 @@ export default class AbstractValue extends Value {
   mightNotBeNull(): boolean {
     let valueType = this.getType();
     if (valueType === NullValue) return false;
-    if (valueType !== Value) return true;
+    if (valueType !== PrimitiveValue && valueType !== Value) return true;
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(NullValue);
   }
 
   mightBeNumber(): boolean {
     let valueType = this.getType();
-    if (valueType === NumberValue) return true;
-    if (valueType !== Value) return false;
+    if (Value.isTypeCompatibleWith(valueType, NumberValue)) return true;
+    if (valueType !== PrimitiveValue && valueType !== Value) return false;
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(NumberValue);
   }
 
   mightNotBeNumber(): boolean {
     let valueType = this.getType();
-    if (valueType === NumberValue) return false;
-    if (valueType !== Value) return true;
+    if (Value.isTypeCompatibleWith(valueType, NumberValue)) return false;
+    if (valueType !== PrimitiveValue && valueType !== Value) return true;
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(NumberValue);
   }
@@ -293,7 +293,7 @@ export default class AbstractValue extends Value {
   mightBeString(): boolean {
     let valueType = this.getType();
     if (valueType === StringValue) return true;
-    if (valueType !== Value) return false;
+    if (valueType !== PrimitiveValue && valueType !== Value) return false;
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(StringValue);
   }
@@ -301,7 +301,7 @@ export default class AbstractValue extends Value {
   mightNotBeString(): boolean {
     let valueType = this.getType();
     if (valueType === StringValue) return false;
-    if (valueType !== Value) return true;
+    if (valueType !== PrimitiveValue && valueType !== Value) return true;
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(StringValue);
   }
@@ -309,7 +309,7 @@ export default class AbstractValue extends Value {
   mightBeUndefined(): boolean {
     let valueType = this.getType();
     if (valueType === UndefinedValue) return true;
-    if (valueType !== Value) return false;
+    if (valueType !== PrimitiveValue && valueType !== Value) return false;
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(UndefinedValue);
   }
@@ -317,7 +317,7 @@ export default class AbstractValue extends Value {
   mightNotBeUndefined(): boolean {
     let valueType = this.getType();
     if (valueType === UndefinedValue) return false;
-    if (valueType !== Value) return true;
+    if (valueType !== PrimitiveValue && valueType !== Value) return true;
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(UndefinedValue);
   }

--- a/test/serializer/abstract/DoWhile6c.js
+++ b/test/serializer/abstract/DoWhile6c.js
@@ -1,0 +1,10 @@
+let n = global.__abstract ? __abstract("number", "2") : 2;
+let i = 0;
+let ob = { j: 1 };
+do {
+  i++;
+  if (i == 1) delete ob.j; else ob.j = undefined;
+} while (i < n);
+let k = ob.j;
+
+inspect = function() { return k + " " + JSON.stringify(Reflect.ownKeys(ob)); }

--- a/test/serializer/abstract/DoWhile6d.js
+++ b/test/serializer/abstract/DoWhile6d.js
@@ -1,0 +1,10 @@
+let n = global.__abstract ? __abstract("number", "1") : 1;
+let i = 0;
+let ob = { j: 1 };
+do {
+  i++;
+  if (i == 1) delete ob.j; else ob.j = undefined;
+} while (i < n);
+let k = ob.j;
+
+inspect = function() { return k + " " + JSON.stringify(Reflect.ownKeys(ob)); }


### PR DESCRIPTION
Release note: none

Add some test cases that have loops that delete properties in some iterations but not others.
Deal with it by explicitly testing for __empty values.

Issue #1174