### PR TITLE
Refactor additional function evaluator to call functions directly

### DIFF
--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -197,7 +197,7 @@ function checkResidualFunctions(modules: Modules, startFunc: number, totalToAnal
     }
     // todo: eventually join these effects, apply them to the global state and iterate to a fixed point
     try {
-      realm.evaluateAndRevertInGlobalEnv(() =>
+      realm.evaluateForEffectsInGlobalEnv(() =>
         EvaluateDirectCallWithArgList(modules.realm, true, env, fv, fv, thisValue, args)
       );
       nonFatalFunctions++;

--- a/src/realm.js
+++ b/src/realm.js
@@ -509,8 +509,8 @@ export class Realm {
     return this.evaluateForEffects(() => env.evaluateCompletionDeref(ast, strictCode), state, generatorName);
   }
 
-  evaluateAndRevertInGlobalEnv(func: () => Value): void {
-    this.wrapInGlobalEnv(() => this.evaluateForEffects(func));
+  evaluateForEffectsInGlobalEnv(func: () => Value): Effects {
+    return this.wrapInGlobalEnv(() => this.evaluateForEffects(func));
   }
 
   evaluateNodeForEffectsInGlobalEnv(node: BabelNode, state?: any, generatorName?: string): Effects {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1725,7 +1725,7 @@ export class ResidualHeapSerializer {
       }
       return this.realm.intrinsics.undefined;
     };
-    this.realm.evaluateAndRevertInGlobalEnv(processAdditionalFunctionValuesFn);
+    this.realm.evaluateForEffectsInGlobalEnv(processAdditionalFunctionValuesFn);
     return rewrittenAdditionalFunctions;
   }
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -935,7 +935,7 @@ export class ResidualHeapVisitor {
       }
       return this.realm.intrinsics.undefined;
     };
-    this.realm.evaluateAndRevertInGlobalEnv(_visitAdditionalFunctionEffects);
+    this.realm.evaluateForEffectsInGlobalEnv(_visitAdditionalFunctionEffects);
 
     // Cleanup
     this.commonScope = prevCommonScope;


### PR DESCRIPTION
Release Notes: None

Instead of creating a call AST node and evaluating the node for effects, the additional functions evaluator now creates a call to the underlying `Call` evaluator. This will allow us to provide it arguments more easily (prerequisite for #987).