### PR TITLE
Add failing test for abstract Object.assign

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -56,6 +56,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) Functional component folding Assign 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (JSX) Functional component folding Circular reference 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
@@ -386,6 +393,13 @@ ReactStatistics {
 `;
 
 exports[`Test React (create-element) Functional component folding Additional functions closure scope capturing 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Assign 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
   "optimizedTrees": 1,

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -266,6 +266,10 @@ function runTestSuite(outputJsx) {
         }
       });
 
+      it("Assign", async () => {
+        await runTest(directory, "assign.js");
+      });
+
       it("Class component as root", async () => {
         await runTest(directory, "class-root.js");
       });

--- a/test/react/functional-components/assign.js
+++ b/test/react/functional-components/assign.js
@@ -1,0 +1,21 @@
+var React = require('react');
+this['React'] = React;
+
+function App(props) {
+  var copyOfProps = {};
+  var copyOfProps2 = {};
+  Object.assign(copyOfProps, props, {x: 20});
+  Object.assign(copyOfProps2, copyOfProps);
+  return copyOfProps2.x;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root x={10} />);
+  return [['simple render with object assign', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/serializer/abstract/ObjectAssign6.js
+++ b/test/serializer/abstract/ObjectAssign6.js
@@ -1,0 +1,17 @@
+// abstract effects
+var a = global.__abstract && global.__makePartial && global.__makeSimple ? __makeSimple(__makePartial(__abstract({}, "({bar: 2})"))) : {bar: 2};
+var b;
+var c;
+
+var __evaluatePureFunction = this.__evaluatePureFunction || (f => f());
+__evaluatePureFunction(() => {
+  b = {};
+  Object.assign(b, a, {bar: 1});
+
+  c = {};
+  Object.assign(c, b);
+});
+
+inspect = function() {  
+  return c.bar;
+}


### PR DESCRIPTION
Something goes wrong when we `Object.assign` twice on master.
I wrote about this here: https://github.com/facebook/prepack/pull/1456#issuecomment-366054695.

I can only reproduce this in pure mode. I tried to add both a React and a non-React test.

Note that applying patch in https://github.com/facebook/prepack/pull/1456 "fixes" the React test, but the serializer test still fails. 

```
 yarn test-serializer --filter ObjectAssign6 
```

I'm not 100% sure the serializer test is correct, but it does show different values for me (1 vs 2).

I'm worried that I can't proceed with https://github.com/facebook/prepack/pull/1456 because it would just hide a possibly nastier bug that this test exposes.