### PR TITLE
[WIP] Poor folding: nullthrows

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -374,6 +374,10 @@ function runTestSuite(outputJsx) {
       it("fb-www 8", async () => {
         await runTest(directory, "fb8.js");
       });
+
+      it("fb-www 10", async () => {
+        await runTest(directory, "fb10.js");
+      });
     });
   });
 }

--- a/test/react/mocks/fb10.js
+++ b/test/react/mocks/fb10.js
@@ -1,0 +1,55 @@
+var React = require('React');
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = this.__evaluatePureFunction(() => {
+  function nullthrows(x) {
+    var message = arguments.length <= 1 || arguments[1] === undefined ? 'Got unexpected null or undefined' : arguments[1];
+    if (x != null) {
+      return x;
+    }
+    var error = new Error(message);
+
+    error.framesToPop = 1;
+    throw error;
+  };
+
+  function A(props) {
+    return (
+      <div className={props.className}>
+        <div>Hello {props.x} {props.y}</div>
+        <B />
+        <C />
+      </div>
+    );
+  }
+
+  function B() {
+    return <div>World</div>;
+  }
+
+  function C() {
+    return "!";
+  }
+
+  function App(props) {
+    nullthrows(props.className);
+    return <A className={props.className} />;
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root className="Rooty McRootface" />);
+    return [['simple render', renderer.toJSON()]];
+  };
+
+  if (this.__registerReactComponentRoot) {
+    __registerReactComponentRoot(App);
+  }
+
+  return App;
+});


### PR DESCRIPTION
Like https://github.com/facebook/prepack/pull/1434, I'm not strictly sure if it's a bug, but this manifests itself as a problem with real code.

If one of the branches can throw, the compiler currently completely fails with an invariant. Instead (I think?) it should at least recover and keep the render function as is. Ideally it would still inline the code (but maybe it's not safe, I'm not sure).