### PR TITLE
Fixes serialization of identifiers in additionalFunctions

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -138,6 +138,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-4.js");
       });
 
+      it("Simple 5", async () => {
+        await runTest(directory, "simple-5.js");
+      });
+
       it("Simple children", async () => {
         await runTest(directory, "simple-children.js");
       });

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1603,10 +1603,13 @@ export class ResidualHeapSerializer {
     let context = this._getContext();
     return this._withGeneratorScope(generator, newBody => {
       let oldCurBody = this.currentFunctionBody;
+      let oldSerialiedValueWithIdentifiers = this._serializedValueWithIdentifiers;
       this.currentFunctionBody = newBody;
+      this._serializedValueWithIdentifiers = new Set(Array.from(this._serializedValueWithIdentifiers));
       generator.serialize(context);
       if (postGeneratorCallback) postGeneratorCallback();
       this.currentFunctionBody = oldCurBody;
+      this._serializedValueWithIdentifiers = oldSerialiedValueWithIdentifiers;
     });
   }
 

--- a/test/react/functional-components/simple-5.js
+++ b/test/react/functional-components/simple-5.js
@@ -1,0 +1,36 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+class Child extends React.Component {
+	constructor() {
+		super();
+		this.state = {
+			id: 5,
+		};
+	}
+	render() {
+		return <span>{this.state.id}</span>
+	}
+}
+
+function App() {
+  return (
+    <div><Child /></div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(Child);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

When entering an additionalFunction, the `this._serializedValueWithIdentifiers` gets stored and a new version created and then restored upon leaving the additionalFunction. Otherwise, identifiers between multiple additionalFunctions get wrongly serialiazed. Test case added too.