### PR TITLE
Provide a join for possibly normal completions.

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -468,9 +468,9 @@ export class Generator {
     this._addEntry({
       args: [],
       buildNode: function([], context) {
-        let statements = [];
-        if (!generator1.empty()) statements.push(serializeBody(generator1, context));
-        if (!generator2.empty()) statements.push(serializeBody(generator2, context));
+        let statements1 = generator1.empty() ? [] : context.serializeGenerator(generator1);
+        let statements2 = generator2.empty() ? [] : context.serializeGenerator(generator2);
+        let statements = statements1.concat(statements2);
         if (statements.length === 1) return statements[0];
         return t.blockStatement(statements);
       },

--- a/test/serializer/abstract/Throw5a.js
+++ b/test/serializer/abstract/Throw5a.js
@@ -1,0 +1,12 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let y = global.__abstract ? __abstract("boolean", "false") : false;
+
+if (x) {
+  if (y) throw new Error("x is true");
+  z = 1;
+} else {
+  if (y) throw new Error("x is false");
+  z = 2;
+}
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Throw5b.js
+++ b/test/serializer/abstract/Throw5b.js
@@ -1,0 +1,12 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let y = global.__abstract ? __abstract("boolean", "false") : false;
+
+if (x) {
+  if (!y) {} else throw new Error("x is true");
+  z = 1;
+} else {
+  if (!y) {} else throw new Error("x is false");
+  z = 2;
+}
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Throw5c.js
+++ b/test/serializer/abstract/Throw5c.js
@@ -1,0 +1,12 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let y = global.__abstract ? __abstract("boolean", "false") : false;
+
+if (x) {
+  if (y) throw new Error("x is true");
+  z = 1;
+} else {
+  if (!y) {} else throw new Error("x is false");
+  z = 2;
+}
+
+inspect = function() { return z; }

--- a/test/serializer/abstract/Throw5d.js
+++ b/test/serializer/abstract/Throw5d.js
@@ -1,0 +1,12 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let y = global.__abstract ? __abstract("boolean", "false") : false;
+
+if (x) {
+  if (!y) {} else throw new Error("x is true");
+  z = 1;
+} else {
+  if (y) throw new Error("x is false");
+  z = 2;
+}
+
+inspect = function() { return z; }


### PR DESCRIPTION
joinResults used to compose rather than join two PossiblyNormalCompletions. Whoops. Fixed now.

Also did some more curly reduction.