### PR TITLE
Compile time error for Set constructor argument if using JSC

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -57,6 +57,7 @@ function runTest(name: string, code: string): boolean {
   let additionalFunctions = code.includes("// additional functions");
   let delayUnsupportedRequires = code.includes("// delay unsupported requires");
   let abstractEffects = code.includes("// abstract effects");
+  let compatibility = code.includes("// jsc") ? "jsc-600-1-4-17" : undefined;
 
   let expectedErrors = code.match(/\/\/\s*expected errors:\s*(.*)/);
   invariant(expectedErrors);
@@ -75,6 +76,7 @@ function runTest(name: string, code: string): boolean {
       serialize: true,
       initializeMoreModules: false,
       abstractEffectsInAdditionalFunctions: abstractEffects,
+      compatibility,
     };
     if (additionalFunctions) (options: any).additionalFunctions = ["global.additional1", "global['additional2']"];
     prepackFileSync([name], options);

--- a/src/intrinsics/ecma262/Set.js
+++ b/src/intrinsics/ecma262/Set.js
@@ -24,6 +24,7 @@ import {
 } from "../../methods/index.js";
 import { Create } from "../../singletons.js";
 import invariant from "../../invariant.js";
+import { CompilerDiagnostic } from "../../errors.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 23.2.1.1
@@ -43,7 +44,15 @@ export default function(realm: Realm): NativeFunctionValue {
 
     // 4. If iterable is not present, let iterable be undefined.
     if (iterable && realm.isCompatibleWith(realm.MOBILE_JSC_VERSION)) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "the set constructor doesn't take arguments");
+      let loc = realm.currentLocation;
+      let error = new CompilerDiagnostic(
+        "This version of JSC ignores the argument to Set, require the polyfill before doing this",
+        loc,
+        "PP0001",
+        "RecoverableError"
+      );
+      realm.handleError(error);
+      iterable = undefined;
     }
     if (!iterable) iterable = realm.intrinsics.undefined;
 

--- a/test/error-handler/Set.js
+++ b/test/error-handler/Set.js
@@ -1,0 +1,7 @@
+// jsc
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":5,"column":22},"end":{"line":5,"column":25},"source":"test/error-handler/Set.js"},"severity":"RecoverableError","errorCode":"PP0001"}]
+ 
+let s = new Set(["a", "a"]);
+
+inspect = function() { return s.size === 1; }


### PR DESCRIPTION
Release note: fixes issue #1340

When the target platform is JSC, issue a compile time diagnostic if an argument is provided to the set constructor. Then proceed as if there were no argument, which is what JSC does at runtime.