### PR TITLE
Do not visit ES2015 class prototypes that are null values

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -214,7 +214,9 @@ export class ResidualHeapVisitor {
     let kind = obj.getKind();
     if (proto === this.realm.intrinsics[kind + "Prototype"]) return;
 
-    this.visitValue(proto);
+    if (!obj.$IsClassPrototype || (obj.$IsClassPrototype && proto !== this.realm.intrinsics.null)) {
+      this.visitValue(proto);
+    }
   }
 
   visitConstructorPrototype(func: FunctionValue) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -214,7 +214,7 @@ export class ResidualHeapVisitor {
     let kind = obj.getKind();
     if (proto === this.realm.intrinsics[kind + "Prototype"]) return;
 
-    if (!obj.$IsClassPrototype || (obj.$IsClassPrototype && proto !== this.realm.intrinsics.null)) {
+    if (!obj.$IsClassPrototype || proto !== this.realm.intrinsics.null) {
       this.visitValue(proto);
     }
   }


### PR DESCRIPTION
Release notes: none

This fixes the serialization error in `/test/error-handler/class.js`. We don't want to serialize the value of `null` out for the prototype when we serialize ES2015 class syntax that extends a value that might have a `null` prototype anyway. This change fixes the test as expected and no errors are printed.