### PR TITLE
Print useful call stacks from prepack-cli

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -247,6 +247,9 @@ function run(
             1}) ${error.severity} ${error.errorCode}: ${error.message}` +
             ` (https://github.com/facebook/prepack/wiki/${error.errorCode})`
         );
+        if (foundFatal) {
+          console.error(error.callStack || "");
+        }
       }
     }
     return foundFatal;


### PR DESCRIPTION
Addresses [#1032](https://github.com/facebook/prepack/issues/1048)
Prints a stack that relates to the code being prepacked.