### PR TITLE
Fix React simple class component folding

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -30,8 +30,8 @@ ReactStatistics {
 
 exports[`Test React (JSX) Class component folding Simple classes 1`] = `
 ReactStatistics {
-  "inlinedComponents": 0,
-  "optimizedTrees": 2,
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
 }
 `;
 
@@ -324,8 +324,8 @@ ReactStatistics {
 
 exports[`Test React (create-element) Class component folding Simple classes 1`] = `
 ReactStatistics {
-  "inlinedComponents": 0,
-  "optimizedTrees": 2,
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -36,6 +36,8 @@ const lifecycleMethods = new Set([
   "componentWillReceiveProps",
 ]);
 
+const whitelistedProperties = new Set(["props", "context", "refs"]);
+
 export function getInitialProps(
   realm: Realm,
   componentType: ECMAScriptSourceFunctionValue | null
@@ -176,7 +178,9 @@ export function evaluateClassConstructor(
         let instanceObject = Construct(realm, constructorFunc, [props, context]);
         invariant(instanceObject instanceof ObjectValue);
         for (let [propertyName] of instanceObject.properties) {
-          instanceProperties.add(propertyName);
+          if (!whitelistedProperties.has(propertyName)) {
+            instanceProperties.add(propertyName);
+          }
         }
         for (let [symbol] of instanceObject.symbols) {
           instanceSymbols.add(symbol);


### PR DESCRIPTION
Release notes: none

We tracked a regression to do with React simple class component folding. This should fix #1423 and the changes are reflected in the snapshot tests.
