### PR TITLE
Allow leaking calls in pure mode with a global scope parent

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -64,6 +64,9 @@ function runTestSuite(outputJsx) {
             QueryRenderer(props) {
               return props.render({ props: {}, error: null });
             },
+            createFragmentContainer() {
+              return null;
+            },
             graphql() {
               return null;
             },
@@ -89,23 +92,25 @@ function runTestSuite(outputJsx) {
     let { compiledSource } = compileSourceWithPrepack(source);
 
     let A = runSource(source);
-    expect(typeof A).toBe("function");
     let B = runSource(compiledSource);
-    expect(typeof B).toBe("function");
+    expect(typeof A).toBe(typeof B);
+    if (typeof A !== "function") {
+      // Test without exports just verifies that the file compiles.
+      return;
+    }
 
     let rendererA = ReactTestRenderer.create(null);
     let rendererB = ReactTestRenderer.create(null);
-
     if (A == null || B == null) {
       throw new Error("React test runner issue");
     }
-    // // Use the original version of the test in case transforming messes it up.
+    // Use the original version of the test in case transforming messes it up.
     let { getTrials } = A;
-    // // Run tests that assert the rendered output matches.
+    // Run tests that assert the rendered output matches.
     let resultA = getTrials(rendererA, A);
     let resultB = getTrials(rendererB, B);
 
-    // // the test has returned many values for us to check
+    // The test has returned many values for us to check
     for (let i = 0; i < resultA.length; i++) {
       let [nameA, valueA] = resultA[i];
       let [nameB, valueB] = resultB[i];
@@ -275,6 +280,10 @@ function runTestSuite(outputJsx) {
 
       it("fb-www 2", async () => {
         await runTest(directory, "fb2.js");
+      });
+
+      it("fb-www 3", async () => {
+        await runTest(directory, "fb3.js");
       });
     });
   });

--- a/src/utils/leak.js
+++ b/src/utils/leak.js
@@ -297,13 +297,11 @@ class ObjectValueLeakingVisitor {
         this.visitValue(record.object);
         continue;
       }
+      if (record instanceof GlobalEnvironmentRecord) {
+        break;
+      }
 
-      invariant(
-        !(record instanceof GlobalEnvironmentRecord),
-        "we should never reach the global scope because it is never newly created in a pure function."
-      );
       invariant(record instanceof DeclarativeEnvironmentRecord);
-
       this.visitDeclarativeEnvironmentRecordBinding(record, remainingLeakedBindings);
 
       if (record instanceof FunctionEnvironmentRecord) {

--- a/test/react/mocks/fb3.js
+++ b/test/react/mocks/fb3.js
@@ -1,0 +1,8 @@
+(function() {
+  function App() {}
+  var ReactRelay = require('RelayModern');
+  ReactRelay.createFragmentContainer(App);
+})();
+
+// This test just verifies that the file compiles.
+// It is pure and doesn't export anything.


### PR DESCRIPTION
This is extracted from https://github.com/facebook/prepack/pull/1377.

It fixes the case where we used to hit [this invariant](https://github.com/facebook/prepack/blob/484b5db37f1e1ede6f3d4a11beece82f49ece6de/src/utils/leak.js#L301-L304) in the leak tracking code. We thought it's impossible but it turns out that this happens when the init code wrapped in the pure env (like we do since https://github.com/facebook/prepack/pull/1374) and is inside of IIFE.

The new regression test fails on master but passes with this PR.