### PR TITLE
Detect abstract recursion

### DIFF
--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -367,11 +367,11 @@ export class WidenImplementation {
     v2: void | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
   ): boolean {
     let e = (v1 && v1[0]) || (v2 && v2[0]);
-    if (e instanceof Value) return this._containsArraysOfValue((v1: any), (v2: any));
+    if (e instanceof Value) return this.containsArraysOfValue((v1: any), (v2: any));
     else return this._containsArrayOfsMapEntries((v1: any), (v2: any));
   }
 
-  _containsArraysOfValue(
+  _containsArrayOfsMapEntries(
     realm: Realm,
     a1: void | Array<{ $Key: void | Value, $Value: void | Value }>,
     a2: void | Array<{ $Key: void | Value, $Value: void | Value }>
@@ -393,13 +393,13 @@ export class WidenImplementation {
     return true;
   }
 
-  _containsArrayOfsMapEntries(realm: Realm, a1: void | Array<Value>, a2: void | Array<Value>): boolean {
+  containsArraysOfValue(realm: Realm, a1: void | Array<Value>, a2: void | Array<Value>): boolean {
     let n = Math.max((a1 && a1.length) || 0, (a2 && a2.length) || 0);
     for (let i = 0; i < n; i++) {
       let [val1, val2] = [a1 && a1[i], a2 && a2[i]];
       if (val1 instanceof Value && val2 instanceof Value && !this._containsValues(val1, val2)) return false;
     }
-    return false;
+    return true;
   }
 
   _containsValues(val1: Value, val2: Value) {

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -214,6 +214,7 @@ function EvaluateCall(
   // 8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
 
   try {
+    realm.currentLocation = ast.loc; // this helps us to detect recursive calls
     return EvaluateDirectCallWithArgList(realm, strictCode, env, ref, func, thisValue, argList, tailCall);
   } catch (err) {
     if (err instanceof Completion) return err;

--- a/src/serializer/modules.js
+++ b/src/serializer/modules.js
@@ -170,10 +170,12 @@ export class ModuleTracer extends Tracer {
             do {
               try {
                 effects = realm.evaluateForEffects(() => performCall(), this);
-              } catch (e) {}
+              } catch (e) {
+                e;
+              }
 
               acceleratedModuleIds = [];
-              if (isTopLevelRequire) {
+              if (isTopLevelRequire && effects !== undefined && !(effects[0] instanceof AbruptCompletion)) {
                 // We gathered all effects, but didn't apply them yet.
                 // Let's check if there was any call to `require` in a
                 // evaluate-for-effects context. If so, try to initialize

--- a/src/types.js
+++ b/src/types.js
@@ -877,6 +877,8 @@ export type WidenType = {
     v2: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
   ): Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
 
+  containsArraysOfValue(realm: Realm, a1: void | Array<Value>, a2: void | Array<Value>): boolean,
+
   // If e2 is the result of a loop iteration starting with effects e1 and it has a subset of elements of e1,
   // then we have reached a fixed point and no further calls to widen are needed. e1/e2 represent a general
   // summary of the loop, regardless of how many iterations will be performed at runtime.

--- a/src/values/ECMAScriptFunctionValue.js
+++ b/src/values/ECMAScriptFunctionValue.js
@@ -11,7 +11,8 @@
 
 import type { Realm } from "../realm.js";
 import type { ObjectValue } from "./index.js";
-import { FunctionValue } from "./index.js";
+import { FunctionValue, Value } from "./index.js";
+import type { BabelNodeSourceLocation } from "babel-types";
 
 /* Abstract base class for non-exotic function objects(either with source or built-in) */
 export default class ECMAScriptFunctionValue extends FunctionValue {
@@ -23,4 +24,6 @@ export default class ECMAScriptFunctionValue extends FunctionValue {
   $ThisMode: "lexical" | "strict" | "global";
   $HomeObject: void | ObjectValue;
   $FunctionKind: "normal" | "classConstructor" | "generator";
+  activeArguments: void | Map<BabelNodeSourceLocation, [number, Array<Value>]>;
+  isSelfRecursive: boolean;
 }

--- a/test/serializer/abstract/Fibonacci.js
+++ b/test/serializer/abstract/Fibonacci.js
@@ -1,0 +1,11 @@
+// throws introspection error
+let n = global.__abstract ? global.__abstract("number", "4") : 4;
+
+function fibonacci(x) {
+  return x <= 1 ? x : fibonacci(x - 1) + fibonacci(x - 2);
+}
+
+let x = fibonacci(n);
+let y = typeof x;
+
+inspect = function() { return x + " " + y; }


### PR DESCRIPTION
This is the first step towards handling recursive functions where the recursive calls as guarded by abstract conditions. Prior to this, Prepack failed with a stack overflow. Now it detects such calls and computes a fixed point to model its state.

As yet, the resulting state cannot be serialized, so currently such recursive functions fail with a generic diagnostic message.

The basic idea is to record the calling arguments and location of each active call that occurs in a guarded block. If the same calling location is reached again, but with an additional guard, this is likely an recursion what will not terminate, so the arguments to the new call are widened and the recording is updated. At some point the recorded arguments contain the widened arguments and a fixed point is reached. At that point the nested call is declared as abstract recursive and it is replaced with an abstract value with domains all set to Top. Eventually, a set of effects is computed for the outer most call.

In future pull requests, these effects will be used to generate a residual function that can be called at runtime (so that recursion can be used).