### PR TITLE
Fixed delayInitializations bug

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -448,7 +448,7 @@ export class ResidualHeapVisitor {
   // function a() { x.push("hi"); }
   // function b() { y.push("bye"); }
   // function c() { return x.length + y.length; }
-  // Here we need to make sure that a, b both initialize x and y because x and y will be in the same
+  // Here we need to make sure that a and b both initialize x and y because x and y will be in the same
   // captured scope because c captures both x and y.
   _recordBindingVisitedAndRevisit(val: FunctionValue, residualFunctionBinding: ResidualFunctionBinding) {
     let refScope = this.containingAdditionalFunction ? this.containingAdditionalFunction : "GLOBAL";

--- a/test/serializer/optimizations/DelayInitCaptures.js
+++ b/test/serializer/optimizations/DelayInitCaptures.js
@@ -1,0 +1,25 @@
+function f () {
+  let x = [];
+  let y = [];
+  function a() { // ================================================= no inline
+    x.push("hi");
+  }
+  function b() { // ================================================= no inline
+    y.push("bye");
+  }
+  function c() { // ================================================= no inline
+    return x.length + y.length;
+  }
+  return [a, b, c];
+}
+
+var res  = f();
+var a = res[0];
+var b = res[1];
+var c = res[2];
+
+inspect = function() {
+  a();
+  b();
+  return c();
+}

--- a/test/serializer/optimizations/DelayInitMult.js
+++ b/test/serializer/optimizations/DelayInitMult.js
@@ -31,7 +31,7 @@ var b = res[1];
 var c = res[2];
 
 inspect = function() {
-  b();
-  a();
-  return c();
+  let toPrint = b() + " ";
+  toPrint += a();
+  return toPrint + " " + c();
 }

--- a/test/serializer/optimizations/DelayInitMult.js
+++ b/test/serializer/optimizations/DelayInitMult.js
@@ -1,0 +1,36 @@
+function f () {
+  var valueA = [];
+  var valueB = {};
+
+  function fun1() { // no inline =============================================
+    let len = valueA.length;
+    valueA = [];
+    valueA.push("hello");
+    return valueA;
+  }
+
+  function fun2() { // no inline =============================================
+    valueB = {};
+    valueB.x = "hello";
+    return valueB.length;
+  }
+
+  function print() { // no inline =============================================
+    valueA;
+    valueB;
+    return valueA.toString() + valueB.toString();
+  }
+
+  return [fun1, fun2, print];
+}
+
+var res  = f();
+var a = res[0];
+var b = res[1];
+var c = res[2];
+
+inspect = function() {
+  b();
+  a();
+  return c();
+}

--- a/test/serializer/optimizations/DelayInitMult.js
+++ b/test/serializer/optimizations/DelayInitMult.js
@@ -3,6 +3,7 @@ function f () {
   var valueB = {};
 
   function fun1() { // no inline =============================================
+    // reference valueA then modify it
     let len = valueA.length;
     valueA = [];
     valueA.push("hello");
@@ -10,14 +11,14 @@ function f () {
   }
 
   function fun2() { // no inline =============================================
+    // modify valueB then reference it
     valueB = {};
     valueB.x = "hello";
     return valueB.length;
   }
 
   function print() { // no inline =============================================
-    valueA;
-    valueB;
+    // Reference both valueA and valueB
     return valueA.toString() + valueB.toString();
   }
 


### PR DESCRIPTION
Fixes a bug in delayInitializations + closure referentialization where in the following case:
```
let x = [];
let y = [];
function a() { x.push("hi"); }
function b() { y.push("bye"); }
function c() { return x.length + y.length; }
```
`a()` would initialize `x` to `[]` but y to `undefined` and cache that in `__captured_scopes` and vice versa for `b()`.