### PR TITLE
 Generate Object.assign() calls for all arguments after first partial

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -189,6 +189,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) Functional component folding Object.assign 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (JSX) Functional component folding React.cloneElement 1`] = `
 ReactStatistics {
   "inlinedComponents": 2,
@@ -522,6 +529,13 @@ exports[`Test React (create-element) Functional component folding Key not changi
 ReactStatistics {
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Object.assign 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -230,6 +230,10 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "key-not-change-fragments.js");
       });
 
+      it("Object.assign", async () => {
+        await runTest(directory, "object-assign.js");
+      });
+
       it("Component type change", async () => {
         await runTest(directory, "type-change.js");
       });

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -88,6 +88,11 @@ export default function(realm: Realm): NativeFunctionValue {
             throw new FatalError();
           }
 
+          to_must_be_partial = true;
+          frm.makeNotPartial();
+        }
+
+        if (to_must_be_partial) {
           // Generate a residual Object.assign call that copies the
           // partial properties that we don't know about.
           AbstractValue.createTemporalFromBuildFunction(
@@ -98,9 +103,6 @@ export default function(realm: Realm): NativeFunctionValue {
               return t.callExpression(methodNode, [targetNode, sourceNode]);
             }
           );
-
-          to_must_be_partial = true;
-          frm.makeNotPartial();
         }
 
         // ii. Let keys be ? from.[[OwnPropertyKeys]]().

--- a/test/react/functional-components/object-assign.js
+++ b/test/react/functional-components/object-assign.js
@@ -1,0 +1,23 @@
+var React = require('react');
+this['React'] = React;
+
+// Regression test for
+// https://github.com/facebook/prepack/pull/1458/
+function App(props) {
+  var copyOfProps = {};
+  var copyOfProps2 = {};
+  Object.assign(copyOfProps, props, {x: 20});
+  Object.assign(copyOfProps2, copyOfProps);
+  return copyOfProps2.x;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root x={10} />);
+  return [['simple render with object assign', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/serializer/abstract/ObjectAssign5.js
+++ b/test/serializer/abstract/ObjectAssign5.js
@@ -1,0 +1,6 @@
+var obj = global.__abstract && global.__makePartial && global.__makeSimple ? __makeSimple(__makePartial(__abstract({}, "({foo:1})"))) : {foo:1};
+var copyOfObj = Object.assign({}, obj, {foo: 2});
+
+inspect = function() {  
+  return JSON.stringify(copyOfObj);
+}


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/facebook/prepack/pull/1448. (That solution was incomplete.)
I first noticed this problem in https://github.com/facebook/prepack/pull/1456#issuecomment-366054695.

In https://github.com/facebook/prepack/pull/1448, we used to only generate residual `Object.assign()` calls for partial arguments.

The problem is, this breaks the case like `Object.assign({}, partial, nonPartial)`.
We would incorrectly skip over `nonPartial` in this case.

The fix is to move the function generation out of the partial source check, and into a partial target check. Once we're dealing with partials, there’s no going back.

With this fix, we generate `Object.assign()` for each argument after (and including) the first partial,
regardless of whether those arguments themselves are partial or not.

As an optimization I think we could maybe queue them up and generate just one `Object.assign` call but I don’t feel strongly about this so I went with this simpler version.

This PR has both a generic and a React-specific test. They both fail on master but pass here.