### PR TITLE
Do not ever ignore the set constructor argument

### DIFF
--- a/src/intrinsics/ecma262/Set.js
+++ b/src/intrinsics/ecma262/Set.js
@@ -52,7 +52,6 @@ export default function(realm: Realm): NativeFunctionValue {
         "RecoverableError"
       );
       realm.handleError(error);
-      iterable = undefined;
     }
     if (!iterable) iterable = realm.intrinsics.undefined;
 


### PR DESCRIPTION
Release note: none

It does not seem likely that code that passes an argument to the Set constructor when targeting jsc-600-1-4-17 actually intended for it to be ignored, so just use it when running Prepack, even if this would deviate from the behavior of the unprepacked code.

This also helps to deal with code that was supposed to use a polyfill, but that runs without the polyfill at Prepack time, because the module that loads the polyfill has been delayed. 