### PR TITLE
Preserve union types in model object properties

### DIFF
--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -619,7 +619,7 @@ export class ToImplementation {
   GetToPrimitivePureResultType(realm: Realm, input: Value): void | typeof Value {
     let type = input.getType();
     if (input instanceof PrimitiveValue) return type;
-    if (input instanceof AbstractValue && Value.isTypeCompatibleWith(type, PrimitiveValue)) return type;
+    if (input instanceof AbstractValue && !input.mightBeObject()) return PrimitiveValue;
     return undefined;
   }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -1041,6 +1041,11 @@ export class Realm {
 
   rebuildObjectProperty(object: Value, key: string, propertyValue: Value, path: string) {
     if (!(propertyValue instanceof AbstractValue)) return;
+    if (propertyValue.kind === "abstractConcreteUnion") {
+      let absVal = propertyValue.args.find(e => e instanceof AbstractValue);
+      invariant(absVal instanceof AbstractValue);
+      propertyValue = absVal;
+    }
     if (!propertyValue.isIntrinsic()) {
       propertyValue.intrinsicName = `${path}.${key}`;
       propertyValue.kind = "rebuiltProperty";

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -229,6 +229,10 @@ export default class AbstractValue extends Value {
     if (valueType === NullValue) return true;
     if (valueType === SymbolValue) return false;
     if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return false;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightBeFalse()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.mightBeFalse();
   }
@@ -239,6 +243,10 @@ export default class AbstractValue extends Value {
     if (valueType === NullValue) return false;
     if (valueType === SymbolValue) return true;
     if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return true;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightNotBeFalse()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.mightNotBeFalse();
   }
@@ -247,6 +255,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (valueType === NullValue) return true;
     if (valueType !== PrimitiveValue && valueType !== Value) return false;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightBeNull()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(NullValue);
   }
@@ -255,6 +267,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (valueType === NullValue) return false;
     if (valueType !== PrimitiveValue && valueType !== Value) return true;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightNotBeNull()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(NullValue);
   }
@@ -263,6 +279,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (Value.isTypeCompatibleWith(valueType, NumberValue)) return true;
     if (valueType !== PrimitiveValue && valueType !== Value) return false;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightBeNumber()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(NumberValue);
   }
@@ -271,6 +291,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (Value.isTypeCompatibleWith(valueType, NumberValue)) return false;
     if (valueType !== PrimitiveValue && valueType !== Value) return true;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightNotBeNumber()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(NumberValue);
   }
@@ -279,6 +303,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (Value.isTypeCompatibleWith(valueType, PrimitiveValue)) return true;
     if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return false;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightNotBeObject()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(ObjectValue);
   }
@@ -287,6 +315,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (Value.isTypeCompatibleWith(valueType, PrimitiveValue)) return false;
     if (Value.isTypeCompatibleWith(valueType, ObjectValue)) return true;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightBeObject()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(ObjectValue);
   }
@@ -295,6 +327,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (valueType === StringValue) return true;
     if (valueType !== PrimitiveValue && valueType !== Value) return false;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightBeString()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(StringValue);
   }
@@ -303,6 +339,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (valueType === StringValue) return false;
     if (valueType !== PrimitiveValue && valueType !== Value) return true;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightNotBeString()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(StringValue);
   }
@@ -311,6 +351,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (valueType === UndefinedValue) return true;
     if (valueType !== PrimitiveValue && valueType !== Value) return false;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightBeUndefined()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueOfType(UndefinedValue);
   }
@@ -319,6 +363,10 @@ export default class AbstractValue extends Value {
     let valueType = this.getType();
     if (valueType === UndefinedValue) return false;
     if (valueType !== PrimitiveValue && valueType !== Value) return true;
+    if (this.kind === "abstractConcreteUnion") {
+      for (let arg of this.args) if (arg.mightNotBeUndefined()) return true;
+      return false;
+    }
     if (this.values.isTop()) return true;
     return this.values.includesValueNotOfType(UndefinedValue);
   }

--- a/test/serializer/abstract/IntrinsicUnion.js
+++ b/test/serializer/abstract/IntrinsicUnion.js
@@ -1,4 +1,5 @@
 // add at runtime:global.ob = { foo: { a: { toString: function() { return "foo.a"; }} }, bar: { b: {} } };
+// does not contain:1 : 2
 if (global.__abstract) {
   __assumeDataProperty(this, "ob", __abstract({
     foo: __abstract({ a: __abstractOrUndefined({}) }),
@@ -11,7 +12,7 @@ let y = ob.bar.b;
 
 let x2;
 if (x !== undefined) {
-  x2 = !x ? 1 : 2;
+  x2 = !x ? 1 : 2; // if x is properly a union of undefined and object, then !x should be false here
 }
 
 inspect = function() { return x === y && x2 === 2; }


### PR DESCRIPTION
Release note: Fixed problems with __abstractOrUndefined and friends

The code for making model property values intrinsic, did not have special knowledge of abstract unions and hence destroyed them. Likewise the code for obtaining an temporal reference to such a property did not preserve the union in the resulting derived value.

Added special case handling for this and added more special cases in the type inspection properties of AbstractValue.