### PR TITLE
Ensure React non-composite nested array children are flattened

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -196,6 +196,20 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (JSX) Functional component folding Render array twice 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (JSX) Functional component folding Render nested array children 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (JSX) Functional component folding Return text 1`] = `
 ReactStatistics {
   "inlinedComponents": 2,
@@ -280,13 +294,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React (JSX) fb-www mocks Hacker News app 1`] = `
-ReactStatistics {
-  "inlinedComponents": 0,
-  "optimizedTrees": 0,
-}
-`;
-
 exports[`Test React (JSX) Functional component folding Simple with Object.assign #2 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
@@ -298,6 +305,13 @@ exports[`Test React (JSX) Functional component folding Simple with Object.assign
 ReactStatistics {
   "inlinedComponents": 1,
   "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (JSX) fb-www mocks Hacker News app 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 0,
 }
 `;
 
@@ -560,6 +574,20 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React (create-element) Functional component folding Render array twice 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) Functional component folding Render nested array children 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React (create-element) Functional component folding Return text 1`] = `
 ReactStatistics {
   "inlinedComponents": 2,
@@ -644,13 +672,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React (create-element) fb-www mocks Hacker News app 1`] = `
-ReactStatistics {
-  "inlinedComponents": 0,
-  "optimizedTrees": 0,
-}
-`;
-
 exports[`Test React (create-element) Functional component folding Simple with Object.assign #2 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
@@ -662,6 +683,13 @@ exports[`Test React (create-element) Functional component folding Simple with Ob
 ReactStatistics {
   "inlinedComponents": 1,
   "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React (create-element) fb-www mocks Hacker News app 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 0,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -276,6 +276,14 @@ function runTestSuite(outputJsx) {
         await runTest(directory, "return-text.js");
       });
 
+      it("Render array twice", async () => {
+        await runTest(directory, "array-twice.js");
+      });
+
+      it("Render nested array children", async () => {
+        await runTest(directory, "nested-array-children.js");
+      });
+
       it("Return undefined", async () => {
         // this test will cause a React console.error to show
         // we monkey patch it to stop it polluting the test output

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -33,6 +33,7 @@ import {
   valueIsFactoryClassComponent,
   valueIsKnownReactAbstraction,
   getReactSymbol,
+  flattenChildren,
 } from "./utils";
 import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
@@ -411,6 +412,10 @@ export class Reconciler {
               let childrenPropertyValue = childrenPropertyDescriptor.value;
               invariant(childrenPropertyValue instanceof Value, `Bad "children" prop passed in JSXElement`);
               let resolvedChildren = this._resolveDeeply(childrenPropertyValue, context, branchStatus, branchState);
+              // we can optimize further and flatten arrays on non-composite components
+              if (resolvedChildren instanceof ArrayValue) {
+                resolvedChildren = flattenChildren(this.realm, resolvedChildren);
+              }
               childrenPropertyDescriptor.value = resolvedChildren;
             }
           }

--- a/test/react/functional-components/array-twice.js
+++ b/test/react/functional-components/array-twice.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>{props.children}{props.children}</div>;
+}
+
+function App() {
+  return (
+    <div>
+      <A>{['hello']}</A>
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['render array twice', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/nested-array-children.js
+++ b/test/react/functional-components/nested-array-children.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>{[[[[["Hello"], "world"], 1, <span>A span</span>], 2], null, <div>A div</div>]}</div>;
+}
+
+function App() {
+  return (
+    <div>
+      <A />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['render nested array children', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This change properly implements non-composite children flattening. This fixes https://github.com/facebook/prepack/pull/1465 too.