### PR TITLE
Fixing serialization order in presence of temporal dependencies

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -140,7 +140,7 @@ export class Emitter {
     this._body = oldBody;
     if (isChild) {
       invariant(lastBody.parentBody === oldBody);
-      invariant(lastBody.nestingLevel > 0);
+      invariant((lastBody.nestingLevel || 0) > 0);
       invariant(!lastBody.done);
       lastBody.done = true;
       // When we are done processing a body, we can propogate all declared abstract values

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -123,7 +123,7 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     };
     let oldBody = this.emitter.beginEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, initializerBody);
     this._emitObjectProperties(obj);
-    this.emitter.endEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, oldBody, /* done */ true);
+    this.emitter.endEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, oldBody);
     return initializerBody;
   }
 

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -115,10 +115,15 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
 
   // TODO: change to use _getTarget() to get the lazy objects initializer body.
   _serializeLazyObjectInitializer(obj: ObjectValue): SerializedBody {
-    const initializerBody = { type: LAZY_OBJECTS_SERIALIZER_BODY_TYPE, parentBody: undefined, entries: [] };
+    const initializerBody = {
+      type: LAZY_OBJECTS_SERIALIZER_BODY_TYPE,
+      parentBody: undefined,
+      entries: [],
+      done: false,
+    };
     let oldBody = this.emitter.beginEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, initializerBody);
     this._emitObjectProperties(obj);
-    this.emitter.endEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, oldBody);
+    this.emitter.endEmitting(LAZY_OBJECTS_SERIALIZER_BODY_TYPE, oldBody, /* done */ true);
     return initializerBody;
   }
 

--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -66,7 +66,7 @@ export class ResidualFunctionInitializers {
           id,
           order: infos.length,
           values: [],
-          body: { type: "DelayInitializations", parentBody: undefined, entries: [] },
+          body: { type: "DelayInitializations", parentBody: undefined, entries: [], done: false },
         })
       );
     initializer.values.push(val);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -395,7 +395,7 @@ export class ResidualHeapSerializer {
         /*isChild*/ true
       );
       this._emitPropertiesWithComputedNames(obj, consequent);
-      let consequentBody = this.emitter.endEmitting("consequent", oldBody, /* done */ true);
+      let consequentBody = this.emitter.endEmitting("consequent", oldBody, /*isChild*/ true);
       let consequentStatement = t.blockStatement(consequentBody.entries);
       oldBody = this.emitter.beginEmitting(
         "alternate",
@@ -408,7 +408,7 @@ export class ResidualHeapSerializer {
         /*isChild*/ true
       );
       this._emitPropertiesWithComputedNames(obj, alternate);
-      let alternateBody = this.emitter.endEmitting("alternate", oldBody, /* done */ true);
+      let alternateBody = this.emitter.endEmitting("alternate", oldBody, /*isChild*/ true);
       let alternateStatement = t.blockStatement(alternateBody.entries);
       this.emitter.emit(t.ifStatement(serializedCond, consequentStatement, alternateStatement));
     }
@@ -1602,7 +1602,7 @@ export class ResidualHeapSerializer {
     this.activeGeneratorBodies.set(generator, newBody);
     callback(newBody);
     this.activeGeneratorBodies.delete(generator);
-    const statements = this.emitter.endEmitting(generator, oldBody, /* done */ true).entries;
+    const statements = this.emitter.endEmitting(generator, oldBody, /*isChild*/ true).entries;
     if (this._options.debugScopes) {
       let comment = `generator "${generator.getName()}"`;
       if (generator.parent !== undefined) {
@@ -1772,7 +1772,7 @@ export class ResidualHeapSerializer {
 
   serialize(): BabelNodeFile {
     this.generator.serialize(this._getContext());
-    //invariant(this.emitter._declaredAbstractValues.size <= this.preludeGenerator.derivedIds.size);
+    invariant(this.emitter.declaredCount() <= this.preludeGenerator.derivedIds.size);
 
     this.postGeneratorSerialization();
 

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -640,7 +640,8 @@ export class ResidualHeapSerializer {
 
     // This value is referenced from more than one generator or function.
     // Let's find the body associated with their common ancestor.
-    let commonAncestor = Array.from(scopes).reduce((x, y) => commonAncestorOf(x, y), scopes.values().next().value);
+    let firstScope = scopes.values().next().value;
+    let commonAncestor = Array.from(scopes).reduce((x, y) => commonAncestorOf(x, y), firstScope);
     invariant(commonAncestor);
     let body;
     while (true) {
@@ -678,7 +679,7 @@ export class ResidualHeapSerializer {
           (scopeBody.nestingLevel || 0) > (body.nestingLevel || 0) &&
           notYetDoneBodies.has(scopeBody)
         ) {
-          // TODO: If there are multiple such scopeBody's, why is it okay to pick a random one?
+          // TODO: If there are multiple such scopeBody's, why is it okay to pick an arbitrary one?
           body = scopeBody;
           break;
         }

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { DeclarativeEnvironmentRecord, type Binding } from "../environment.js";
-import { ConcreteValue, Value, ObjectValue } from "../values/index.js";
+import { ConcreteValue, Value, ObjectValue, AbstractValue } from "../values/index.js";
 import type { ECMAScriptSourceFunctionValue, FunctionValue } from "../values/index.js";
 import type { BabelNodeExpression, BabelNodeStatement } from "babel-types";
 import { SameValue } from "../methods/abstract.js";
@@ -29,8 +29,11 @@ export type SerializedBodyType =
 
 export type SerializedBody = {
   type: SerializedBodyType,
-  parentBody: void | SerializedBody,
   entries: Array<BabelNodeStatement>,
+  done: boolean,
+  declaredAbstractValues?: Map<AbstractValue, SerializedBody>,
+  parentBody?: SerializedBody,
+  nestingLevel?: number,
 };
 
 export type AdditionalFunctionEffects = {

--- a/test/serializer/abstract/WaitGenerator0.js
+++ b/test/serializer/abstract/WaitGenerator0.js
@@ -1,0 +1,13 @@
+(function () {
+    let a = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let b = global.__abstract ? __abstract("boolean", "(true )") : true;
+    let x;
+    if (a) {
+        if (b) {
+            x=Date.now(); // definition
+        }
+        xx=x; // use of `x`
+    }
+    xxx=x; // use of `x`
+    inspect = function() { return xx >= 0; };
+})();

--- a/test/serializer/abstract/WaitGenerator0a.js
+++ b/test/serializer/abstract/WaitGenerator0a.js
@@ -1,0 +1,18 @@
+(function () {
+    let a = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let b = global.__abstract ? __abstract("boolean", "(true )") : true;
+    let c = global.__abstract ? __abstract("boolean", "(true  )") : true;
+    let x;
+    if (a) {
+        if (b) {
+            x=Date.now(); // definition
+        }
+        if (c) {
+            xx=x; // use of `x`
+        } else {
+            xx=x; // use of `x`
+        }
+    }
+    xxx=x; // use of `x`
+    inspect = function() { return Object.is(xx, xxx) && xx >= 0; };
+})();

--- a/test/serializer/abstract/WaitGenerator0b.js
+++ b/test/serializer/abstract/WaitGenerator0b.js
@@ -1,0 +1,18 @@
+(function () {
+    let a = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let b = global.__abstract ? __abstract("boolean", "(true )") : true;
+    let c = global.__abstract ? __abstract("boolean", "(true  )") : true;
+    let x;
+    if (a) {
+        if (b) {
+            x=Date.now(); // definition
+        }
+        if (c) {
+            xx=x+1; // use of `x`
+        } else {
+            xx=x+2; // use of `x`
+        }
+    }
+    xxx=x+3; // use of `x`
+    inspect = function() { return xx >= 0; };
+})();


### PR DESCRIPTION
Release notes: Fixing ordering issues in serializer.

This is a refactoring of how serialization is done in the presence of temporal dependencies.

Before, there was a global set of declared identifiers that were already processed.
However, this was an imprecise approach, as the serializer can process values out-of-order for a number of reasons (when a value is used from multiple scopes and its definition needs to go to a particular body, and for lazy objects, and for lazy initializations (that get moved into residual functions)).
After this change, the serializer keeps track of declared-value sets for particular (nested) generators, and only merges them back into their parent generators when the generator is "done". This fixes the behavior of the waiting-logic to defer references to a declared value until after the generator that declares the value is "done".

Furthermore, when a value is used from multiple scopes, we used to emit that value into the body that corresponds to the common ancestor of all scopes; however, if that value was dependent on another value that was only declared in a nested generator that is stilled being processed (not yet done), then the code for that value would effectively end up *before* the nested generator with the dependent value declaration gets embedded in the code.
To address this issue, the algorithm in `getTarget` now checks if any of the scopes of a value intersects with the set of bodies that are not done yet contain a relevant dependency declaration. And if so, pick the most nested such body.

Adding test cases.