### PR TITLE
Support circular references in props

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -146,6 +146,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-refs.js");
       });
 
+      it("Circular reference", async () => {
+        await runTest(directory, "circular-reference.js");
+      });
+
       it("Conditional", async () => {
         await runTest(directory, "conditional.js");
       });

--- a/src/react/hoisting.js
+++ b/src/react/hoisting.js
@@ -28,33 +28,43 @@ import { ResidualHeapVisitor } from "../serializer/ResidualHeapVisitor.js";
 
 // a nested object of a React Element should be hoisted where all its properties are known
 // at evaluation time to be safe to hoist (because of the heuristics of a React render)
-function canHoistObject(realm: Realm, object: ObjectValue, residualHeapVisitor: ResidualHeapVisitor): boolean {
+function canHoistObject(
+  realm: Realm,
+  object: ObjectValue,
+  residualHeapVisitor: ResidualHeapVisitor,
+  visitedValues: Set<Value>
+): boolean {
   if (isReactElement(object)) {
-    return canHoistReactElement(realm, object, residualHeapVisitor);
+    return canHoistReactElement(realm, object, residualHeapVisitor, visitedValues);
   }
   for (let [propName] of object.properties) {
     let prop = Get(realm, object, propName);
-    if (!canHoistValue(realm, prop, residualHeapVisitor)) {
+    if (!canHoistValue(realm, prop, residualHeapVisitor, visitedValues)) {
       return false;
     }
   }
   for (let [symbol] of object.symbols) {
     let prop = Get(realm, object, symbol);
-    if (!canHoistValue(realm, prop, residualHeapVisitor)) {
+    if (!canHoistValue(realm, prop, residualHeapVisitor, visitedValues)) {
       return false;
     }
   }
   return true;
 }
 
-function canHoistArray(realm: Realm, array: ArrayValue, residualHeapVisitor: ResidualHeapVisitor): boolean {
+function canHoistArray(
+  realm: Realm,
+  array: ArrayValue,
+  residualHeapVisitor: ResidualHeapVisitor,
+  visitedValues: Set<Value>
+): boolean {
   let lengthValue = Get(realm, array, "length");
   invariant(lengthValue instanceof NumberValue);
   let length = lengthValue.value;
   for (let i = 0; i < length; i++) {
     let element = Get(realm, array, "" + i);
 
-    if (!canHoistValue(realm, element, residualHeapVisitor)) {
+    if (!canHoistValue(realm, element, residualHeapVisitor, visitedValues)) {
       return false;
     }
   }
@@ -64,7 +74,8 @@ function canHoistArray(realm: Realm, array: ArrayValue, residualHeapVisitor: Res
 export function canHoistFunction(
   realm: Realm,
   func: FunctionValue,
-  residualHeapVisitor?: ResidualHeapVisitor
+  residualHeapVisitor?: ResidualHeapVisitor,
+  visitedValues: Set<Value>
 ): boolean {
   if (realm.react.hoistableFunctions.has(func)) {
     // cast because Flow thinks that we may have set a value to be something other than a boolean?
@@ -84,7 +95,7 @@ export function canHoistFunction(
       // so we can assume that we can still hoist this function
       if (declarativeEnvironmentRecord !== null) {
         invariant(value instanceof Value);
-        if (!canHoistValue(realm, value, residualHeapVisitor)) {
+        if (!canHoistValue(realm, value, residualHeapVisitor, visitedValues)) {
           return false;
         }
       }
@@ -123,23 +134,34 @@ function isPrimitive(realm: Realm, value: Value) {
   );
 }
 
-function canHoistValue(realm: Realm, value: Value, residualHeapVisitor: ResidualHeapVisitor): boolean {
-  if (
-    (value instanceof ArrayValue && canHoistArray(realm, value, residualHeapVisitor)) ||
-    (value instanceof FunctionValue && canHoistFunction(realm, value, residualHeapVisitor)) ||
-    (value instanceof ObjectValue && canHoistObject(realm, value, residualHeapVisitor)) ||
-    (value instanceof AbstractValue && canHoistAbstract(realm, value, residualHeapVisitor)) ||
-    isPrimitive(realm, value)
-  ) {
-    return true;
+function canHoistValue(
+  realm: Realm,
+  value: Value,
+  residualHeapVisitor: ResidualHeapVisitor,
+  visitedValues: Set<Value>
+): boolean {
+  if (visitedValues.has(value)) {
+    // If there is a cycle, bail out.
+    // TODO: is there some way to *not* bail out in this case?
+    // Currently if we don't, the output is broken.
+    return false;
   }
-  return false;
+  visitedValues.add(value);
+  const canHoist =
+    (value instanceof ArrayValue && canHoistArray(realm, value, residualHeapVisitor, visitedValues)) ||
+    (value instanceof FunctionValue && canHoistFunction(realm, value, residualHeapVisitor, visitedValues)) ||
+    (value instanceof ObjectValue && canHoistObject(realm, value, residualHeapVisitor, visitedValues)) ||
+    (value instanceof AbstractValue && canHoistAbstract(realm, value, residualHeapVisitor)) ||
+    isPrimitive(realm, value);
+  visitedValues.delete(value);
+  return canHoist;
 }
 
 export function canHoistReactElement(
   realm: Realm,
   reactElement: ObjectValue,
-  residualHeapVisitor?: ResidualHeapVisitor
+  residualHeapVisitor?: ResidualHeapVisitor,
+  visitedValues: Set<Value> | void
 ): boolean {
   if (realm.react.hoistableReactElements.has(reactElement)) {
     // cast because Flow thinks that we may have set a value to be something other than a boolean?
@@ -153,13 +175,17 @@ export function canHoistReactElement(
   let key = Get(realm, reactElement, "key");
   let props = Get(realm, reactElement, "props");
 
+  if (visitedValues === undefined) {
+    visitedValues = new Set();
+    visitedValues.add(reactElement);
+  }
   if (
-    canHoistValue(realm, type, residualHeapVisitor) &&
+    canHoistValue(realm, type, residualHeapVisitor, visitedValues) &&
     // we can't hoist string "refs" or if they're abstract, as they might be abstract strings
     !(ref instanceof String || ref instanceof AbstractValue) &&
-    canHoistValue(realm, ref, residualHeapVisitor) &&
-    canHoistValue(realm, key, residualHeapVisitor) &&
-    canHoistValue(realm, props, residualHeapVisitor)
+    canHoistValue(realm, ref, residualHeapVisitor, visitedValues) &&
+    canHoistValue(realm, key, residualHeapVisitor, visitedValues) &&
+    canHoistValue(realm, props, residualHeapVisitor, visitedValues)
   ) {
     realm.react.hoistableReactElements.set(reactElement, true);
     return true;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1083,7 +1083,7 @@ export class ResidualHeapSerializer {
       if (--delayed === 0) {
         invariant(instance);
         // hoist if we are in an additionalFunction
-        if (this.currentFunctionBody !== this.mainBody && canHoistFunction(this.realm, val)) {
+        if (this.currentFunctionBody !== this.mainBody && canHoistFunction(this.realm, val, undefined, new Set())) {
           instance.insertionPoint = new BodyReference(this.mainBody, this.mainBody.entries.length);
           instance.containingAdditionalFunction = undefined;
         } else {

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -12,7 +12,15 @@ type JSONValue = Array<JSONValue> | string | number | JSON;
 type JSON = { [key: string]: JSONValue };
 
 // this will mutate the original JSON object
-export function mergeAdacentJSONTextNodes(node: JSON) {
+export function mergeAdacentJSONTextNodes(node: JSON, visitedNodes?: Set<JSON>) {
+  if (visitedNodes === undefined) {
+    visitedNodes = new Set();
+  }
+  if (visitedNodes.has(node)) {
+    return "[Circular]";
+  }
+  visitedNodes.add(node);
+
   // we merge adjacent text nodes
   if (Array.isArray(node)) {
     // we create a new array rather than mutating the original
@@ -33,7 +41,7 @@ export function mergeAdacentJSONTextNodes(node: JSON) {
           arr.push(concatString);
           concatString = null;
         }
-        arr.push(mergeAdacentJSONTextNodes(child));
+        arr.push(mergeAdacentJSONTextNodes(child, visitedNodes));
       }
     }
     if (concatString !== null) {
@@ -44,7 +52,7 @@ export function mergeAdacentJSONTextNodes(node: JSON) {
     for (let key in node) {
       let value = node[key];
       if (typeof value === "object" && value !== null) {
-        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON));
+        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), visitedNodes);
       }
     }
   }

--- a/test/react/functional-components/circular-reference.js
+++ b/test/react/functional-components/circular-reference.js
@@ -3,17 +3,26 @@ var React = require('React');
 this['React'] = React;
 
 function App() {
-  // Simple circular reference
+  // A circular reference
   let selfRef = {};
   selfRef.selfRef = selfRef;
 
-  // A cycle
+  // A cycle between two references
   let mutualRefA = {};
   let mutualRefB = {};
   mutualRefA.indirect = {b: mutualRefB};
   mutualRefB.indirect = {a: mutualRefA};
 
-  return <div data-x={selfRef} data-y={mutualRefA} data-y={mutualRefB} />;
+  return (
+    <div
+      data-x={selfRef}
+      data-y={mutualRefA}
+      data-z={mutualRefB}
+      data-a={mutualRefA === mutualRefA.indirect.b.indirect.a}
+      data-b={mutualRefB === mutualRefB.indirect.a.indirect.b}
+      data-c={selfRef === selfRef.selfRef}
+    />
+  );
 }
 
 App.getTrials = function(renderer, Root) {

--- a/test/react/functional-components/circular-reference.js
+++ b/test/react/functional-components/circular-reference.js
@@ -1,0 +1,28 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App() {
+  // Simple circular reference
+  let selfRef = {};
+  selfRef.selfRef = selfRef;
+
+  // A cycle
+  let mutualRefA = {};
+  let mutualRefB = {};
+  mutualRefA.indirect = {b: mutualRefB};
+  mutualRefB.indirect = {a: mutualRefA};
+
+  return <div data-x={selfRef} data-y={mutualRefA} data-y={mutualRefB} />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['circular-reference', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
This adds a failing test that demonstrates circular references between objects in props leads to a stack overflow when we check whether it's safe to hoist them:

```
      at canHoistValue (lib/react/hoisting.js:225:232)
      at canHoistObject (lib/react/hoisting.js:56:12)
      at canHoistValue (lib/react/hoisting.js:225:232)
      at canHoistObject (lib/react/hoisting.js:56:12)
      at canHoistValue (lib/react/hoisting.js:225:232)
      at canHoistObject (lib/react/hoisting.js:56:12)
      at canHoistValue (lib/react/hoisting.js:225:232)
      at canHoistObject (lib/react/hoisting.js:56:12)
      at canHoistValue (lib/react/hoisting.js:225:232)
      at canHoistObject (lib/react/hoisting.js:56:12)
      at canHoistValue (lib/react/hoisting.js:225:232)
      at canHoistObject (lib/react/hoisting.js:56:12)
```

We could probably fix this by keeping track of visited objects.

The second commit tracks which objects have been visited, and bails out of hoisting if we find a circular reference. I also had to fix up the React test infra that assumed JSON objects don't have cycles.