### PR TITLE
Website publication script should remove its temporary directories

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -5,6 +5,7 @@
 .*/lib/.*
 .*/test/serializer/.*
 .*/scripts/prettier.js
+.*/tmp_website_build/.*
 
 [include]
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 npm-debug.log
 .DS_Store
 build/
+tmp_website_build/
 coverage*/
 .vscode
 facebook/test

--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -10,8 +10,8 @@ SRC_DIR="website"
 DEST_BRANCH="gh-pages"
 DEST_DIR="."
 
-TMP_DIR="$PWD/build" # careful, the script will rm -rf this directory
-                     # make sure it's an absolute path
+TMP_DIR="$PWD/tmp_website_build" # careful, the script will rm -rf this directory
+                                 # make sure it's an absolute path
 SRC_CLONE_DIR="$TMP_DIR/master"
 DEST_CLONE_DIR="$TMP_DIR/gh-pages"
 
@@ -30,6 +30,11 @@ print_ok() { print_green "[ OK ]\n"; }
 print_error() { print_red "[ ERROR ]\n"; }
 pushd_quiet() { pushd $1 > /dev/null; }
 popd_quiet() { popd $1 > /dev/null; }
+remove_tmp_dir() {
+  if [ -d $TMP_DIR ]; then
+    rm -rf $TMP_DIR
+  fi
+}
 
 echo ---------------------------------------------------------------------------
 echo "This script will erase the content of the destination branch and replace \
@@ -54,9 +59,7 @@ fi
 
 # Clean build directory to fetch a fresh copy of the branches everytime the
 # script is run. Stateless scripts are easier to debug.
-if [ -d $TMP_DIR ]; then
-  rm -rf $TMP_DIR
-fi
+remove_tmp_dir
 
 print_green "Cloning source branch from remote..."
 git clone --single-branch -b $SRC_BRANCH $ORIGIN_URI $SRC_CLONE_DIR
@@ -106,7 +109,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
   popd_quiet
   print_ok
 else
-  print_error
   echo "Operation aborted. Changes have not been pushed to origin/$DEST_BRANCH."
-  echo "Commit can be pushed manually from $DEST_CLONE_DIR."
+  print_error
 fi
+
+print_green "Cleanup! Removing temporary files..."
+remove_tmp_dir
+print_ok


### PR DESCRIPTION
The [website publication script](https://github.com/facebook/prepack/blob/master/scripts/publish-gh-pages.sh) creates a temporary directory (`build`) to fetch fresh copies of the `master` and `gh-pages` branches.

This temporary directory is not removed and causes `flow` to check it when running `yarn flow`, causing many errors.

To address this issue, this PR:
- Changes the publication script to clean up temporary directories at the end of its execution
- Renames the temporary directory name from `build` to `tmp_website_build` to make it clearer that it can be safely removed, should the script fail to remove it
- Changes `.gitignore` and `.flowconfig` to ignore the temporary directory, should the script fail to remove it

Thanks to @hermanventer for reporting the issue