### PR TITLE
Fix website dropdowns

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -656,3 +656,8 @@ a.nav-item.is-brand {
 .oss-logo {
   height: 45px;
 }
+
+/* TETHER SELECT */
+.select.select-theme-dark {
+  z-index: 100;
+}


### PR DESCRIPTION
Issue https://github.com/facebook/prepack/issues/1296.

The previous version of Tether Select that was used in the website had `z-index: 100;` (still can check it in `gh-pages` branch) but in the version that we use from CDN, in order to reduce the size of Prepack repo, there is no `z-index`. So I've added it to the website styles.