### PR TITLE
[WIP] Poor folding/bug: objectWithoutProperties() and extends() deopt the whole subtree

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -329,6 +329,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) fb-www mocks fb-www 9 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (create-element) Class component folding Classes with state 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
@@ -655,5 +662,12 @@ exports[`Test React (create-element) fb-www mocks fb-www 8 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React (create-element) fb-www mocks fb-www 9 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
 }
 `;

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -374,6 +374,10 @@ function runTestSuite(outputJsx) {
       it("fb-www 8", async () => {
         await runTest(directory, "fb8.js");
       });
+
+      it("fb-www 9", async () => {
+        await runTest(directory, "fb9.js");
+      });
     });
   });
 }

--- a/test/react/mocks/fb9.js
+++ b/test/react/mocks/fb9.js
@@ -58,9 +58,23 @@ module.exports = this.__evaluatePureFunction(() => {
   }
 
   function App(props) {
-    return React.createElement(
-      A,
-      babelHelpers.objectWithoutProperties(props, ['x'])
+    const propsCopyWithDeletedProp = babelHelpers.extends({}, props);
+    delete propsCopyWithDeletedProp.y;
+    return React.createElement('div', null,
+      // Feel free to comment out either of these children
+      // individually when debugging specific cases.
+      React.createElement(
+        A,
+        babelHelpers.objectWithoutProperties(props, ['x'])
+      ),
+      React.createElement(
+        A,
+        babelHelpers.extends({}, props, {x: 30})
+      ),
+      React.createElement(
+        A,
+        propsCopyWithDeletedProp
+      ),
     );
   }
 

--- a/test/react/mocks/fb9.js
+++ b/test/react/mocks/fb9.js
@@ -1,0 +1,77 @@
+var React = require('React');
+this['React'] = React;
+
+// FB www polyfill
+if (!this.babelHelpers) {
+  this.babelHelpers = {
+    inherits(subClass, superClass) {
+      Object.assign(subClass, superClass);
+      subClass.prototype = Object.create(superClass && superClass.prototype);
+      subClass.prototype.constructor = subClass;
+      subClass.__superConstructor__ = superClass;
+      return superClass;
+    },
+    _extends: Object.assign,
+    extends: Object.assign,
+    objectWithoutProperties(obj, keys) {
+      var target = {};
+      var hasOwn = Object.prototype.hasOwnProperty;
+      for (var i in obj) {
+        if (!hasOwn.call(obj, i) || keys.indexOf(i) >= 0) {
+          continue;
+        }
+        target[i] = obj[i];
+      }
+      return target;
+    },
+    taggedTemplateLiteralLoose(strings, raw) {
+      strings.raw = raw;
+      return strings;
+    },
+    bind: Function.prototype.bind,
+  };
+}
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = this.__evaluatePureFunction(() => {  
+  function A(props) {
+    return (
+      <React.Fragment>
+        <div>Hello {props.x} {props.y}</div>
+        <B />
+        <C />
+      </React.Fragment>
+    );
+  }
+
+  function B() {
+    return <div>World</div>;
+  }
+
+  function C() {
+    return "!";
+  }
+
+  function App(props) {
+    return React.createElement(
+      A,
+      babelHelpers.objectWithoutProperties(props, ['x'])
+    );
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root x={10} y={20} />);
+    return [['simple render', renderer.toJSON()]];
+  };
+
+  if (this.__registerReactComponentRoot) {
+    __registerReactComponentRoot(App);
+  }
+
+  return App;
+});


### PR DESCRIPTION
This is not strictly saying a bug, but it seems like a big issue for folding.

As soon as we meet `objectWithoutProperties()` (result of the rest transform, i.e. `var {something, ...rest} = props`), we bail out completely.

I don't know if it's possible to not bail out for `A` itself (probably not?)

But we definitely should somehow "jump" into it, and inline `B` and `C` into it. Completely missing `B` and `C` now that we've given up on `A` seems like a problem.

There's likely more similar patterns, this is just the first one I found.