### PR TITLE
Add evaluateWithPossibleThrowCompletion

### DIFF
--- a/test/error-handler/try-and-access-abstract-property.js
+++ b/test/error-handler/try-and-access-abstract-property.js
@@ -1,7 +1,7 @@
 // additional functions
 // abstract effects
 // recover-from-errors
-// expected errors: [{location: {"start":{"line":14,"column":11},"end":{"line":14,"column":15},"identifierName":"obj1","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possibly throwing getter inside try/catch"},{location: {"start":{"line":22,"column":11},"end":{"line":22,"column":15},"identifierName":"obj2","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possibly throwing getter inside try/catch"}]
+// expected errors: [{location: {"start":{"line":14,"column":11},"end":{"line":14,"column":15},"identifierName":"obj1","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"},{location: {"start":{"line":22,"column":11},"end":{"line":22,"column":15},"identifierName":"obj2","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
 
 let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
 let obj2 = global.__abstract ? __abstract('object', '({foo:{bar:"baz"}})') : {foo:{bar:"baz"}};

--- a/test/error-handler/try-and-call-abstract-function.js
+++ b/test/error-handler/try-and-call-abstract-function.js
@@ -1,6 +1,6 @@
 // additional functions
 // abstract effects
-// expected errors: [{location: {"start":{"line":26,"column":11},"end":{"line":26,"column":21},"identifierName":"abstractFn","source":"test/error-handler/try-and-call-abstract-function.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possibly throwing function call inside try/catch"}]
+// expected errors: [{location: {"start":{"line":26,"column":11},"end":{"line":26,"column":21},"identifierName":"abstractFn","source":"test/error-handler/try-and-call-abstract-function.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
 
 let abstractFn = global.__abstract ? __abstract('function', '(function() { return true; })') : function() { return true; };
 


### PR DESCRIPTION
I'm going to need to add a lot of these things that might throw so I wanted to start preparing the infrastructure for #1264. See that issue for more info on the approach.

The idea is that code inside this scope might emit temporal operations that might throw. In the future we can wrap these in a try/catch to extract a caught error and a flag. These can be used to generate a PossiblyNormalCompletion.

However, for now I just keep the existing strategy of erroring in this case while I add more callers of this helper.