### PR TITLE
Make it so that !!(!x ? null : {}) => x

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -27,6 +27,7 @@ import {
   Value,
 } from "../values/index.js";
 import type { AbstractValueBuildNodeFunction } from "../values/AbstractValue.js";
+import { hashString } from "../methods/index.js";
 import type { Descriptor } from "../types.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import * as base62 from "base62";
@@ -362,7 +363,7 @@ export class Generator {
     let options = {};
     if (optionalArgs && optionalArgs.kind) options.kind = optionalArgs.kind;
     let Constructor = Value.isTypeCompatibleWith(types.getType(), ObjectValue) ? AbstractObjectValue : AbstractValue;
-    let res = new Constructor(this.realm, types, values, 0, [], id, options);
+    let res = new Constructor(this.realm, types, values, hashString(id.name), [], id, options);
     this._addEntry({
       isPure: optionalArgs ? optionalArgs.isPure : undefined,
       declared: res,

--- a/test/serializer/abstract/IntrinsicUnion2.js
+++ b/test/serializer/abstract/IntrinsicUnion2.js
@@ -5,5 +5,8 @@ if (global.__assumeDataProperty) __assumeDataProperty(global, "inspect", undefin
 if (global.__makePartial) __makePartial(global);
 
 let res;
-if(global.obj) res = global.obj;
-inspect = function() { return res + ""; }
+if (global.obj) res = global.obj;
+let x = !!res ? (res ? {} : undefined) : null;
+let y = !!(!res ? null : {});
+let z = y ? (!res ? 1 : 2) : 3;
+inspect = function() { return res + " " + x + " " + y + " " + z; }


### PR DESCRIPTION
Release note: Add another special case to the simplifier

Since !x on the path causes !!(!x ? null : {}) to simplify to false, it is not OK to explore a path with condition !x while exploring a path with condition !!(!x ? null : {}) because the existing path condition will be refined with the new condition, which will cause the simplifier to push a false condition on the path, which we disallow since such a path is clearly infeasible.

The null and {} in the above are illustrative only. Any expressions that coerce to false and true, respectively will do.