### PR TITLE
[WIP] Improve the ReactElement logic for evaluation to improve folding cases

### DIFF
--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -16,7 +16,7 @@ import { createAbstract } from "../prepack/utils.js";
 import * as t from "babel-types";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import invariant from "../../invariant";
-import { createReactHint } from "../../react/utils.js";
+import { createReactHintObject } from "../../react/utils.js";
 
 function createReactRelayContainer(realm: Realm, reactRelay: ObjectValue, containerName: string) {
   // we create a ReactRelay container function that returns an abstract object
@@ -35,7 +35,7 @@ function createReactRelayContainer(realm: Realm, reactRelay: ObjectValue, contai
           ((otherArgs: any): Array<any>)
         );
       });
-      realm.react.abstractHints.set(value, createReactHint(reactRelay, containerName, args));
+      realm.react.abstractHints.set(value, createReactHintObject(reactRelay, containerName, args));
       return value;
     }),
     writable: false,

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -57,6 +57,7 @@ export function getInitialProps(
     }
   }
   let value = AbstractValue.createAbstractObject(realm, propsName || "props");
+  realm.react.abstractHints.set(value, "HAS_NO_KEY_OR_REF");
   invariant(value instanceof AbstractObjectValue);
   return value;
 }

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -74,6 +74,7 @@ export class Reconciler {
     this.simpleClassComponents = simpleClassComponents;
     this.logger = moduleTracer.modules.logger;
     this.branchReactComponentTrees = branchReactComponentTrees;
+    this.realm.react.logger = this.logger;
   }
 
   realm: Realm;

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -277,7 +277,7 @@ export function normalizeFunctionalComponentParamaters(func: ECMAScriptSourceFun
   });
 }
 
-export function createReactHint(object: ObjectValue, propertyName: string, args: Array<Value>): ReactHint {
+export function createReactHintObject(object: ObjectValue, propertyName: string, args: Array<Value>): ReactHint {
   return {
     object,
     propertyName,
@@ -296,7 +296,7 @@ export function getComponentTypeFromRootValue(realm: Realm, value: Value): ECMAS
     let reactHint = realm.react.abstractHints.get(value);
 
     invariant(reactHint);
-    if (reactHint.object === realm.fbLibraries.reactRelay) {
+    if (typeof reactHint !== "string" && reactHint.object === realm.fbLibraries.reactRelay) {
       switch (reactHint.propertyName) {
         case "createFragmentContainer":
         case "createPaginationContainer":

--- a/src/realm.js
+++ b/src/realm.js
@@ -44,6 +44,7 @@ import { Generator, PreludeGenerator } from "./utils/generator.js";
 import { emptyExpression, voidExpression } from "./utils/internalizer.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
+import type { Logger } from "./utils/logger.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
 import * as t from "babel-types";
 
@@ -184,6 +185,7 @@ export class Realm {
       classComponentMetadata: new Map(),
       enabled: opts.reactEnabled || false,
       output: opts.reactOutput || "create-element",
+      logger: undefined,
       symbols: new Map(),
       currentOwner: undefined,
       abstractHints: new WeakMap(),
@@ -252,6 +254,7 @@ export class Realm {
     // (for example, when we use Relay's React containers with "fb-www" – which are AbstractObjectValues,
     // we need to know what React component was passed to this AbstractObjectValue so we can visit it next)
     abstractHints: WeakMap<AbstractValue, ReactHint>,
+    logger?: Logger,
     output?: ReactOutputTypes,
     symbols: Map<ReactSymbolTypes, SymbolValue>,
   };

--- a/src/types.js
+++ b/src/types.js
@@ -324,11 +324,7 @@ export type ClassComponentMetadata = {
   instanceSymbols: Set<SymbolValue>,
 };
 
-export type ReactHint = {|
-  object: ObjectValue,
-  propertyName: string,
-  args: Array<Value>,
-|};
+export type ReactHint = {| object: ObjectValue, propertyName: string, args: Array<Value> |} | "HAS_NO_KEY_OR_REF";
 
 export type DebugServerType = {
   checkForActions: BabelNode => void,


### PR DESCRIPTION
Currently, there are too many cases where ReactElement evaluation bails out. This PR aims to solve many of those cases:

- Refactor JSX evaluation to properly handle and deal with JSX spreads
- Refactor React.createElement mock to work like the JSX evaluator
- Introduce a `reactHint` for abstract `props` that we have no `key` or `ref`
- Ensure that we internally pass around `reactHint` in cases of `Object.assign`, for in` etc
- Rather than throw an error, unsafely make a warning that we've detected cases where `key` and `ref` could not properly be determined ahead-of-time