### PR TITLE
Fix class visiting/serialization with inheritance chains

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -266,8 +266,8 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-classes-3.js");
       });
 
-      it("Multiple inheritance", async () => {
-        await runTest(directory, "multiple-inheritance.js");
+      it("Inheritance chaining", async () => {
+        await runTest(directory, "inheritance-chain.js");
       });
 
       it("Classes with state", async () => {

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -266,6 +266,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-classes-3.js");
       });
 
+      it("Multiple inheritance", async () => {
+        await runTest(directory, "multiple-inheritance.js");
+      });
+
       it("Classes with state", async () => {
         await runTest(directory, "classes-with-state.js");
       });

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -172,6 +172,7 @@ export function ClassDefinitionEvaluation(
 
     // 10. If constructor is empty, then,
     if (constructor instanceof EmptyValue) {
+      emptyConstructor = true;
       let constructorFile;
       // a. If ClassHeritage opt is present, then
       if (ast.superClass) {

--- a/src/invariant.js
+++ b/src/invariant.js
@@ -13,7 +13,6 @@ export default function invariant(condition: any, format: string): void {
   if (condition) return;
   const message = `${format}
 This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.`;
-
   let error = new Error(message);
   error.name = "Invariant Violation";
   throw error;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1315,9 +1315,15 @@ export class ResidualHeapSerializer {
     return t.objectExpression(props);
   }
 
-  _serializeValueObjectViaConstructor(val: ObjectValue, isClass: boolean, classConstructor?: Value) {
+  _serializeValueObjectViaConstructor(val: ObjectValue, skipPrototype: boolean, classConstructor?: Value) {
     let proto = val.$Prototype;
-    this._emitObjectProperties(val, val.properties, /*objectPrototypeAlreadyEstablished*/ true, undefined, isClass);
+    this._emitObjectProperties(
+      val,
+      val.properties,
+      /*objectPrototypeAlreadyEstablished*/ true,
+      undefined,
+      skipPrototype
+    );
     this.needsAuxiliaryConstructor = true;
     let serializedProto = this.serializeValue(classConstructor ? classConstructor : proto);
     return t.sequenceExpression([

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -70,6 +70,7 @@ import {
   withDescriptorValue,
   ClassPropertiesToIgnore,
   canIgnoreClassLengthProperty,
+  getObjectPrototypeMetadata,
 } from "./utils.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { canHoistFunction } from "../react/hoisting.js";
@@ -1142,11 +1143,7 @@ export class ResidualHeapSerializer {
 
     // handle class inheritance
     if (!(classFunc.$Prototype instanceof NativeFunctionValue)) {
-      let proto = classFunc.$Prototype;
       classMethodInstance.classSuperNode = this.serializeValue(classFunc.$Prototype);
-      if (proto.$HomeObject instanceof ObjectValue) {
-        this.serializedValues.add(proto.$HomeObject);
-      }
     }
 
     let serializeClassPrototypeId = () => {
@@ -1274,7 +1271,7 @@ export class ResidualHeapSerializer {
   }
 
   // Overridable.
-  serializeValueRawObject(val: ObjectValue, isClass: boolean): BabelNodeExpression {
+  serializeValueRawObject(val: ObjectValue, skipPrototype: boolean): BabelNodeExpression {
     let remainingProperties = new Map(val.properties);
     const dummyProperties = new Set();
     let props = [];
@@ -1313,16 +1310,12 @@ export class ResidualHeapSerializer {
       remainingProperties,
       /*objectPrototypeAlreadyEstablished*/ false,
       dummyProperties,
-      isClass
+      skipPrototype
     );
     return t.objectExpression(props);
   }
 
-  _serializeValueObjectViaConstructor(
-    val: ObjectValue,
-    isClass: boolean,
-    classConstructor?: ECMAScriptSourceFunctionValue
-  ) {
+  _serializeValueObjectViaConstructor(val: ObjectValue, isClass: boolean, classConstructor?: Value) {
     let proto = val.$Prototype;
     this._emitObjectProperties(val, val.properties, /*objectPrototypeAlreadyEstablished*/ true, undefined, isClass);
     this.needsAuxiliaryConstructor = true;
@@ -1331,7 +1324,7 @@ export class ResidualHeapSerializer {
       t.assignmentExpression(
         "=",
         t.memberExpression(constructorExpression, t.identifier("prototype")),
-        serializedProto
+        classConstructor ? t.memberExpression(serializedProto, t.identifier("prototype")) : serializedProto
       ),
       t.newExpression(constructorExpression, []),
     ]);
@@ -1419,38 +1412,11 @@ export class ResidualHeapSerializer {
           proto !== this.realm.intrinsics.ObjectPrototype &&
           this._findLastObjectPrototype(val) === this.realm.intrinsics.ObjectPrototype &&
           proto instanceof ObjectValue;
-        let isClass = false;
-        let classConstructor;
-
-        if (val.$IsClassPrototype) {
-          isClass = true;
-        }
-        if (proto.$IsClassPrototype) {
-          invariant(proto instanceof ObjectValue);
-          // we now need to check if the prototpe has a constructor
-          // if it does, we can serialize back the original class syntax
-          // by using the original class function
-          if (proto.properties.has("constructor")) {
-            let _classConstructor = proto.properties.get("constructor");
-            invariant(_classConstructor !== undefined);
-            // if the contructor has been deleted then we have no way
-            // to serialize the original class AST as it won't have been
-            // evluated and thus visited
-            if (_classConstructor.descriptor === undefined) {
-              throw new FatalError(
-                "TODO #1024: implement object prototype serialization with deleted class constructor"
-              );
-            }
-            let classFunc = Get(this.realm, proto, "constructor");
-            _classConstructor = classFunc;
-            invariant(_classConstructor instanceof ECMAScriptSourceFunctionValue);
-            isClass = true;
-          }
-        }
+        let { skipPrototype, constructor: _constructor } = getObjectPrototypeMetadata(this.realm, val);
 
         return createViaAuxiliaryConstructor
-          ? this._serializeValueObjectViaConstructor(val, isClass, classConstructor)
-          : this.serializeValueRawObject(val, isClass);
+          ? this._serializeValueObjectViaConstructor(val, skipPrototype, _constructor)
+          : this.serializeValueRawObject(val, skipPrototype);
     }
   }
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -209,7 +209,11 @@ export class ResidualHeapVisitor {
       // they we be need to be emitted during serialization
       this.visitObjectPrototype(obj);
     }
-    if (obj instanceof FunctionValue) this.visitConstructorPrototype(constructor ? constructor : obj);
+    if (obj instanceof FunctionValue) {
+      this.visitConstructorPrototype(constructor ? constructor : obj);
+    } else if (obj instanceof ObjectValue && skipPrototype && constructor) {
+      this.visitValue(constructor);
+    }
   }
 
   visitObjectPrototype(obj: ObjectValue) {
@@ -514,6 +518,12 @@ export class ResidualHeapVisitor {
     for (let [symbol, method] of classPrototype.symbols) {
       withDescriptorValue(symbol, method.descriptor, visitClassMethod);
     }
+
+    // handle class inheritance
+    if (!(classFunc.$Prototype instanceof NativeFunctionValue)) {
+      this.visitValue(classFunc.$Prototype);
+    }
+
     if (classPrototype.properties.has("constructor")) {
       let constructor = classPrototype.properties.get("constructor");
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -54,6 +54,7 @@ import {
   ClassPropertiesToIgnore,
   withDescriptorValue,
   canIgnoreClassLengthProperty,
+  getObjectPrototypeMetadata,
 } from "./utils.js";
 import { Environment, To } from "../singletons.js";
 import { isReactElement, valueIsReactLibraryObject } from "../react/utils.js";
@@ -152,6 +153,8 @@ export class ResidualHeapVisitor {
   }
 
   visitObjectProperties(obj: ObjectValue, kind?: ObjectKind): void {
+    let { skipPrototype, constructor } = getObjectPrototypeMetadata(this.realm, obj);
+
     // visit properties
     if (kind !== "ReactElement") {
       for (let [symbol, propertyBinding] of obj.symbols) {
@@ -176,12 +179,11 @@ export class ResidualHeapVisitor {
       }
       // we don't want to visit these as we handle the serialization ourselves
       // via a different logic route for classes
+      let descriptor = propertyBindingValue.descriptor;
       if (
         obj.$FunctionKind === "classConstructor" &&
-        (propertyBindingKey === "arguments" ||
-          propertyBindingKey === "length" ||
-          propertyBindingKey === "name" ||
-          propertyBindingKey === "caller")
+        (ClassPropertiesToIgnore.has(propertyBindingKey) ||
+          (propertyBindingKey === "length" && canIgnoreClassLengthProperty(obj, descriptor, this.logger)))
       ) {
         continue;
       }
@@ -201,13 +203,13 @@ export class ResidualHeapVisitor {
     }
 
     // prototype
-    if (kind !== "ReactElement") {
+    if (kind !== "ReactElement" && !skipPrototype) {
       // we don't want to the ReactElement prototype visited
       // as this is contained within the JSXElement, otherwise
       // they we be need to be emitted during serialization
       this.visitObjectPrototype(obj);
     }
-    if (obj instanceof FunctionValue) this.visitConstructorPrototype(obj);
+    if (obj instanceof FunctionValue) this.visitConstructorPrototype(constructor ? constructor : obj);
   }
 
   visitObjectPrototype(obj: ObjectValue) {
@@ -221,10 +223,11 @@ export class ResidualHeapVisitor {
     }
   }
 
-  visitConstructorPrototype(func: FunctionValue) {
+  visitConstructorPrototype(func: Value) {
     // If the original prototype object was mutated,
     // request its serialization here as this might be observable by
     // residual code.
+    invariant(func instanceof FunctionValue);
     let prototype = ResidualHeapInspector.getPropertyValue(func, "prototype");
     if (
       prototype instanceof ObjectValue &&

--- a/test/react/class-components/inheritance-chain.js
+++ b/test/react/class-components/inheritance-chain.js
@@ -33,7 +33,7 @@ class App extends React.Component {
 
 App.getTrials = function(renderer, Root) {
   renderer.update(<Root />);
-  return [['multiple inheritance', renderer.toJSON()]];
+  return [['inheritance chain', renderer.toJSON()]];
 };
 
 if (this.__registerReactComponentRoot) {

--- a/test/react/class-components/multiple-inheritance.js
+++ b/test/react/class-components/multiple-inheritance.js
@@ -1,0 +1,43 @@
+const React = require("react");
+this['React'] = React;
+
+class Parent extends React.Component {
+  constructor() {
+    super();
+    this.state ={
+      a: 100,
+    };
+  }
+  render() {
+    if (this.props.x === 5) {
+      return <span>{this.state.a}</span>;
+    } else {
+      return <span>Hello world</span>;
+    }
+  }
+}
+
+this['Parent'] = Parent;
+
+class Child extends Parent {
+  constructor() {
+    super();
+  }
+}
+
+class App extends React.Component {
+  render() {
+    return <div><Child x={10} /></div>;
+  }
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['multiple inheritance', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/serializer/basic/ClassExpression6.js
+++ b/test/serializer/basic/ClassExpression6.js
@@ -1,0 +1,22 @@
+x = 0;
+
+var A = class {
+  constructor(y) {
+    x = y + 10;
+  }
+  render() {
+
+  }
+};
+
+var b = new A();
+
+var C = class extends b.constructor {
+  constructor(y) {
+    super(y);
+  }
+};
+
+new C(1);
+
+inspect = function() { return x; }


### PR DESCRIPTION
Release notes: none

This PR fixes bugs in visiting and serializing the prototype. I've also added the test that this fails with before. I moved much of the duplicated logic from before that was the cause of this into a single function `getObjectPrototypeMetadata()`.