### PR TITLE
Object.assign simple object fixes

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -273,6 +273,20 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) Functional component folding Simple with Object.assign #2 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (JSX) Functional component folding Simple with Object.assign 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (JSX) fb-www mocks fb-www 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
@@ -603,6 +617,20 @@ ReactStatistics {
 `;
 
 exports[`Test React (create-element) Functional component folding Simple refs 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Simple with Object.assign #2 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Simple with Object.assign 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
   "optimizedTrees": 1,

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -198,6 +198,14 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "simple-refs.js");
       });
 
+      it("Simple with Object.assign", async () => {
+        await runTest(directory, "simple-wth-object-assign.js");
+      });
+
+      it("Simple with Object.assign #2", async () => {
+        await runTest(directory, "simple-wth-object-assign2.js");
+      });
+
       it("Circular reference", async () => {
         await runTest(directory, "circular-reference.js");
       });

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -145,8 +145,10 @@ export default function(realm: Realm): NativeFunctionValue {
     // 5. Return to.
     if (to_must_be_partial) {
       to.makePartial();
-      // if all sources are simple, then the target object must be too
-      if (simple_sources_count === sources.length) {
+      let to_keys = to.$OwnPropertyKeys();
+      // if all sources are simple and the target has no keys
+      // then we can safely mark the target as a simple object
+      if (simple_sources_count === sources.length && to_keys.length === 0) {
         to.makeSimple();
       }
     }

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -60,6 +60,7 @@ export default function(realm: Realm): NativeFunctionValue {
     // 1. Let to be ? ToObject(target).
     let to = To.ToObjectPartial(realm, target);
     let to_must_be_partial = false;
+    let to_can_be_simple = true;
 
     // 2. If only one argument was passed, return to.
     if (!sources.length) return to;
@@ -113,6 +114,7 @@ export default function(realm: Realm): NativeFunctionValue {
         // For now, just throw if this happens.
         let to_keys = to.$OwnPropertyKeys();
         if (to_keys.length !== 0) {
+          to_can_be_simple = false;
           AbstractValue.reportIntrospectionError(nextSource);
           throw new FatalError();
         }
@@ -142,10 +144,12 @@ export default function(realm: Realm): NativeFunctionValue {
     // 5. Return to.
     if (to_must_be_partial) {
       to.makePartial();
-      // at this point, we know the target is partial and started with
-      // no keys, otherwise the above FatalError() would have been thrown
-      // so we can safely make it simple
-      to.makeSimple();
+      if (to_can_be_simple) {
+        // at this point, we know the target is partial and started with
+        // no keys, otherwise the above FatalError() would have been thrown
+        // so we can safely make it simple
+        to.makeSimple();
+      }
     }
     return to;
   });

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -149,7 +149,7 @@ export default function(realm: Realm): NativeFunctionValue {
     if (to_must_be_partial) {
       to.makePartial();
     }
-    if (to_must_be_simple) {
+    if (realm.isInPureScope() && to_must_be_simple) {
       to.makeSimple();
     }
     return to;

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -60,7 +60,6 @@ export default function(realm: Realm): NativeFunctionValue {
     // 1. Let to be ? ToObject(target).
     let to = To.ToObjectPartial(realm, target);
     let to_must_be_partial = false;
-    let simple_sources_count = 0;
 
     // 2. If only one argument was passed, return to.
     if (!sources.length) return to;
@@ -88,8 +87,6 @@ export default function(realm: Realm): NativeFunctionValue {
             AbstractValue.reportIntrospectionError(nextSource);
             throw new FatalError();
           }
-          // increment simple sources counter
-          simple_sources_count++;
 
           // Generate a residual Object.assign call that copies the
           // partial properties that we don't know about.
@@ -145,12 +142,10 @@ export default function(realm: Realm): NativeFunctionValue {
     // 5. Return to.
     if (to_must_be_partial) {
       to.makePartial();
-      let to_keys = to.$OwnPropertyKeys();
-      // if all sources are simple and the target has no keys
-      // then we can safely mark the target as a simple object
-      if (simple_sources_count === sources.length && to_keys.length === 0) {
-        to.makeSimple();
-      }
+      // at this point, we know the target is partial and started with
+      // no keys, otherwise the above FatalError() would have been thrown
+      // so we can safely make it simple
+      to.makeSimple();
     }
     return to;
   });

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -60,6 +60,7 @@ export default function(realm: Realm): NativeFunctionValue {
     // 1. Let to be ? ToObject(target).
     let to = To.ToObjectPartial(realm, target);
     let to_must_be_partial = false;
+    let simple_sources_count = 0;
 
     // 2. If only one argument was passed, return to.
     if (!sources.length) return to;
@@ -87,6 +88,8 @@ export default function(realm: Realm): NativeFunctionValue {
             AbstractValue.reportIntrospectionError(nextSource);
             throw new FatalError();
           }
+          // increment simple sources counter
+          simple_sources_count++;
 
           // Generate a residual Object.assign call that copies the
           // partial properties that we don't know about.
@@ -140,7 +143,13 @@ export default function(realm: Realm): NativeFunctionValue {
     }
 
     // 5. Return to.
-    if (to_must_be_partial) to.makePartial();
+    if (to_must_be_partial) {
+      to.makePartial();
+      // if all sources are simple, then the target object must be too
+      if (simple_sources_count === sources.length) {
+        to.makeSimple();
+      }
+    }
     return to;
   });
 

--- a/test/react/functional-components/simple-wth-object-assign.js
+++ b/test/react/functional-components/simple-wth-object-assign.js
@@ -1,0 +1,27 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>Hello {props.x}</div>;
+}
+
+function App(props) {
+	var copyOfProps = Object.assign({}, props);
+  return (
+    <div>
+      <A x={copyOfProps.x} />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root x={10} />);
+  return [['simple render with object assign', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/simple-wth-object-assign.js
+++ b/test/react/functional-components/simple-wth-object-assign.js
@@ -7,7 +7,7 @@ function A(props) {
 }
 
 function App(props) {
-	var copyOfProps = Object.assign({}, props);
+  var copyOfProps = Object.assign({}, props);
   return (
     <div>
       <A x={copyOfProps.x} />

--- a/test/react/functional-components/simple-wth-object-assign2.js
+++ b/test/react/functional-components/simple-wth-object-assign2.js
@@ -4,11 +4,19 @@ this['React'] = React;
 
 function A(props) {
   var copyOfProps = Object.assign({}, props.bag);
-  return <div>Hello {copyOfProps.x}</div>;
+  Object.assign(copyOfProps, "y", {
+    get() {
+      return 30;
+    },
+    set(x) {
+      return x;
+    },
+  })
+  return <div>Hello {copyOfProps.x} {copyOfProps.y}</div>;
 }
 
 function App(props) {
-	var copyOfProps = Object.assign({}, props);
+	var copyOfProps = Object.assign({}, props, {x: 20});
   return (
     <A bag={copyOfProps} />
   );

--- a/test/react/functional-components/simple-wth-object-assign2.js
+++ b/test/react/functional-components/simple-wth-object-assign2.js
@@ -4,7 +4,7 @@ this['React'] = React;
 
 function A(props) {
   var copyOfProps = Object.assign({}, props.bag);
-  Object.assign(copyOfProps, "y", {
+  Object.defineProperty(copyOfProps, "y", {
     get() {
       return 30;
     },

--- a/test/react/functional-components/simple-wth-object-assign2.js
+++ b/test/react/functional-components/simple-wth-object-assign2.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  var copyOfProps = Object.assign({}, props.bag);
+  return <div>Hello {copyOfProps.x}</div>;
+}
+
+function App(props) {
+	var copyOfProps = Object.assign({}, props);
+  return (
+    <A bag={copyOfProps} />
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root x={10} />);
+  return [['simple render with object assign', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

Extending on from https://github.com/facebook/prepack/pull/1448, this PR ensures the assigned value from `Object.assign` is made simple if **all** of the sources are also simple themselves. I've pulled in the failing test from that PR and it now passes with this change.