### PR TITLE
Relay mock should be serializable

### DIFF
--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -15,7 +15,7 @@ import { Create } from "../../singletons.js";
 import { createAbstract } from "../prepack/utils.js";
 
 export function createMockReactRelay(realm: Realm, relayRequireName: string): ObjectValue {
-  let reactRelay = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, `require("${relayRequireName}")`, true);
+  let reactRelay = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, `require("${relayRequireName}")`);
   // for QueryRenderer, we want to leave the component alone but process it's "render" prop
   let queryRendererComponent = createAbstract(realm, "function", `require("${relayRequireName}").QueryRenderer`);
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "QueryRenderer", queryRendererComponent);


### PR DESCRIPTION
This fixes an error I'm seeing trying to compile UFI2. @trueadm confirms this was unintentional.