### PR TITLE
Invariant fix 2

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1175,6 +1175,8 @@ export class PropertiesImplementation {
         invariant(realmGenerator);
         value = realmGenerator.derive(value.types, value.values, value.args, value.getBuildNode(), {
           kind: "resolved",
+          // We can't emit the invariant here otherwise it'll assume the AbstractValue's type not the union type
+          skipInvariant: true,
         });
         if (savedUnion !== undefined) {
           invariant(savedIndex !== undefined);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1184,6 +1184,7 @@ export class PropertiesImplementation {
           args[savedIndex] = value;
           value = AbstractValue.createAbstractConcreteUnion(realm, ...args);
         }
+        if (typeof P === "string") realmGenerator.emitFullInvariant(O, P, value);
         InternalSetProperty(realm, O, P, {
           value: value,
           writable: "writable" in X ? X.writable : false,

--- a/test/serializer/abstract/AbstractOrNullOrUndefined.js
+++ b/test/serializer/abstract/AbstractOrNullOrUndefined.js
@@ -1,0 +1,8 @@
+// add at runtime: global.o = { foo: undefined };
+if (global.__abstract)
+  o = __abstract({
+    foo: __abstractOrNullOrUndefined('number')
+  }, "global.o");
+let check = o && typeof o.foo === 'number' && o.foo >= 3;
+
+inspect = function() { return check + ' ' + o.foo; }


### PR DESCRIPTION
See comment in code -- we mistakenly were emitting invariants for abstractOrNullOrUndefined types that checked for only the non-null/non-undefined type.