### PR TITLE
Error if an abstract function that might throw is called within a try

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -56,6 +56,7 @@ function runTest(name: string, code: string): boolean {
   let recover = code.includes("// recover-from-errors");
   let additionalFunctions = code.includes("// additional functions");
   let delayUnsupportedRequires = code.includes("// delay unsupported requires");
+  let abstractEffects = code.includes("// abstract effects");
 
   let expectedErrors = code.match(/\/\/\s*expected errors:\s*(.*)/);
   invariant(expectedErrors);
@@ -73,6 +74,7 @@ function runTest(name: string, code: string): boolean {
       errorHandler: errorHandler.bind(null, recover ? "Recover" : "Fail", errors),
       serialize: true,
       initializeMoreModules: false,
+      abstractEffectsInAdditionalFunctions: abstractEffects,
     };
     if (additionalFunctions) (options: any).additionalFunctions = ["global.additional1", "global['additional2']"];
     prepackFileSync([name], options);

--- a/src/realm.js
+++ b/src/realm.js
@@ -133,6 +133,7 @@ export class Realm {
     this.isReadOnly = false;
     this.useAbstractInterpretation = !!opts.serialize || !!opts.residual;
     this.trackLeaks = !!opts.abstractEffectsInAdditionalFunctions;
+    this.isInPureTryStatement = false;
     if (opts.mathRandomSeed !== undefined) {
       this.mathRandomGenerator = seedrandom(opts.mathRandomSeed);
     }
@@ -194,6 +195,7 @@ export class Realm {
   useAbstractInterpretation: boolean;
   trackLeaks: boolean;
   debugNames: void | boolean;
+  isInPureTryStatement: boolean; // TODO(1264): Remove this once we implement proper exception handling in abstract calls.
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;

--- a/test/error-handler/try-and-call-abstract-function.js
+++ b/test/error-handler/try-and-call-abstract-function.js
@@ -1,0 +1,36 @@
+// additional functions
+// abstract effects
+// expected errors: [{location: {"start":{"line":26,"column":11},"end":{"line":26,"column":21},"identifierName":"abstractFn","source":"test/error-handler/try-and-call-abstract-function.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possibly throwing function call inside try/catch"}]
+
+let abstractFn = global.__abstract ? __abstract('function', '(function() { return true; })') : function() { return true; };
+
+function concreteFunction() {
+  return true;
+}
+
+function additional1() {
+  let value;
+  try {
+    // This is ok.
+    value = concreteFunction();
+  } catch (x) {
+    value = false;
+  }
+  // This is ok.
+  return abstractFn(value);
+}
+
+function additional2() {
+  try {
+    // This is not ok.
+    return abstractFn();
+  } catch (x) {
+    return false;
+  }
+}
+
+inspect = function() {
+  let ret1 = additional1();
+  let ret2 = additional2();
+  return JSON.stringify({ ret1, ret2 });
+}


### PR DESCRIPTION
This is a follow up to #1142. If we call an unknown function it might throw which will take a different control flow. #1264 is the follow up to do this properly but since we don't have a use case right now, we can just issue a recoverable error if this happens.
