### PR TITLE
Provide for intrinsic abstract arrays

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -14,12 +14,13 @@ import {
   AbstractObjectValue,
   AbstractValue,
   BooleanValue,
+  ConcreteValue,
+  ECMAScriptSourceFunctionValue,
   FunctionValue,
   NativeFunctionValue,
-  ConcreteValue,
   ObjectValue,
+  StringValue,
   Value,
-  ECMAScriptSourceFunctionValue,
 } from "../../values/index.js";
 import { To } from "../../singletons.js";
 import { ValuesDomain } from "../../domains/index.js";
@@ -29,10 +30,13 @@ import invariant from "../../invariant.js";
 import { createAbstract, parseTypeNameOrTemplate } from "./utils.js";
 
 export function createAbstractFunction(realm: Realm, ...additionalValues: Array<ConcreteValue>): NativeFunctionValue {
-  return new NativeFunctionValue(realm, "global.__abstract", "__abstract", 0, (context, [typeNameOrTemplate, name]) =>
-    // this line really confuses Flow
-    createAbstract(realm, typeNameOrTemplate, ((name: any): string | void), ...additionalValues)
-  );
+  return new NativeFunctionValue(realm, "global.__abstract", "__abstract", 0, (context, [typeNameOrTemplate, name]) => {
+    if (name instanceof StringValue) name = name.value;
+    if (name !== undefined && typeof name !== "string") {
+      throw new TypeError("intrinsic name argument is not a string");
+    }
+    return createAbstract(realm, typeNameOrTemplate, name, ...additionalValues);
+  });
 }
 
 export default function(realm: Realm): void {

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -83,29 +83,28 @@ export function createAbstract(
     );
     if (locString !== undefined) break;
   }
-  let nameString = name ? To.ToStringPartial(realm, name) : "";
-  if (nameString === "") {
+  if (!name) {
     let locVal = new StringValue(realm, locString || "(unknown location)");
     let kind = "__abstract_" + realm.objectCount++; // need not be an object, but must be unique
     result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
   } else {
-    let kind = "__abstract_" + nameString;
-    if (!realm.isNameStringUnique(nameString)) {
+    let kind = "__abstract_" + name;
+    if (!realm.isNameStringUnique(name)) {
       let error = new CompilerDiagnostic("An abstract value with the same name exists", loc, "PP0019", "FatalError");
       realm.handleError(error);
       throw new FatalError();
     } else {
-      realm.saveNameString(nameString);
+      realm.saveNameString(name);
     }
-    result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(nameString), type, [], kind);
-    result.intrinsicName = nameString;
+    result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(name), type, [], kind);
+    result.intrinsicName = name;
   }
 
   if (template) result.values = new ValuesDomain(new Set([template]));
   if (template && !(template instanceof FunctionValue)) {
     // why exclude functions?
     template.makePartial();
-    if (nameString) realm.rebuildNestedProperties(result, nameString);
+    if (name) realm.rebuildNestedProperties(result, name);
   }
 
   if (additionalValues.length > 0)

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -567,7 +567,8 @@ export default class AbstractValue extends Value {
     realm: Realm,
     resultType: typeof Value,
     args: Array<Value>,
-    buildFunction: AbstractValueBuildNodeFunction
+    buildFunction: AbstractValueBuildNodeFunction,
+    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |}
   ): AbstractValue | UndefinedValue {
     let types = new TypesDomain(resultType);
     let values = ValuesDomain.topVal;
@@ -575,7 +576,7 @@ export default class AbstractValue extends Value {
     if (resultType === UndefinedValue) {
       return realm.generator.emitVoidExpression(types, values, args, buildFunction);
     } else {
-      return realm.generator.derive(types, values, args, buildFunction);
+      return realm.generator.derive(types, values, args, buildFunction, optionalArgs);
     }
   }
 

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -13,6 +13,7 @@ import type { BabelNodeSourceLocation } from "babel-types";
 import type { Realm } from "../realm.js";
 import {
   AbstractObjectValue,
+  ArrayValue,
   BooleanValue,
   ConcreteValue,
   EmptyValue,
@@ -68,6 +69,8 @@ export default class Value {
         return NumberValue;
       case "object":
         return ObjectValue;
+      case "array":
+        return ArrayValue;
       case "function":
         return FunctionValue;
       default:

--- a/test/error-handler/bad-functions.js
+++ b/test/error-handler/bad-functions.js
@@ -1,7 +1,7 @@
 // additional functions
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":8,"column":26},"end":{"line":8,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function global.additional1 may terminate abruptly"}]
-var wildcard = global.__abstract ? global.__abstract("number", 123, "123") : 123;
+var wildcard = global.__abstract ? global.__abstract("number", "123") : 123;
 global.a = "";
 
 function additional1() {

--- a/test/error-handler/bad-functions2.js
+++ b/test/error-handler/bad-functions2.js
@@ -2,7 +2,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":13,"column":26},"end":{"line":13,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions2.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function global['additional2'] may terminate abruptly"}]
 
-var wildcard = global.__abstract ? global.__abstract("number", 123, "123") : 123;
+var wildcard = global.__abstract ? global.__abstract("number", "123") : 123;
 global.a = "";
 
 function additional1() {

--- a/test/error-handler/binaryExpression.js
+++ b/test/error-handler/binaryExpression.js
@@ -1,8 +1,8 @@
 // recover-from-errors
 // expected errors: [{location: {"start":{"line":11,"column":12},"end":{"line":11,"column":13},"identifierName":"y","source":"test/error-handler/binaryExpression.js"}, errorCode: "PP0002", severity: "RecoverableError", message: "might be an object with an unknown valueOf or toString or Symbol.toPrimitive method"},{location: {"start":{"line":12,"column":6},"end":{"line":12,"column":7},"identifierName":"y","source":"test/error-handler/binaryExpression.js"}, errorCode: "PP0002", severity: "RecoverableError", message: "might be an object with an unknown valueOf or toString or Symbol.toPrimitive method"}, {"location":{"start":{"line":17,"column":5},"end":{"line":17,"column":6},"identifierName":"y","source":"test/error-handler/binaryExpression.js"},"severity":"RecoverableError","errorCode":"PP0002"}, {"location":{"start":{"line":17,"column":55},"end":{"line":17,"column":56},"identifierName":"y","source":"test/error-handler/binaryExpression.js"},"severity":"RecoverableError","errorCode":"PP0002"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
-var x = global.__abstract ? __abstract("number", 123) : 123;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
+var x = global.__abstract ? __abstract("number", "123") : 123;
 var badOb = { valueOf: function() { throw 13;} }
 var ob = global.__makePartial ? __makePartial({}) : badOb;
 var y = b ? ob : x;

--- a/test/error-handler/in1.js
+++ b/test/error-handler/in1.js
@@ -1,7 +1,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":9,"column":16},"end":{"line":9,"column":17},"identifierName":"b","source":"test/error-handler/in1.js"},"severity":"RecoverableError","errorCode":"PP0003"}, {"location":{"start":{"line":14,"column":12},"end":{"line":14,"column":13},"identifierName":"b","source":"test/error-handler/in1.js"},"severity":"RecoverableError","errorCode":"PP0003"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 var p = global.__abstract ? __abstract("string", '("abc")') : "abc";
 
 x1 = "xyz" in {};

--- a/test/error-handler/in2.js
+++ b/test/error-handler/in2.js
@@ -1,7 +1,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":13,"column":12},"end":{"line":13,"column":14},"identifierName":"a2","source":"test/error-handler/in2.js"},"severity":"RecoverableError","errorCode":"PP0004"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 var a0 = { "4": 5 };
 var a1 = global.__makeSimple ? __makeSimple({ '4': 5 }) : a0;
 

--- a/test/error-handler/instanceof.js
+++ b/test/error-handler/instanceof.js
@@ -1,7 +1,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":11,"column":20},"end":{"line":11,"column":23},"identifierName":"foo","source":"test/error-handler/instanceof.js"},"severity":"RecoverableError","errorCode":"PP0004"}, {"location":{"start":{"line":17,"column":20},"end":{"line":17,"column":21},"identifierName":"b","source":"test/error-handler/instanceof.js"},"severity":"RecoverableError","errorCode":"PP0003"}, {"location":{"start":{"line":23,"column":20},"end":{"line":23,"column":21},"identifierName":"f","source":"test/error-handler/instanceof.js"},"severity":"RecoverableError","errorCode":"PP0004"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 function foo(){};
 Object.defineProperty(foo, Symbol.hasInstance, { value: function() { throw 123; } })
 var f = global.__abstract ? __abstract("object", "foo") : foo;

--- a/test/error-handler/member.js
+++ b/test/error-handler/member.js
@@ -1,7 +1,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":8,"column":0},"end":{"line":8,"column":2},"identifierName":"oq","source":"test/error-handler/member.js"},"severity":"FatalError","errorCode":"PP0012"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 var o = global.__abstract ? __abstract("object", "({})") : {};
 var oq = b ? o : null;
 

--- a/test/error-handler/member2.js
+++ b/test/error-handler/member2.js
@@ -1,7 +1,7 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":8,"column":4},"end":{"line":8,"column":6},"identifierName":"oq","source":"test/error-handler/member2.js"},"severity":"FatalError","errorCode":"PP0012"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 var o = global.__abstract ? __abstract("object", "({})") : {};
 var oq = b ? o : null;
 

--- a/test/error-handler/unaryExpression.js
+++ b/test/error-handler/unaryExpression.js
@@ -1,8 +1,8 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":11,"column":10},"end":{"line":11,"column":19},"identifierName":"mysteryOb","source":"test/error-handler/unaryExpression.js"},"severity":"RecoverableError","errorCode":"PP0008"}, {"location":{"start":{"line":13,"column":10},"end":{"line":13,"column":19},"identifierName":"mysteryOb","source":"test/error-handler/unaryExpression.js"},"severity":"RecoverableError","errorCode":"PP0008"}, {"location":{"start":{"line":15,"column":10},"end":{"line":15,"column":19},"identifierName":"mysteryOb","source":"test/error-handler/unaryExpression.js"},"severity":"RecoverableError","errorCode":"PP0008"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
-var x = global.__abstract ? __abstract("number", 123) : 123;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
+var x = global.__abstract ? __abstract("number", "123") : 123;
 var badOb = {};
 if (global.__makeSimple) global.__makeSimple(badOb);
 badOb[Symbol.toPrimitive] = function() { throw 13;}

--- a/test/error-handler/updateExpression.js
+++ b/test/error-handler/updateExpression.js
@@ -1,8 +1,8 @@
 // recover-from-errors
 // expected errors: [{"location":{"start":{"line":10,"column":0},"end":{"line":10,"column":1},"identifierName":"y","source":"test/error-handler/updateExpression.js"},"severity":"RecoverableError","errorCode":"PP0008"}, {"location":{"start":{"line":11,"column":2},"end":{"line":11,"column":4},"identifierName":"ob","source":"test/error-handler/updateExpression.js"},"severity":"RecoverableError","errorCode":"PP0008"}]
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
-var x = global.__abstract ? __abstract("number", 123) : 123;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
+var x = global.__abstract ? __abstract("number", "123") : 123;
 var badOb = { valueOf: function() { throw 13;} }
 var ob = global.__abstract ? __abstract("object", "({ valueOf: function() { throw 13;} })") : badOb;
 var y = b ? ob : x;

--- a/test/serializer/abstract/BinaryExpression2.js
+++ b/test/serializer/abstract/BinaryExpression2.js
@@ -1,7 +1,7 @@
 // throws introspection error
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
-var x = global.__abstract ? __abstract("number", 123) : 123;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
+var x = global.__abstract ? __abstract("number", "123") : 123;
 var badOb = { valueOf: function() { throw 13;} }
 var ob = global.__abstract ? __abstract("object", "({ valueOf: function() { throw 13;} })") : badOb;
 var y = b ? ob : x;

--- a/test/serializer/abstract/DoWhile8a.js
+++ b/test/serializer/abstract/DoWhile8a.js
@@ -1,0 +1,10 @@
+let a = global.__abstract ? __makeSimple(__abstract("array", "[1, 2, 3]")) : [1, 2, 3];
+let i = 0;
+let b = [];
+do {
+  b[i] = a[i++];
+} while (i < a.length);
+let x = b[1];
+let j = b.length;
+
+inspect = function() { return i + " " + j + " " + x + " " + JSON.stringify(b); }

--- a/test/serializer/abstract/In2.js
+++ b/test/serializer/abstract/In2.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 var p = global.__abstract ? __abstract("string", '("abc")') : "abc";
 
 x1 = "xyz" in {};

--- a/test/serializer/abstract/In3.js
+++ b/test/serializer/abstract/In3.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 var a0 = { "4": 5 };
 var a1 = global.__abstract ? __abstract(a0, "({ '4': 5 })") : a0;
 if (global.__makeSimple) global.__makeSimple(a1);

--- a/test/serializer/abstract/Instanceof2.js
+++ b/test/serializer/abstract/Instanceof2.js
@@ -1,6 +1,6 @@
 // throws introspection error
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
 var o = global.__abstract ? __abstract("object", "({})") : {};
 
 try {

--- a/test/serializer/abstract/ToString.js
+++ b/test/serializer/abstract/ToString.js
@@ -1,4 +1,4 @@
-let x = global.__abstract ? __abstract("number", 42) : 42;
+let x = global.__abstract ? __abstract("number", "42") : 42;
 let s = x.toString();
 let t = s.toString();
 inspect = function() {

--- a/test/serializer/abstract/TypeDomain5.js
+++ b/test/serializer/abstract/TypeDomain5.js
@@ -1,6 +1,6 @@
 // does not contain:===
 (function() {
-  let x = global.__abstract? global.__abstract("boolean", true): true;
+  let x = global.__abstract? global.__abstract("boolean", "true"): true;
   let a = {};
   if (x) {
       a = 100;

--- a/test/serializer/abstract/UnaryExpression2.js
+++ b/test/serializer/abstract/UnaryExpression2.js
@@ -1,7 +1,7 @@
 // throws introspection error
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
-var x = global.__abstract ? __abstract("number", 123) : 123;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
+var x = global.__abstract ? __abstract("number", "123") : 123;
 var badOb = { valueOf: function() { throw 13;} }
 var ob = global.__abstract ? __abstract("object", "({ valueOf: function() { throw 13;} })") : badOb;
 var y = b ? ob : x;

--- a/test/serializer/abstract/UpdateExpression4.js
+++ b/test/serializer/abstract/UpdateExpression4.js
@@ -1,7 +1,7 @@
 // throws introspection error
 
-var b = global.__abstract ? __abstract("boolean", true) : true;
-var x = global.__abstract ? __abstract("number", 123) : 123;
+var b = global.__abstract ? __abstract("boolean", "true") : true;
+var x = global.__abstract ? __abstract("number", "123") : 123;
 badOb = { valueOf: function() { throw 13;} }
 var ob = global.__abstract ? __abstract("object", "badOb") : badOb;
 var y = b ? ob : x;


### PR DESCRIPTION
Release note: none

Add a do-while test where the termination condition involves the length of an abstract array.

Since we did not have abstract arrays, this is mainly about adding those. Also, there was no support for getting a property from an abstract object that is not template based, so added that too. Also added a special case to return an abstract value of type NumberValue if the abstract object is known to be an array and the property name is known to be "length".

Finally, fixed a typing error in createAbstractFunction. It turns out, ahem, that Flow was not confused at all, just obtused.