### PR TITLE
Add mocks for more Relay public APIs

### DIFF
--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -44,5 +44,17 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
   );
   Create.CreateDataPropertyOrThrow(realm, reactRelay, "createRefetchContainer", createRefetchContainer);
 
+  let commitLocalUpdate = createAbstract(realm, "function", `require("${relayRequireName}").commitLocalUpdate`);
+  Create.CreateDataPropertyOrThrow(realm, reactRelay, "commitLocalUpdate", commitLocalUpdate);
+
+  let commitMutation = createAbstract(realm, "function", `require("${relayRequireName}").commitMutation`);
+  Create.CreateDataPropertyOrThrow(realm, reactRelay, "commitMutation", commitMutation);
+
+  let fetchQuery = createAbstract(realm, "function", `require("${relayRequireName}").fetchQuery`);
+  Create.CreateDataPropertyOrThrow(realm, reactRelay, "fetchQuery", fetchQuery);
+
+  let requestSubscription = createAbstract(realm, "function", `require("${relayRequireName}").requestSubscription`);
+  Create.CreateDataPropertyOrThrow(realm, reactRelay, "requestSubscription", requestSubscription);
+
   return reactRelay;
 }


### PR DESCRIPTION
We were missing some of them. I got the list by reading the top-level exports in the npm package.
We need these for UFI.