### PR TITLE
Better handling of fb-www `require`, `cx` and `Bootloader`

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -289,6 +289,10 @@ function runTestSuite(outputJsx) {
       it("fb-www 4", async () => {
         await runTest(directory, "fb4.js");
       });
+
+      it("fb-www 5", async () => {
+        await runTest(directory, "fb5.js");
+      });
     });
   });
 }

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -128,7 +128,7 @@ export default function(realm: Realm): void {
   global.$DefineOwnProperty("cx", {
     value: new NativeFunctionValue(realm, "cx", "cx", 0, (context, [cxString]) => {
       invariant(cxString instanceof StringValue);
-      let cxValue = `Bootloader("${cxString.value}")`;
+      let cxValue = `cx("${cxString.value}")`;
       let cx;
 
       if (realm.fbLibraries.other.has(cxValue)) {
@@ -145,21 +145,11 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
-  global.$DefineOwnProperty("Bootloader", {
-    value: new NativeFunctionValue(realm, "Bootloader", "Bootloader", 0, (context, [bootloaderString]) => {
-      invariant(bootloaderString instanceof StringValue);
-      let bootloaderValue = `Bootloader("${bootloaderString.value}")`;
-      let bootloader;
+  let bootloader = AbstractValue.createAbstractObject(realm, "Bootloader");
+  bootloader.kind = "resolved";
 
-      if (realm.fbLibraries.other.has(bootloaderValue)) {
-        bootloader = realm.fbLibraries.other.get(bootloaderValue);
-      } else {
-        bootloader = createAbstract(realm, "function", bootloaderValue);
-        realm.fbLibraries.other.set(bootloaderValue, bootloader);
-      }
-      invariant(bootloader instanceof AbstractValue);
-      return bootloader;
-    }),
+  global.$DefineOwnProperty("Bootloader", {
+    value: bootloader,
     writable: true,
     enumerable: false,
     configurable: true,

--- a/src/realm.js
+++ b/src/realm.js
@@ -187,6 +187,7 @@ export class Realm {
       fbt: undefined,
       idx: undefined,
       ix: undefined,
+      other: new Map(),
       react: undefined,
       reactRelay: undefined,
     };
@@ -249,6 +250,7 @@ export class Realm {
     fbt: void | ObjectValue,
     idx: void | ObjectValue,
     ix: void | ObjectValue,
+    other: Map<string, AbstractValue>,
     react: void | ObjectValue,
     reactRelay: void | ObjectValue,
   };

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -303,8 +303,7 @@ export class ModuleTracer extends Tracer {
         for (let i = 0; i < lengthValue.value; i++) {
           const elementValue = logger.tryQuery(
             () => Get(realm, ((value: any): ArrayValue), "" + i),
-            realm.intrinsics.undefined,
-            false
+            realm.intrinsics.undefined
           );
           dependencies.push(elementValue);
         }

--- a/test/react/mocks/fb5.js
+++ b/test/react/mocks/fb5.js
@@ -1,3 +1,11 @@
+if (!this.Bootloader) {
+  this.Bootloader = {loadAllModules() {}};
+}
+
+if (!this.cx) {
+  this.cx = () => {};
+}
+
 function getValue() {
   return cx("yar/Jar");
 }

--- a/test/react/mocks/fb5.js
+++ b/test/react/mocks/fb5.js
@@ -1,0 +1,11 @@
+function getValue() {
+  return cx("yar/Jar");
+}
+
+var a = [Bootloader.loadAllModules("somethingYes"), getValue()];
+
+function App() {
+  return [cx("foo/Bar"), a];
+}
+
+this.WrappedApp = App;


### PR DESCRIPTION
Release notes: none

These are mainly targeted at internal fixes to require calls we need.

- Fixes the `require` system so that it returns the same abstract function for the same call. We now memoize values on a `Map` on `realm.fbLibraries.other`
- Adds two new FB internal globals `cx` and `Bootloader`
- To prevent extra serialization bloat, kind = "resolved" is used on some objects.