### PR TITLE
Adds `__evaluatePureFunction()` pure wrapper hook

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1147,11 +1147,7 @@ export class LexicalEnvironment {
       let ast;
       [ast, code] = this.concatenateAndParse(sources, sourceType);
       if (onParse) onParse(ast);
-      if (this.realm.isCompatibleWith("fb-www")) {
-        res = this.realm.evaluatePure(() => this.evaluateCompletion(ast, false));
-      } else {
-        res = this.evaluateCompletion(ast, false);
-      }
+      res = this.evaluateCompletion(ast, false);
     } finally {
       this.realm.popContext(context);
       this.realm.onDestroyScope(context.lexicalEnvironment);

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -156,6 +156,24 @@ export default function(realm: Realm): void {
     });
   }
 
+  global.$DefineOwnProperty("__evaluatePureFunction", {
+    value: new NativeFunctionValue(
+      realm,
+      "global.__evaluatePureFunction",
+      "__evaluatePureFunction",
+      0,
+      (context, [functionValue]) => {
+        invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
+        invariant(typeof functionValue.$Call === "function");
+        let functionCall: Function = functionValue.$Call;
+        return realm.evaluatePure(() => functionCall(realm.intrinsics.undefined, []));
+      }
+    ),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
   // Maps from initialized moduleId to exports object
   // NB: Changes to this shouldn't ever be serialized
   global.$DefineOwnProperty("__initializedModules", {

--- a/test/react/mocks/fb1.js
+++ b/test/react/mocks/fb1.js
@@ -3,30 +3,38 @@ var React = require('React');
 this['React'] = React;
 var {QueryRenderer, graphql} = require('RelayModern');
 
-var FBEnvironment = require('FBEnvironment');
-
-function App({ initialNumComments, someVariables, query, pageSize, onCommit }) {
-  return (
-    <QueryRenderer
-      environment={FBEnvironment}
-      query={graphql`
-        ${query}
-      `}
-      variables={someVariables}
-      render={({error, props}) => {
-        return <span>Hello world</span>
-      }}
-    />
-  );
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
 }
 
-App.getTrials = function(renderer, Root) {
-  renderer.update(<Root />);
-  return [['fb1 mocks', renderer.toJSON()]];
-};
+module.exports = this.__evaluatePureFunction(() => {
+  var FBEnvironment = require('FBEnvironment');
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
-}
+  function App({ initialNumComments, someVariables, query, pageSize, onCommit }) {
+    return (
+      <QueryRenderer
+        environment={FBEnvironment}
+        query={graphql`
+          ${query}
+        `}
+        variables={someVariables}
+        render={({error, props}) => {
+          return <span>Hello world</span>
+        }}
+      />
+    );
+  }
 
-module.exports = App;
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root />);
+    return [['fb1 mocks', renderer.toJSON()]];
+  };
+
+  if (this.__registerReactComponentRoot) {
+    __registerReactComponentRoot(App);
+  }
+
+  return App;
+});

--- a/test/react/mocks/fb3.js
+++ b/test/react/mocks/fb3.js
@@ -1,7 +1,16 @@
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
 (function() {
   function App() {}
   var ReactRelay = require('RelayModern');
-  ReactRelay.createFragmentContainer(App);
+
+  this.__evaluatePureFunction(() => {
+    ReactRelay.createFragmentContainer(App);
+  });
 })();
 
 // This test just verifies that the file compiles.

--- a/test/react/mocks/fb4.js
+++ b/test/react/mocks/fb4.js
@@ -1,3 +1,9 @@
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
 function App() {}
 App.prototype.hi = function() {};
 
@@ -5,4 +11,7 @@ App.arr = [1, 2, 3];
 App.otherArray = [];
 App.otherArray.length = 10;
 
-this.WrappedApp = require("RelayModern").createFragmentContainer(App);
+this.WrappedApp = this.__evaluatePureFunction(() => {
+	return require("RelayModern").createFragmentContainer(App);
+});
+

--- a/test/react/mocks/fb5.js
+++ b/test/react/mocks/fb5.js
@@ -2,58 +2,66 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-if (!this.Bootloader) {
-  this.Bootloader = {loadModules() {}};
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
 }
 
-if (!this.JSResource) {
-  this.JSResource = {loadAll() {}};
-}
-
-if (!this.ix) {
-  this.ix = () => {};
-}
-
-// Verify that the generated code can still reference abstract values correctly.
-this.abstractTrue = this.__abstract ? __abstract("boolean", "true") : true;
-this.abstractFalse = this.__abstract ? __abstract("boolean", "false") : false;
-
-function getClassNames() {
-  return [cx("cx-one"), cx("cx-multi-1", "cx-multi-2"), cx({
-    "cx-obj-1": true,
-    "cx-obj-2": false,
-    "cx-obj-3-true": abstractTrue,
-    "cx-obj-4-false": abstractFalse,
-  })];
-}
-
-JSResource.loadAll('hi')
-Bootloader.loadModules("somethingYes", function() {});
-
-// Hoist to force the init time calculation
-var classNames = getClassNames();
-function App() {
-  return <div className={classNames} />;
-}
-App.getClassNames = getClassNames;
-
-function assertMatchesInSource(fn, regex, expectedCount) {
-  const matches = fn.toString().match(regex);
-  const count = matches ? matches.length : 0;
-  if (count !== expectedCount) {
-    throw new Error(
-      `Expected ${expectedCount} matches of ${regex} in the function ` +
-      `source but found ${count}:\n\n${fn.toString()}`
-    );
+module.exports = this.__evaluatePureFunction(() => {
+  if (!this.Bootloader) {
+    this.Bootloader = {loadModules() {}};
   }
-}
+  
+  if (!this.JSResource) {
+    this.JSResource = {loadAll() {}};
+  }
+  
+  if (!this.ix) {
+    this.ix = () => {};
+  }
+  
+  // Verify that the generated code can still reference abstract values correctly.
+  this.abstractTrue = this.__abstract ? __abstract("boolean", "true") : true;
+  this.abstractFalse = this.__abstract ? __abstract("boolean", "false") : false;
+  
+  function getClassNames() {
+    return [cx("cx-one"), cx("cx-multi-1", "cx-multi-2"), cx({
+      "cx-obj-1": true,
+      "cx-obj-2": false,
+      "cx-obj-3-true": abstractTrue,
+      "cx-obj-4-false": abstractFalse,
+    })];
+  }
+  
+  JSResource.loadAll('hi')
+  Bootloader.loadModules("somethingYes", function() {});
+  
+  // Hoist to force the init time calculation
+  var classNames = getClassNames();
+  function App() {
+    return <div className={classNames} />;
+  }
+  App.getClassNames = getClassNames;
+  
+  function assertMatchesInSource(fn, regex, expectedCount) {
+    const matches = fn.toString().match(regex);
+    const count = matches ? matches.length : 0;
+    if (count !== expectedCount) {
+      throw new Error(
+        `Expected ${expectedCount} matches of ${regex} in the function ` +
+        `source but found ${count}:\n\n${fn.toString()}`
+      );
+    }
+  }
+  
+  App.getTrials = function(renderer, Root) {
+    // Check that matches didn't get renamed
+    assertMatchesInSource(Root.getClassNames, /[^\w]cx\(/g, 3);
+  
+    renderer.update(<Root />);
+    return [['fb5 mocks', renderer.toJSON()]];
+  };
 
-App.getTrials = function(renderer, Root) {
-  // Check that matches didn't get renamed
-  assertMatchesInSource(Root.getClassNames, /[^\w]cx\(/g, 3);
-
-  renderer.update(<Root />);
-  return [['fb5 mocks', renderer.toJSON()]];
-};
-
-module.exports = App;
+  return App;
+});;


### PR DESCRIPTION
Release notes: none

This RR removes implicit pure wrapper from fb-www and instead adds a new __evaluatePureFunction hook to apply the same logic. I've updated the tests to reflect these changes too.

This was taken from: https://github.com/facebook/prepack/pull/1412 as our tool to allow us to land the PR wasn't picking up the PR.