### PR TITLE
Remove react-relay from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "babylon": "^6.18.0",
     "base62": "^1.1.2",
     "queue-fifo": "^0.2.3",
-    "react-relay": "^1.4.1",
     "seedrandom": "^2.4.2",
     "source-map": "^0.5.6",
     "vscode-debugadapter": "^1.24.0",


### PR DESCRIPTION
`react-relay` is already added as a dev dependency.
`scripts/test-react.js` is the only place that requires it, so it
appears a dev dependency should be enough.

`src/intrinsics/fb-www/global.js` also refers to `react-relay`, but
only by name.