### PR TITLE
Don't relativize global things

### DIFF
--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -83,7 +83,7 @@ export type FactoryFunctionInfo = { factoryId: BabelNodeIdentifier, functionInfo
 export type ResidualFunctionBinding = {
   value: void | Value,
   modified: boolean,
-  // void means a global binding
+  // null means a global binding
   declarativeEnvironmentRecord: null | DeclarativeEnvironmentRecord,
   // The serializedValue is only not yet present during the initialization of a binding that involves recursive dependencies.
   serializedValue?: void | BabelNodeExpression,

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -102,7 +102,8 @@ export let ClosureRefReplacer = {
     let residualFunctionBindings = state.residualFunctionBindings;
     let name = path.node.name;
     let residualFunctionBinding = residualFunctionBindings.get(name);
-    if (residualFunctionBinding) replaceName(path, residualFunctionBinding, name, residualFunctionBindings);
+    if (residualFunctionBinding && residualFunctionBinding.declarativeEnvironmentRecord !== null)
+      replaceName(path, residualFunctionBinding, name, residualFunctionBindings);
   },
 
   CallExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
@@ -127,7 +128,7 @@ export let ClosureRefReplacer = {
     let ids = path.getBindingIdentifierPaths();
     for (let name in ids) {
       let residualFunctionBinding = residualFunctionBindings.get(name);
-      if (residualFunctionBinding) {
+      if (residualFunctionBinding && residualFunctionBinding.declarativeEnvironmentRecord !== null) {
         let nestedPath = ids[name];
         replaceName(nestedPath, residualFunctionBinding, name, residualFunctionBindings);
       }

--- a/test/serializer/basic/GlobalThing.js
+++ b/test/serializer/basic/GlobalThing.js
@@ -1,0 +1,2 @@
+// does contain: globalThing
+inspect = function() { return globalThing; }

--- a/test/serializer/basic/UndefinedInResidualFunction.js
+++ b/test/serializer/basic/UndefinedInResidualFunction.js
@@ -1,2 +1,0 @@
-// does not contain:undefined
-global.inspect = function() { return undefined; }


### PR DESCRIPTION
Release notes: Do not rewrite residual functions to make all references to global things relative.

Currently, Prepack rewrites all references to global things in residual function from a simple name to something like `_$_.foo` where `_$_` effectively binds to the global object.

This was a useful thing to do to avoid name clashes with generated names, but now Prepack does a pass over the entire AST to collect identifiers, and then avoids using those as generated names.