### PR TITLE
Create new React component trees on ReactElement bail outs

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -45,7 +45,7 @@ ReactStatistics {
 exports[`Test React (JSX) Factory class component folding Simple factory classes 2 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
-  "optimizedTrees": 1,
+  "optimizedTrees": 2,
 }
 `;
 
@@ -381,7 +381,7 @@ ReactStatistics {
 exports[`Test React (create-element) Factory class component folding Simple factory classes 2 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
-  "optimizedTrees": 1,
+  "optimizedTrees": 2,
 }
 `;
 


### PR DESCRIPTION
Release notes: none

When we bail out of rendering a ReactElement during the React reconciliation phase, we should take the `type` from the ReactElement and queue that value up so we visit as part of a new React component tree.