### PR TITLE
Moving some promise-related property declarations

### DIFF
--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -22,6 +22,7 @@ import {
   UndefinedValue,
   AbstractObjectValue,
 } from "./index.js";
+import type { PromiseCapability } from "../types.js";
 import { ReturnCompletion } from "../completions.js";
 import { Functions } from "../singletons.js";
 export type NativeFunctionCallback = (
@@ -123,4 +124,16 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
 
   // for Proxy
   $RevocableProxy: void | NullValue | ProxyValue;
+
+  // for Promise resolve/reject functions
+  $Promise: ?ObjectValue;
+  $AlreadyResolved: void | { value: boolean };
+
+  // for Promise resolve functions
+  $Capability: void | PromiseCapability;
+  $AlreadyCalled: void | { value: boolean };
+  $Index: void | number;
+  $Values: void | Array<Value>;
+  $Capabilities: void | PromiseCapability;
+  $RemainingElements: void | { value: number };
 }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -16,7 +16,6 @@ import type {
   Descriptor,
   IterationKind,
   ObjectKind,
-  PromiseCapability,
   PromiseReaction,
   PropertyBinding,
   PropertyKeyValue,
@@ -164,19 +163,11 @@ export default class ObjectValue extends ConcreteValue {
   $Construct: void | ((argumentsList: Array<Value>, newTarget: ObjectValue) => ObjectValue);
 
   // promise
-  $Promise: ?ObjectValue;
-  $AlreadyResolved: void | { value: boolean };
   $PromiseState: void | "pending" | "fulfilled" | "rejected";
   $PromiseResult: void | Value;
   $PromiseFulfillReactions: void | Array<PromiseReaction>;
   $PromiseRejectReactions: void | Array<PromiseReaction>;
   $PromiseIsHandled: void | boolean;
-  $Capability: void | PromiseCapability;
-  $AlreadyCalled: void | { value: boolean };
-  $Index: void | number;
-  $Values: void | Array<Value>;
-  $Capabilities: void | PromiseCapability;
-  $RemainingElements: void | { value: number };
 
   // iterator
   $IteratedList: void | Array<Value>;


### PR DESCRIPTION
Release notes: none

Moving some promise-related property declarations from ObjectValue to the more precise NativeFunctionValue type.