### PR TITLE
Return AbstractValue when trying to Object.assign an abstract from value

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -273,6 +273,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) Functional component folding Simple with Object.assign 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (JSX) fb-www mocks fb-www 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
@@ -596,6 +603,13 @@ ReactStatistics {
 `;
 
 exports[`Test React (create-element) Functional component folding Simple refs 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Simple with Object.assign 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
   "optimizedTrees": 1,

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -185,6 +185,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-6.js");
       });
 
+      it("Simple with Object.assign", async () => {
+        await runTest(directory, "simple-with-object-assign.js");
+      });
+
       it("Simple fragments", async () => {
         await runTest(directory, "simple-fragments.js");
       });

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -80,7 +80,7 @@ export default function(realm: Realm): NativeFunctionValue {
       } else {
         // If the source is abstract that is partial, we don't know what
         // properties it has, we need to serialize back an abstract value
-        if (nextSource instanceof AbstractValue && nextSource.isPartialObject()) {
+        if (nextSource instanceof AbstractValue && nextSource.isPartialObject() && realm.isInPureScope()) {
           to_must_be_abstract = true;
           break;
         }
@@ -147,6 +147,7 @@ export default function(realm: Realm): NativeFunctionValue {
         target.makeSimple();
         // the abstract value will also need to be simple as the target object was an
         // object
+        invariant(to instanceof AbstractObjectValue);
         to.makeSimple();
       }
       return to;

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -140,11 +140,15 @@ export default function(realm: Realm): NativeFunctionValue {
           ((_args: any): Array<any>)
         );
       });
-      target.makePartial();
-      target.makeSimple();
-      // Make AbstractObjectValue as Object.assign doesn't copy getters/setter
-      invariant(to instanceof AbstractObjectValue);
-      to.makeSimple();
+      if (target instanceof ObjectValue) {
+        // we have to make the target partial and simple, because it was
+        // an object before and needs to be treated the same to prevent failures
+        target.makePartial();
+        target.makeSimple();
+        // the abstract value will also need to be simple as the target object was an
+        // object
+        to.makeSimple();
+      }
       return to;
     }
     // 5. Return to.

--- a/test/react/functional-components/simple-with-object-assign.js
+++ b/test/react/functional-components/simple-with-object-assign.js
@@ -1,0 +1,27 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>Hello {props.x}</div>;
+}
+
+function App(props) {
+	var copyOfProps = Object.assign({}, props);
+  return (
+    <div>
+      <A x={copyOfProps.x} />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root x={10} />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/serializer/abstract/ObjectAssign4.js
+++ b/test/serializer/abstract/ObjectAssign4.js
@@ -1,0 +1,6 @@
+var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "obj")) : {};
+var copyOfObj = Object.assign({}, obj);
+
+inspect = function() {
+  return copyOfObj;
+}

--- a/test/serializer/abstract/ObjectAssign4.js
+++ b/test/serializer/abstract/ObjectAssign4.js
@@ -1,6 +1,0 @@
-var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "obj")) : {};
-var copyOfObj = Object.assign({}, obj);
-
-inspect = function() {
-  return copyOfObj;
-}


### PR DESCRIPTION
Release notes: none

This PR fixes a Prepack issue where `Object.assign` would let partial+simple `Abstract` values pass through, giving incorrect results. Instead we now return an `AbstractObjectValue` for the `Object.assign` call instead. How can we ever possibly `Object.assign` from a source that is abstract and its properties are partial+simple?