### PR TITLE
Transitively simple objects

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -305,7 +305,7 @@ function InternalCloneObject(realm: Realm, val: ObjectValue): ObjectValue {
   }
   if (val.isPartialObject()) clone.makePartial();
   if (val.isSimpleObject()) clone.makeSimple();
-  clone.isTemplate = true; // because this object doesn't exist ahead of time, and the visitor would otherwise declare it in the common scope
+  clone._isScopedTemplate = true; // because this object doesn't exist ahead of time, and the visitor would otherwise declare it in the common scope
   return clone;
 }
 

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -276,9 +276,8 @@ export default function(realm: Realm): void {
   // __makePartial(object) marks an (abstract) object as partial.
   global.$DefineOwnProperty("__makePartial", {
     value: new NativeFunctionValue(realm, "global.__makePartial", "__makePartial", 1, (context, [object]) => {
-      // casting to any to avoid Flow bug
-      if ((object: any) instanceof AbstractObjectValue || (object: any) instanceof ObjectValue) {
-        (object: any).makePartial();
+      if (object instanceof AbstractObjectValue || object instanceof ObjectValue) {
+        object.makePartial();
         return object;
       }
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an (abstract) object");
@@ -290,10 +289,9 @@ export default function(realm: Realm): void {
 
   // __makeSimple(object) marks an (abstract) object as one that has no getters or setters.
   global.$DefineOwnProperty("__makeSimple", {
-    value: new NativeFunctionValue(realm, "global.__makeSimple", "__makeSimple", 1, (context, [object]) => {
-      // casting to any to avoid Flow bug
-      if ((object: any) instanceof AbstractObjectValue || (object: any) instanceof ObjectValue) {
-        (object: any).makeSimple();
+    value: new NativeFunctionValue(realm, "global.__makeSimple", "__makeSimple", 1, (context, [object, option]) => {
+      if (object instanceof AbstractObjectValue || object instanceof ObjectValue) {
+        object.makeSimple(option);
         return object;
       }
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not an (abstract) object");
@@ -315,8 +313,7 @@ export default function(realm: Realm): void {
           throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
         }
 
-        // casting to any to avoid Flow bug "*** Recursion limit exceeded ***"
-        if ((object: any) instanceof AbstractObjectValue || (object: any) instanceof ObjectValue) {
+        if (object instanceof AbstractObjectValue || object instanceof ObjectValue) {
           let generator = realm.generator;
           invariant(generator);
 

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -191,7 +191,7 @@ function checkResidualFunctions(modules: Modules, startFunc: number, totalToAnal
     for (let i = 0; i < n; i++) {
       let name = "dummy parameter";
       let ob: AbstractObjectValue = (AbstractValue.createFromType(realm, ObjectValue, name): any);
-      ob.makeSimple();
+      ob.makeSimple("transitive");
       ob.intrinsicName = name;
       args[i] = ob;
     }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1116,13 +1116,6 @@ export class Realm {
     if (abstractValue.values.isTop()) return;
     let template = abstractValue.getTemplate();
     invariant(!template.intrinsicName || template.intrinsicName === path);
-    // TODO #882: We are using the concept of "intrinsic values" to mark the template
-    // object as intrinsic, so that we'll never emit code that creates it, as it instead is used
-    // to refer to an unknown but existing object.
-    // However, it's not really an intrinsic object, and it might not exist ahead of time, but only starting
-    // from this point on, which might be tied to some nested generator.
-    // Which we currently don't track, and that needs to get fixed.
-    // For now, we use intrinsicNameGenerated to mark this case.
     template.intrinsicName = path;
     template.intrinsicNameGenerated = true;
     for (let [key, binding] of template.properties) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -755,8 +755,8 @@ export class ResidualHeapVisitor {
       if (this.preProcessValue(val)) this.visitAbstractValue(val);
     } else if (val.isIntrinsic()) {
       // All intrinsic values exist from the beginning of time...
-      // ...except for a few that come into existence as templates for abstract objects (TODO #882).
-      if (val.isTemplate) this.preProcessValue(val);
+      // ...except for a few that come into existence as templates for abstract objects via executable code.
+      if (val._isScopedTemplate) this.preProcessValue(val);
       else
         this._withScope(this.commonScope, () => {
           this.preProcessValue(val);

--- a/src/utils/leak.js
+++ b/src/utils/leak.js
@@ -387,7 +387,7 @@ class ObjectValueLeakingVisitor {
       if (this.mustVisit(val)) this.visitAbstractValue(val);
     } else if (val.isIntrinsic()) {
       // All intrinsic values exist from the beginning of time...
-      // ...except for a few that come into existance as templates for abstract objects (TODO #882).
+      // ...except for a few that come into existance as templates for abstract objects.
       this.mustVisit(val);
     } else if (val instanceof EmptyValue) {
       this.mustVisit(val);

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -130,18 +130,19 @@ export default class AbstractObjectValue extends AbstractValue {
     }
   }
 
-  makeSimple(): void {
+  makeSimple(option?: string | Value): void {
     if (this.values.isTop() && this.getType() === ObjectValue) {
       let obj = new ObjectValue(this.$Realm, this.$Realm.intrinsics.ObjectPrototype);
       obj.intrinsicName = this.intrinsicName;
       obj.intrinsicNameGenerated = true;
       obj.makePartial();
+      obj._templateFor = this;
       this.values = new ValuesDomain(obj);
     }
     if (!this.values.isTop()) {
       for (let element of this.values.getElements()) {
         invariant(element instanceof ObjectValue);
-        element.makeSimple();
+        element.makeSimple(option);
       }
     }
     this.cachedIsSimpleObject = true;

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -626,6 +626,24 @@ export default class AbstractValue extends Value {
     return realm.generator.derive(types, values, args, buildNode_, optionalArgs);
   }
 
+  static createFromBuildFunction(
+    realm: Realm,
+    resultType: typeof Value,
+    args: Array<Value>,
+    buildFunction: AbstractValueBuildNodeFunction,
+    optionalArgs?: {| kind?: string |}
+  ): AbstractValue | UndefinedValue {
+    let types = new TypesDomain(resultType);
+    let values = ValuesDomain.topVal;
+    let Constructor = Value.isTypeCompatibleWith(resultType, ObjectValue) ? AbstractObjectValue : AbstractValue;
+    let kind = (optionalArgs && optionalArgs.kind) || "build function";
+    let hash;
+    [hash, args] = hashCall(kind, ...args);
+    let result = new Constructor(realm, types, values, hash, args, buildFunction);
+    result.kind = kind;
+    return result;
+  }
+
   static createTemporalFromBuildFunction(
     realm: Realm,
     resultType: typeof Value,

--- a/test/serializer/abstract/SimpleObject3.js
+++ b/test/serializer/abstract/SimpleObject3.js
@@ -1,0 +1,29 @@
+// add at runtime: var foo = { props: { toolbox: {}, trackingCodes: null, feedProps: [],  unit: { firstItem: { edges: [{ node: 123 }] } } } };
+function render(_ref3) {
+  var _ref;
+  var props = _ref3.props;
+  if (props == null) return null;
+  var item =
+    (_ref = props.unit) != null
+      ? (_ref = _ref.firstItem) != null
+        ? (_ref = _ref.edges) != null ? ((_ref = _ref[0]) != null ? _ref.node : _ref) : _ref
+        : _ref
+      : _ref;
+  if (!item) {
+    return null;
+  } else {
+    return {
+      unit: props.unit,
+      item: item,
+      toolbox: props.toolbox,
+      trackingCodes: props.trackingCodes,
+      feedProps: props.feedProps,
+    };
+  }
+}
+let wellBehavedObject = { props: { toolbox: {}, trackingCodes: null, feedProps: [],  unit: { firstItem: { edges: [{ node: 123 }] } } } };
+let wellBehavedParameter = global.__abstract ? __abstract("object", "foo"): wellBehavedObject;
+if (global.__makeSimple) __makeSimple(wellBehavedParameter, "transitive");
+prepackedRender = render(wellBehavedParameter);
+
+inspect = function() { return JSON.stringify(prepackedRender); }

--- a/test/serializer/abstract/SimpleObject4.js
+++ b/test/serializer/abstract/SimpleObject4.js
@@ -1,0 +1,13 @@
+// add at runtime: var ob = { x: { y: { z: {  } } } };
+function render(ob) {
+  var x = ob.x;
+  if (x == null) return null;
+  var y = x.y;
+  if (y == null) return null;
+  return y.z;
+}
+let absOb = global.__abstract ? __abstract("object", "ob"): { x: { y: { z: {  } } } };
+if (global.__makeSimple) __makeSimple(absOb, "transitive");
+prepackedRender = render(absOb);
+
+inspect = function() { return JSON.stringify(prepackedRender); }


### PR DESCRIPTION
Release note: Provides a way to make every unknown property value from a simple object be a simple object. Fixes issue: #1410

