### PR TITLE
Move __captured_scopes logic to visitor

### DIFF
--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -60,10 +60,11 @@ export function prepackSources(
   if (options.check) {
     realm.generator = new Generator(realm, "main");
     let logger = new Logger(realm, !!options.internalDebug);
+    let serializerStats = new SerializerStatistics();
     let modules = new Modules(
       realm,
       logger,
-      new SerializerStatistics(),
+      serializerStats,
       !!options.logModules,
       !!options.delayUnsupportedRequires,
       !!options.accelerateUnsupportedRequires
@@ -175,7 +176,7 @@ function checkResidualFunctions(modules: Modules, startFunc: number, totalToAnal
     else return "Recover";
   };
   modules.resolveInitializedModules();
-  let residualHeapVisitor = new ResidualHeapVisitor(realm, modules.logger, modules, new Map());
+  let residualHeapVisitor = new ResidualHeapVisitor(realm, modules.logger, modules, new Map(), "NO_REFERENTIALIZE");
   residualHeapVisitor.visitRoots();
   if (modules.logger.hasErrors()) return;
   let totalFunctions = 0;

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -60,11 +60,10 @@ export function prepackSources(
   if (options.check) {
     realm.generator = new Generator(realm, "main");
     let logger = new Logger(realm, !!options.internalDebug);
-    let serializerStats = new SerializerStatistics();
     let modules = new Modules(
       realm,
       logger,
-      serializerStats,
+      new SerializerStatistics(),
       !!options.logModules,
       !!options.delayUnsupportedRequires,
       !!options.accelerateUnsupportedRequires

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -40,6 +40,7 @@ import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js"
 import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { getOrDefault } from "./utils.js";
 import type { DeclarativeEnvironmentRecord } from "../environment.js";
+import type { Referentializer } from "./Referentializer.js";
 
 const LAZY_OBJECTS_SERIALIZER_BODY_TYPE = "LazyObjectInitializer";
 
@@ -70,7 +71,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
     declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>,
     statistics: SerializerStatistics,
-    react: ReactSerializerState
+    react: ReactSerializerState,
+    referentializer: Referentializer
   ) {
     super(
       realm,
@@ -88,7 +90,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       additionalFunctionValueInfos,
       declarativeEnvironmentRecordsBindings,
       statistics,
-      react
+      react,
+      referentializer
     );
     this._lazyObjectIdSeed = 1;
     this._valueLazyIds = new Map();

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -241,7 +241,7 @@ export class Referentializer {
                 new CompilerDiagnostic(
                   "Referentialization for prepacked functions unimplemented",
                   instance.functionValue.loc,
-                  "PP001",
+                  "PP1005",
                   "FatalError"
                 )
               );

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { DeclarativeEnvironmentRecord } from "../environment.js";
-import { FatalError } from "../errors.js";
+import { FatalError, CompilerDiagnostic } from "../errors.js";
 import { FunctionValue } from "../values/index.js";
 import type { SerializerOptions } from "../options.js";
 import * as t from "babel-types";
@@ -20,6 +20,7 @@ import invariant from "../invariant.js";
 import type { ResidualFunctionBinding, ScopeBinding, FunctionInstance } from "./types.js";
 import { SerializerStatistics } from "./types.js";
 import { getOrDefault } from "./utils.js";
+import { Realm } from "../realm.js";
 
 // Each of these will correspond to a different preludeGenerator and thus will
 // have different values available for initialization. FunctionValues should
@@ -42,6 +43,7 @@ type ReferentializationState = {|
  */
 export class Referentializer {
   constructor(
+    realm: Realm,
     options: SerializerOptions,
     scopeNameGenerator: NameGenerator,
     referentializedNameGenerator: NameGenerator,
@@ -53,11 +55,13 @@ export class Referentializer {
 
     this.referentializationState = new Map();
     this._referentializedNameGenerator = referentializedNameGenerator;
+    this.realm = realm;
   }
 
   _options: SerializerOptions;
   scopeNameGenerator: NameGenerator;
   statistics: SerializerStatistics;
+  realm: Realm;
 
   _newCapturedScopeInstanceIdx: number;
   referentializationState: Map<ReferentializationScope, ReferentializationState>;
@@ -233,6 +237,14 @@ export class Referentializer {
           if (!residualBinding.referentialized) {
             if (!shouldReferentializeInstanceFn(instance)) {
               // TODO #989: Fix additional functions and referentialization
+              this.realm.handleError(
+                new CompilerDiagnostic(
+                  "Referentialization for prepacked functions unimplemented",
+                  instance.functionValue.loc,
+                  "PP001",
+                  "FatalError"
+                )
+              );
               throw new FatalError("TODO: implement referentialization for prepacked functions");
             }
             if (!this._options.simpleClosures) this._getSerializedBindingScopeInstance(residualBinding);

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -53,7 +53,6 @@ export class Referentializer {
 
     this.referentializationState = new Map();
     this._referentializedNameGenerator = referentializedNameGenerator;
-    this._referentializedBindings = new Set();
   }
 
   _options: SerializerOptions;
@@ -63,7 +62,6 @@ export class Referentializer {
   _newCapturedScopeInstanceIdx: number;
   referentializationState: Map<ReferentializationScope, ReferentializationState>;
   _referentializedNameGenerator: NameGenerator;
-  _referentializedBindings: Set<ResidualFunctionBinding>;
 
   _createReferentializationState(): ReferentializationState {
     return {
@@ -132,7 +130,6 @@ export class Referentializer {
       scope = {
         name: this.scopeNameGenerator.generate(),
         id: refState.capturedScopeInstanceIdx++,
-        containedBindings: [],
         initializationValues: [],
         containingAdditionalFunction: residualBinding.referencedOnlyFromAdditionalFunctions,
       };
@@ -182,7 +179,6 @@ export class Referentializer {
       // an improvement to split these variables into multiple
       // scopes.
       const variableIndexInScope = scope.initializationValues.length;
-      scope.containedBindings.push(residualBinding);
       invariant(residualBinding.serializedValue);
       scope.initializationValues.push(residualBinding.serializedValue);
       scope.capturedScope = capturedScope;
@@ -211,7 +207,6 @@ export class Referentializer {
         if (refState) {
           let scope = refState.serializedScopes.get(declarativeEnvironmentRecord);
           if (scope) {
-            scope.containedBindings = [];
             scope.initializationValues = [];
           }
         }
@@ -241,7 +236,6 @@ export class Referentializer {
               throw new FatalError("TODO: implement referentialization for prepacked functions");
             }
             if (!this._options.simpleClosures) this._getSerializedBindingScopeInstance(residualBinding);
-            //this.referentializeBinding(residualBinding, name, instance);
             residualBinding.referentialized = true;
           }
 

--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -37,6 +37,7 @@ export class ResidualFunctionInitializers {
     this.prelude = prelude;
   }
 
+  // ownId: uid of the FunctionValue, initializer ids are strings of sorted lists of FunctionValues referencing the value
   functionInitializerInfos: Map<FunctionValue, { ownId: string, initializerIds: Set<string> }>;
   initializers: Map<string, { id: string, order: number, body: SerializedBody, values: Array<Value> }>;
   sharedInitializers: Map<string, BabelNodeStatement>;

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -55,13 +55,12 @@ export class ResidualFunctions {
     prelude: Array<BabelNodeStatement>,
     initializerNameGenerator: NameGenerator,
     factoryNameGenerator: NameGenerator,
-    scopeNameGenerator: NameGenerator,
-    referentializedNameGenerator: NameGenerator,
     residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>,
     residualFunctionInstances: Map<FunctionValue, FunctionInstance>,
     residualClassMethodInstances: Map<FunctionValue, ClassMethodInstance>,
     additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
-    additionalFunctionValueNestedFunctions: Set<FunctionValue>
+    additionalFunctionValueNestedFunctions: Set<FunctionValue>,
+    referentializer: Referentializer
   ) {
     this.realm = realm;
     this.statistics = statistics;
@@ -84,7 +83,7 @@ export class ResidualFunctions {
     this.residualFunctionInstances = residualFunctionInstances;
     this.residualClassMethodInstances = residualClassMethodInstances;
     this.additionalFunctionValueInfos = additionalFunctionValueInfos;
-    this.referentializer = new Referentializer(options, scopeNameGenerator, referentializedNameGenerator, statistics);
+    this.referentializer = referentializer;
     for (let instance of residualFunctionInstances.values()) {
       invariant(instance !== undefined);
       if (!additionalFunctionValueInfos.has(instance.functionValue)) this.addFunctionInstance(instance);
@@ -229,7 +228,7 @@ export class ResidualFunctions {
     let strictFunctionBodies = [];
     let funcNodes: Map<FunctionValue, BabelNodeFunctionExpression> = new Map();
 
-    for (let [funcBody, instances] of functionEntries) {
+    /*for (let [funcBody, instances] of functionEntries) {
       let functionInfo = this.residualFunctionInfos.get(funcBody);
       invariant(functionInfo);
       this.referentializer.referentialize(
@@ -237,7 +236,7 @@ export class ResidualFunctions {
         instances,
         instance => !rewrittenAdditionalFunctions.has(instance.functionValue)
       );
-    }
+    }*/
 
     let defineFunction = (instance, funcId, funcOrClassNode) => {
       let { functionValue } = instance;

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -228,16 +228,6 @@ export class ResidualFunctions {
     let strictFunctionBodies = [];
     let funcNodes: Map<FunctionValue, BabelNodeFunctionExpression> = new Map();
 
-    /*for (let [funcBody, instances] of functionEntries) {
-      let functionInfo = this.residualFunctionInfos.get(funcBody);
-      invariant(functionInfo);
-      this.referentializer.referentialize(
-        functionInfo.unbound,
-        instances,
-        instance => !rewrittenAdditionalFunctions.has(instance.functionValue)
-      );
-    }*/
-
     let defineFunction = (instance, funcId, funcOrClassNode) => {
       let { functionValue } = instance;
 

--- a/src/serializer/ResidualHeapGraphGenerator.js
+++ b/src/serializer/ResidualHeapGraphGenerator.js
@@ -11,6 +11,7 @@
 
 import type { Logger } from "../utils/logger.js";
 import type { Modules } from "../utils/modules.js";
+import type { Referentializer } from "./Referentializer.js";
 import type { Realm } from "../realm.js";
 import type { ObjectRefCount, AdditionalFunctionEffects } from "./types.js";
 import type { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers";
@@ -43,9 +44,10 @@ export class ResidualHeapGraphGenerator extends ResidualHeapVisitor {
     modules: Modules,
     additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
     valueIdentifiers: ResidualHeapValueIdentifiers,
-    valueToEdgeRecord: Map<Value, ObjectRefCount>
+    valueToEdgeRecord: Map<Value, ObjectRefCount>,
+    referentializer: Referentializer
   ) {
-    super(realm, logger, modules, additionalFunctionValuesAndEffects);
+    super(realm, logger, modules, additionalFunctionValuesAndEffects, referentializer);
     this._valueToEdgeRecord = valueToEdgeRecord;
     this._valueIdentifiers = valueIdentifiers;
     this._visitedValues = new Set();

--- a/src/serializer/ResidualHeapRefCounter.js
+++ b/src/serializer/ResidualHeapRefCounter.js
@@ -11,6 +11,7 @@
 
 import type { Logger } from "../utils/logger.js";
 import type { Modules } from "../utils/modules.js";
+import type { Referentializer } from "./Referentializer.js";
 import type { Realm } from "../realm.js";
 import type { ObjectRefCount, AdditionalFunctionEffects } from "./types.js";
 
@@ -27,9 +28,10 @@ export class ResidualHeapRefCounter extends ResidualHeapVisitor {
     realm: Realm,
     logger: Logger,
     modules: Modules,
-    additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>
+    additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
+    referentializer: Referentializer
   ) {
-    super(realm, logger, modules, additionalFunctionValuesAndEffects);
+    super(realm, logger, modules, additionalFunctionValuesAndEffects, referentializer);
     this._valueToEdgeRecord = new Map();
     this._path = [];
   }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -555,7 +555,11 @@ export class ResidualHeapSerializer {
     return t.expressionStatement(t.sequenceExpression(body));
   }
 
-  _serializeDeclarativeEnvironmentRecordBinding(residualFunctionBinding: ResidualFunctionBinding, name: string, instance: FunctionInstance) {
+  _serializeDeclarativeEnvironmentRecordBinding(
+    residualFunctionBinding: ResidualFunctionBinding,
+    name: string,
+    instance: FunctionInstance
+  ) {
     if (!residualFunctionBinding.serializedValue) {
       let value = residualFunctionBinding.value;
       invariant(value);
@@ -1833,11 +1837,7 @@ export class ResidualHeapSerializer {
     // TODO: find better way to do this?
     // revert changes to functionInstances in case we do multiple serialization passes
     for (let instance of this.residualFunctionInstances.values()) {
-      for (let binding of ((instance: any): FunctionInstance).residualFunctionBindings.values()) {
-        let b = ((binding: any): ResidualFunctionBinding);
-        delete b.serializedValue;
-        delete b.referentialized;
-      }
+      this.referentializer.cleanInstance(instance);
     }
 
     let program_directives = [];

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1087,7 +1087,7 @@ export class ResidualHeapSerializer {
     invariant(val instanceof ECMAScriptSourceFunctionValue);
 
     let instance = this.residualFunctionInstances.get(val);
-    invariant(instance);
+    invariant(instance !== undefined);
     let residualBindings = instance.residualFunctionBindings;
 
     let inAdditionalFunction = this.currentFunctionBody !== this.mainBody;
@@ -1112,7 +1112,7 @@ export class ResidualHeapSerializer {
         serializeBindingFunc = () => this._serializeGlobalBinding(boundName, residualBinding);
       } else {
         serializeBindingFunc = () => {
-          invariant(instance);
+          invariant(instance !== undefined);
           return this._serializeDeclarativeEnvironmentRecordBinding(residualBinding, boundName, instance);
         };
         let bindingValue = residualBinding.value;
@@ -1659,7 +1659,6 @@ export class ResidualHeapSerializer {
           // Allows us to emit function declarations etc. inside of this additional
           // function instead of adding them at global scope
           // TODO: make sure this generator isn't getting mutated oddly
-          //this.additionalFunctionValueNestedFunctions.clear();
           ((nestedFunctions: any): Set<FunctionValue>).forEach(val =>
             this.additionalFunctionValueNestedFunctions.add(val)
           );

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -47,6 +47,8 @@ import { ClosureRefVisitor } from "./visitors.js";
 import { Logger } from "../utils/logger.js";
 import { Modules } from "../utils/modules.js";
 import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
+import { Referentializer } from "./Referentializer.js";
+import type { ReferentializationScope } from "./Referentializer.js";
 import {
   commonAncestorOf,
   getSuggestedArrayLiteralLength,
@@ -60,7 +62,6 @@ import { Environment, To } from "../singletons.js";
 import { isReactElement, valueIsReactLibraryObject } from "../react/utils.js";
 import { canHoistReactElement } from "../react/hoisting.js";
 import ReactElementSet from "../react/ReactElementSet.js";
-import type { ReferentializationScope } from "./Referentializer.js";
 
 export type Scope = FunctionValue | Generator;
 type BindingState = {|
@@ -79,12 +80,14 @@ export class ResidualHeapVisitor {
     realm: Realm,
     logger: Logger,
     modules: Modules,
-    additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>
+    additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
+    referentializer: Referentializer
   ) {
     invariant(realm.useAbstractInterpretation);
     this.realm = realm;
     this.logger = logger;
     this.modules = modules;
+    this.referentializer = referentializer;
 
     this.declarativeEnvironmentRecordsBindings = new Map();
     this.globalBindings = new Map();
@@ -106,18 +109,20 @@ export class ResidualHeapVisitor {
     this.containingAdditionalFunction = undefined;
     this.additionalRoots = new Set();
     this.inClass = false;
-    this.functionToBindingState = new Map();
+    this.functionToCapturedScopes = new Map();
+    this.additionalFunctionToNestedFunctions = new Map();
   }
 
   realm: Realm;
   logger: Logger;
   modules: Modules;
+  referentializer: Referentializer;
 
   // Caches that ensure one ResidualFunctionBinding exists per (record, name) pair
   declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>;
   globalBindings: Map<string, ResidualFunctionBinding>;
 
-  functionToBindingState: Map<ReferentializationScope, Map<DeclarativeEnvironmentRecord, BindingState>>;
+  functionToCapturedScopes: Map<ReferentializationScope, Map<DeclarativeEnvironmentRecord, BindingState>>;
   functionInfos: Map<BabelNodeBlockStatement, FunctionInfo>;
   scope: Scope;
   // Either the realm's generator or the FunctionValue of an additional function to serialize
@@ -136,6 +141,7 @@ export class ResidualHeapVisitor {
 
   // We only want to add to additionalRoots when we're in an additional function
   containingAdditionalFunction: void | FunctionValue;
+  additionalFunctionToNestedFunctions: Map<FunctionValue, Set<FunctionValue>>;
   // Tracks objects + functions that were visited from inside additional functions that need to be serialized in a
   // parent scope of the additional function (e.g. functions/objects only used from additional functions that were
   // declared outside the additional function need to be serialized in the additional function's parent scope for
@@ -464,13 +470,15 @@ export class ResidualHeapVisitor {
   // captured scope because c captures both x and y.
   _recordBindingVisitedAndRevisit(val: FunctionValue, residualFunctionBinding: ResidualFunctionBinding) {
     let refScope = this.containingAdditionalFunction ? this.containingAdditionalFunction : "GLOBAL";
-    let funcToBindingState = getOrDefault(this.functionToBindingState, refScope, () => new Map());
+    invariant(!(refScope instanceof Generator));
+    let funcToScopes = getOrDefault(this.functionToCapturedScopes, refScope, () => new Map());
     let envRec = residualFunctionBinding.declarativeEnvironmentRecord;
     invariant(envRec !== null);
-    let bindingState = getOrDefault(funcToBindingState, envRec, () => ({
-      capturedBindings: new Set(),
-      capturingFunctionsToCommonScope: new Map(),
-    }));
+    let bindingState = getOrDefault(funcToScopes, envRec,
+      () => ({
+        capturedBindings: new Set(),
+        capturingFunctionsToCommonScope: new Map(),
+      }));
     // If the binding is new for this bindingState, have all functions capturing bindings from that scope visit it
     if (!bindingState.capturedBindings.has(residualFunctionBinding)) {
       if (residualFunctionBinding.value) {
@@ -538,6 +546,7 @@ export class ResidualHeapVisitor {
         referencedBase,
         () => new Map()
       );
+      let createdBinding = !residualFunctionBindings.has(referencedName);
       residualFunctionBinding = getFromMap(residualFunctionBindings, referencedName, (): ResidualFunctionBinding => {
         invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
         let binding = referencedBase.bindings[referencedName];
@@ -548,7 +557,13 @@ export class ResidualHeapVisitor {
           declarativeEnvironmentRecord: referencedBase,
         };
       });
-      if (residualFunctionBinding) this._recordBindingVisitedAndRevisit(val, residualFunctionBinding);
+      if (residualFunctionBinding) {
+        if (this.containingAdditionalFunction && createdBinding)
+          residualFunctionBinding.referencedOnlyFromAdditionalFunctions = this.containingAdditionalFunction;
+        if (!this.containingAdditionalFunction && residualFunctionBinding.referencedOnlyFromAdditionalFunctions)
+          delete residualFunctionBinding.referencedOnlyFromAdditionalFunctions;
+        this._recordBindingVisitedAndRevisit(val, residualFunctionBinding);
+      }
     }
     if (residualFunctionBinding && residualFunctionBinding.value) {
       residualFunctionBinding.value = this.visitEquivalentValue(residualFunctionBinding.value);
@@ -854,6 +869,8 @@ export class ResidualHeapVisitor {
         modifiedProperties: Map<PropertyBinding, void | Descriptor>,
         createdObjects,
       ] = effects;
+      let nestedFunctions = new Set([...createdObjects].filter(object => object instanceof FunctionValue));
+      this.additionalFunctionToNestedFunctions.set(functionValue, nestedFunctions);
       // result -- ignore TODO: return the result from the function somehow
       // Generator -- visit all entries
       // Bindings -- (modifications to named variables) only need to serialize bindings if they're
@@ -956,6 +973,7 @@ export class ResidualHeapVisitor {
           let residualBinding = this.visitBinding(functionValue, innerName, false);
           if (residualBinding) {
             funcInstance.residualFunctionBindings.set(innerName, residualBinding);
+            delete residualBinding.referencedOnlyFromAdditionalFunctions;
           }
         }
         this.additionalRoots = prevReVisit;
@@ -986,6 +1004,43 @@ export class ResidualHeapVisitor {
         });
       }
     }
+
+    let bodyToInstances = new Map();
+    for (let instance of this.functionInstances.values()) {
+      if (this.additionalFunctionValuesAndEffects.has(instance.functionValue)) {
+        /*let nestedFunctions = this.additionalFunctionToNestedFunctions.get(instance.functionValue);
+        for (let residualBinding of instance.residualFunctionBindings.values()) {
+          let foundNonAdditionalFunctionReferent = false;
+          let scopes = this.values.get(residualBinding.value) // but need value at time of effects applied
+          // copy over logic from processAdditionalFunctionValues in RHS, fill in .referencedOnlyFromAdditionalFunctions eagerly
+        }*/
+      } else { // TODO: why this else?
+        let code = instance.functionValue.$ECMAScriptCode;
+        invariant(code !== undefined);
+        getOrDefault(bodyToInstances, code, () => []).push(instance);
+      }
+    }
+
+    for (let [funcBody, instances] of bodyToInstances) {
+      let functionInfo = this.functionInfos.get(funcBody);
+      invariant(functionInfo !== undefined);
+      this.referentializer.referentialize(functionInfo.unbound, instances, instance => !this.additionalFunctionValuesAndEffects.has(instance.functionValue));
+    }
+
+    // Additional functions ?
+    /*for (let [refScope, refState] of this.referentializer.referentializationState) {
+      let prevScope = this.commonScope;
+      if (refScope !== "GLOBAL") this.commonScope =  refScope
+      for (let { containedBindings } of refState.serializedScopes.values())
+        //console.log(containedBindings);
+        //containedBindings.forEach(residualBinding => this.visitBinding(residualBinding.value, residualBinding.name, false));
+      this.commonScope = prevScope;
+    }
+    for (let [refScope, capturedScopes] of this.functionToCapturedScopes) {
+      for (let [declRec, functionValues] of capturedScopes)
+        //console.log(capturedScopes);
+      //this.referentializer.referentializationState.get()
+    }*/
 
     // Artificially add additionalRoots to generators so that they can get serialized in parent scopes of additionalFunctions
     // if necessary.

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1009,15 +1009,8 @@ export class ResidualHeapVisitor {
     if (referentializer !== undefined) {
       let bodyToInstances = new Map();
       for (let instance of this.functionInstances.values()) {
-        if (this.additionalFunctionValuesAndEffects.has(instance.functionValue)) {
-          /*let nestedFunctions = this.additionalFunctionToNestedFunctions.get(instance.functionValue);
-          for (let residualBinding of instance.residualFunctionBindings.values()) {
-            let foundNonAdditionalFunctionReferent = false;
-            let scopes = this.values.get(residualBinding.value) // but need value at time of effects applied
-            // copy over logic from processAdditionalFunctionValues in RHS, fill in .referencedOnlyFromAdditionalFunctions eagerly
-          }*/
-        } else {
-          // TODO: why this else?
+        // TODO: do something for additional functions
+        if (!this.additionalFunctionValuesAndEffects.has(instance.functionValue)) {
           let code = instance.functionValue.$ECMAScriptCode;
           invariant(code !== undefined);
           getOrDefault(bodyToInstances, code, () => []).push(instance);
@@ -1034,21 +1027,6 @@ export class ResidualHeapVisitor {
         );
       }
     }
-
-    // Additional functions ?
-    /*for (let [refScope, refState] of this.referentializer.referentializationState) {
-      let prevScope = this.commonScope;
-      if (refScope !== "GLOBAL") this.commonScope =  refScope
-      for (let { containedBindings } of refState.serializedScopes.values())
-        //console.log(containedBindings);
-        //containedBindings.forEach(residualBinding => this.visitBinding(residualBinding.value, residualBinding.name, false));
-      this.commonScope = prevScope;
-    }
-    for (let [refScope, capturedScopes] of this.functionToCapturedScopes) {
-      for (let [declRec, functionValues] of capturedScopes)
-        //console.log(capturedScopes);
-      //this.referentializer.referentializationState.get()
-    }*/
 
     // Artificially add additionalRoots to generators so that they can get serialized in parent scopes of additionalFunctions
     // if necessary.

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -136,6 +136,7 @@ export class Serializer {
     let preludeGenerator = this.realm.preludeGenerator;
     invariant(preludeGenerator !== undefined);
     let referentializer = new Referentializer(
+      this.realm,
       this.options,
       preludeGenerator.createNameGenerator("__scope_"),
       preludeGenerator.createNameGenerator("$"),

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -103,7 +103,6 @@ export type ResidualFunctionBinding = {
 export type ScopeBinding = {
   name: string,
   id: number,
-  containedBindings: Array<ResidualFunctionBinding>,
   initializationValues: Array<BabelNodeExpression>,
   capturedScope?: string,
   containingAdditionalFunction: void | FunctionValue,

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -103,6 +103,7 @@ export type ResidualFunctionBinding = {
 export type ScopeBinding = {
   name: string,
   id: number,
+  containedBindings: Array<ResidualFunctionBinding>,
   initializationValues: Array<BabelNodeExpression>,
   capturedScope?: string,
   containingAdditionalFunction: void | FunctionValue,

--- a/test/serializer/basic/CapturedScope9.js
+++ b/test/serializer/basic/CapturedScope9.js
@@ -4,5 +4,5 @@
   let x = 13, y = 35;
   let f = function() { x += 3; y -= 39; return x + y;};
   let g = function() { x -= 2; y += 19; return x + y; }
-  inspect = function() { return f() + g(); };
+  inspect = function() { return f() + g() + f(); };
 })();


### PR DESCRIPTION
It's easier to reason about the delayInitializations logic when the captured scopes are computed in the visitor. This also makes it easier to centralize the Additional Functions logic and make Additional Functions compatible with delayInitializations.

The visitor now:
- Marks `ResidualFunctionBinding`s as `referencedOnlyFromAdditionalFunctions` if necessary
- `referentialize`s the bindings (recording the groups of bindings by populating the referentializer's `scopes` correctly)

The serializer still:
- calls `referentializeBinding` which records the serializedValue in the `__capturedScopes` function and replaces it with a reference to the `serializedBindingScopeInstance`