### PR TITLE
Fix additional function mutable binding function scope

### DIFF
--- a/src/react/hoisting.js
+++ b/src/react/hoisting.js
@@ -102,7 +102,9 @@ function canHoistAbstract(realm: Realm, abstract: AbstractValue, residualHeapVis
   // we can safely hoist abstracts that are created in the common scope
   if (scopes !== undefined) {
     for (let scope of scopes) {
-      if (scope === residualHeapVisitor.commonScope) {
+      const currentAdditionalFunction = residualHeapVisitor.commonScope;
+      invariant(currentAdditionalFunction instanceof FunctionValue);
+      if (scope === currentAdditionalFunction.parent) {
         return true;
       }
     }

--- a/test/serializer/additional-functions/referentialization.js
+++ b/test/serializer/additional-functions/referentialization.js
@@ -1,0 +1,18 @@
+(function() {
+  function additional() {
+    var obj = {};
+    global.nested = function() {
+      obj = {};
+      obj.p = 100;
+      return obj;
+    };
+    return obj;
+  }
+  if (global.__registerAdditionalFunctionToPrepack) {
+    global.__registerAdditionalFunctionToPrepack(additional);
+  }
+  inspect = function() {
+    additional();
+    return JSON.stringify(nested());
+  };
+})();

--- a/test/serializer/additional-functions/referentialization2.js
+++ b/test/serializer/additional-functions/referentialization2.js
@@ -1,0 +1,18 @@
+(function() {
+  var obj = {};
+  function additional() {
+    global.nested = function() {
+      obj = {};
+      obj.p = 100;
+      return obj;
+    };
+    return obj;
+  }
+  if (global.__registerAdditionalFunctionToPrepack) {
+    global.__registerAdditionalFunctionToPrepack(additional);
+  }
+  inspect = function() {
+    additional();
+    return JSON.stringify(nested());
+  };
+})();


### PR DESCRIPTION
Release Note: none

Fix #1238
The behavior of the bug is that, get_scope_binding() helper function is generated in wrong scope: global scope instead of additional function scope.
It happens because there are two scopes referencing it, additional function itself and its parent generator scope. The second one is problematic because "obj" is not referenced in parent generator scope. We should visitPropertiesAndBindings only from additional function scope itself instead of parent generator scope.

[The changes in react compiler]: with above change, all the hoistable react elements will be in additional function's parent generator scope so align the change in the react/hoisting.js file.