### PR TITLE
[RFC] Rename leaking terminology to escaping terminology

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -18,7 +18,7 @@ import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { Value } from "../values/index.js";
 import { AbstractValue, BooleanValue, ConcreteValue, FunctionValue } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { Environment, Functions, Join, Leak } from "../singletons.js";
+import { Environment, Functions, Join, Escape } from "../singletons.js";
 import {
   ArgumentListEvaluation,
   EvaluateDirectCall,
@@ -113,7 +113,7 @@ function generateRuntimeCall(
   args = args.concat(ArgumentListEvaluation(realm, strictCode, env, ast.arguments));
   for (let arg of args) {
     if (arg !== func) {
-      Leak.leakValue(realm, arg, ast.loc);
+      Escape.escapeValue(realm, arg, ast.loc);
     }
   }
   return AbstractValue.createTemporalFromBuildFunction(realm, Value, args, nodes => {

--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -14,7 +14,7 @@ import { CreateImplementation } from "./methods/create.js";
 import { EnvironmentImplementation } from "./methods/environment.js";
 import { FunctionImplementation } from "./methods/function.js";
 import { JoinImplementation } from "./methods/join.js";
-import { LeakImplementation } from "./utils/leak.js";
+import { EscapeImplementation } from "./utils/escape-analysis.js";
 import { PathImplementation } from "./utils/paths.js";
 import { PropertiesImplementation } from "./methods/properties.js";
 import { ToImplementation } from "./methods/to.js";
@@ -25,7 +25,7 @@ export default function() {
   Singletons.setEnvironment(new EnvironmentImplementation());
   Singletons.setFunctions(new FunctionImplementation());
   Singletons.setJoin(new JoinImplementation());
-  Singletons.setLeak(new LeakImplementation());
+  Singletons.setEscape(new EscapeImplementation());
   Singletons.setPath(new PathImplementation());
   Singletons.setProperties((new PropertiesImplementation(): any));
   Singletons.setTo((new ToImplementation(): any));

--- a/src/methods/integrity.js
+++ b/src/methods/integrity.js
@@ -20,7 +20,7 @@ type IntegrityLevels = "sealed" | "frozen";
 
 // ECMA262 9.1.4.1
 export function OrdinaryPreventExtensions(realm: Realm, O: ObjectValue): boolean {
-  if (O.isLeakedObject() && O.getExtensible()) {
+  if (O.isEscapedObject() && O.getExtensible()) {
     throw new FatalError();
   }
 

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -750,14 +750,14 @@ export class JoinImplementation {
       return this.joinValuesAsConditional(realm, joinCondition, v1, v2);
     };
     let join = (b: Binding, b1: void | BindingEntry, b2: void | BindingEntry) => {
-      let l1 = b1 === undefined ? b.hasLeaked : b1.hasLeaked;
-      let l2 = b2 === undefined ? b.hasLeaked : b2.hasLeaked;
+      let l1 = b1 === undefined ? b.hasEscaped : b1.hasEscaped;
+      let l2 = b2 === undefined ? b.hasEscaped : b2.hasEscaped;
       let v1 = b1 === undefined ? b.value : b1.value;
       let v2 = b2 === undefined ? b.value : b2.value;
-      let hasLeaked = l1 || l2; // If either has leaked, then this binding has leaked.
+      let hasEscaped = l1 || l2; // If either has escaped, then this binding has escaped.
       let value = this.joinValues(realm, v1, v2, getAbstractValue);
       invariant(value instanceof Value);
-      return { hasLeaked, value };
+      return { hasEscaped, value };
     };
     return this.joinMaps(m1, m2, join);
   }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -430,7 +430,7 @@ export class ToImplementation {
       default:
         if (realm.isInPureScope()) {
           // Create a placeholder value to represent the ObjectValue that we would've
-          // received, but this object should never leak so as an optimization we will
+          // received, but this object should never escape so as an optimization we will
           // let operations on top of this object force the ToObject operations instead.
           obj = AbstractValue.createFromType(realm, ObjectValue, "sentinel ToObject");
           invariant(obj instanceof AbstractObjectValue);

--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -128,9 +128,9 @@ export class WidenImplementation {
 
   widenBindings(realm: Realm, m1: Bindings, m2: Bindings): Bindings {
     let widen = (b: Binding, b1: void | BindingEntry, b2: void | BindingEntry) => {
-      let l1 = b1 === undefined ? b.hasLeaked : b1.hasLeaked;
-      let l2 = b2 === undefined ? b.hasLeaked : b2.hasLeaked;
-      let hasLeaked = l1 || l2; // If either has leaked, then this binding has leaked.
+      let l1 = b1 === undefined ? b.hasEscaped : b1.hasEscaped;
+      let l2 = b2 === undefined ? b.hasEscaped : b2.hasEscaped;
+      let hasEscaped = l1 || l2; // If either has escaped, then this binding has escaped.
       let v1 = b1 === undefined || b1.value === undefined ? b.value : b1.value;
       invariant(b2 !== undefined); // Local variables are not going to get deleted as a result of widening
       let v2 = b2.value;
@@ -154,7 +154,7 @@ export class WidenImplementation {
         result._buildNode = args => t.identifier(phiName);
       }
       invariant(result instanceof Value);
-      return { hasLeaked, value: result };
+      return { hasEscaped, value: result };
     };
     return this.widenMaps(m1, m2, widen);
   }
@@ -340,7 +340,7 @@ export class WidenImplementation {
         b1.value === undefined ||
         b2.value === undefined ||
         !this._containsValues(b1.value, b2.value) ||
-        b1.hasLeaked !== b2.hasLeaked
+        b1.hasEscaped !== b2.hasEscaped
       ) {
         return false;
       }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -680,7 +680,10 @@ export class ResidualHeapSerializer {
 
     if (!residualBinding.referentialized) {
       let additionalFunction = residualBinding.referencedOnlyFromAdditionalFunctions;
-      invariant(additionalFunction, "residual bindings like this are only caused by leaked bindings in pure functions");
+      invariant(
+        additionalFunction,
+        "residual bindings like this are only caused by escaped bindings in pure functions"
+      );
       let instance = this.residualFunctionInstances.get(additionalFunction);
       invariant(instance, "any serialized function must exist in the scope");
       this.residualFunctions.referentializer.referentializeBinding(residualBinding, binding.name, instance);
@@ -887,8 +890,8 @@ export class ResidualHeapSerializer {
   ): void {
     const realm = this.realm;
     let lenProperty;
-    if (val.isLeakedObject()) {
-      lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
+    if (val.isEscapedObject()) {
+      lenProperty = this.realm.evaluateWithoutEscapeLogic(() => Get(realm, val, "length"));
     } else {
       lenProperty = Get(realm, val, "length");
     }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -277,8 +277,8 @@ export class ResidualHeapVisitor {
     this.visitObjectProperties(val);
     const realm = this.realm;
     let lenProperty;
-    if (val.isLeakedObject()) {
-      lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
+    if (val.isEscapedObject()) {
+      lenProperty = this.realm.evaluateWithoutEscapeLogic(() => Get(realm, val, "length"));
     } else {
       lenProperty = Get(realm, val, "length");
     }

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -14,7 +14,7 @@ import type {
   EnvironmentType,
   FunctionType,
   JoinType,
-  LeakType,
+  EscapeType,
   PathType,
   PropertiesType,
   ToType,
@@ -25,7 +25,7 @@ export let Create: CreateType = (null: any);
 export let Environment: EnvironmentType = (null: any);
 export let Functions: FunctionType = (null: any);
 export let Join: JoinType = (null: any);
-export let Leak: LeakType = (null: any);
+export let Escape: EscapeType = (null: any);
 export let Path: PathType = (null: any);
 export let Properties: PropertiesType = (null: any);
 export let To: ToType = (null: any);
@@ -47,8 +47,8 @@ export function setJoin(singleton: JoinType) {
   Join = singleton;
 }
 
-export function setLeak(singleton: LeakType) {
-  Leak = singleton;
+export function setEscape(singleton: EscapeType) {
+  Escape = singleton;
 }
 
 export function setPath(singleton: PathType) {

--- a/src/types.js
+++ b/src/types.js
@@ -338,8 +338,8 @@ export type PathType = {
   pushInverseAndRefine(condition: AbstractValue): void,
 };
 
-export type LeakType = {
-  leakValue(realm: Realm, value: Value, loc: ?BabelNodeSourceLocation): void,
+export type EscapeType = {
+  escapeValue(realm: Realm, value: Value, loc: ?BabelNodeSourceLocation): void,
 };
 
 export type PropertiesType = {

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -16,7 +16,7 @@ import { AbstractValue, ArrayValue, ObjectValue, StringValue, Value } from "./in
 import type { AbstractValueBuildNodeFunction } from "./AbstractValue.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { IsDataDescriptor, cloneDescriptor, equalDescriptors } from "../methods/index.js";
-import { Join, Widen, Leak } from "../singletons.js";
+import { Join, Widen, Escape } from "../singletons.js";
 import type { BabelNodeExpression } from "babel-types";
 import invariant from "../invariant.js";
 import NumberValue from "./NumberValue";
@@ -341,8 +341,8 @@ export default class AbstractObjectValue extends AbstractValue {
       if (this.isSimpleObject() && this.isIntrinsic()) {
         return generateAbstractGet();
       } else if (this.$Realm.isInPureScope()) {
-        // This object might have leaked to a getter.
-        Leak.leakValue(this.$Realm, this);
+        // This object might have escaped to a getter.
+        Escape.escapeValue(this.$Realm, this);
         // The getter might throw anything.
         return this.$Realm.evaluateWithPossibleThrowCompletion(
           generateAbstractGet,

--- a/test/serializer/basic/AvoidIdEscapes.js
+++ b/test/serializer/basic/AvoidIdEscapes.js
@@ -1,4 +1,4 @@
-// Making sure we don't leak ids in global scope
+// Making sure we don't escape ids in global scope
 
 inspect = function() {
     return global._0 !== undefined;


### PR DESCRIPTION
This PR renames `leaks` -> `escapes` and `leak` -> `escape`. There are no logic changes, just renames throughout the codebase. 

We might not want to do this, but I feel the benefits of a different naming terminology might help others who might get confused with thinking of problems in terms of leaks (which in my opinion has a relation to "memory leaks"). I think the escaping terminology is actually more accurate as to what is occurring here, in relation to escape analysis.