### PR TITLE
Fixes a few bugs in additionalFunctions

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -134,6 +134,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-3.js");
       });
 
+      it("Simple 4", async () => {
+        await runTest(directory, "simple-4.js");
+      });
+
       it("Simple children", async () => {
         await runTest(directory, "simple-children.js");
       });

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -122,7 +122,15 @@ export class Serializer {
     }
 
     let additionalFunctionValuesAndEffects = this.functions.getAdditionalFunctionValuesToEffects();
-    //Deep traversal of the heap to identify the necessary scope of residual functions
+    for (let [functionValue, effectsAndTransforms] of additionalFunctionValuesAndEffects) {
+      // Need to do this fixup because otherwise we will skip over this function's
+      // generator in the _getTarget scope lookup
+      let generator = effectsAndTransforms.effects[1];
+      generator.parent = functionValue.parent;
+      functionValue.parent = generator;
+    }
+
+    // Deep traversal of the heap to identify the necessary scope of residual functions
     if (timingStats !== undefined) timingStats.deepTraversalTime = Date.now();
     let residualHeapVisitor = new ResidualHeapVisitor(
       this.realm,
@@ -130,7 +138,7 @@ export class Serializer {
       this.modules,
       additionalFunctionValuesAndEffects
     );
-    residualHeapVisitor.visitRoots();
+    residualHeapVisitor.visitRoots(true);
     if (this.logger.hasErrors()) return undefined;
     if (timingStats !== undefined) timingStats.deepTraversalTime = Date.now() - timingStats.deepTraversalTime;
 

--- a/test/react/functional-components/simple-4.js
+++ b/test/react/functional-components/simple-4.js
@@ -1,0 +1,30 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+class Child extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      title: "It works!",
+    };
+  }
+  render() {
+    return <div>{this.state.title}</div>;
+  }
+}
+
+function App() {
+  return <Child />
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render 4', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
This fixes two bugs with additionalFunctions:

- ensures additionalFunctions are only visited once (otherwise the generator parents reference becomes circular referenced to the additionalFunction generator)
- ensures class methods/objects don't get added to `additionalRoots` in an additionalFunction if the visitor is already inside a ES2015 class.