### PR TITLE
Adds `abstractEffectsInAdditionalFunctions` to the React component reconciler

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -32,6 +32,7 @@ function runTestSuite(outputJsx) {
     inlineExpressions: true,
     simpleClosures: true,
     omitInvariants: true,
+    abstractEffectsInAdditionalFunctions: true,
   };
 
   function compileSourceWithPrepack(source) {
@@ -111,6 +112,14 @@ function runTestSuite(outputJsx) {
 
       it("Simple", async () => {
         await runTest(directory, "simple.js");
+      });
+
+      it("Simple 2", async () => {
+        await runTest(directory, "simple-2.js");
+      });
+
+      it("Simple 3", async () => {
+        await runTest(directory, "simple-3.js");
       });
 
       it("Simple children", async () => {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -56,41 +56,43 @@ export class Reconciler {
 
   render(componentType: ECMAScriptSourceFunctionValue): Effects {
     return this.realm.wrapInGlobalEnv(() =>
-      // TODO: (sebmarkbage): You could use the return value of this to detect if there are any mutations on objects other
-      // than newly created ones. Then log those to the error logger. That'll help us track violations in
-      // components. :)
-      this.realm.evaluateForEffects(
-        () => {
-          // initialProps and initialContext are created from Flow types from:
-          // - if a functional component, the 1st and 2nd paramater of function
-          // - if a class component, use this.props and this.context
-          // if there are no Flow types for props or context, we will throw a
-          // FatalError, unless it's a functional component that has no paramater
-          // i.e let MyComponent = () => <div>Hello world</div>
-          try {
-            let initialProps = getInitialProps(this.realm, componentType);
-            let initialContext = getInitialContext(this.realm, componentType);
-            let { result } = this._renderComponent(componentType, initialProps, initialContext, "ROOT", null);
-            this.statistics.optimizedTrees++;
-            return result;
-          } catch (error) {
-            // if there was a bail-out on the root component in this reconcilation process, then this
-            // should be an invariant as the user has explicitly asked for this component to get folded
-            if (error instanceof ExpectedBailOut) {
-              let diagnostic = new CompilerDiagnostic(
-                `__registerReactComponentRoot() failed due to - ${error.message}`,
-                this.realm.currentLocation,
-                "PP0020",
-                "FatalError"
-              );
-              this.realm.handleError(diagnostic);
-              throw new FatalError();
+      this.realm.evaluatePure(() =>
+        // TODO: (sebmarkbage): You could use the return value of this to detect if there are any mutations on objects other
+        // than newly created ones. Then log those to the error logger. That'll help us track violations in
+        // components. :)
+        this.realm.evaluateForEffects(
+          () => {
+            // initialProps and initialContext are created from Flow types from:
+            // - if a functional component, the 1st and 2nd paramater of function
+            // - if a class component, use this.props and this.context
+            // if there are no Flow types for props or context, we will throw a
+            // FatalError, unless it's a functional component that has no paramater
+            // i.e let MyComponent = () => <div>Hello world</div>
+            try {
+              let initialProps = getInitialProps(this.realm, componentType);
+              let initialContext = getInitialContext(this.realm, componentType);
+              let { result } = this._renderComponent(componentType, initialProps, initialContext, "ROOT", null);
+              this.statistics.optimizedTrees++;
+              return result;
+            } catch (error) {
+              // if there was a bail-out on the root component in this reconcilation process, then this
+              // should be an invariant as the user has explicitly asked for this component to get folded
+              if (error instanceof ExpectedBailOut) {
+                let diagnostic = new CompilerDiagnostic(
+                  `__registerReactComponentRoot() failed due to - ${error.message}`,
+                  this.realm.currentLocation,
+                  "PP0020",
+                  "FatalError"
+                );
+                this.realm.handleError(diagnostic);
+                throw new FatalError();
+              }
+              throw error;
             }
-            throw error;
-          }
-        },
-        /*state*/ null,
-        `react component: ${componentType.getName()}`
+          },
+          /*state*/ null,
+          `react component: ${componentType.getName()}`
+        )
       )
     );
   }

--- a/test/react/functional-components/simple-2.js
+++ b/test/react/functional-components/simple-2.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>Hello {props.x}</div>;
+}
+
+function App(props: any) {
+  return (
+    <div>
+      <A x={props.x.toString()} />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root x={10} />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/simple-3.js
+++ b/test/react/functional-components/simple-3.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>Hello {props.x}</div>;
+}
+
+function App(props: any) {
+  return (
+    <div>
+      <A x={props.toString()} />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root x={10} />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
This adds the `abstractEffectsInAdditionalFunctions` features to the React component reconciler, so we can better handle bail-outs in React components due to abstract value effects. This PR also adds a test to demonstrate this working – which currently fails right now.