### PR TITLE
[WIP] Bug: event handlers as named functions get assigned to the global object

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -147,6 +147,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) Functional component folding Event handler bug 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (JSX) Functional component folding Key change 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
@@ -470,6 +477,13 @@ ReactStatistics {
 `;
 
 exports[`Test React (create-element) Functional component folding Dynamic props 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Event handler bug 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
   "optimizedTrees": 1,

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -205,6 +205,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "conditional.js");
       });
 
+      it("Event handler", async () => {
+        await runTest(directory, "event-handler.js");
+      });
+
       it("Key nesting", async () => {
         await runTest(directory, "key-nesting.js");
       });

--- a/test/react/functional-components/event-handler.js
+++ b/test/react/functional-components/event-handler.js
@@ -1,0 +1,26 @@
+var React = require('React');
+this['React'] = React;
+
+function App(props) {
+  // This being a named function is a regression test for a bug
+  // that emitted a global.onClick assignment.
+  return <div onClick={function onClick(x) {
+    props.onClick(x * 2);
+  }} />
+}
+
+App.getTrials = function(renderer, Root) {
+  let result;
+  renderer.update(<Root onClick={res => { result = res; }} />);
+  renderer.root.findByType('div').props.onClick(10);
+  return [
+    ['onClick gets called', result],
+    ['regression: onClick is not global', typeof this.onClick],
+  ];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
```js
<div onClick={function onClick() {}} />
```

creates a global `onClick` function.

Attached is a regression test.