### PR TITLE
Add babelHelpers mock for fb-www

### DIFF
--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -15,7 +15,6 @@ import { AbstractValue, NativeFunctionValue, Value, ObjectValue, StringValue } f
 import buildExpressionTemplate from "../../utils/builder.js";
 import { createMockReact } from "./react-mocks.js";
 import { createMockReactRelay } from "./relay-mocks.js";
-import { Environment } from "../../singletons.js";
 import invariant from "../../invariant";
 
 // Based on www babelHelpers fork.


### PR DESCRIPTION
Needed for our www class transform.

I verified `extends` works. However I get weird results with inheritance.

Input: https://gist.github.com/gaearon/f70a187badf877e3d29c49252471686d

Output without https://github.com/facebook/prepack/pull/1348: (crashes)

```
Invariant Violation: undefined
This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.
    at invariant (/Users/gaearon/p/prepack/lib/invariant.js:20:15)
    at Functions.checkReactRootComponents (/Users/gaearon/p/prepack/lib/serializer/functions.js:204:35)
```

Output with https://github.com/facebook/prepack/pull/1348: https://gist.github.com/gaearon/3c60fce62a354b3571618704b51aeb2a

(note it uses undefined `props` variable).