### PR TITLE
Small improvements to error reporting

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -326,7 +326,7 @@ function run(
     printDiagnostics();
     //FatalErrors must have generated at least one CompilerDiagnostic.
     if (err instanceof FatalError) {
-      invariant(errors.size > 0, "FatalError must generate at least one CompilerDiagnostic");
+      invariant(errors.size > 0 || errorList.length > 0, "FatalError must generate at least one CompilerDiagnostic");
     } else {
       // if it is not a FatalError, it means prepack failed, and we should display the Prepack stack trace.
       console.error(err.stack);

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -245,8 +245,8 @@ export class Functions {
       if (funcLength && funcLength > 0) {
         // TODO #987: Make Additional Functions work with arguments
         let error = new CompilerDiagnostic(
-          `Additional function ${fun1Name} has parameters which is not yet supported`,
-          undefined, // TODO: a location would be really useful here
+          `Additional function ${fun1Name} has parameters, which is not yet supported`,
+          fun1.expressionLocation,
           "PP1005",
           "FatalError"
         );

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -239,17 +239,24 @@ export class Functions {
     // check that functions are independent
     let conflicts: Map<BabelNodeSourceLocation, CompilerDiagnostic> = new Map();
     for (let [fun1, call1] of calls) {
+      let fun1Name = this.functionExpressions.get(fun1) || fun1.intrinsicName || "(unknown function)";
       // Also do argument validation here
       let funcLength = fun1.getLength();
       if (funcLength && funcLength > 0) {
         // TODO #987: Make Additional Functions work with arguments
-        throw new FatalError("TODO: implement arguments to additional functions");
+        let error = new CompilerDiagnostic(
+          `Additional function ${fun1Name} has parameters which is not yet supported`,
+          undefined, // TODO: a location would be really useful here
+          "PP1005",
+          "FatalError"
+        );
+        this.realm.handleError(error);
+        throw new FatalError();
       }
       let additionalFunctionEffects = this.writeEffects.get(fun1);
       invariant(additionalFunctionEffects !== undefined);
       let e1 = additionalFunctionEffects.effects;
       invariant(e1 !== undefined);
-      let fun1Name = this.functionExpressions.get(fun1) || fun1.intrinsicName || "unknown";
       if (e1[0] instanceof Completion) {
         let error = new CompilerDiagnostic(
           `Additional function ${fun1Name} may terminate abruptly`,


### PR DESCRIPTION
Release notes: none

Covered another case where a FatalError was thrown without CompilerDiagnostics
Fixing invariant that triggers when no CompilerDiagnostics is present