### PR TITLE
Make certain abstract functions safe from leaking logic

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -112,7 +112,7 @@ function generateRuntimeCall(
   if (propName !== undefined && typeof propName !== "string") args.push(propName);
   args = args.concat(ArgumentListEvaluation(realm, strictCode, env, ast.arguments));
   for (let arg of args) {
-    if (arg !== func) {
+    if (arg !== func && !func.safeFromLeaks) {
       Leak.leakValue(realm, arg, ast.loc);
     }
   }

--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -18,9 +18,11 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
   let reactRelay = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, `require("${relayRequireName}")`);
   // for QueryRenderer, we want to leave the component alone but process it's "render" prop
   let queryRendererComponent = createAbstract(realm, "function", `require("${relayRequireName}").QueryRenderer`);
+  queryRendererComponent.makeSafeFromLeaks();
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "QueryRenderer", queryRendererComponent);
 
   let graphql = createAbstract(realm, "function", `require("${relayRequireName}").graphql`);
+  graphql.makeSafeFromLeaks();
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "graphql", graphql);
 
   let createFragmentContainer = createAbstract(
@@ -28,6 +30,7 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
     "function",
     `require("${relayRequireName}").createFragmentContainer`
   );
+  createFragmentContainer.makeSafeFromLeaks();
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "createFragmentContainer", createFragmentContainer);
 
   let createPaginationContainer = createAbstract(
@@ -35,6 +38,7 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
     "function",
     `require("${relayRequireName}").createPaginationContainer`
   );
+  createPaginationContainer.makeSafeFromLeaks();
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "createPaginationContainer", createPaginationContainer);
 
   let createRefetchContainer = createAbstract(
@@ -42,6 +46,7 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
     "function",
     `require("${relayRequireName}").createRefetchContainer`
   );
+  createRefetchContainer.makeSafeFromLeaks();
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "createRefetchContainer", createRefetchContainer);
 
   return reactRelay;

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -35,6 +35,7 @@ import {
   SymbolValue,
   UndefinedValue,
   Value,
+  FunctionValue,
 } from "./index.js";
 import { hashBinary, hashCall, hashString, hashTernary, hashUnary } from "../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -66,6 +67,7 @@ export default class AbstractValue extends Value {
     this.args = args;
     this.hashValue = hashValue;
     this.kind = optionalArgs ? optionalArgs.kind : undefined;
+    this.safeFromLeaks = false;
   }
 
   hashValue: number;
@@ -74,6 +76,7 @@ export default class AbstractValue extends Value {
   values: ValuesDomain;
   mightBeEmpty: boolean;
   args: Array<Value>;
+  safeFromLeaks: boolean;
   _buildNode: void | AbstractValueBuildNodeFunction | BabelNodeExpression;
 
   addSourceLocationsTo(locations: Array<BabelNodeSourceLocation>, seenValues?: Set<AbstractValue> = new Set()) {
@@ -220,6 +223,14 @@ export default class AbstractValue extends Value {
       }
     }
     return false;
+  }
+
+  makeSafeFromLeaks() {
+    invariant(
+      this.getType() === FunctionValue,
+      "makeSafeFromLeaks() can only be applied to abstract values with a function type"
+    );
+    this.safeFromLeaks = true;
   }
 
   // todo: abstract values should never be of type UndefinedValue or NullValue, assert this


### PR DESCRIPTION
Release notes: none

When we define some abstract functions in the `fb-www` mocks, we know ahead of time that they're safe from leaking logic. So we no longer have to traverse all the nodes looking for leaks for the abstract functions that are safe.

We could expand on this in the future for other known types by a form of whitelist.