### PR TITLE
Added more helpful message to invariant

### DIFF
--- a/src/invariant.js
+++ b/src/invariant.js
@@ -11,8 +11,10 @@
 
 export default function invariant(condition: any, format: string): void {
   if (condition) return;
+  const message = `${format}
+This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.`;
 
-  let error = new Error(format);
+  let error = new Error(message);
   error.name = "Invariant Violation";
   throw error;
 }


### PR DESCRIPTION
Release Note: Added more helpful message to invariant

Related Issue: https://github.com/facebook/prepack/issues/1305

This just extends the error message on invariants to outline that this is likely related to Prepack, not user-land code, and encourages GitHub issues.

Here is what this looks like when fired:
<img width="670" alt="screen shot 2018-01-14 at 6 07 07 pm" src="https://user-images.githubusercontent.com/12440573/34914025-74e53406-f956-11e7-90cb-6190a048d040.png">
