### PR TITLE
Default to no heapGraphFormat to avoid visiting unnecessarily

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -80,7 +80,7 @@ function run(
   let timeout: number;
   let additionalFunctions: Array<string>;
   let lazyObjectsRuntime: string;
-  let heapGraphFilePath: string;
+  let heapGraphFilePath: void | string;
   let debugInFilePath: string;
   let debugOutFilePath: string;
   let reactOutput: ReactOutputTypes = "create-element";
@@ -216,13 +216,13 @@ function run(
       timeout: timeout,
       additionalFunctions: additionalFunctions,
       lazyObjectsRuntime: lazyObjectsRuntime,
-      heapGraphFormat: "DotLanguage",
       debugInFilePath: debugInFilePath,
       debugOutFilePath: debugOutFilePath,
       reactOutput: reactOutput,
     },
     flags
   );
+  if (heapGraphFilePath) resolvedOptions.heapGraphFormat = "DotLanguage";
   if (
     lazyObjectsRuntime &&
     (resolvedOptions.additionalFunctions || resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)


### PR DESCRIPTION
Release Notes: None

`heapGraphFormat` is used to determine whether to run the heap graph related visitors in `serializer.js`. This change makes it so these visitors no longer run if a heap graph output file has not been specified.