### PR TITLE
Flag isComputed on t.memberExpression for generateAbstractGet

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -312,6 +312,8 @@ export default class AbstractObjectValue extends AbstractValue {
   // ECMA262 9.1.8
   $Get(P: PropertyKeyValue, Receiver: Value): Value {
     if (P instanceof StringValue) P = P.value;
+    let isComputed = (typeof P === "string" && !isNaN(P)) || P instanceof AbstractValue;
+
     if (this.values.isTop()) {
       let generateAbstractGet = () => {
         let type = Value;
@@ -323,7 +325,7 @@ export default class AbstractObjectValue extends AbstractValue {
           [object],
           ([o]) => {
             invariant(typeof P === "string");
-            return t.memberExpression(o, t.identifier(P));
+            return t.memberExpression(o, t.identifier(P), isComputed);
           },
           {
             skipInvariant: true,

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -312,7 +312,6 @@ export default class AbstractObjectValue extends AbstractValue {
   // ECMA262 9.1.8
   $Get(P: PropertyKeyValue, Receiver: Value): Value {
     if (P instanceof StringValue) P = P.value;
-    let isComputed = (typeof P === "string" && !isNaN(P)) || P instanceof AbstractValue;
 
     if (this.values.isTop()) {
       let generateAbstractGet = () => {
@@ -325,7 +324,7 @@ export default class AbstractObjectValue extends AbstractValue {
           [object],
           ([o]) => {
             invariant(typeof P === "string");
-            return t.memberExpression(o, t.identifier(P), isComputed);
+            return t.memberExpression(o, t.identifier(P), !t.isValidIdentifier(P));
           },
           {
             skipInvariant: true,


### PR DESCRIPTION
Release notes: none

We need to ensure that we pass `isComputed` boolean to `t.memberExpression` otherwise property accesses with a string `"0"` will incorrectly get serialized to `object.0` instead of `object[0]`.