### PR TITLE
[WIP] Properly handle PossiblyNormalCompletion in React reconcilation

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -376,6 +376,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "fb8.js");
       });
 
+      it("fb-www 9", async () => {
+        await runTest(directory, "fb9.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -138,6 +138,12 @@ export class Functions {
     let additionalFunctionEffects = this._createAdditionalEffects(effects);
     let value = effects[0];
 
+    // for the failing test, `value` will be a `PossiblyNormalCompletion`
+    // we want the value from it instead? How do we best do that?
+    // furthermore, when we get that value, it needs to be the value used
+    // for this additionalFunction during visiting/serialization so the test
+    // passes
+
     if (value === this.realm.intrinsics.undefined) {
       // if we get undefined, then this component tree failed and a message was already logged
       // in the reconciler

--- a/test/react/mocks/fb9.js
+++ b/test/react/mocks/fb9.js
@@ -1,0 +1,55 @@
+var React = require('React');
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = this.__evaluatePureFunction(() => {
+  function nullthrows(x) {
+    var message = arguments.length <= 1 || arguments[1] === undefined ? 'Got unexpected null or undefined' : arguments[1];
+    if (x != null) {
+      return x;
+    }
+    var error = new Error(message);
+
+    error.framesToPop = 1;
+    throw error;
+  };
+
+  function A(props) {
+    return (
+      <div className={props.className}>
+        <div>Hello {props.x} {props.y}</div>
+        <B />
+        <C />
+      </div>
+    );
+  }
+
+  function B() {
+    return <div>World</div>;
+  }
+
+  function C() {
+    return "!";
+  }
+
+  function App(props) {
+    nullthrows(props.className);
+    return <A className={props.className} />;
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root className="Rooty McRootface" />);
+    return [['simple render', renderer.toJSON()]];
+  };
+
+  if (this.__registerReactComponentRoot) {
+    __registerReactComponentRoot(App);
+  }
+
+  return App;
+});


### PR DESCRIPTION
Release notes: none

We need to properly handle the effects from a rendered React component tree when the value is a `PossiblyNormalCompletion`. I can't get this working, maybe @cblappert can help?