### PR TITLE
Refactored serializer error handling

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -101,27 +101,27 @@ export function valueIsReactLibraryObject(realm: Realm, value: ObjectValue, logg
   }
   // we check that the object is the React or React-like library by checking for
   // core properties that should exist on it
-  let reactVersion = logger.tryQuery(() => Get(realm, value, "version"), undefined, false);
+  let reactVersion = logger.tryQuery(() => Get(realm, value, "version"), undefined);
   if (!(reactVersion instanceof StringValue)) {
     return false;
   }
-  let reactCreateElement = logger.tryQuery(() => Get(realm, value, "createElement"), undefined, false);
+  let reactCreateElement = logger.tryQuery(() => Get(realm, value, "createElement"), undefined);
   if (!(reactCreateElement instanceof FunctionValue)) {
     return false;
   }
-  let reactCloneElement = logger.tryQuery(() => Get(realm, value, "cloneElement"), undefined, false);
+  let reactCloneElement = logger.tryQuery(() => Get(realm, value, "cloneElement"), undefined);
   if (!(reactCloneElement instanceof FunctionValue)) {
     return false;
   }
-  let reactIsValidElement = logger.tryQuery(() => Get(realm, value, "isValidElement"), undefined, false);
+  let reactIsValidElement = logger.tryQuery(() => Get(realm, value, "isValidElement"), undefined);
   if (!(reactIsValidElement instanceof FunctionValue)) {
     return false;
   }
-  let reactComponent = logger.tryQuery(() => Get(realm, value, "Component"), undefined, false);
+  let reactComponent = logger.tryQuery(() => Get(realm, value, "Component"), undefined);
   if (!(reactComponent instanceof FunctionValue)) {
     return false;
   }
-  let reactChildren = logger.tryQuery(() => Get(realm, value, "Children"), undefined, false);
+  let reactChildren = logger.tryQuery(() => Get(realm, value, "Children"), undefined);
   if (!(reactChildren instanceof ObjectValue)) {
     return false;
   }

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -89,8 +89,7 @@ export class Functions {
     let realm = this.realm;
     let globalRecordedAdditionalFunctionsMap = this.moduleTracer.modules.logger.tryQuery(
       () => Get(realm, realm.$GlobalObject, globalKey),
-      realm.intrinsics.undefined,
-      false
+      realm.intrinsics.undefined
     );
     invariant(globalRecordedAdditionalFunctionsMap instanceof ObjectValue);
     for (let funcId of globalRecordedAdditionalFunctionsMap.getOwnPropertyKeysArray()) {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -17,7 +17,7 @@ import { SameValue } from "../methods/abstract.js";
 import { Realm, type Effects } from "../realm.js";
 import invariant from "../invariant.js";
 
-export type TryQuery<T> = (f: () => T, defaultValue: T, logFailures: boolean) => T;
+export type TryQuery<T> = (f: () => T, defaultValue: T) => T;
 
 // TODO: add type for additional functions.
 export type SerializedBodyType =

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -372,7 +372,7 @@ export class Modules {
     this.active = true;
     try {
       let realm = this.realm;
-      return this.logger.tryQuery(() => Get(realm, realm.$GlobalObject, name), realm.intrinsics.undefined, false);
+      return this.logger.tryQuery(() => Get(realm, realm.$GlobalObject, name), realm.intrinsics.undefined);
     } finally {
       this.active = false;
     }
@@ -417,8 +417,7 @@ export class Modules {
         let doesNotMatter = true;
         let reference = logger.tryQuery(
           () => Environment.ResolveBinding(realm, innerName, doesNotMatter, f.$Environment),
-          undefined,
-          false
+          undefined
         );
         if (reference === undefined) {
           // We couldn't resolve as we came across some behavior that we cannot deal with abstractly
@@ -430,7 +429,7 @@ export class Modules {
         if (typeof referencedName !== "string") return false;
         let value;
         if (reference.base instanceof GlobalEnvironmentRecord) {
-          value = logger.tryQuery(() => Get(realm, realm.$GlobalObject, innerName), realm.intrinsics.undefined, false);
+          value = logger.tryQuery(() => Get(realm, realm.$GlobalObject, innerName), realm.intrinsics.undefined);
         } else {
           invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
           let binding = referencedBase.bindings[referencedName];


### PR DESCRIPTION
Release notes: none

- Removed unnecessary (dead) parameter to tryQuery
- In _visitReactLibrary, don't just throw a FatalError --- fatal errors must always be preceeded by issuing CompilerDiagnostics, otherwise an ugly internal invariant violation is reported --- instead, use the current standard for error reporting in the serializer: logError
- Made logError play nice with CompilerDiagnostics + FatalError