### PR TITLE
Do not double report diagnostics

### DIFF
--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -112,7 +112,7 @@ export function prepackString(
 }
 
 /* deprecated: please use prepackSources instead. */
-export function prepack(code: string, options: PrepackOptions = defaultOptions) {
+export function prepack(code: string, options: PrepackOptions = defaultOptions): SerializedResult {
   let filename = options.filename || "unknown";
   let sources = [{ filePath: filename, fileContents: code }];
 
@@ -134,7 +134,7 @@ export function prepackFromAst(
   ast: BabelNodeFile | BabelNodeProgram,
   code: string,
   options: PrepackOptions = defaultOptions
-) {
+): SerializedResult {
   if (ast && ast.type === "Program") {
     ast = t.file(ast, [], []);
   }


### PR DESCRIPTION
Release note: Fix prepack-cli to not report the same diagnostics twice

The CLI code for dealing with diagnostics was a bit messy and its use by prepack-node led to a subtle error where printDiagnostics was called twice. This pull request adds types, cleans up the code and tweaks the interface between prepack-cli and prepack-node.