### PR TITLE
Emit Object.assign for partials or fatal

### DIFF
--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -79,15 +79,15 @@ export default function(realm: Realm): NativeFunctionValue {
         // i. Let from be ToObject(nextSource).
         frm = To.ToObjectPartial(realm, nextSource);
 
-        if (!frm.isSimpleObject()) {
-          // If this is not a simple object, it may have getters on it that can
-          // mutate any state as a result. We don't yet support this.
-          AbstractValue.reportIntrospectionError(nextSource);
-          throw new FatalError();
-        }
-
         let frm_was_partial = frm.isPartialObject();
         if (frm_was_partial) {
+          if (!frm.isSimpleObject()) {
+            // If this is not a simple object, it may have getters on it that can
+            // mutate any state as a result. We don't yet support this.
+            AbstractValue.reportIntrospectionError(nextSource);
+            throw new FatalError();
+          }
+
           to_must_be_partial = true;
           frm.makeNotPartial();
         }

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -33,6 +33,8 @@ import {
   HasSomeCompatibleType,
 } from "../../methods/index.js";
 import { Create, Properties as Props, To } from "../../singletons.js";
+import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
+import * as t from "babel-types";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
@@ -54,7 +56,7 @@ export default function(realm: Realm): NativeFunctionValue {
   });
 
   // ECMA262 19.1.2.1
-  func.defineNativeMethod("assign", 2, (context, [target, ...sources]) => {
+  let ObjectAssign = func.defineNativeMethod("assign", 2, (context, [target, ...sources]) => {
     // 1. Let to be ? ToObject(target).
     let to = To.ToObjectPartial(realm, target);
     let to_must_be_partial = false;
@@ -76,6 +78,14 @@ export default function(realm: Realm): NativeFunctionValue {
         // b. Else,
         // i. Let from be ToObject(nextSource).
         frm = To.ToObjectPartial(realm, nextSource);
+
+        if (!frm.isSimpleObject()) {
+          // If this is not a simple object, it may have getters on it that can
+          // mutate any state as a result. We don't yet support this.
+          AbstractValue.reportIntrospectionError(nextSource);
+          throw new FatalError();
+        }
+
         let frm_was_partial = frm.isPartialObject();
         if (frm_was_partial) {
           to_must_be_partial = true;
@@ -95,6 +105,16 @@ export default function(realm: Realm): NativeFunctionValue {
           AbstractValue.reportIntrospectionError(nextSource);
           throw new FatalError();
         }
+
+        AbstractValue.createTemporalFromBuildFunction(
+          realm,
+          ObjectValue,
+          [ObjectAssign, target, nextSource],
+          (nodes: Array<BabelNodeExpression>) => {
+            let fun_args = nodes.slice(1);
+            return t.callExpression(nodes[0], ((fun_args: any): Array<BabelNodeExpression | BabelNodeSpreadElement>));
+          }
+        );
       }
 
       invariant(frm, "from required");

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -376,7 +376,7 @@ export default class ObjectValue extends ConcreteValue {
     length: number,
     callback: NativeFunctionCallback,
     desc?: Descriptor = {}
-  ) {
+  ): Value {
     let intrinsicName;
     if (typeof name === "string") {
       if (this.intrinsicName) intrinsicName = `${this.intrinsicName}.${name}`;
@@ -385,11 +385,9 @@ export default class ObjectValue extends ConcreteValue {
     } else {
       invariant(false);
     }
-    this.defineNativeProperty(
-      name,
-      new NativeFunctionValue(this.$Realm, intrinsicName, name, length, callback, false),
-      desc
-    );
+    let fnValue = new NativeFunctionValue(this.$Realm, intrinsicName, name, length, callback, false);
+    this.defineNativeProperty(name, fnValue, desc);
+    return fnValue;
   }
 
   defineNativeProperty(name: SymbolValue | string, value?: Value | Array<Value>, desc?: Descriptor = {}) {

--- a/test/error-handler/object-assign.js
+++ b/test/error-handler/object-assign.js
@@ -1,0 +1,5 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":5,"column":34},"end":{"line":5,"column":37},"identifierName":"obj","source":"test/error-handler/object-assign.js"},"severity":"FatalError","errorCode":"PP0001"}]
+
+var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
+var copyOfObj = Object.assign({}, obj);

--- a/test/error-handler/object-assign2.js
+++ b/test/error-handler/object-assign2.js
@@ -1,0 +1,5 @@
+// recover-from-errors
+// expected errors: [{"location":{"start":{"line":5,"column":44},"end":{"line":5,"column":47},"identifierName":"obj","source":"test/error-handler/object-assign2.js"},"severity":"FatalError","errorCode":"PP0001"}]
+
+var obj = global.__abstract && global.__makePartial && global.__makeSimple ? __makeSimple(__makePartial(__abstract({}, "({foo:1})"))) : {foo:1};
+var copyOfObj = Object.assign({}, {foo: 2}, obj);

--- a/test/serializer/abstract/ObjectAssign2.js
+++ b/test/serializer/abstract/ObjectAssign2.js
@@ -15,6 +15,7 @@ let dims = {
   }
 };
 
+if (global.__makeSimple) __makeSimple(dims);
 if (global.__makePartial) __makePartial(dims);
 
 let windowPhysicalPixels = dims.windowPhysicalPixels;

--- a/test/serializer/abstract/ObjectAssign4.js
+++ b/test/serializer/abstract/ObjectAssign4.js
@@ -1,0 +1,6 @@
+var obj = global.__abstract && global.__makePartial && global.__makeSimple ? __makeSimple(__makePartial(__abstract({}, "({foo:1})"))) : {foo:1};
+var copyOfObj = Object.assign({}, obj);
+
+inspect = function() {	
+  return JSON.stringify(copyOfObj);
+}

--- a/test/serializer/pure-functions/ObjectAssign.js
+++ b/test/serializer/pure-functions/ObjectAssign.js
@@ -1,0 +1,18 @@
+// additional functions
+// abstract effects
+
+var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
+
+function additional1() {
+  return Object.assign({}, obj);
+}
+
+function additional2() {
+  return Object.assign(obj, {bar:1});
+}
+
+inspect = function() {
+  var obj1 = additional1();
+  var obj2 = additional2();
+  return JSON.stringify({ obj1, obj2 });
+}


### PR DESCRIPTION
Currently, `Object.assign` is special cased to handle partials but it gets a few things wrong.

1) It doesn't require the source to be simple, yet those getters will be invoked. Therefore, I add a fatal introspection error in that case. This case still works in pure functions by leaking all the arguments.

2) It correctly handles the simple case where `Object.assign` gets called on empty targets with a partial source, by making the target partial. However, it never actually serializes an `Object.assign` call in that case. Therefore I add a temporal call to the Object.assign function in that scenario.
