### PR TITLE
Add support for React factory class components

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -271,6 +271,14 @@ function runTestSuite(outputJsx) {
       });
     });
 
+    describe("Factory class component folding", () => {
+      let directory = "factory-components";
+
+      it("Simple factory classes", async () => {
+        await runTest(directory, "simple.js");
+      });
+    });
+
     describe("fb-www mocks", () => {
       let directory = "mocks";
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -277,6 +277,10 @@ function runTestSuite(outputJsx) {
       it("Simple factory classes", async () => {
         await runTest(directory, "simple.js");
       });
+
+      it("Simple factory classes 2", async () => {
+        await runTest(directory, "simple2.js");
+      });
     });
 
     describe("fb-www mocks", () => {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -25,7 +25,13 @@ import {
   AbstractObjectValue,
 } from "../values/index.js";
 import { ReactStatistics, type ReactSerializerState } from "../serializer/types.js";
-import { isReactElement, valueIsClassComponent, forEachArrayValue, valueIsLegacyCreateClassComponent } from "./utils";
+import {
+  isReactElement,
+  valueIsClassComponent,
+  forEachArrayValue,
+  valueIsLegacyCreateClassComponent,
+  valueIsFactroyClassComponent,
+} from "./utils";
 import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
@@ -166,6 +172,24 @@ export class Reconciler {
     return renderMethod.$Call(instance, []);
   }
 
+  _renderFactoryClassComponent(
+    instance: ObjectValue,
+    branchStatus: BranchStatusEnum,
+    branchState: BranchState | null
+  ): Value {
+    if (branchStatus !== "ROOT") {
+      throw new NewComponentTreeBranch();
+    }
+    // get the "render" method off the instance
+    let renderMethod = Get(this.realm, instance, "render");
+    invariant(
+      renderMethod instanceof ECMAScriptSourceFunctionValue && renderMethod.$Call,
+      "Expected render method to be a FunctionValue with $Call method"
+    );
+    // the render method doesn't have any arguments, so we just assign the context of "this" to be the instance
+    return renderMethod.$Call(instance, []);
+  }
+
   _renderSimpleClassComponent(
     componentType: ECMAScriptSourceFunctionValue,
     props: ObjectValue | AbstractObjectValue,
@@ -286,6 +310,15 @@ export class Reconciler {
       }
     } else {
       value = this._renderFunctionalComponent(componentType, props, context);
+      if (valueIsFactroyClassComponent(this.realm, value)) {
+        invariant(value instanceof ObjectValue);
+        // TODO: use this._renderFactoryClassComponent to handle the render method (like a render prop)
+        // for now we just return the object;
+        return {
+          result: value,
+          childContext,
+        };
+      }
     }
     invariant(value !== undefined);
     return {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -315,7 +315,7 @@ export class Reconciler {
         // TODO: use this._renderFactoryClassComponent to handle the render method (like a render prop)
         // for now we just return the object
         if (branchStatus !== "ROOT") {
-          throw new ExpectedBailOut("non-root factory class components are not suppoted ");
+          throw new ExpectedBailOut("non-root factory class components are not suppoted");
         } else {
           return {
             result: value,

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -313,11 +313,15 @@ export class Reconciler {
       if (valueIsFactoryClassComponent(this.realm, value)) {
         invariant(value instanceof ObjectValue);
         // TODO: use this._renderFactoryClassComponent to handle the render method (like a render prop)
-        // for now we just return the object;
-        return {
-          result: value,
-          childContext,
-        };
+        // for now we just return the object
+        if (branchStatus !== "ROOT") {
+          throw new ExpectedBailOut("non-root factory class components are not suppoted ");
+        } else {
+          return {
+            result: value,
+            childContext,
+          };
+        }
       }
     }
     invariant(value !== undefined);

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -30,7 +30,7 @@ import {
   valueIsClassComponent,
   forEachArrayValue,
   valueIsLegacyCreateClassComponent,
-  valueIsFactroyClassComponent,
+  valueIsFactoryClassComponent,
 } from "./utils";
 import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
@@ -310,7 +310,7 @@ export class Reconciler {
       }
     } else {
       value = this._renderFunctionalComponent(componentType, props, context);
-      if (valueIsFactroyClassComponent(this.realm, value)) {
+      if (valueIsFactoryClassComponent(this.realm, value)) {
         invariant(value instanceof ObjectValue);
         // TODO: use this._renderFactoryClassComponent to handle the render method (like a render prop)
         // for now we just return the object;

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -140,7 +140,7 @@ export function valueIsLegacyCreateClassComponent(realm: Realm, value: Value): b
   return false;
 }
 
-export function valueIsFactroyClassComponent(realm: Realm, value: Value): boolean {
+export function valueIsFactoryClassComponent(realm: Realm, value: Value): boolean {
   if (value instanceof ObjectValue) {
     return To.ToBooleanPartial(realm, Get(realm, value, "render"));
   }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -140,6 +140,13 @@ export function valueIsLegacyCreateClassComponent(realm: Realm, value: Value): b
   return false;
 }
 
+export function valueIsFactroyClassComponent(realm: Realm, value: Value): boolean {
+  if (value instanceof ObjectValue) {
+    return To.ToBooleanPartial(realm, Get(realm, value, "render"));
+  }
+  return false;
+}
+
 export function addKeyToReactElement(
   realm: Realm,
   reactSerializerState: ReactSerializerState,

--- a/test/react/factory-components/simple.js
+++ b/test/react/factory-components/simple.js
@@ -1,14 +1,18 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
 function FactoryComponent(props) {
-	return {
-		render() {
-			return <div>{props.title}</div>;
-		},
-	}
+  return {
+    render() {
+      return <div>{props.title}</div>;
+    },
+  }
 }
 
 FactoryComponent.getTrials = function(renderer, Root) {
-	renderer.update(<Root />);
-	return [['render simple factory classes', renderer.toJSON()]];
+  renderer.update(<Root />);
+  return [['render simple factory classes', renderer.toJSON()]];
 };
 
 if (this.__registerReactComponentRoot) {

--- a/test/react/factory-components/simple.js
+++ b/test/react/factory-components/simple.js
@@ -1,0 +1,18 @@
+function FactoryComponent(props) {
+	return {
+		render() {
+			return <div>{props.title}</div>;
+		},
+	}
+}
+
+FactoryComponent.getTrials = function(renderer, Root) {
+	renderer.update(<Root />);
+	return [['render simple factory classes', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(FactoryComponent);
+}
+
+module.exports = FactoryComponent;

--- a/test/react/factory-components/simple2.js
+++ b/test/react/factory-components/simple2.js
@@ -3,11 +3,11 @@ var React = require('react');
 this['React'] = React;
 
 function FactoryComponent(props) {
-	return {
-		render() {
-			return <div>{props.title}</div>;
-		},
-	}
+  return {
+    render() {
+      return <div>{props.title}</div>;
+    },
+  }
 }
 
 function App(props) {
@@ -15,8 +15,8 @@ function App(props) {
 }
 
 App.getTrials = function(renderer, Root) {
-	renderer.update(<Root />);
-	return [['render simple factory classes #2', renderer.toJSON()]];
+  renderer.update(<Root />);
+  return [['render simple factory classes #2', renderer.toJSON()]];
 };
 
 if (this.__registerReactComponentRoot) {

--- a/test/react/factory-components/simple2.js
+++ b/test/react/factory-components/simple2.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function FactoryComponent(props) {
+	return {
+		render() {
+			return <div>{props.title}</div>;
+		},
+	}
+}
+
+function App(props) {
+  return <div>Hello, <FactoryComponent title={props.title} /></div>;
+}
+
+App.getTrials = function(renderer, Root) {
+	renderer.update(<Root />);
+	return [['render simple factory classes #2', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This PR adds support for the uncommon React factory component pattern – which is used by ReactRelay. I've also added a test.