### PR TITLE
Fix duplicate edges issue in Prepack heap visualization

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -9,7 +9,6 @@
 
 /* @flow */
 
-import type { HeapGraphFormat } from "./types";
 import type { ErrorHandler } from "./errors.js";
 
 export type Compatibility = "browser" | "jsc-600-1-4-17" | "node-source-maps" | "node-cli" | "react-mocks";
@@ -48,7 +47,7 @@ export type SerializerOptions = {
   inlineExpressions?: boolean,
   simpleClosures?: boolean,
   trace?: boolean,
-  heapGraphFormat?: HeapGraphFormat,
+  heapGraphFormat?: "DotLanguage" | "VISJS",
 };
 
 export type PartialEvaluatorOptions = {

--- a/src/options.js
+++ b/src/options.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import type { HeapGraphFormat } from "./types";
 import type { ErrorHandler } from "./errors.js";
 
 export type Compatibility = "browser" | "jsc-600-1-4-17" | "node-source-maps" | "node-cli" | "react-mocks";
@@ -47,7 +48,7 @@ export type SerializerOptions = {
   inlineExpressions?: boolean,
   simpleClosures?: boolean,
   trace?: boolean,
-  heapGraph?: boolean,
+  heapGraphFormat?: HeapGraphFormat,
 };
 
 export type PartialEvaluatorOptions = {

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -201,7 +201,7 @@ function run(
       timeout: timeout,
       additionalFunctions: additionalFunctions,
       lazyObjectsRuntime: lazyObjectsRuntime,
-      heapGraphFilePath: heapGraphFilePath,
+      heapGraphFormat: "DotLanguage",
       debugInFilePath: debugInFilePath,
       debugOutFilePath: debugOutFilePath,
     },

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -9,7 +9,6 @@
 
 /* @flow */
 
-import type { HeapGraphFormat } from "./types";
 import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility, DebuggerOptions, ReactOutputTypes } from "./options";
 import { Realm } from "./realm.js";
@@ -20,7 +19,7 @@ export type PrepackOptions = {|
   additionalFunctions?: Array<string>,
   abstractEffectsInAdditionalFunctions?: boolean,
   lazyObjectsRuntime?: string,
-  heapGraphFormat?: HeapGraphFormat,
+  heapGraphFormat?: "DotLanguage" | "VISJS",
   compatibility?: Compatibility,
   debugNames?: boolean,
   delayInitializations?: boolean,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import type { HeapGraphFormat } from "./types";
 import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility, DebuggerOptions, ReactOutputTypes } from "./options";
 import { Realm } from "./realm.js";
@@ -19,7 +20,7 @@ export type PrepackOptions = {|
   additionalFunctions?: Array<string>,
   abstractEffectsInAdditionalFunctions?: boolean,
   lazyObjectsRuntime?: string,
-  heapGraphFilePath?: string,
+  heapGraphFormat?: HeapGraphFormat,
   compatibility?: Compatibility,
   debugNames?: boolean,
   delayInitializations?: boolean,
@@ -90,7 +91,7 @@ export function getRealmOptions({
 export function getSerializerOptions({
   additionalFunctions,
   lazyObjectsRuntime,
-  heapGraphFilePath,
+  heapGraphFormat,
   delayInitializations = false,
   delayUnsupportedRequires = false,
   accelerateUnsupportedRequires = true,
@@ -117,11 +118,13 @@ export function getSerializerOptions({
     inlineExpressions,
     simpleClosures,
     trace,
-    heapGraph: !!heapGraphFilePath,
   };
   if (additionalFunctions) result.additionalFunctions = additionalFunctions;
   if (lazyObjectsRuntime !== undefined) {
     result.lazyObjectsRuntime = lazyObjectsRuntime;
+  }
+  if (heapGraphFormat !== undefined) {
+    result.heapGraphFormat = heapGraphFormat;
   }
   return result;
 }

--- a/src/serializer/ResidualHeapGraphGenerator.js
+++ b/src/serializer/ResidualHeapGraphGenerator.js
@@ -14,7 +14,6 @@ import type { Modules } from "./modules.js";
 import type { Realm } from "../realm.js";
 import type { ObjectRefCount, AdditionalFunctionEffects } from "./types.js";
 import type { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers";
-import type { HeapGraphFormat } from "../types";
 
 import invariant from "../invariant.js";
 import {
@@ -198,7 +197,7 @@ export class ResidualHeapGraphGenerator extends ResidualHeapVisitor {
     return shape;
   }
 
-  generateResult(heapGraphFormat: HeapGraphFormat): string {
+  generateResult(heapGraphFormat: "DotLanguage" | "VISJS"): string {
     return heapGraphFormat === "DotLanguage"
       ? this._generateDotGraphData(this._visitedValues, this._edges)
       : this._generateVisJSGraphData(this._visitedValues, this._edges);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -143,7 +143,7 @@ export class Serializer {
     );
 
     let heapGraph;
-    if (this.options.heapGraph) {
+    if (this.options.heapGraphFormat) {
       const heapRefCounter = new ResidualHeapRefCounter(
         this.realm,
         this.logger,
@@ -161,7 +161,8 @@ export class Serializer {
         heapRefCounter.getResult()
       );
       heapGraphGenerator.visitRoots();
-      heapGraph = heapGraphGenerator.generateResult();
+      invariant(this.options.heapGraphFormat);
+      heapGraph = heapGraphGenerator.generateResult(this.options.heapGraphFormat);
     }
 
     // Phase 2: Let's serialize the heap and generate code.

--- a/src/types.js
+++ b/src/types.js
@@ -997,6 +997,3 @@ export type ToType = {
   // ECMA262 7.1.16
   CanonicalNumericIndexString(realm: Realm, argument: StringValue): number | void,
 };
-
-// VIS.JS is used by https://prepack.io REPL to visualize the graph.
-export type HeapGraphFormat = "DotLanguage" | "VISJS";

--- a/src/types.js
+++ b/src/types.js
@@ -997,3 +997,6 @@ export type ToType = {
   // ECMA262 7.1.16
   CanonicalNumericIndexString(realm: Realm, argument: StringValue): number | void,
 };
+
+// VIS.JS is used by https://prepack.io REPL to visualize the graph.
+export type HeapGraphFormat = "DotLanguage" | "VISJS";

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -1,13 +1,13 @@
 self.importScripts('prepack.min.js');
 
 onmessage = function(e) {
-  var buffer = [];
+  let buffer = [];
 
   function errorHandler(error) {
     // Syntax errors contain their location at the end, remove that
-    if (error.errorCode === 'PP1004') {
+    if (error.errorCode === "PP1004") {
       let msg = error.message;
-      error.message = msg.substring(0, msg.lastIndexOf('('));
+      error.message = msg.substring(0, msg.lastIndexOf("("));
     }
     buffer.push({
       severity: error.severity,
@@ -15,25 +15,25 @@ onmessage = function(e) {
       message: error.message,
       errorCode: error.errorCode,
     });
-    return 'Recover';
+    return "Recover";
   }
 
   try {
-    var sources = [{ filePath: 'dummy', fileContents: e.data.code }];
-    var options = {
-      compatibility: 'browser',
-      filename: 'repl',
+    let sources = [{ filePath: "dummy", fileContents: e.data.code }];
+    let options = {
+      compatibility: "browser",
+      filename: "repl",
       timeout: 1000,
       serialize: true,
-      heapGraphFilePath: "/tmp/foo.txt", /* this path will not be used, it is needed to trigger the graph computation */
+      heapGraphFormat: "VISJS",
       errorHandler,
     };
-    for (var property in e.data.options) {
+    for (let property in e.data.options) {
       if (e.data.options.hasOwnProperty(property)) {
         options[property] = e.data.options[property];
       }
     }
-    var result = Prepack.prepackSources(sources, options);
+    let result = Prepack.prepackSources(sources, options);
     if (result && !buffer.length) {
       postMessage({ type: 'success', data: result.code, graph: result.heapGraph });
     } else {


### PR DESCRIPTION
Release Note: Fix duplicate edges issue in Prepack heap visualization.

This PR did two things:
1. Fix duplicate edges issue in Prepack heap visualization by using unique identifier for edge id field.(#1300)
2. Prepack heap visualization supports two formats: 1. Dot language formatted used by CLI. 2. JSON format used by Vis.js library to visualize in website REPL. This PR allows both. 