### PR TITLE
ReVisit fix for additional functions and modified bindings

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -30,7 +30,6 @@ function runTestSuite(outputJsx) {
     reactEnabled: true,
     reactOutput: outputJsx ? "jsx" : "create-element",
     inlineExpressions: true,
-    simpleClosures: true,
     omitInvariants: true,
     abstractEffectsInAdditionalFunctions: true,
   };
@@ -236,6 +235,10 @@ function runTestSuite(outputJsx) {
 
       it("Class component as root with instance variables #2", async () => {
         await runTest(directory, "class-root-with-instance-vars-2.js");
+      });
+
+      it("Additional functions closure scope capturing", async () => {
+        await runTest(directory, "additional-function-regression.js");
       });
     });
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -880,7 +880,6 @@ export class ResidualHeapVisitor {
         for (let innerName of functionInfo.unbound) {
           let residualBinding = this.visitBinding(functionValue, innerName, false);
           if (residualBinding) {
-            residualBinding.modified = true;
             funcInstance.residualFunctionBindings.set(innerName, residualBinding);
           }
         }

--- a/test/react/functional-components/additional-function-regression.js
+++ b/test/react/functional-components/additional-function-regression.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Component2() {
+    // nothing here
+}
+  
+function App() {
+    return (
+            <div ref={() => {
+    var foo = <Component2 />
+                }} />
+            );
+}
+  
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

While revisiting bindings for additional functions, don't mark them all as `modified`.
This seems to address #1346, while not breaking any existing test.
