### PR TITLE
Process multiple sub React component tree branches

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -242,6 +242,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-classes-2.js");
       });
 
+      it("Simple classes #3", async () => {
+        await runTest(directory, "simple-classes-3.js");
+      });
+
       it("Classes with state", async () => {
         await runTest(directory, "classes-with-state.js");
       });

--- a/src/react/errors.js
+++ b/src/react/errors.js
@@ -39,3 +39,15 @@ export class SimpleClassBailOut {
 }
 Object.setPrototypeOf(SimpleClassBailOut, Error);
 Object.setPrototypeOf(SimpleClassBailOut.prototype, Error.prototype);
+
+// NewComponentTreeBranch only occur when a complex class is found in a
+// component tree and the reconciler can no longer fold the component of that branch
+export class NewComponentTreeBranch {
+  constructor() {
+    let self = new Error();
+    Object.setPrototypeOf(self, NewComponentTreeBranch.prototype);
+    return self;
+  }
+}
+Object.setPrototypeOf(NewComponentTreeBranch, Error);
+Object.setPrototypeOf(NewComponentTreeBranch.prototype, Error.prototype);

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -37,12 +37,18 @@ import {
   createSimpleClassInstance,
   evaluateClassConstructor,
 } from "./components.js";
-import { ExpectedBailOut, SimpleClassBailOut } from "./errors.js";
+import { ExpectedBailOut, SimpleClassBailOut, NewComponentTreeBranch } from "./errors.js";
 import { Completion } from "../completions.js";
 import { Logger } from "../utils/logger.js";
 import type { ClassComponentMetadata } from "../types.js";
 
 type RenderStrategy = "NORMAL" | "RELAY_QUERY_RENDERER";
+
+export type BranchReactComponentTree = {
+  componentType: ECMAScriptSourceFunctionValue,
+  props: ObjectValue | AbstractObjectValue,
+  context: ObjectValue | AbstractObjectValue,
+};
 
 export class Reconciler {
   constructor(
@@ -50,13 +56,16 @@ export class Reconciler {
     moduleTracer: ModuleTracer,
     statistics: ReactStatistics,
     reactSerializerState: ReactSerializerState,
-    simpleClassComponents: Set<Value>
+    simpleClassComponents: Set<Value>,
+    branchReactComponentTrees: Array<BranchReactComponentTree>
   ) {
     this.realm = realm;
     this.moduleTracer = moduleTracer;
     this.statistics = statistics;
     this.reactSerializerState = reactSerializerState;
     this.simpleClassComponents = simpleClassComponents;
+    this.logger = moduleTracer.modules.logger;
+    this.branchReactComponentTrees = branchReactComponentTrees;
   }
 
   realm: Realm;
@@ -64,8 +73,15 @@ export class Reconciler {
   statistics: ReactStatistics;
   reactSerializerState: ReactSerializerState;
   simpleClassComponents: Set<Value>;
+  logger: Logger;
+  branchReactComponentTrees: Array<BranchReactComponentTree>;
 
-  render(componentType: ECMAScriptSourceFunctionValue, logger: Logger): Effects {
+  render(
+    componentType: ECMAScriptSourceFunctionValue,
+    props: ObjectValue | AbstractObjectValue | null,
+    context: ObjectValue | AbstractObjectValue | null,
+    isRoot: boolean
+  ): Effects {
     return this.realm.wrapInGlobalEnv(() =>
       this.realm.evaluatePure(() =>
         // TODO: (sebmarkbage): You could use the return value of this to detect if there are any mutations on objects other
@@ -80,26 +96,35 @@ export class Reconciler {
             // FatalError, unless it's a functional component that has no paramater
             // i.e let MyComponent = () => <div>Hello world</div>
             try {
-              let initialProps = getInitialProps(this.realm, componentType);
-              let initialContext = getInitialContext(this.realm, componentType);
+              let initialProps = props || getInitialProps(this.realm, componentType);
+              let initialContext = context || getInitialContext(this.realm, componentType);
               let { result } = this._renderComponent(componentType, initialProps, initialContext, "ROOT", null);
               this.statistics.optimizedTrees++;
               return result;
             } catch (error) {
+              // if we get an error and we're not dealing with the root
+              // rather than throw a FatalError, we log the error and continue
+              if (!isRoot) {
+                this.logger.logError(
+                  componentType,
+                  `__registerReactComponentRoot() React component tree (branch) failed due to - ${error.message}`
+                );
+                return this.realm.intrinsics.undefined;
+              }
               // if there was a bail-out on the root component in this reconcilation process, then this
               // should be an invariant as the user has explicitly asked for this component to get folded
               if (error instanceof Completion) {
-                logger.logCompletion(error);
+                this.logger.logCompletion(error);
                 throw error;
               } else if (error instanceof ExpectedBailOut) {
                 let diagnostic = new CompilerDiagnostic(
-                  `__registerReactComponentRoot() failed due to - ${error.message}`,
+                  `__registerReactComponentRoot() React component tree (root) failed due to - ${error.message}`,
                   this.realm.currentLocation,
                   "PP0020",
                   "FatalError"
                 );
                 this.realm.handleError(diagnostic);
-                throw new FatalError();
+                if (this.realm.handleError(diagnostic) === "Fail") throw new FatalError();
               }
               throw error;
             }
@@ -120,9 +145,12 @@ export class Reconciler {
     branchState: BranchState | null
   ): Value {
     if (branchStatus !== "ROOT") {
-      throw new ExpectedBailOut(
-        "only complex class components at the root of __registerReactComponentRoot() are supported"
-      );
+      this.branchReactComponentTrees.push({
+        componentType,
+        props,
+        context,
+      });
+      throw new NewComponentTreeBranch();
     }
     // create a new instance of this React class component
     let instance = createClassInstance(this.realm, componentType, props, context, classMetadata);
@@ -389,7 +417,9 @@ export class Reconciler {
         return result;
       } catch (error) {
         // assign a bail out message
-        if (error instanceof ExpectedBailOut) {
+        if (error instanceof NewComponentTreeBranch) {
+          // NO-OP
+        } else if (error instanceof ExpectedBailOut) {
           this._assignBailOutMessage(reactElement, "Bail-out: " + error.message);
         } else if (error instanceof FatalError) {
           this._assignBailOutMessage(reactElement, "Evaluation bail-out");

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -103,9 +103,11 @@ export class Reconciler {
               return result;
             } catch (error) {
               // if we get an error and we're not dealing with the root
-              // rather than throw a FatalError, we log the error and continue
+              // rather than throw a FatalError, we log the error as a warning
+              // and continue with the other tree roots
+              // TODO: maybe control what levels gets treated as warning/error?
               if (!isRoot) {
-                this.logger.logError(
+                this.logger.logWarning(
                   componentType,
                   `__registerReactComponentRoot() React component tree (branch) failed due to - ${error.message}`
                 );

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1135,6 +1135,15 @@ export class ResidualHeapSerializer {
     let hasSerializedClassProtoId = false;
     let propertiesToSerialize = new Map();
 
+    // handle class inheritance
+    if (!(classFunc.$Prototype instanceof NativeFunctionValue)) {
+      let proto = classFunc.$Prototype;
+      classMethodInstance.classSuperNode = this.serializeValue(classFunc.$Prototype);
+      if (proto.$HomeObject instanceof ObjectValue) {
+        this.serializedValues.add(proto.$HomeObject);
+      }
+    }
+
     let serializeClassPrototypeId = () => {
       if (!hasSerializedClassProtoId) {
         let classId = this.getSerializeObjectIdentifier(classFunc);
@@ -1214,15 +1223,6 @@ export class ResidualHeapSerializer {
     }
     // assign the AST method key node for the "constructor"
     classMethodInstance.classMethodKeyNode = t.identifier("constructor");
-
-    // handle class inheritance
-    if (!(classFunc.$Prototype instanceof NativeFunctionValue)) {
-      let proto = classFunc.$Prototype;
-      classMethodInstance.classSuperNode = this.serializeValue(classFunc.$Prototype);
-      if (proto.$HomeObject instanceof ObjectValue) {
-        this.serializedValues.add(proto.$HomeObject);
-      }
-    }
   }
 
   _serializeClassMethod(key: string | SymbolValue, methodFunc: ECMAScriptSourceFunctionValue): void {

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -110,7 +110,7 @@ export class Serializer {
     let reactStatistics = null;
     if (this.realm.react.enabled) {
       reactStatistics = new ReactStatistics();
-      this.functions.checkReactRootComponents(reactStatistics, this.react);
+      this.functions.checkRootReactComponentTrees(reactStatistics, this.react);
     }
 
     if (this.options.initializeMoreModules) {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -124,6 +124,11 @@ export class Logger {
   }
 
   logError(value: Value, message: string) {
+    this.logWarning(value, message);
+    this._hasErrors = true;
+  }
+
+  logWarning(value: Value, message: string) {
     let loc = value.expressionLocation;
     if (loc) {
       let locString = `${loc.start.line}:${loc.start.column + 1}`;
@@ -134,7 +139,6 @@ export class Logger {
     }
 
     console.error(message);
-    this._hasErrors = true;
   }
 
   hasErrors() {

--- a/test/react/class-components/simple-classes-3.js
+++ b/test/react/class-components/simple-classes-3.js
@@ -1,0 +1,35 @@
+const React = require("react");
+this['React'] = React;
+
+class Child extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      a: 1,
+    };
+  }
+  render() {
+    if (this.props.x === 5) {
+      return <span>{this.state.a}</span>;
+    } else {
+      return <span>Hello world</span>;
+    }
+  }
+}
+
+class App extends React.Component {
+  render() {
+    return <div><Child x={10} /></div>;
+  }
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['render simple classes', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

The React reconciler now detects new component trees when rendering a root component tree. Currently this only when it encounters a complex class component. So rather than bailing out and stopping all optimizations, it flags the complex class component as the start of a new tree.

Each component tree branch that fails, outputs a warning rather than throwing a `FatalError`. Otherwise there is far too much friction when using the React compiler on large component trees.

Requires fixes from: https://github.com/facebook/prepack/pull/1359