### PR TITLE
Bug: Add a failing test for rendering an array twice

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -280,6 +280,10 @@ function runTestSuite(outputJsx) {
         }
       });
 
+      it("Render array twice", async () => {
+        await runTest(directory, "array-twice.js");
+      });
+
       it("Class component as root", async () => {
         await runTest(directory, "class-root.js");
       });

--- a/test/react/functional-components/array-twice.js
+++ b/test/react/functional-components/array-twice.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>{props.children}{props.children}</div>;
+}
+
+function App() {
+  return (
+    <div>
+      <A>{['hello']}</A>
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['render array twice', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Seems like either a serializer or a reconciler bug.
The error is worrying because it is a runtime error.

```js
Uncaught [ReferenceError: _c is not defined]
```