### PR TITLE
Properly supporting Object.[freeze|sealed|preventExtensions] in serializer.

### DIFF
--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -61,7 +61,6 @@ export class ResidualHeapInspector {
           let anyWritable = false,
             anyConfigurable = false;
           for (let propertyBinding of val.properties.values()) {
-            invariant(propertyBinding);
             let desc = propertyBinding.descriptor;
             if (desc === undefined) continue; //deleted
             if (desc.configurable) anyConfigurable = true;

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -14,6 +14,7 @@ import type { Descriptor } from "../types.js";
 import { IsArray } from "../methods/index.js";
 import {
   SymbolValue,
+  BooleanValue,
   AbstractValue,
   FunctionValue,
   ECMAScriptSourceFunctionValue,
@@ -22,20 +23,68 @@ import {
   ObjectValue,
   PrimitiveValue,
   UndefinedValue,
+  ProxyValue,
 } from "../values/index.js";
 import invariant from "../invariant.js";
 import { Logger } from "../utils/logger.js";
+
+type TargetIntegrityCommand = "freeze" | "seal" | "preventExtensions" | "";
 
 export class ResidualHeapInspector {
   constructor(realm: Realm, logger: Logger) {
     this.realm = realm;
     this.logger = logger;
     this.ignoredProperties = new Map();
+    this._targetIntegrityCommands = new Map();
   }
 
   realm: Realm;
   logger: Logger;
   ignoredProperties: Map<ObjectValue, Set<string>>;
+  _targetIntegrityCommands: Map<ObjectValue, TargetIntegrityCommand>;
+
+  getTargetIntegrityCommand(val: ObjectValue): TargetIntegrityCommand {
+    let command = this._targetIntegrityCommands.get(val);
+    if (command === undefined) {
+      command = "";
+      if (val instanceof ProxyValue) {
+        // proxies don't participate in regular object freezing/sealing,
+        // only their underlying proxied objects do
+      } else {
+        let extensible = val.$Extensible;
+        if (!(extensible instanceof BooleanValue)) {
+          this.logger.logError(
+            val,
+            "Object that might or might not be sealed or frozen are not supported in residual heap."
+          );
+        } else if (!extensible.value) {
+          let anyWritable = false,
+            anyConfigurable = false;
+          for (let propertyBinding of val.properties.values()) {
+            invariant(propertyBinding);
+            let desc = propertyBinding.descriptor;
+            if (desc === undefined) continue; //deleted
+            if (desc.configurable) anyConfigurable = true;
+            else if (desc.value !== undefined && desc.writable) anyWritable = true;
+          }
+          command = anyConfigurable ? "preventExtensions" : anyWritable ? "seal" : "freeze";
+        }
+      }
+      this._targetIntegrityCommands.set(val, command);
+    }
+    return command;
+  }
+
+  static _integrityDescriptors = {
+    "": { writable: true, configurable: true },
+    preventExtensions: { writable: true, configurable: true },
+    seal: { writable: true, configurable: false },
+    freeze: { writable: false, configurable: false },
+  };
+
+  getTargetIntegrityDescriptor(val: ObjectValue) {
+    return ResidualHeapInspector._integrityDescriptors[this.getTargetIntegrityCommand(val)];
+  }
 
   static isLeaf(val: Value): boolean {
     if (val instanceof SymbolValue) {
@@ -74,8 +123,10 @@ export class ResidualHeapInspector {
   }
 
   _canIgnoreProperty(val: ObjectValue, key: string, desc: Descriptor) {
+    let targetDescriptor = this.getTargetIntegrityDescriptor(val);
+
     if (IsArray(this.realm, val)) {
-      if (key === "length" && desc.writable && !desc.enumerable && !desc.configurable) {
+      if (key === "length" && desc.writable === targetDescriptor.writable && !desc.enumerable && !desc.configurable) {
         // length property has the correct descriptor values
         return true;
       }
@@ -86,7 +137,12 @@ export class ResidualHeapInspector {
           // Rationale: .bind() would call the accessor, which might throw, mutate state, or do whatever...
         }
         // length property will be inferred already by the amount of parameters
-        return !desc.writable && !desc.enumerable && desc.configurable && val.hasDefaultLength();
+        return (
+          !desc.writable &&
+          !desc.enumerable &&
+          desc.configurable === targetDescriptor.configurable &&
+          val.hasDefaultLength()
+        );
       }
 
       if (key === "name") {
@@ -112,9 +168,9 @@ export class ResidualHeapInspector {
         invariant(val instanceof ECMAScriptSourceFunctionValue);
         if (
           !val.$Strict &&
-          desc.writable &&
+          desc.writable === (!val.$Strict && targetDescriptor.writable) &&
           !desc.enumerable &&
-          desc.configurable &&
+          desc.configurable === targetDescriptor.configurable &&
           desc.value instanceof UndefinedValue &&
           val.$FunctionKind === "normal"
         )
@@ -126,7 +182,7 @@ export class ResidualHeapInspector {
         if (
           !desc.configurable &&
           !desc.enumerable &&
-          desc.writable &&
+          desc.writable === targetDescriptor.writable &&
           desc.value instanceof ObjectValue &&
           desc.value.originalConstructor === val
         ) {
@@ -137,7 +193,12 @@ export class ResidualHeapInspector {
       let kind = val.getKind();
       switch (kind) {
         case "RegExp":
-          if (key === "lastIndex" && desc.writable && !desc.enumerable && !desc.configurable) {
+          if (
+            key === "lastIndex" &&
+            desc.writable === targetDescriptor.writable &&
+            !desc.enumerable &&
+            !desc.configurable
+          ) {
             // length property has the correct descriptor values
             let v = desc.value;
             return v instanceof NumberValue && v.value === 0;
@@ -149,7 +210,13 @@ export class ResidualHeapInspector {
     }
 
     if (key === "constructor") {
-      if (desc.configurable && !desc.enumerable && desc.writable && desc.value === val.originalConstructor) return true;
+      if (
+        desc.configurable === targetDescriptor.configurable &&
+        !desc.enumerable &&
+        desc.writable === targetDescriptor.writable &&
+        desc.value === val.originalConstructor
+      )
+        return true;
     }
 
     return false;
@@ -168,9 +235,10 @@ export class ResidualHeapInspector {
     if (
       prototype.symbols.size !== 0 ||
       prototype.$Prototype !== this.realm.intrinsics.ObjectPrototype ||
-      !prototype.getExtensible()
-    )
+      prototype.$Extensible.mightNotBeTrue()
+    ) {
       return false;
+    }
     let foundConstructor = false;
     for (let name of prototype.properties.keys())
       if (

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -139,7 +139,7 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   $Prototype: ObjectValue | NullValue;
-  $Extensible: BooleanValue;
+  $Extensible: BooleanValue | AbstractValue;
 
   $ParameterMap: void | ObjectValue; // undefined when the property is "missing"
   $SymbolData: void | SymbolValue | AbstractValue;
@@ -344,7 +344,7 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   getExtensible(): boolean {
-    return this.$Extensible.value;
+    return this.$Extensible.throwIfNotConcreteBoolean().value;
   }
 
   setExtensible(v: boolean) {

--- a/test/serializer/basic/ObjectFreeze1.js
+++ b/test/serializer/basic/ObjectFreeze1.js
@@ -1,0 +1,7 @@
+// does contain:freeze
+// does not contain:defineProperty
+(function () {
+    var o = { x: 23, y: 42 };
+    Object.freeze(o);
+    global.inspect = function() { o.z = "bug"; return o.z; }
+})();

--- a/test/serializer/basic/ObjectFreeze2.js
+++ b/test/serializer/basic/ObjectFreeze2.js
@@ -1,0 +1,7 @@
+// does contain:freeze
+// does not contain:defineProperty
+(function () {
+    var f = function(){}
+    Object.freeze(f);
+    global.inspect = function() { f.z = "bug"; return f.z; }
+})();

--- a/test/serializer/basic/ObjectFreeze3.js
+++ b/test/serializer/basic/ObjectFreeze3.js
@@ -1,0 +1,7 @@
+// does contain:freeze
+// does not contain:defineProperty
+(function () {
+    var a = [1,2,3];
+    Object.freeze(a);
+    global.inspect = function() { a.z = "bug"; return a.z; }
+})();

--- a/test/serializer/basic/ObjectFreeze4.js
+++ b/test/serializer/basic/ObjectFreeze4.js
@@ -1,0 +1,7 @@
+// does contain:freeze
+// does not contain:defineProperty
+(function () {
+    var re = RegExp();
+    Object.freeze(re);
+    global.inspect = function() { re.z = "bug"; return re.z; }
+})();

--- a/test/serializer/basic/ObjectFreeze5.js
+++ b/test/serializer/basic/ObjectFreeze5.js
@@ -1,0 +1,7 @@
+// does contain:freeze
+(function () {
+    var o = { x: 23, y: 42 };
+    Object.defineProperty(o, "foo", { enumerable: false, writable: false, configurable: false, value: 42 });
+    Object.freeze(o);
+    global.inspect = function() { o.z = "bug"; return o.z + Object.getOwnPropertyDescriptor(o, "foo").enumerable; }
+})();

--- a/test/serializer/basic/ObjectPreventExtensions1.js
+++ b/test/serializer/basic/ObjectPreventExtensions1.js
@@ -1,0 +1,7 @@
+// does contain:preventExtensions
+// does not contain:defineProperty
+(function () {
+    var o = { x: 23, y: 42 };
+    Object.preventExtensions(o);
+    global.inspect = function() { o.z = "bug"; return o.z; }
+})();

--- a/test/serializer/basic/ObjectSeal1.js
+++ b/test/serializer/basic/ObjectSeal1.js
@@ -1,0 +1,7 @@
+// does contain:seal
+// does not contain:defineProperty
+(function () {
+    var o = { x: 23, y: 42 };
+    Object.seal(o);
+    global.inspect = function() { o.z = "bug"; return o.z; }
+})();

--- a/test/serializer/basic/ObjectSeal2.js
+++ b/test/serializer/basic/ObjectSeal2.js
@@ -1,0 +1,7 @@
+// does contain:seal
+(function () {
+    var o = { x: 23, y: 42 };
+    Object.defineProperty(o, "foo", { enumerable: false, writable: false, configurable: false, value: 42 });
+    Object.seal(o);
+    global.inspect = function() { o.z = "bug"; return o.z + Object.getOwnPropertyDescriptor(o, "foo").writable; }
+})();


### PR DESCRIPTION
Release notes: Support for Object.freeze, Object.seal, and Object.preventExtensions.

The interpreter always did the right things, but the serializer ignored the $Extensible internal slot.
This is now fixed, and the serializer generates minimal code that first creates an object with simple assignments or an object literal when possible, followed by a call to Object.freeze / Object.seal/ Object.preventExtensions if needed.
This addresses #953 and #585.