### PR TITLE
Various fixes/changes and code changes to React compiler

### DIFF
--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -54,8 +54,9 @@ let reactCode = `
 
     class Component {
       constructor(props, context) {
-        // stub, this constructor is never evaluated
-        throw new Error("React.Component constructor should never evaluate");
+        this.props = props;
+        this.context = context;
+        this.refs = {};
       }
       getChildContext() {}
     }
@@ -64,8 +65,9 @@ let reactCode = `
 
     class PureComponent {
       constructor(props, context) {
-        // stub, this constructor is never evaluated
-        throw new Error("React.PureComponent constructor should never evaluate");
+        this.props = props;
+        this.context = context;
+        this.refs = {};
       }
     }
 

--- a/src/options.js
+++ b/src/options.js
@@ -20,7 +20,7 @@ export const CompatibilityValues = [
   "node-cli",
   "react-mocks",
 ];
-export type ReactOutputTypes = "create-element" | "jsx";
+export type ReactOutputTypes = "create-element" | "jsx" | "bytecode";
 
 export type RealmOptions = {
   check?: boolean,

--- a/src/react/branching.js
+++ b/src/react/branching.js
@@ -23,7 +23,7 @@ import {
   ObjectValue,
 } from "../values/index.js";
 import { type ReactSerializerState } from "../serializer/types.js";
-import { isReactElement, addKeyToReactElement, mapOverArrayValue } from "./utils";
+import { isReactElement, addKeyToReactElement, forEachArrayValue } from "./utils";
 import { ExpectedBailOut } from "./errors.js";
 
 // Branch status is used for when Prepack returns an abstract value from a render
@@ -56,7 +56,7 @@ export class BranchState {
     } else if (value instanceof ObjectValue && isReactElement(value)) {
       addKeyToReactElement(realm, reactSerializerState, value);
     } else if (value instanceof ArrayValue) {
-      mapOverArrayValue(realm, value, elementValue => {
+      forEachArrayValue(realm, value, elementValue => {
         this._applyBranchedLogicValue(realm, reactSerializerState, elementValue);
       });
     } else if (value instanceof AbstractValue) {

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -18,6 +18,7 @@ import { ExpectedBailOut, SimpleClassBailOut } from "./errors.js";
 import { Get } from "../methods/index.js";
 import { Properties } from "../singletons.js";
 import invariant from "../invariant.js";
+import type { ClassComponentMetadata } from "../types.js";
 
 const lifecycleMethods = new Set([
   "componentWillUnmount",
@@ -51,10 +52,6 @@ export function getInitialProps(
   invariant(value instanceof AbstractObjectValue);
   return value;
 }
-
-export type ClassComponentMetadata = {
-  thisAssignments: Set<string>,
-};
 
 export function getInitialContext(realm: Realm, componentType: ECMAScriptSourceFunctionValue): AbstractObjectValue {
   let contextName = null;

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -47,6 +47,10 @@ export function getInitialProps(realm: Realm, componentType: ECMAScriptSourceFun
   return value;
 }
 
+export type ClassComponentMetadata = {
+  thisAssignments: Set<string>,
+};
+
 export function getInitialContext(realm: Realm, componentType: ECMAScriptSourceFunctionValue): AbstractObjectValue {
   let contextName = null;
   if (valueIsClassComponent(realm, componentType)) {
@@ -114,14 +118,18 @@ export function createClassInstance(
   realm: Realm,
   componentType: ECMAScriptSourceFunctionValue,
   props: ObjectValue | AbstractValue,
-  context: ObjectValue | AbstractValue
+  context: ObjectValue | AbstractValue,
+  classMetadata: ClassComponentMetadata
 ): AbstractObjectValue {
   let componentPrototype = Get(realm, componentType, "prototype");
   invariant(componentPrototype instanceof ObjectValue);
+  let thisAssignments = classMetadata.thisAssignments;
+
   // create an instance object and disable serialization as we don't want to output the internals we set below
   let instance = new ObjectValue(realm, componentPrototype, "this", true);
   for (let [name] of componentPrototype.properties) {
-    if (name !== "constructor") {
+    // ensure we don't set constructor or prototype methods that get set in the constructor
+    if (name !== "constructor" && !thisAssignments.has(name)) {
       Properties.Set(realm, instance, name, Get(realm, componentPrototype, name), true);
     }
   }

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -36,14 +36,9 @@ import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { BranchState, type BranchStatusEnum } from "./branching.js";
-import {
-  getInitialProps,
-  getInitialContext,
-  createClassInstance,
-  createSimpleClassInstance,
-  type ClassComponentMetadata,
-} from "./components.js";
+import { getInitialProps, getInitialContext, createClassInstance, createSimpleClassInstance } from "./components.js";
 import { ExpectedBailOut, SimpleClassBailOut } from "./errors.js";
+import type { ClassComponentMetadata } from "../types.js";
 
 type RenderStrategy = "NORMAL" | "RELAY_QUERY_RENDERER";
 

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -25,12 +25,24 @@ import {
   AbstractObjectValue,
 } from "../values/index.js";
 import { ReactStatistics, type ReactSerializerState } from "../serializer/types.js";
-import { isReactElement, valueIsClassComponent, mapOverArrayValue, valueIsLegacyCreateClassComponent } from "./utils";
+import {
+  isReactElement,
+  valueIsClassComponent,
+  forEachArrayValue,
+  valueIsLegacyCreateClassComponent,
+  getThisAssignments,
+} from "./utils";
 import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { BranchState, type BranchStatusEnum } from "./branching.js";
-import { getInitialProps, getInitialContext, createClassInstance, createSimpleClassInstance } from "./components.js";
+import {
+  getInitialProps,
+  getInitialContext,
+  createClassInstance,
+  createSimpleClassInstance,
+  type ClassComponentMetadata,
+} from "./components.js";
 import { ExpectedBailOut, SimpleClassBailOut } from "./errors.js";
 
 export class Reconciler {
@@ -101,6 +113,7 @@ export class Reconciler {
     componentType: ECMAScriptSourceFunctionValue,
     props: ObjectValue | AbstractObjectValue,
     context: ObjectValue | AbstractObjectValue,
+    classMetadata: ClassComponentMetadata,
     branchStatus: BranchStatusEnum,
     branchState: BranchState | null
   ): Value {
@@ -110,7 +123,7 @@ export class Reconciler {
       );
     }
     // create a new instance of this React class component
-    let instance = createClassInstance(this.realm, componentType, props, context);
+    let instance = createClassInstance(this.realm, componentType, props, context, classMetadata);
     // get the "render" method off the instance
     let renderMethod = Get(this.realm, instance, "render");
     invariant(
@@ -149,6 +162,25 @@ export class Reconciler {
     return componentType.$Call(this.realm.intrinsics.undefined, [props, context]);
   }
 
+  _getClassComponentMetadata(componentType: ECMAScriptSourceFunctionValue): ClassComponentMetadata {
+    if (this.realm.react.classComponentMetadata.has(componentType)) {
+      let classMetadata = this.realm.react.classComponentMetadata.get(componentType);
+      invariant(classMetadata);
+      return classMetadata;
+    }
+    // get all this assignments in the constructor
+    let componentPrototype = Get(this.realm, componentType, "prototype");
+    invariant(componentPrototype instanceof ObjectValue);
+    let constructorMethod = Get(this.realm, componentPrototype, "constructor");
+    invariant(constructorMethod instanceof ECMAScriptSourceFunctionValue);
+    let thisAssignments = getThisAssignments(constructorMethod.$ECMAScriptCode);
+    let classMetadata = {
+      thisAssignments,
+    };
+    this.realm.react.classComponentMetadata.set(componentType, classMetadata);
+    return classMetadata;
+  }
+
   _renderComponent(
     componentType: ECMAScriptSourceFunctionValue,
     props: ObjectValue | AbstractObjectValue,
@@ -163,39 +195,52 @@ export class Reconciler {
     if (valueIsLegacyCreateClassComponent(this.realm, componentType)) {
       throw new ExpectedBailOut("components created with create-react-class are not supported");
     } else if (valueIsClassComponent(this.realm, componentType)) {
-      // We first need to know what type of class component we're dealing with.
-      // A "simple" class component is defined as:
-      //
-      // - having only a "render" method or many method, i.e. render(), _renderHeader(), _renderFooter()
-      // - having no lifecycle events
-      // - having no state
-      // - having no instance variables
-      //
-      // the only things a class component should be able to access on "this" are:
-      // - this.props
-      // - this.context
-      // - this._someRenderMethodX() etc
-      //
-      // Otherwise, the class component is a "complex" one.
-      // To begin with, we don't know what type of component it is, so we try and render it as if it were
-      // a simple component using the above heuristics. If an error occurs during this process, we assume
-      // that the class wasn't simple, then try again with the "complex" heuristics.
-      try {
-        value = this._renderSimpleClassComponent(componentType, props, context, branchStatus, branchState);
-        this.simpleClassComponents.add(value);
-      } catch (error) {
-        // if we get back a SimpleClassBailOut error, we know that this class component
-        // wasn't a simple one and is likely to be a complex class component instead
-        if (error instanceof SimpleClassBailOut) {
-          // the component was not simple, so we continue with complex case
-        } else {
-          // else we rethrow the error
-          throw error;
+      let classMetadata = this._getClassComponentMetadata(componentType);
+      let thisAssignments = classMetadata.thisAssignments;
+
+      // if there were no this assignments we can try and render it as a simple class component
+      if (thisAssignments.size === 0) {
+        // We first need to know what type of class component we're dealing with.
+        // A "simple" class component is defined as:
+        //
+        // - having only a "render" method or many method, i.e. render(), _renderHeader(), _renderFooter()
+        // - having no lifecycle events
+        // - having no state
+        // - having no instance variables
+        //
+        // the only things a class component should be able to access on "this" are:
+        // - this.props
+        // - this.context
+        // - this._someRenderMethodX() etc
+        //
+        // Otherwise, the class component is a "complex" one.
+        // To begin with, we don't know what type of component it is, so we try and render it as if it were
+        // a simple component using the above heuristics. If an error occurs during this process, we assume
+        // that the class wasn't simple, then try again with the "complex" heuristics.
+        try {
+          value = this._renderSimpleClassComponent(componentType, props, context, branchStatus, branchState);
+          this.simpleClassComponents.add(value);
+        } catch (error) {
+          // if we get back a SimpleClassBailOut error, we know that this class component
+          // wasn't a simple one and is likely to be a complex class component instead
+          if (error instanceof SimpleClassBailOut) {
+            // the component was not simple, so we continue with complex case
+          } else {
+            // else we rethrow the error
+            throw error;
+          }
         }
       }
       // handle the complex class component if there is not value
       if (value === undefined) {
-        value = this._renderComplexClassComponent(componentType, props, context, branchStatus, branchState);
+        value = this._renderComplexClassComponent(
+          componentType,
+          props,
+          context,
+          classMetadata,
+          branchStatus,
+          branchState
+        );
       }
     } else {
       value = this._renderFunctionalComponent(componentType, props, context);
@@ -339,7 +384,7 @@ export class Reconciler {
     branchStatus: BranchStatusEnum,
     branchState: BranchState | null
   ) {
-    mapOverArrayValue(this.realm, arrayValue, (elementValue, elementPropertyDescriptor) => {
+    forEachArrayValue(this.realm, arrayValue, (elementValue, elementPropertyDescriptor) => {
       elementPropertyDescriptor.value = this._resolveDeeply(elementValue, context, branchStatus, branchState);
     });
   }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { Realm } from "../realm.js";
-import type { BabelNode, BabelNodeJSXIdentifier } from "babel-types";
+import type { BabelNode, BabelNodeJSXIdentifier, BabelNodeBlockStatement } from "babel-types";
 import {
   Value,
   NumberValue,
@@ -18,7 +18,6 @@ import {
   SymbolValue,
   FunctionValue,
   StringValue,
-  ArrayValue,
   ECMAScriptSourceFunctionValue,
 } from "../values/index.js";
 import type { Descriptor } from "../types";
@@ -172,8 +171,8 @@ export function getUniqueReactElementKey(index?: string, usedReactElementKeys: S
   return key;
 }
 
-// a helper function to map over ArrayValues
-export function mapOverArrayValue(realm: Realm, array: ArrayValue, mapFunc: Function): void {
+// a helper function to loop over ArrayValues
+export function forEachArrayValue(realm: Realm, array: ObjectValue, mapFunc: Function): void {
   let lengthValue = Get(realm, array, "length");
   invariant(lengthValue instanceof NumberValue, "Invalid length on ArrayValue during reconcilation");
   let length = lengthValue.value;
@@ -263,4 +262,36 @@ export function normalizeFunctionalComponentParamaters(func: ECMAScriptSourceFun
       return t.identifier("context");
     }
   });
+}
+
+export function getThisAssignments(functionBody: BabelNodeBlockStatement): Set<string> {
+  let assignments = new Set();
+  traverse(
+    t.file(t.program([t.functionDeclaration(t.identifier("dummy"), [], functionBody)])),
+    {
+      "ThisExpression|Identifier": function(path) {
+        if (t.isThisExpression(path.node) || path.node.name === "this") {
+          let parentPath = path.parentPath;
+          let parentNode = parentPath.node;
+
+          if (parentPath && t.isMemberExpression(parentNode) && parentPath.parentPath) {
+            let topNode = parentPath.parentPath.node;
+            if (t.isAssignmentExpression(topNode) && topNode.operator === "=") {
+              let thisObjectProperty = parentNode.property;
+
+              while (t.isMemberExpression(thisObjectProperty)) {
+                thisObjectProperty = thisObjectProperty.object;
+              }
+              invariant(t.isIdentifier(thisObjectProperty));
+              assignments.add(thisObjectProperty.name);
+            }
+          }
+        }
+      },
+    },
+    undefined,
+    (undefined: any),
+    undefined
+  );
+  return assignments;
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { Realm } from "../realm.js";
-import type { BabelNode, BabelNodeJSXIdentifier, BabelNodeBlockStatement } from "babel-types";
+import type { BabelNode, BabelNodeJSXIdentifier } from "babel-types";
 import {
   Value,
   NumberValue,
@@ -262,36 +262,4 @@ export function normalizeFunctionalComponentParamaters(func: ECMAScriptSourceFun
       return t.identifier("context");
     }
   });
-}
-
-export function getThisAssignments(functionBody: BabelNodeBlockStatement): Set<string> {
-  let assignments = new Set();
-  traverse(
-    t.file(t.program([t.functionDeclaration(t.identifier("dummy"), [], functionBody)])),
-    {
-      "ThisExpression|Identifier": function(path) {
-        if (t.isThisExpression(path.node) || path.node.name === "this") {
-          let parentPath = path.parentPath;
-          let parentNode = parentPath.node;
-
-          if (parentPath && t.isMemberExpression(parentNode) && parentPath.parentPath) {
-            let topNode = parentPath.parentPath.node;
-            if (t.isAssignmentExpression(topNode) && topNode.operator === "=") {
-              let thisObjectProperty = parentNode.property;
-
-              while (t.isMemberExpression(thisObjectProperty)) {
-                thisObjectProperty = thisObjectProperty.object;
-              }
-              invariant(t.isIdentifier(thisObjectProperty));
-              assignments.add(thisObjectProperty.name);
-            }
-          }
-        }
-      },
-    },
-    undefined,
-    (undefined: any),
-    undefined
-  );
-  return assignments;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -38,6 +38,7 @@ import { emptyExpression, voidExpression } from "./utils/internalizer.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
+import type { ClassComponentMetadata } from "./react/components.js";
 import * as t from "babel-types";
 
 export type BindingEntry = { hasLeaked: boolean, value: void | Value };
@@ -172,6 +173,7 @@ export class Realm {
     this.$GlobalEnv = ((undefined: any): LexicalEnvironment);
 
     this.react = {
+      classComponentMetadata: new Map(),
       enabled: opts.reactEnabled || false,
       output: opts.reactOutput || "create-element",
       symbols: new Map(),
@@ -223,13 +225,14 @@ export class Realm {
   intrinsics: Intrinsics;
 
   react: {
-    enabled: boolean,
-    output?: ReactOutputTypes,
-    symbols: Map<ReactSymbolTypes, SymbolValue>,
+    classComponentMetadata: Map<ECMAScriptSourceFunctionValue, ClassComponentMetadata>,
     currentOwner?: ObjectValue,
-    reactLibraryObject?: ObjectValue,
-    hoistableReactElements: WeakMap<ObjectValue, boolean>,
+    enabled: boolean,
     hoistableFunctions: WeakMap<FunctionValue, boolean>,
+    hoistableReactElements: WeakMap<ObjectValue, boolean>,
+    output?: ReactOutputTypes,
+    reactLibraryObject?: ObjectValue,
+    symbols: Map<ReactSymbolTypes, SymbolValue>,
   };
 
   $GlobalObject: ObjectValue | AbstractObjectValue;

--- a/src/realm.js
+++ b/src/realm.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { Intrinsics, PropertyBinding, Descriptor, DebugServerType } from "./types.js";
+import type { Intrinsics, PropertyBinding, Descriptor, DebugServerType, ClassComponentMetadata } from "./types.js";
 import { CompilerDiagnostic, type ErrorHandlerResult, type ErrorHandler, FatalError } from "./errors.js";
 import {
   AbstractObjectValue,
@@ -38,7 +38,6 @@ import { emptyExpression, voidExpression } from "./utils/internalizer.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
-import type { ClassComponentMetadata } from "./react/components.js";
 import * as t from "babel-types";
 
 export type BindingEntry = { hasLeaked: boolean, value: void | Value };

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -74,7 +74,7 @@ import {
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { canHoistFunction } from "../react/hoisting.js";
 import { To } from "../singletons.js";
-import { ResidualReactElements } from "./ResidualReactElements.js";
+import { ResidualReactElementSerializer } from "./ResidualReactElementSerializer.js";
 import type { Binding } from "../environment.js";
 import { DeclarativeEnvironmentRecord } from "../environment.js";
 
@@ -129,7 +129,7 @@ export class ResidualHeapSerializer {
     this.serializedValues = new Set();
     this._serializedValueWithIdentifiers = new Set();
     this.additionalFunctionValueNestedFunctions = new Set();
-    this.residualReactElements = new ResidualReactElements(this.realm, this);
+    this.residualReactElementSerializer = new ResidualReactElementSerializer(this.realm, this);
     this.residualFunctions = new ResidualFunctions(
       this.realm,
       this.statistics,
@@ -212,7 +212,7 @@ export class ResidualHeapSerializer {
   additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>;
   declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>;
   react: ReactSerializerState;
-  residualReactElements: ResidualReactElements;
+  residualReactElementSerializer: ResidualReactElementSerializer;
 
   // function values nested in additional functions can't delay initializations
   // TODO: revisit this and fix additional functions to be capable of delaying initializations
@@ -1397,7 +1397,7 @@ export class ResidualHeapSerializer {
       case "ArrayBuffer":
         return this._serializeValueArrayBuffer(val);
       case "ReactElement":
-        this.residualReactElements.serializeReactElement(val);
+        this.residualReactElementSerializer.serializeReactElement(val);
         return;
       case "Map":
       case "WeakMap":
@@ -1694,7 +1694,7 @@ export class ResidualHeapSerializer {
             }
             if (!(result instanceof UndefinedValue)) this.emitter.emit(t.returnStatement(this.serializeValue(result)));
 
-            const lazyHoistedReactNodes = this.residualReactElements.serializeLazyHoistedNodes();
+            const lazyHoistedReactNodes = this.residualReactElementSerializer.serializeLazyHoistedNodes();
             Array.prototype.push.apply(this.mainBody.entries, lazyHoistedReactNodes);
           };
           this.currentAdditionalFunction = additionalFunctionValue;

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -23,7 +23,7 @@ import { FatalError } from "../errors";
 import type { ReactOutputTypes } from "../options.js";
 import type { LazilyHoistedNodes } from "./types.js";
 
-export class ResidualReactElements {
+export class ResidualReactElementSerializer {
   constructor(realm: Realm, residualHeapSerializer: ResidualHeapSerializer) {
     this.realm = realm;
     this.residualHeapSerializer = residualHeapSerializer;

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -134,23 +134,28 @@ export class Functions {
         "only ECMAScriptSourceFunctionValue function values are supported as React root components"
       );
       let effects = reconciler.render(componentType);
-      let additionalFunctionEffects = this._createAdditionalEffects(effects);
-      invariant(effects[0] instanceof Value);
-      if (simpleClassComponents.has(effects[0])) {
-        // if the root component was a class and is now simple, we can convert it from a class
-        // component to a functional component
-        convertSimpleClassComponentToFunctionalComponent(this.realm, componentType, additionalFunctionEffects);
-        normalizeFunctionalComponentParamaters(componentType);
-        this.writeEffects.set(componentType, additionalFunctionEffects);
-      } else if (valueIsClassComponent(this.realm, componentType)) {
-        let prototype = Get(this.realm, componentType, "prototype");
-        invariant(prototype instanceof ObjectValue);
-        let renderMethod = Get(this.realm, prototype, "render");
-        invariant(renderMethod instanceof ECMAScriptSourceFunctionValue);
-        this.writeEffects.set(renderMethod, additionalFunctionEffects);
+
+      if (this.realm.react.output === "bytecode") {
+        throw new FatalError("TODO: implement React bytecode output format");
       } else {
-        normalizeFunctionalComponentParamaters(componentType);
-        this.writeEffects.set(componentType, additionalFunctionEffects);
+        let additionalFunctionEffects = this._createAdditionalEffects(effects);
+        invariant(effects[0] instanceof Value);
+        if (simpleClassComponents.has(effects[0])) {
+          // if the root component was a class and is now simple, we can convert it from a class
+          // component to a functional component
+          convertSimpleClassComponentToFunctionalComponent(this.realm, componentType, additionalFunctionEffects);
+          normalizeFunctionalComponentParamaters(componentType);
+          this.writeEffects.set(componentType, additionalFunctionEffects);
+        } else if (valueIsClassComponent(this.realm, componentType)) {
+          let prototype = Get(this.realm, componentType, "prototype");
+          invariant(prototype instanceof ObjectValue);
+          let renderMethod = Get(this.realm, prototype, "render");
+          invariant(renderMethod instanceof ECMAScriptSourceFunctionValue);
+          this.writeEffects.set(renderMethod, additionalFunctionEffects);
+        } else {
+          normalizeFunctionalComponentParamaters(componentType);
+          this.writeEffects.set(componentType, additionalFunctionEffects);
+        }
       }
     }
   }

--- a/src/types.js
+++ b/src/types.js
@@ -319,6 +319,10 @@ export type ObjectKind =
   | "ReactElement";
 // TODO #26 #712: Promises. All kinds of iterators. Generators.
 
+export type ClassComponentMetadata = {
+  thisAssignments: Set<string>,
+};
+
 export type DebugServerType = {
   checkForActions: BabelNode => void,
   shutdown: () => void,

--- a/src/types.js
+++ b/src/types.js
@@ -320,7 +320,8 @@ export type ObjectKind =
 // TODO #26 #712: Promises. All kinds of iterators. Generators.
 
 export type ClassComponentMetadata = {
-  thisAssignments: Set<string>,
+  instanceProperties: Set<string>,
+  instanceSymbols: Set<SymbolValue>,
 };
 
 export type DebugServerType = {


### PR DESCRIPTION
Various fixes and changes:

- `mapOverArrayValue` - > `forEachArrayValue`
- now evaluates the React class constructor
- adds `bytecode` React output type for future use
- `ResidualReactElements.js` -> `ResidualReactElementSerializer.js`