### PR TITLE
Improve generator debugging for additional function

### DIFF
--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -86,7 +86,7 @@ export class WidenImplementation {
     let bindings = this.widenBindings(realm, bindings1, bindings2);
     let properties = this.widenPropertyBindings(realm, properties1, properties2, createdObj1, createdObj2);
     let createdObjects = new Set(); // Top, since the empty set knows nothing. There is no other choice for widen.
-    let generator = new Generator(realm); // code subject to widening will be generated somewhere else
+    let generator = new Generator(realm, "widen"); // code subject to widening will be generated somewhere else
     return [result, generator, bindings, properties, createdObjects];
   }
 

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -59,35 +59,39 @@ export class Reconciler {
       // TODO: (sebmarkbage): You could use the return value of this to detect if there are any mutations on objects other
       // than newly created ones. Then log those to the error logger. That'll help us track violations in
       // components. :)
-      this.realm.evaluateForEffects(() => {
-        // initialProps and initialContext are created from Flow types from:
-        // - if a functional component, the 1st and 2nd paramater of function
-        // - if a class component, use this.props and this.context
-        // if there are no Flow types for props or context, we will throw a
-        // FatalError, unless it's a functional component that has no paramater
-        // i.e let MyComponent = () => <div>Hello world</div>
-        try {
-          let initialProps = getInitialProps(this.realm, componentType);
-          let initialContext = getInitialContext(this.realm, componentType);
-          let { result } = this._renderComponent(componentType, initialProps, initialContext, "ROOT", null);
-          this.statistics.optimizedTrees++;
-          return result;
-        } catch (error) {
-          // if there was a bail-out on the root component in this reconcilation process, then this
-          // should be an invariant as the user has explicitly asked for this component to get folded
-          if (error instanceof ExpectedBailOut) {
-            let diagnostic = new CompilerDiagnostic(
-              `__registerReactComponentRoot() failed due to - ${error.message}`,
-              this.realm.currentLocation,
-              "PP0020",
-              "FatalError"
-            );
-            this.realm.handleError(diagnostic);
-            throw new FatalError();
+      this.realm.evaluateForEffects(
+        () => {
+          // initialProps and initialContext are created from Flow types from:
+          // - if a functional component, the 1st and 2nd paramater of function
+          // - if a class component, use this.props and this.context
+          // if there are no Flow types for props or context, we will throw a
+          // FatalError, unless it's a functional component that has no paramater
+          // i.e let MyComponent = () => <div>Hello world</div>
+          try {
+            let initialProps = getInitialProps(this.realm, componentType);
+            let initialContext = getInitialContext(this.realm, componentType);
+            let { result } = this._renderComponent(componentType, initialProps, initialContext, "ROOT", null);
+            this.statistics.optimizedTrees++;
+            return result;
+          } catch (error) {
+            // if there was a bail-out on the root component in this reconcilation process, then this
+            // should be an invariant as the user has explicitly asked for this component to get folded
+            if (error instanceof ExpectedBailOut) {
+              let diagnostic = new CompilerDiagnostic(
+                `__registerReactComponentRoot() failed due to - ${error.message}`,
+                this.realm.currentLocation,
+                "PP0020",
+                "FatalError"
+              );
+              this.realm.handleError(diagnostic);
+              throw new FatalError();
+            }
+            throw error;
           }
-          throw error;
-        }
-      })
+        },
+        /*state*/ null,
+        `react component: ${componentType.getName()}`
+      )
     );
   }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -424,16 +424,22 @@ export class Realm {
   // Evaluate the given ast in a sandbox and return the evaluation results
   // in the form of a completion, a code generator, a map of changed variable
   // bindings and a map of changed property bindings.
-  evaluateNodeForEffects(ast: BabelNode, strictCode: boolean, env: LexicalEnvironment, state?: any): Effects {
-    return this.evaluateForEffects(() => env.evaluateCompletionDeref(ast, strictCode), state);
+  evaluateNodeForEffects(
+    ast: BabelNode,
+    strictCode: boolean,
+    env: LexicalEnvironment,
+    state?: any,
+    generatorName?: string
+  ): Effects {
+    return this.evaluateForEffects(() => env.evaluateCompletionDeref(ast, strictCode), state, generatorName);
   }
 
   evaluateAndRevertInGlobalEnv(func: () => Value): void {
     this.wrapInGlobalEnv(() => this.evaluateForEffects(func));
   }
 
-  evaluateNodeForEffectsInGlobalEnv(node: BabelNode, state?: any): Effects {
-    return this.wrapInGlobalEnv(() => this.evaluateNodeForEffects(node, false, this.$GlobalEnv, state));
+  evaluateNodeForEffectsInGlobalEnv(node: BabelNode, state?: any, generatorName?: string): Effects {
+    return this.wrapInGlobalEnv(() => this.evaluateNodeForEffects(node, false, this.$GlobalEnv, state, generatorName));
   }
 
   partiallyEvaluateNodeForEffects(
@@ -452,13 +458,13 @@ export class Realm {
     return [effects, nodeAst, nodeIO];
   }
 
-  evaluateForEffects(f: () => Completion | Value, state: any): Effects {
+  evaluateForEffects(f: () => Completion | Value, state: any, generatorName: void | string): Effects {
     // Save old state and set up empty state for ast
     let [savedBindings, savedProperties] = this.getAndResetModifiedMaps();
     let saved_generator = this.generator;
     let saved_createdObjects = this.createdObjects;
     let saved_completion = this.savedCompletion;
-    this.generator = new Generator(this);
+    this.generator = new Generator(this, generatorName);
     this.createdObjects = new Set();
     this.savedCompletion = undefined; // while in this call, we only explore the normal path.
 

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -206,12 +206,6 @@ export class ResidualHeapSerializer {
   additionalFunctionValueNestedFunctions: Set<FunctionValue>;
   currentAdditionalFunction: void | FunctionValue;
 
-  _getScopeName(s: Scope): string {
-    if (s instanceof Generator) return s.getName();
-    invariant(s instanceof FunctionValue);
-    return s.getName();
-  }
-
   // Configures all mutable aspects of an object, in particular:
   // symbols, properties, prototype.
   // For every created object that corresponds to a value,
@@ -718,10 +712,10 @@ export class ResidualHeapSerializer {
         if (this._options.debugScopes) {
           let scopes = this.residualValues.get(val);
           invariant(scopes !== undefined);
-          const scopeList = Array.from(scopes).map(s => `"${this._getScopeName(s)}"`).join(",");
+          const scopeList = Array.from(scopes).map(s => `"${s.getName()}"`).join(",");
           let comment = `${this._getValueDebugName(val)} referenced from scopes [${scopeList}]`;
           if (target.commonAncestor !== undefined)
-            comment = `${comment} with common ancestor: ${this._getScopeName(target.commonAncestor)}`;
+            comment = `${comment} with common ancestor: ${target.commonAncestor.getName()}`;
           if (target.description !== undefined) comment = `${comment} => ${target.description} `;
           this.emitter.emit(commentStatement(comment));
         }
@@ -1374,9 +1368,9 @@ export class ResidualHeapSerializer {
     this.activeGeneratorBodies.delete(generator);
     const statements = this.emitter.endEmitting(generator, oldBody).entries;
     if (this._options.debugScopes) {
-      let comment = `generator "${this._getScopeName(generator)}"`;
+      let comment = `generator "${generator.getName()}"`;
       if (generator.parent !== undefined) {
-        comment = `${comment} with parent "${this._getScopeName(generator.parent)}"`;
+        comment = `${comment} with parent "${generator.parent.getName()}"`;
       }
       statements.unshift(commentStatement("begin " + comment));
       statements.push(commentStatement("end " + comment));

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -185,7 +185,11 @@ export class Functions {
       // There may also be warnings reported for errors that happen inside imported modules that can be postponed.
 
       let effects = this.realm.evaluatePure(() =>
-        this.realm.evaluateNodeForEffectsInGlobalEnv(call, this.moduleTracer)
+        this.realm.evaluateNodeForEffectsInGlobalEnv(
+          call,
+          this.moduleTracer,
+          `additional function(${funcValue.getName()})`
+        )
       );
       let additionalFunctionEffects = this._createAdditionalEffects(effects);
       this.writeEffects.set(funcValue, additionalFunctionEffects);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -37,7 +37,7 @@ export class Serializer {
   constructor(realm: Realm, serializerOptions: SerializerOptions = {}) {
     invariant(realm.useAbstractInterpretation);
     // Start tracking mutations
-    realm.generator = new Generator(realm);
+    realm.generator = new Generator(realm, "main");
 
     this.realm = realm;
     this.logger = new Logger(this.realm, !!serializerOptions.internalDebug);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -81,7 +81,7 @@ function serializeBody(generator: Generator, context: SerializationContext): Bab
 }
 
 export class Generator {
-  constructor(realm: Realm) {
+  constructor(realm: Realm, name: void | string) {
     invariant(realm.useAbstractInterpretation);
     let realmPreludeGenerator = realm.preludeGenerator;
     invariant(realmPreludeGenerator);
@@ -90,6 +90,7 @@ export class Generator {
     this.realm = realm;
     this._entries = [];
     this.id = realm.nextGeneratorId++;
+    this._name = name;
   }
 
   realm: Realm;
@@ -97,6 +98,11 @@ export class Generator {
   preludeGenerator: PreludeGenerator;
   parent: void | Generator;
   id: number;
+  _name: void | string;
+
+  getName(): string {
+    return this._name || `#${this.id}`;
+  }
 
   getAsPropertyNameExpression(key: string, canBeIdentifier: boolean = true) {
     // If key is a non-negative numeric string literal, parse it and set it as a numeric index instead.

--- a/src/values/BoundFunctionValue.js
+++ b/src/values/BoundFunctionValue.js
@@ -23,6 +23,11 @@ export default class BoundFunctionValue extends FunctionValue {
   $BoundThis: Value;
   $BoundArguments: Array<Value>;
 
+  // Override.
+  getName(): string {
+    return "Bound";
+  }
+
   hasDefaultLength(): boolean {
     let f = this.$BoundTargetFunction;
     if (!(f instanceof FunctionValue) || !f.hasDefaultLength()) return false;

--- a/src/values/ECMAScriptSourceFunctionValue.js
+++ b/src/values/ECMAScriptSourceFunctionValue.js
@@ -11,8 +11,10 @@
 
 import type { Realm } from "../realm.js";
 import type { BabelNodeBlockStatement, BabelNodeSourceLocation, BabelNodeLVal } from "babel-types";
+import type { FunctionBodyAstNode } from "../types.js";
 import { ECMAScriptFunctionValue } from "./index.js";
 import * as t from "babel-types";
+import invariant from "../invariant";
 
 /* Non built-in ECMAScript function objects with source code */
 export default class ECMAScriptSourceFunctionValue extends ECMAScriptFunctionValue {
@@ -24,6 +26,14 @@ export default class ECMAScriptSourceFunctionValue extends ECMAScriptFunctionVal
   $FormalParameters: Array<BabelNodeLVal>;
   $ECMAScriptCode: BabelNodeBlockStatement;
   loc: ?BabelNodeSourceLocation;
+
+  // Override.
+  getName(): string {
+    const uniqueTag = ((this.$ECMAScriptCode: any): FunctionBodyAstNode).uniqueOrderedTag;
+    // Should only be called after the function is initialized.
+    invariant(uniqueTag);
+    return this.__originalName ? this.__originalName : `f#${uniqueTag}`;
+  }
 
   hasDefaultLength(): boolean {
     let params = this.$FormalParameters;

--- a/src/values/FunctionValue.js
+++ b/src/values/FunctionValue.js
@@ -35,6 +35,10 @@ export default class FunctionValue extends ObjectValue {
   // Allows for residual function with inference of parameters
   isUnsafeResidual: void | true;
 
+  getName(): string {
+    throw new Error("Abstract method");
+  }
+
   getKind(): ObjectKind {
     return "Function";
   }

--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -101,6 +101,11 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
   callback: NativeFunctionCallback;
   length: number;
 
+  // Override.
+  getName(): string {
+    return this.name;
+  }
+
   callCallback(
     context: UndefinedValue | NullValue | ObjectValue | AbstractObjectValue,
     argsList: Array<Value>,


### PR DESCRIPTION
Release Note: improve generator debugging for additional function

While investigating additional function/react, I found it is very hard to distinguish the additional function's generator from sub-generators in global code.
This PR adds some debugging support to ease the pain:
1. All the additional function generator will have name "additional function(name)"
2. React elements generator will have name "React element(name)"
3. Function's debug name is consolidated into FunctionValue class API so that it is easier to use.
4. Generators in additional function will also emit its scope range under --debugScopes option.
