### PR TITLE
Add more FB www magic global definitions

### DIFF
--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { parseExpression } from "babylon";
+import type { Realm } from "../../realm.js";
+import {
+  AbstractValue,
+  AbstractObjectValue,
+  NativeFunctionValue,
+  ObjectValue,
+  StringValue,
+} from "../../values/index.js";
+import { createAbstract } from "../prepack/utils.js";
+import invariant from "../../invariant";
+
+// Based on www babelHelpers fork.
+const babelHelpersCode = `
+{
+  inherits(subClass, superClass) {
+    Object.assign(subClass, superClass);
+    subClass.prototype = Object.create(superClass && superClass.prototype);
+    subClass.prototype.constructor = subClass;
+    subClass.__superConstructor__ = superClass;
+    return superClass;
+  },
+  _extends: Object.assign,
+  extends: Object.assign,
+  objectWithoutProperties(obj, keys) {
+    var target = {};
+    for (var i in obj) {
+      if (!hasOwn.call(obj, i) || keys.indexOf(i) >= 0) {
+        continue;
+      }
+      target[i] = obj[i];
+    }
+    return target;
+  },
+  taggedTemplateLiteralLoose(strings, raw) {
+    strings.raw = raw;
+    return strings;
+  },
+  bind: Function.prototype.bind,
+}
+`;
+let babelHelpersAST = parseExpression(babelHelpersCode);
+
+const fbMagicGlobalFunctions = [
+  "asset",
+  "cx",
+  "cssVar",
+  "csx",
+  "errorDesc",
+  "errorHelpCenterID",
+  "errorSummary",
+  "gkx",
+  "glyph",
+  "ifRequired",
+  "ix",
+  "fbglyph",
+  "requireWeak",
+  "xuiglyph",
+];
+
+const fbMagicGlobalObjects = ["JSResource", "Bootloader"];
+
+function createMagicGlobalFunction(realm: Realm, global: ObjectValue | AbstractObjectValue, functionName: string) {
+  global.$DefineOwnProperty(functionName, {
+    value: new NativeFunctionValue(realm, functionName, functionName, 0, (context, [string]) => {
+      invariant(string instanceof StringValue);
+      let value = `${functionName}("${string.value}")`;
+      let functionValue;
+
+      if (realm.fbLibraries.other.has(value)) {
+        functionValue = realm.fbLibraries.other.get(value);
+      } else {
+        functionValue = createAbstract(realm, "function", value);
+        realm.fbLibraries.other.set(value, functionValue);
+      }
+      invariant(functionValue instanceof AbstractValue);
+      return functionValue;
+    }),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+function createMagicGlobalObject(realm: Realm, global: ObjectValue | AbstractObjectValue, objectName: string) {
+  let globalObject = AbstractValue.createAbstractObject(realm, objectName);
+  globalObject.kind = "resolved";
+
+  global.$DefineOwnProperty(objectName, {
+    value: globalObject,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+export function createFbMocks(realm: Realm, global: ObjectValue | AbstractObjectValue) {
+  global.$DefineOwnProperty("__DEV__", {
+    // TODO: we'll likely want to make this configurable from the outside.
+    value: realm.intrinsics.false,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  const babelHelpersValue = realm.$GlobalEnv.evaluate(babelHelpersAST, false);
+  invariant(babelHelpersValue instanceof ObjectValue);
+  global.$DefineOwnProperty("babelHelpers", {
+    value: babelHelpersValue,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  for (let functionName of fbMagicGlobalFunctions) {
+    createMagicGlobalFunction(realm, global, functionName);
+  }
+
+  for (let objectName of fbMagicGlobalObjects) {
+    createMagicGlobalObject(realm, global, objectName);
+  }
+}

--- a/src/realm.js
+++ b/src/realm.js
@@ -183,10 +183,6 @@ export class Realm {
     };
 
     this.fbLibraries = {
-      cx: undefined,
-      fbt: undefined,
-      idx: undefined,
-      ix: undefined,
       other: new Map(),
       react: undefined,
       reactRelay: undefined,
@@ -246,10 +242,6 @@ export class Realm {
   };
 
   fbLibraries: {
-    cx: void | ObjectValue,
-    fbt: void | ObjectValue,
-    idx: void | ObjectValue,
-    ix: void | ObjectValue,
     other: Map<string, AbstractValue>,
     react: void | ObjectValue,
     reactRelay: void | ObjectValue,

--- a/test/react/mocks/fb5.js
+++ b/test/react/mocks/fb5.js
@@ -2,15 +2,23 @@ if (!this.Bootloader) {
   this.Bootloader = {loadAllModules() {}};
 }
 
+if (!this.JSResource) {
+  this.JSResource = {loadAll() {}};
+}
+
 if (!this.cx) {
   this.cx = () => {};
 }
 
-function getValue() {
-  return cx("yar/Jar");
+if (!this.ix) {
+  this.ix = () => {};
 }
 
-var a = [Bootloader.loadAllModules("somethingYes"), getValue()];
+function getValue() {
+  return [cx("yar/Jar"), ix("yar/Jar")];
+}
+
+var a = [Bootloader.loadAllModules("somethingYes"), getValue(), JSResource.loadAll];
 
 function App() {
   return [cx("foo/Bar"), a];


### PR DESCRIPTION
Release notes: none

- Moves `fb-www` specific mocks to their own file
- Adds the rest of the FB magic global functions/objects