### PR TITLE
Wrap fb-www require calls in `evaluateImpure()`

### DIFF
--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -47,14 +47,14 @@ export default function(realm: Realm): void {
 
       if (requireNameValValue === "react" || requireNameValValue === "React") {
         if (realm.fbLibraries.react === undefined) {
-          let react = createMockReact(realm, requireNameValValue);
+          let react = realm.evaluateImpure(() => createMockReact(realm, requireNameValValue));
           realm.fbLibraries.react = react;
           return react;
         }
         return realm.fbLibraries.react;
       } else if (requireNameValValue === "react-relay" || requireNameValValue === "RelayModern") {
         if (realm.fbLibraries.reactRelay === undefined) {
-          let reactRelay = createMockReactRelay(realm, requireNameValValue);
+          let reactRelay = realm.evaluateImpure(() => createMockReactRelay(realm, requireNameValValue));
           realm.fbLibraries.reactRelay = reactRelay;
           return reactRelay;
         }

--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -43,6 +43,5 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
     `require("${relayRequireName}").createRefetchContainer`
   );
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "createRefetchContainer", createRefetchContainer);
-
   return reactRelay;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -437,6 +437,20 @@ export class Realm {
     }
   }
 
+  // the inverse of evaluatePure
+  evaluateImpure<T>(f: () => T) {
+    if (!this.trackLeaks) {
+      return f();
+    }
+    let saved_createdObjectsTrackedForLeaks = this.createdObjectsTrackedForLeaks;
+    this.createdObjectsTrackedForLeaks = undefined;
+    try {
+      return f();
+    } finally {
+      this.createdObjectsTrackedForLeaks = saved_createdObjectsTrackedForLeaks;
+    }
+  }
+
   isInPureScope() {
     return !!this.createdObjectsTrackedForLeaks;
   }


### PR DESCRIPTION
Release notes: none

When evaluating require calls for React and ReactRelay, we treat them as impure, so objects created during this phase are not tracked for leaks. This requires no changes to our existing bundling implementation nor does it need to change the init phase. `evaluateImpure()` does the inverse of `evalautePure()`.