### PR TITLE
[RFC] Ignore leaking during serialization

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -276,6 +276,10 @@ function runTestSuite(outputJsx) {
       it("fb-www 2", async () => {
         await runTest(directory, "fb2.js");
       });
+
+      it("fb-www 4", async () => {
+        await runTest(directory, "fb4.js");
+      });
     });
   });
 }

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -209,7 +209,7 @@ function parentPermitsChildPropertyCreation(realm: Realm, O: ObjectValue, P: Pro
 export class PropertiesImplementation {
   // ECMA262 9.1.9.1
   OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value, Receiver: Value): boolean {
-    if (O.isLeakedObject()) {
+    if (!realm.ignoreLeakLogic && O.isLeakedObject()) {
       Leak.leakValue(realm, V);
       if (realm.generator) {
         realm.generator.emitPropertyAssignment(O, StringKey(P), V);
@@ -480,7 +480,7 @@ export class PropertiesImplementation {
 
     // 3. If desc is undefined, return true.
     if (!desc) {
-      if (O.isLeakedObject()) {
+      if (!realm.ignoreLeakLogic && O.isLeakedObject()) {
         if (realm.generator) {
           realm.generator.emitPropertyDelete(O, StringKey(P));
         }
@@ -607,7 +607,7 @@ export class PropertiesImplementation {
       // b. Assert: extensible is true.
       invariant(extensible === true, "expected extensible to be true");
 
-      if (O !== undefined && O.isLeakedObject() && P !== undefined) {
+      if (O !== undefined && !realm.ignoreLeakLogic && O.isLeakedObject() && P !== undefined) {
         leakDescriptor(realm, Desc);
         if (realm.generator) {
           realm.generator.emitDefineProperty(O, StringKey(P), Desc);
@@ -692,7 +692,7 @@ export class PropertiesImplementation {
       }
     }
 
-    if (O !== undefined && O.isLeakedObject() && P !== undefined) {
+    if (O !== undefined && !realm.ignoreLeakLogic && O.isLeakedObject() && P !== undefined) {
       leakDescriptor(realm, Desc);
       if (realm.generator) {
         realm.generator.emitDefineProperty(O, StringKey(P), Desc);
@@ -1103,7 +1103,7 @@ export class PropertiesImplementation {
 
   // ECMA262 9.1.5.1
   OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue): Descriptor | void {
-    if (O.isLeakedObject()) {
+    if (!realm.ignoreLeakLogic && O.isLeakedObject()) {
       invariant(realm.generator);
       let pname = realm.generator.getAsPropertyNameExpression(StringKey(P));
       let absVal = AbstractValue.createTemporalFromBuildFunction(realm, Value, [O], ([node]) =>
@@ -1217,7 +1217,7 @@ export class PropertiesImplementation {
 
   // ECMA262 9.1.2.1
   OrdinarySetPrototypeOf(realm: Realm, O: ObjectValue, V: ObjectValue | NullValue): boolean {
-    if (O.isLeakedObject()) {
+    if (!realm.ignoreLeakLogic && O.isLeakedObject()) {
       throw new FatalError();
     }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -448,6 +448,7 @@ export class Realm {
   }
 
   evaluateWithoutLeakLogic(f: () => Value): Value {
+    invariant(!this.ignoreLeakLogic, "Nesting evaluateWithoutLeakLogic() calls is not supported.");
     this.ignoreLeakLogic = true;
     try {
       return f();

--- a/src/realm.js
+++ b/src/realm.js
@@ -134,6 +134,7 @@ export class Realm {
     this.isReadOnly = false;
     this.useAbstractInterpretation = !!opts.serialize || !!opts.residual || !!opts.check;
     this.trackLeaks = !!opts.abstractEffectsInAdditionalFunctions;
+    this.ignoreLeakLogic = false;
     this.isInPureTryStatement = false;
     if (opts.mathRandomSeed !== undefined) {
       this.mathRandomGenerator = seedrandom(opts.mathRandomSeed);
@@ -210,6 +211,7 @@ export class Realm {
   strictlyMonotonicDateNow: boolean;
   maxStackDepth: number;
   omitInvariants: boolean;
+  ignoreLeakLogic: boolean;
 
   modifiedBindings: void | Bindings;
   modifiedProperties: void | PropertyBindings;
@@ -443,6 +445,15 @@ export class Realm {
 
   isInPureScope() {
     return !!this.createdObjectsTrackedForLeaks;
+  }
+
+  evaluateWithoutLeakLogic(f: () => Value): Value {
+    this.ignoreLeakLogic = true;
+    try {
+      return f();
+    } finally {
+      this.ignoreLeakLogic = false;
+    }
   }
 
   // Evaluate some code that might generate temporal values knowing that it might end in an abrupt

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -886,7 +886,12 @@ export class ResidualHeapSerializer {
     remainingProperties: Map<string, PropertyBinding>
   ): void {
     const realm = this.realm;
-    let lenProperty = Get(realm, val, "length");
+    let lenProperty;
+    if (val.isLeakedObject()) {
+      lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
+    } else {
+      lenProperty = Get(realm, val, "length");
+    }
     // Need to serialize length property if:
     // 1. array length is abstract.
     // 2. array length is concrete, but different from number of index properties

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -886,12 +886,8 @@ export class ResidualHeapSerializer {
     remainingProperties: Map<string, PropertyBinding>
   ): void {
     const realm = this.realm;
-    let lenProperty;
-    if (val.isLeakedObject()) {
-      lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
-    } else {
-      lenProperty = Get(realm, val, "length");
-    }
+    const lenProperty = Get(realm, val, "length");
+
     // Need to serialize length property if:
     // 1. array length is abstract.
     // 2. array length is concrete, but different from number of index properties

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -276,12 +276,7 @@ export class ResidualHeapVisitor {
   visitValueArray(val: ObjectValue): void {
     this.visitObjectProperties(val);
     const realm = this.realm;
-    let lenProperty;
-    if (val.isLeakedObject()) {
-      lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
-    } else {
-      lenProperty = Get(realm, val, "length");
-    }
+    const lenProperty = Get(realm, val, "length");
     if (
       lenProperty instanceof AbstractValue ||
       To.ToLength(realm, lenProperty) !== getSuggestedArrayLiteralLength(realm, val)

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -276,7 +276,12 @@ export class ResidualHeapVisitor {
   visitValueArray(val: ObjectValue): void {
     this.visitObjectProperties(val);
     const realm = this.realm;
-    let lenProperty = Get(realm, val, "length");
+    let lenProperty;
+    if (val.isLeakedObject()) {
+      lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
+    } else {
+      lenProperty = Get(realm, val, "length");
+    }
     if (
       lenProperty instanceof AbstractValue ||
       To.ToLength(realm, lenProperty) !== getSuggestedArrayLiteralLength(realm, val)

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import type { ObjectValue, SymbolValue } from "../values/index.js";
+import { ObjectValue, SymbolValue } from "../values/index.js";
 import type { Realm } from "../realm.js";
 
 import type { Descriptor } from "../types.js";

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { ObjectValue, SymbolValue } from "../values/index.js";
+import type { ObjectValue, SymbolValue } from "../values/index.js";
 import type { Realm } from "../realm.js";
 
 import type { Descriptor } from "../types.js";

--- a/src/utils/leak.js
+++ b/src/utils/leak.js
@@ -362,10 +362,7 @@ class ObjectValueLeakingVisitor {
         this.visitValueSet(val);
         return;
       default:
-        invariant(
-          kind === "Object" || kind === "Array",
-          `Object of kind ${kind} is not supported in calls to abstract functions.`
-        );
+        invariant(kind === "Object", `Object of kind ${kind} is not supported in calls to abstract functions.`);
         invariant(
           this.$ParameterMap === undefined,
           `Arguments object is not supported in calls to abstract functions.`

--- a/src/utils/leak.js
+++ b/src/utils/leak.js
@@ -332,6 +332,7 @@ class ObjectValueLeakingVisitor {
       case "Boolean":
       case "ReactElement":
       case "ArrayBuffer":
+      case "Array":
         return;
       case "Date":
         let dateValue = val.$DateValue;

--- a/src/utils/leak.js
+++ b/src/utils/leak.js
@@ -363,7 +363,10 @@ class ObjectValueLeakingVisitor {
         this.visitValueSet(val);
         return;
       default:
-        invariant(kind === "Object", `Object of kind ${kind} is not supported in calls to abstract functions.`);
+        invariant(
+          kind === "Object" || kind === "Array",
+          `Object of kind ${kind} is not supported in calls to abstract functions.`
+        );
         invariant(
           this.$ParameterMap === undefined,
           `Arguments object is not supported in calls to abstract functions.`

--- a/test/react/mocks/fb4.js
+++ b/test/react/mocks/fb4.js
@@ -5,4 +5,4 @@ App.arr = [1, 2, 3];
 App.otherArray = [];
 App.otherArray.length = 10;
 
-global.WrappedApp = require("RelayModern").createFragmentContainer(App);
+this.WrappedApp = require("RelayModern").createFragmentContainer(App);

--- a/test/react/mocks/fb4.js
+++ b/test/react/mocks/fb4.js
@@ -1,0 +1,8 @@
+function App() {}
+App.prototype.hi = function() {};
+
+App.arr = [1, 2, 3];
+App.otherArray = [];
+App.otherArray.length = 10;
+
+global.WrappedApp = require("RelayModern").createFragmentContainer(App);


### PR DESCRIPTION
This builds on #1382 and tries a different approach in the last commit.

https://github.com/facebook/prepack/pull/1384/commits/cec5bf4b75c9bce37e599db2008972323549f3ca?w=1 (make sure to ignore whitespace, most of it is a re-indent)

Instead of wrapping specific callsites into `evaluateWithoutLeakLogic` we wrap the whole serialization in it. The idea being that during serialization, we don't execute any user code and thus shouldn't need to worry about the leaks.

I don't actually know if it's safe because I don't understand Prepack well enough yet. Just throwing this out there.