### PR TITLE
[WIP] Enable unrooted intrinsic names.

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -596,7 +596,12 @@ export class PreludeGenerator {
     } else {
       let i = key.lastIndexOf(".");
       if (i === -1) {
-        init = t.memberExpression(this.memoizeReference("global"), t.identifier(key));
+        if (key.startsWith("::")) {
+          // Special convention to avoid rooting certain names at the global object.
+          init = t.identifier(key.substring(2));
+        } else {
+          init = t.memberExpression(this.memoizeReference("global"), t.identifier(key));
+        }
       } else {
         init = t.memberExpression(this.memoizeReference(key.substr(0, i)), t.identifier(key.substr(i + 1)));
       }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -379,7 +379,8 @@ export default class ObjectValue extends ConcreteValue {
   ) {
     let intrinsicName;
     if (typeof name === "string") {
-      if (this.intrinsicName) intrinsicName = `${this.intrinsicName}.${name}`;
+      if (name.startsWith("::")) intrinsicName = name;
+      else if (this.intrinsicName) intrinsicName = `${this.intrinsicName}.${name}`;
     } else if (name instanceof SymbolValue) {
       if (this.intrinsicName && name.intrinsicName) intrinsicName = `${this.intrinsicName}[${name.intrinsicName}]`;
     } else {


### PR DESCRIPTION
Release notes: none

After defining a built-in property, with this change one can tweak it's intrinsic name to be one that is not explicitly rooted anywhere,
e.g. with the following statement:

  global.$GetOwnProperty("__DEV__").value.intrinsicName = "::__DEV__";