### PR TITLE
Unescape uniqueSuffix for test-runner output

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -255,6 +255,10 @@ function verifyFunctionOrderings(code: string): boolean {
   return true;
 }
 
+function unescapleUniqueSuffix(code: string, uniqueSuffix?: string) {
+  return uniqueSuffix != null ? code.replace(new RegExp(uniqueSuffix, "g"), "") : code;
+}
+
 function runTest(name, code, options: PrepackOptions, args) {
   console.log(chalk.inverse(name) + " " + JSON.stringify(options));
   let compatibility = code.includes("// jsc") ? "jsc-600-1-4-17" : undefined;
@@ -443,7 +447,7 @@ function runTest(name, code, options: PrepackOptions, args) {
           codeToRun = augmentCodeWithLazyObjectSupport(codeToRun, args.lazyObjectsRuntime);
         }
         if (args.verbose) console.log(codeToRun);
-        codeIterations.push(codeToRun);
+        codeIterations.push(unescapleUniqueSuffix(codeToRun, options.uniqueSuffix));
         if (args.es5) {
           codeToRun = transformWithBabel(codeToRun, [], [["env", { forceAllTransforms: true, modules: false }]]);
         }
@@ -480,8 +484,7 @@ function runTest(name, code, options: PrepackOptions, args) {
         }
         if (singleIterationOnly) return true;
         if (
-          oldCode.replace(new RegExp(oldUniqueSuffix, "g"), "") ===
-            newCode.replace(new RegExp(newUniqueSuffix, "g"), "") ||
+          unescapleUniqueSuffix(oldCode, oldUniqueSuffix) === unescapleUniqueSuffix(newCode, newUniqueSuffix) ||
           delayUnsupportedRequires
         ) {
           // The generated code reached a fixed point!


### PR DESCRIPTION
Release Note: none.

Currently, if a test failed, the output of the prepacked code is augmented with uniqueSuffix "_unique_27787". This makes the code very hard to read and not efficient for troubleshooting. 
Unescape uniqueSuffix for the Prepacked output to fix this issue. 

Furthermore, is there any deep technical reason that we need to use uniqueSuffix? I know it is supposed for test-runner fixed point calculation, but I do not see any technical reason it is needed. For example, I removed uniqueSuffix, all tests still pass. Let me know if you want me to remove it completely from test runner.