### PR TITLE
Handle abstract `toString` casting in pure additionalFunctions

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -138,6 +138,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-4.js");
       });
 
+      it("Simple 6", async () => {
+        await runTest(directory, "simple-6.js");
+      });
+
       it("Simple children", async () => {
         await runTest(directory, "simple-children.js");
       });

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -138,12 +138,12 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-4.js");
       });
 
-      it("Simple 6", async () => {
-        await runTest(directory, "simple-6.js");
-      });
-
       it("Simple 5", async () => {
         await runTest(directory, "simple-5.js");
+      });
+
+      it("Simple 6", async () => {
+        await runTest(directory, "simple-6.js");
       });
 
       it("Simple children", async () => {

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -134,7 +134,7 @@ function generateRuntimeCall(
   });
 }
 
-function evaluatePureCall(
+function tryToEvaluateCallOrLeaveAsAbstract(
   ref: Value | Reference,
   func: Value,
   ast: BabelNodeCallExpression,
@@ -160,7 +160,6 @@ function evaluatePureCall(
       throw error;
     }
   }
-  // the returned effects is undefined, it means there was a FatalError
   realm.applyEffects(effects);
   let completion = effects[0];
   // return or throw completion
@@ -264,7 +263,7 @@ function EvaluateCall(
 
   // 8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
   if (realm.isInPureScope()) {
-    return evaluatePureCall(ref, func, ast, strictCode, env, realm, thisValue, tailCall);
+    return tryToEvaluateCallOrLeaveAsAbstract(ref, func, ast, strictCode, env, realm, thisValue, tailCall);
   } else {
     return EvaluateDirectCall(realm, strictCode, env, ref, func, thisValue, ast.arguments, tailCall);
   }

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -134,7 +134,7 @@ function generateRuntimeCall(
   });
 }
 
-function evalautePureCall(
+function evaluatePureCall(
   ref: Value | Reference,
   func: Value,
   ast: BabelNodeCallExpression,
@@ -264,7 +264,7 @@ function EvaluateCall(
 
   // 8. Return ? EvaluateDirectCall(func, thisValue, Arguments, tailCall).
   if (realm.isInPureScope()) {
-    return evalautePureCall(ref, func, ast, strictCode, env, realm, thisValue, tailCall);
+    return evaluatePureCall(ref, func, ast, strictCode, env, realm, thisValue, tailCall);
   } else {
     return EvaluateDirectCall(realm, strictCode, env, ref, func, thisValue, ast.arguments, tailCall);
   }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1737,7 +1737,6 @@ export class ResidualHeapSerializer {
     invariant(this.emitter._declaredAbstractValues.size <= this.preludeGenerator.derivedIds.size);
 
     this.postGeneratorSerialization();
-    Array.prototype.push.apply(this.prelude, this.preludeGenerator.prelude);
 
     // TODO #20: add timers
 
@@ -1748,6 +1747,8 @@ export class ResidualHeapSerializer {
 
     // Make sure additional functions get serialized.
     let rewrittenAdditionalFunctions = this.processAdditionalFunctionValues();
+
+    Array.prototype.push.apply(this.prelude, this.preludeGenerator.prelude);
 
     this.modules.resolveInitializedModules();
 

--- a/test/error-handler/try-and-call-abstract-function.js
+++ b/test/error-handler/try-and-call-abstract-function.js
@@ -1,6 +1,7 @@
 // additional functions
 // abstract effects
-// expected errors: [{location: {"start":{"line":26,"column":11},"end":{"line":26,"column":21},"identifierName":"abstractFn","source":"test/error-handler/try-and-call-abstract-function.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
+// expected errors: [{location: {"start":{"line":27,"column":11},"end":{"line":27,"column":21},"identifierName":"abstractFn","source":"test/error-handler/try-and-call-abstract-function.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
+// recover-from-errors
 
 let abstractFn = global.__abstract ? __abstract('function', '(function() { return true; })') : function() { return true; };
 

--- a/test/react/functional-components/simple-6.js
+++ b/test/react/functional-components/simple-6.js
@@ -1,0 +1,20 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App(props) {
+  return (
+    <div>{String(props.title)}</div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/serializer/pure-functions/CastStringOnUnknown.js
+++ b/test/serializer/pure-functions/CastStringOnUnknown.js
@@ -1,0 +1,22 @@
+// additional functions
+// abstract effects
+
+let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
+let obj2 = global.__abstract ? __abstract('object', '({foo:{bar:"baz"}})') : {foo:{bar:"baz"}};
+if (global.__makeSimple) {
+  __makeSimple(obj2);
+}
+
+function additional1() {
+  return String(obj1.foo);
+}
+
+function additional2() {
+  return String(obj2.foo.bar);
+}
+
+inspect = function() {
+  let ret1 = additional1();
+  let ret2 = additional2();
+  return ret1 + ret2;
+}


### PR DESCRIPTION
Release notes: none

When attempting to do `String(props.title)` on an abstract value, it currently throws a FatalError: `PP0001: This operation is not yet supported on abstract value`. Ideally, when we're in pure evaluation we can mark this as dirty too like we do other abstract values. I've added a test case to show this failing.