### PR TITLE
Bug: functional components break with different argument naming

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -252,6 +252,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) Functional component folding Simple 7 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (JSX) Functional component folding Simple children 1`] = `
 ReactStatistics {
   "inlinedComponents": 2,
@@ -575,6 +582,13 @@ ReactStatistics {
 `;
 
 exports[`Test React (create-element) Functional component folding Simple 6 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Simple 7 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
   "optimizedTrees": 1,

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -185,6 +185,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-6.js");
       });
 
+      it("Simple 7", async () => {
+        await runTest(directory, "simple-7.js");
+      });
+
       it("Simple fragments", async () => {
         await runTest(directory, "simple-fragments.js");
       });

--- a/test/react/functional-components/simple-7.js
+++ b/test/react/functional-components/simple-7.js
@@ -1,0 +1,20 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App(_ref) {
+  return (
+    <div>{String(_ref.title)}</div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
This new test currently fails because the generated code assumes the argument is called `props`.

```js
    function (props) {
        var _$1 = _ref.title;
    
        var _$2 = _$5(_$1);
    
        var _7 = React.createElement(
          "div",
          null,
          _$2
        );
    
        return _7;
      }
```