### PR TITLE
Support Abstract Property Access in Pure Functions

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -53,6 +53,7 @@ import { HasProperty, Get, IsExtensible, HasOwnProperty, IsDataDescriptor } from
 import { Environment, Leak, Properties, To } from "./singletons.js";
 import * as t from "babel-types";
 import { TypesDomain, ValuesDomain } from "./domains/index.js";
+import PrimitiveValue from "./values/PrimitiveValue";
 
 const sourceMap = require("source-map");
 
@@ -1326,9 +1327,18 @@ export class LexicalEnvironment {
 export type BaseValue = void | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue | EnvironmentRecord;
 export type ReferenceName = string | SymbolValue;
 
-export function canBecomeAnObject(base: Value): boolean {
+export function mightBecomeAnObject(base: Value): boolean {
   let type = base.getType();
-  return type === BooleanValue || type === StringValue || type === SymbolValue || type === NumberValue;
+  // The top Value type might be able to become an object. We let it
+  // pass and error later if it can't.
+  return (
+    type === Value ||
+    type === PrimitiveValue ||
+    type === BooleanValue ||
+    type === StringValue ||
+    type === SymbolValue ||
+    type === NumberValue
+  );
 }
 
 export class Reference {
@@ -1348,7 +1358,7 @@ export class Reference {
         base === undefined ||
         base instanceof ObjectValue ||
         base instanceof EnvironmentRecord ||
-        canBecomeAnObject(base)
+        mightBecomeAnObject(base)
     );
     this.base = base;
     this.referencedName = refName;

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -74,6 +74,10 @@ export function RequireObjectCoercible(
   argLoc?: ?BabelNodeSourceLocation
 ): AbstractValue | ObjectValue | BooleanValue | StringValue | SymbolValue | NumberValue {
   if (arg instanceof AbstractValue && (arg.mightBeNull() || arg.mightBeUndefined())) {
+    if (realm.isInPureScope()) {
+      // In a pure function it is ok to throw if this happens to be null or undefined.
+      return arg;
+    }
     if (argLoc) {
       let error = new CompilerDiagnostic("member expression object is unknown", argLoc, "PP0012", "FatalError");
       realm.handleError(error);

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -127,6 +127,11 @@ export class EnvironmentImplementation {
 
     // 5. If IsPropertyReference(V) is true, then
     if (this.IsPropertyReference(realm, V)) {
+      if (base instanceof AbstractValue) {
+        // Ensure that abstract values are coerced to objects. This might yield
+        // an operation that might throw.
+        base = To.ToObjectPartial(realm, base);
+      }
       // a. If HasPrimitiveBase(V) is true, then
       if (this.HasPrimitiveBase(realm, V)) {
         // i. Assert: In this case, base will never be null or undefined.

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1488,7 +1488,10 @@ export class ResidualHeapSerializer {
   }
 
   _serializeAbstractValue(val: AbstractValue): void | BabelNodeExpression {
-    invariant(val.kind !== "sentinel member expression", "invariant established by visitor");
+    invariant(
+      val.kind !== "sentinel member expression" && val.kind !== "sentinel ToObject",
+      "invariant established by visitor"
+    );
     if (val.hasIdentifier()) {
       return this._serializeAbstractValueHelper(val);
     } else {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -622,6 +622,7 @@ export class ResidualHeapVisitor {
   visitAbstractValue(val: AbstractValue): void {
     if (val.kind === "sentinel member expression")
       this.logger.logError(val, "expressions of type o[p] are not yet supported for partially known o and unknown p");
+    if (val.kind === "sentinel ToObject") this.logger.logError(val, "Unknown object cannot be coerced to Object");
     for (let i = 0, n = val.args.length; i < n; i++) {
       val.args[i] = this.visitEquivalentValue(val.args[i]);
     }

--- a/test/error-handler/try-and-access-abstract-property.js
+++ b/test/error-handler/try-and-access-abstract-property.js
@@ -1,0 +1,32 @@
+// additional functions
+// abstract effects
+// recover-from-errors
+// expected errors: [{location: {"start":{"line":14,"column":11},"end":{"line":14,"column":15},"identifierName":"obj1","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possibly throwing getter inside try/catch"},{location: {"start":{"line":22,"column":11},"end":{"line":22,"column":15},"identifierName":"obj2","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possibly throwing getter inside try/catch"}]
+
+let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
+let obj2 = global.__abstract ? __abstract('object', '({foo:{bar:"baz"}})') : {foo:{bar:"baz"}};
+if (global.__makeSimple) {
+  __makeSimple(obj2);
+}
+
+function additional1() {
+  try {
+    return obj1.foo;
+  } catch (x) {
+    return 1;
+  }
+}
+
+function additional2() {
+  try {
+    return obj2.foo.bar;
+  } finally {
+    return 2;
+  }
+}
+
+inspect = function() {
+  let ret1 = additional1();
+  let ret2 = additional2();
+  return JSON.stringify({ ret1, ret2 });
+}

--- a/test/serializer/pure-functions/AbstractPropertyRead.js
+++ b/test/serializer/pure-functions/AbstractPropertyRead.js
@@ -1,0 +1,22 @@
+// additional functions
+// abstract effects
+
+let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
+let obj2 = global.__abstract ? __abstract('object', '({foo:{bar:"baz"}})') : {foo:{bar:"baz"}};
+if (global.__makeSimple) {
+  __makeSimple(obj2);
+}
+
+function additional1() {
+  return obj1.foo;
+}
+
+function additional2() {
+  return obj2.foo.bar;
+}
+
+inspect = function() {
+  let ret1 = additional1();
+  let ret2 = additional2();
+  return ret1 + ret2;
+}


### PR DESCRIPTION
Builds on top of #1321

Lets $Get succeed on abstract values. Property access is not safe on abstract object values because they could be getters with side-effects or might throw.

However, this is safe in a pure function context. We just have to make sure we leak the object that might get passed to a getter.

It is also safe to coerce a non-object abstract value to an object, since all it can do is throw.