### PR TITLE
Bug: Computed properties aren't serialized with quotes around their names

### DIFF
--- a/test/react/mocks/fb2.js
+++ b/test/react/mocks/fb2.js
@@ -40,7 +40,8 @@ Hello.prototype.componentDidMount = function() {
 Hello.prototype.render = function() {
   return React.createElement(
     "h1",
-    null,
+    // Regression test for bad serialization of computed properties
+    babelHelpers['extends']({}, this.__unknownAbstract),
     "Hello world",
   );
 };


### PR DESCRIPTION
I get `babelHelpers[extends]` rather than `babelHelpers["extends"]` in the output.
This is a regression test.