### PR TITLE
Resurrecting "require optimization" with dependency indirections.

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -444,7 +444,9 @@ export class ResidualFunctions {
                   modified,
                   requireReturns: this.requireReturns,
                   requireStatistics,
-                  isRequire: this.modules.getIsRequire(methodParams, [functionValue]),
+                  getModuleIdIfNodeIsRequireFunction: this.modules.getGetModuleIdIfNodeIsRequireFunction(methodParams, [
+                    functionValue,
+                  ]),
                   factoryFunctionInfos,
                 }
               );
@@ -488,7 +490,9 @@ export class ResidualFunctions {
               modified,
               requireReturns: this.requireReturns,
               requireStatistics,
-              isRequire: this.modules.getIsRequire(funcParams, [functionValue]),
+              getModuleIdIfNodeIsRequireFunction: this.modules.getGetModuleIdIfNodeIsRequireFunction(funcParams, [
+                functionValue,
+              ]),
               factoryFunctionInfos,
             });
           }
@@ -592,7 +596,10 @@ export class ResidualFunctions {
           modified,
           requireReturns: this.requireReturns,
           requireStatistics,
-          isRequire: this.modules.getIsRequire(factoryParams, normalInstances.map(instance => instance.functionValue)),
+          getModuleIdIfNodeIsRequireFunction: this.modules.getGetModuleIdIfNodeIsRequireFunction(
+            factoryParams,
+            normalInstances.map(instance => instance.functionValue)
+          ),
           factoryFunctionInfos,
         });
 

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -14,7 +14,7 @@ import { FunctionValue } from "../values/index.js";
 import * as t from "babel-types";
 import { convertExpressionToJSXIdentifier } from "../react/jsx";
 import type { BabelNodeExpression, BabelNodeCallExpression, BabelNodeFunctionExpression } from "babel-types";
-import type { BabelTraversePath } from "babel-traverse";
+import type { BabelTraversePath, BabelTraverseScope } from "babel-traverse";
 import type { FunctionBodyAstNode } from "../types.js";
 import type { TryQuery, FunctionInfo, FactoryFunctionInfo, ResidualFunctionBinding } from "./types.js";
 import { nullExpression } from "../utils/internalizer.js";
@@ -31,7 +31,9 @@ export type ClosureRefReplacerState = {
   modified: Set<string>,
   requireReturns: Map<number | string, BabelNodeExpression>,
   requireStatistics: { replaced: 0, count: 0 },
-  getModuleIdIfNodeIsRequireFunction: void | ((scope: any, node: BabelNodeCallExpression) => void | number | string),
+  getModuleIdIfNodeIsRequireFunction:
+    | void
+    | ((scope: BabelTraverseScope, node: BabelNodeCallExpression) => void | number | string),
   factoryFunctionInfos: Map<number, FactoryFunctionInfo>,
 };
 

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -31,7 +31,7 @@ export type ClosureRefReplacerState = {
   modified: Set<string>,
   requireReturns: Map<number | string, BabelNodeExpression>,
   requireStatistics: { replaced: 0, count: 0 },
-  isRequire: void | ((scope: any, node: BabelNodeCallExpression) => boolean),
+  getModuleIdIfNodeIsRequireFunction: void | ((scope: any, node: BabelNodeCallExpression) => void | number | string),
   factoryFunctionInfos: Map<number, FactoryFunctionInfo>,
 };
 
@@ -109,12 +109,14 @@ export let ClosureRefReplacer = {
     // Here we apply the require optimization by replacing require calls with their
     // corresponding initialized modules.
     let requireReturns = state.requireReturns;
-    if (!state.isRequire || !state.isRequire(path.scope, path.node)) return;
+    if (state.getModuleIdIfNodeIsRequireFunction === undefined) return;
+    let moduleId = state.getModuleIdIfNodeIsRequireFunction(path.scope, path.node);
+    if (moduleId === undefined) return;
+
     state.requireStatistics.count++;
     if (state.modified.has(path.node.callee.name)) return;
 
-    let moduleId = "" + path.node.arguments[0].value;
-    let new_node = requireReturns.get(moduleId);
+    let new_node = requireReturns.get("" + moduleId);
     if (new_node !== undefined) {
       markVisited(new_node, state.residualFunctionBindings);
       path.replaceWith(new_node);

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -311,6 +311,7 @@ export class ModuleTracer extends Tracer {
         return dependencies;
       }
     }
+    return undefined;
   }
 
   detourCall(

--- a/test/serializer/optimizations/require_opt_with_dependencies.js
+++ b/test/serializer/optimizations/require_opt_with_dependencies.js
@@ -1,0 +1,126 @@
+// es6
+// does not contain:require(dependencies[0])
+
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+      try {
+
+   var _moduleObject = { exports: exports };
+
+   factory(global, require, _moduleObject, exports, dependencyMap);
+
+      module.factory = undefined;
+
+   return module.exports = _moduleObject.exports;
+ } catch (e) {
+   module.hasError = true;
+   module.isInitialized = false;
+   module.exports = undefined;
+   throw e;
+ }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+define(function(global, require, module, exports) {
+  module.exports = { foo: " hello " };
+}, 0, null);
+
+define(function(global, require, module, exports, dependencies) {
+  var x = require(dependencies[0]);
+  var y = require(dependencies[1]);
+  module.exports = {
+    bar: " goodbye",
+    foo2: x.foo,
+    baz: y.baz
+  };
+}, 1, [0, 2]);
+
+define(function(global, require, module, exports) {
+  module.exports = { baz: " foo " };
+}, 2, null);
+
+var x = require(0);
+
+function f() {
+  return x.foo === " hello " && modules[1].exports === undefined &&
+    require(1).bar === " goodbye";
+}
+
+inspect = function() {
+  // the require(dependencies[ 0]) should be entirely eliminated from 1's factory function
+  // but the require(dependencies[1]) will remain
+  return f();
+}


### PR DESCRIPTION
Release notes: Calls to the require-function within modules are (again) replaced by direct referenced to the prepacked exported object, if the required module has been prepacked.

This addresses #1101, and is achieved by additional pattern matching for the new __d and require call patterns emitted by the Metro bundler.

Verified with an internal sizable benchmark that this affects as expected a large number of require calls.