### PR TITLE
Simple arguments for additional functions

### DIFF
--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -38,7 +38,7 @@ import {
   valueIsKnownReactAbstraction,
 } from "../react/utils.js";
 import * as t from "babel-types";
-import { createAbstract } from "../intrinsics/prepack/utils.js";
+import { createAbstractArgument } from "../intrinsics/prepack/utils.js";
 
 export class Functions {
   constructor(realm: Realm, functions: ?Array<string>, moduleTracer: ModuleTracer) {
@@ -233,8 +233,14 @@ export class Functions {
     if (numArgs && numArgs > 0 && params) {
       for (let parameterId of params) {
         if (t.isIdentifier(parameterId)) {
-          // Create a generic AbstractValue
-          args.push(createAbstract(this.realm, undefined, ((parameterId: any): BabelNodeIdentifier).name));
+          // Create an AbstractValue similar to __abstract being called
+          args.push(
+            createAbstractArgument(
+              this.realm,
+              ((parameterId: any): BabelNodeIdentifier).name,
+              funcValue.expressionLocation
+            )
+          );
         } else {
           this.realm.handleError(
             new CompilerDiagnostic(

--- a/test/serializer/additional-functions/arguments.js
+++ b/test/serializer/additional-functions/arguments.js
@@ -1,0 +1,16 @@
+// does not contain:x = 5;
+
+function additional1(argument) {
+  var z = { foo: argument };
+  var x = 5;
+  return z;
+}
+if (global.__registerAdditionalFunctionToPrepack)
+  __registerAdditionalFunctionToPrepack(additional1);
+
+inspect = function inspect() {
+  let z = additional1(7);
+  let z2 = additional1(10);
+
+  return '' + JSON.stringify(z) + ' ' + JSON.stringify(z2);
+}

--- a/test/serializer/additional-functions/arguments2.js
+++ b/test/serializer/additional-functions/arguments2.js
@@ -1,0 +1,25 @@
+// does not contain:x = 5;
+
+function additional1(argument) {
+  var z = { foo: argument };
+  var x = 5;
+  return z;
+}
+
+function additional2(argument) {
+  var z = { bar: argument };
+  var x = 5;
+  return z;
+}
+
+if (global.__registerAdditionalFunctionToPrepack) {
+  __registerAdditionalFunctionToPrepack(additional1);
+  __registerAdditionalFunctionToPrepack(additional2);
+}
+
+inspect = function inspect() {
+  let z = additional1(7);
+  let z2 = additional2(42);
+
+  return '' + JSON.stringify(z) + ' ' + JSON.stringify(z2);
+}

--- a/test/serializer/additional-functions/arguments3.js
+++ b/test/serializer/additional-functions/arguments3.js
@@ -1,0 +1,15 @@
+// does not contain:x = 5;
+
+function additional1(argument, argument) {
+  var z = { foo: argument };
+  var x = 5;
+  return z;
+}
+if (global.__registerAdditionalFunctionToPrepack)
+  __registerAdditionalFunctionToPrepack(additional1);
+
+inspect = function inspect() {
+  let z = additional1(7, 10);
+
+  return '' + JSON.stringify(z);
+}

--- a/test/serializer/additional-functions/arguments4.js
+++ b/test/serializer/additional-functions/arguments4.js
@@ -1,0 +1,16 @@
+// does not contain:x = 5;
+
+function additional1(argument1, argument2) {
+  var z = { foo: argument1 };
+  var w = { bar: argument2 };
+  var x = 5;
+  return [w, z];
+}
+if (global.__registerAdditionalFunctionToPrepack)
+  __registerAdditionalFunctionToPrepack(additional1);
+
+inspect = function inspect() {
+  let z = additional1(12, 3);
+
+  return '' + JSON.stringify(z);
+}


### PR DESCRIPTION
Release Notes: None

This causes additional functions to automatically convert their arguments into `AbstractValue`s. Later PRs will allow more granular specification of arguments.