### PR TITLE
Non destructive update of unions that get derived

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -13,18 +13,18 @@ import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 import { construct_empty_effects, type Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding, PropertyKeyValue } from "../types.js";
 import {
+  AbstractObjectValue,
+  AbstractValue,
   ArrayValue,
-  UndefinedValue,
-  NumberValue,
-  SymbolValue,
-  NullValue,
   BooleanValue,
+  ConcreteValue,
+  NullValue,
+  NumberValue,
   ObjectValue,
   StringValue,
+  SymbolValue,
+  UndefinedValue,
   Value,
-  ConcreteValue,
-  AbstractValue,
-  AbstractObjectValue,
 } from "../values/index.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression";
 import { EnvironmentRecord, Reference } from "../environment.js";
@@ -1178,8 +1178,9 @@ export class PropertiesImplementation {
         });
         if (savedUnion !== undefined) {
           invariant(savedIndex !== undefined);
-          savedUnion.args[savedIndex] = value;
-          value = savedUnion;
+          let args = savedUnion.args.slice(0);
+          args[savedIndex] = value;
+          value = AbstractValue.createAbstractConcreteUnion(realm, ...args);
         }
         InternalSetProperty(realm, O, P, {
           value: value,

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -646,8 +646,8 @@ export default class AbstractValue extends Value {
       values = ValuesDomain.topVal;
     }
     let types = TypesDomain.topVal;
-    let [hash, operands] = hashCall("abstractConcreteUnion", ...elements);
-    let result = new AbstractValue(realm, types, values, hash, operands, abstractValue._buildNode, {
+    let [hash, operands] = hashCall("abstractConcreteUnion", abstractValue, ...concreteValues);
+    let result = new AbstractValue(realm, types, values, hash, operands, nodes => nodes[0], {
       kind: "abstractConcreteUnion",
     });
     result.expressionLocation = realm.currentLocation;

--- a/test/serializer/abstract/IntrinsicUnion2.js
+++ b/test/serializer/abstract/IntrinsicUnion2.js
@@ -1,0 +1,9 @@
+// omit invariants
+// add at runtime:global.obj={};
+if (global.__assumeDataProperty) __assumeDataProperty(global, "obj", __abstractOrNull("object"));
+if (global.__assumeDataProperty) __assumeDataProperty(global, "inspect", undefined);
+if (global.__makePartial) __makePartial(global);
+
+let res;
+if(global.obj) res = global.obj;
+inspect = function() { return res + ""; }


### PR DESCRIPTION
Release note: fixes issue #1411

When an abstract value that is of kind "abstractConcreteUnion" is specified as the value of an environmental object property, a derived value is created to capture the temporal value of the environment. This value must be turned back into a union, in order to preserve the original behavior.

This was done by mutating the original union, which is all sort of wrong and wreak havoc when the environmental property is accessed more than once.