### PR TITLE
Add --reactOutput as a CLI option

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,7 @@ import type { ErrorHandler } from "./errors.js";
 export type Compatibility = "browser" | "jsc-600-1-4-17" | "mobile" | "node-source-maps" | "node-cli" | "fb-www";
 export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "mobile", "node-source-maps", "node-cli", "fb-www"];
 export type ReactOutputTypes = "create-element" | "jsx";
+export const ReactOutputValues = ["create-element", "jsx"];
 
 export type RealmOptions = {
   check?: boolean,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -83,6 +83,7 @@ function run(
   let heapGraphFilePath: string;
   let debugInFilePath: string;
   let debugOutFilePath: string;
+  let reactOutput: string = "create-element";
   let flags = {
     initializeMoreModules: false,
     trace: false,
@@ -103,7 +104,6 @@ function run(
     check: false,
     profile: false,
     reactEnabled: false,
-    reactOutput: "create-element",
   };
 
   while (args.length) {
@@ -169,6 +169,9 @@ function run(
         case "heapGraphFilePath":
           heapGraphFilePath = args.shift();
           break;
+        case "reactOutput":
+          reactOutput = args.shift();
+          break;
         case "help":
           console.log(
             "Usage: prepack.js [ -- | input.js ] [ --out output.js ] [ --compatibility jsc ] [ --mathRandomSeed seedvalue ] [ --srcmapIn inputMap ] [ --srcmapOut outputMap ] [ --maxStackDepth depthValue ] [ --timeout seconds ] [ --additionalFunctions fnc1,fnc2,... ] [ --lazyObjectsRuntime lazyObjectsRuntimeName] [ --heapGraphFilePath heapGraphFilePath]" +
@@ -211,6 +214,7 @@ function run(
       heapGraphFormat: "DotLanguage",
       debugInFilePath: debugInFilePath,
       debugOutFilePath: debugOutFilePath,
+      reactOutput: reactOutput,
     },
     flags
   );

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -12,7 +12,7 @@
 /* eslint-disable no-shadow */
 
 import { CompilerDiagnostic, type ErrorHandlerResult, FatalError } from "./errors.js";
-import { type Compatibility, CompatibilityValues } from "./options.js";
+import { type Compatibility, CompatibilityValues, type ReactOutputTypes, ReactOutputValues } from "./options.js";
 import { type SerializedResult } from "./serializer/types.js";
 import { prepackStdin, prepackFileSync } from "./prepack-node.js";
 import type { BabelNodeSourceLocation } from "babel-types";
@@ -83,7 +83,7 @@ function run(
   let heapGraphFilePath: string;
   let debugInFilePath: string;
   let debugOutFilePath: string;
-  let reactOutput: string = "create-element";
+  let reactOutput: ReactOutputTypes = "create-element";
   let flags = {
     initializeMoreModules: false,
     trace: false,
@@ -170,7 +170,12 @@ function run(
           heapGraphFilePath = args.shift();
           break;
         case "reactOutput":
-          reactOutput = args.shift();
+          arg = args.shift();
+          if (!ReactOutputValues.includes(arg)) {
+            console.error(`Unsupported reactOutput: ${arg}`);
+            process.exit(1);
+          }
+          reactOutput = (arg: any);
           break;
         case "help":
           console.log(


### PR DESCRIPTION
Without this, passing `--reactOutput` to the CLI fails because it's treated as a boolean flag.
I moved it off the `flags` object and instead treat it as a string (which it is).

Test plan: `--reactOutput jsx` now works instead of crashing.