### PR TITLE
Avoid multiple serializations of generators when called functions may throw

### DIFF
--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -14,13 +14,7 @@ import type { PropertyKeyValue, FunctionBodyAstNode } from "../types.js";
 import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { ECMAScriptFunctionValue } from "../values/index.js";
-import {
-  Completion,
-  ReturnCompletion,
-  AbruptCompletion,
-  JoinedAbruptCompletions,
-  NormalCompletion,
-} from "../completions.js";
+import { Completion, ReturnCompletion, AbruptCompletion, NormalCompletion } from "../completions.js";
 import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord } from "../environment.js";
 import {
@@ -124,9 +118,6 @@ function InternalCall(
   // 9. If result.[[Type]] is return, return NormalCompletion(result.[[Value]]).
   if (result instanceof ReturnCompletion) {
     return result.value;
-  }
-  if (result instanceof JoinedAbruptCompletions) {
-    result = Join.joinAndRemoveNestedReturnCompletions(realm, result);
   }
 
   // 10. ReturnIfAbrupt(result).  or if possibly abrupt

--- a/src/types.js
+++ b/src/types.js
@@ -720,11 +720,6 @@ export type JoinType = {
     v: Value
   ): void,
 
-  joinAndRemoveNestedReturnCompletions(
-    realm: Realm,
-    c: AbruptCompletion
-  ): AbruptCompletion | PossiblyNormalCompletion | Value,
-
   joinEffectsAndPromoteNestedReturnCompletions(
     realm: Realm,
     c: Completion | Value,

--- a/test/serializer/abstract/Throw8.js
+++ b/test/serializer/abstract/Throw8.js
@@ -1,0 +1,34 @@
+function call(fn) {
+  var template = {};
+  if (global.__makeSimple) __makeSimple(template);
+  function residualCall(fn) {
+    var value;
+    var exception;
+    var success = true;
+    try {
+      value = fn();
+    } catch (e) {
+      exception = e;
+      success = false;
+    }
+    return {value, exception, success};
+  }
+  var res = global.__residual? __residual(template, residualCall, fn) : residualCall(fn);
+  if (!res.success) {
+    throw res.exception;
+  }
+  return res.value;
+}
+
+var fn = global.__abstract ? __abstract('function', '(function () { })') : function () { };
+
+var x = 1;
+try {
+  call(fn);
+  x = 2;
+  //call(fn);
+  x = 3;
+} catch (err) {
+}
+
+inspect = function() { return x; }


### PR DESCRIPTION
Release note: partially fixes issue #1266

When a joined abrupt completions are unbundled into throw completions stashed into a possibly normal completion and a return completion, do not propagate the nested generators. These will have already escaped and will be serialized as part of the current generator. Leaving them in the results of unbundleReturnCompletion will just cause those generators to get serialized more than once.

Also remove joinAndRemoveNestedReturnCompletions since it became unnecessary a while ago and survived by accident.
