### PR TITLE
Add more React Relay mocks

### DIFF
--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -29,5 +29,20 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
     `require("${relayRequireName}").createFragmentContainer`
   );
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "createFragmentContainer", createFragmentContainer);
+
+  let createPaginationContainer = createAbstract(
+    realm,
+    "function",
+    `require("${relayRequireName}").createPaginationContainer`
+  );
+  Create.CreateDataPropertyOrThrow(realm, reactRelay, "createPaginationContainer", createPaginationContainer);
+
+  let createRefetchContainer = createAbstract(
+    realm,
+    "function",
+    `require("${relayRequireName}").createRefetchContainer`
+  );
+  Create.CreateDataPropertyOrThrow(realm, reactRelay, "createRefetchContainer", createRefetchContainer);
+
   return reactRelay;
 }


### PR DESCRIPTION
I need them for the UFI.

(Side note: the "not a function" message I got otherwise was pretty terrible. Would never have figured out it was due to a missing definition without a debugger. We should improve it to show the actual name of the function that doesn't exist.)