### PR TITLE
Adding lazyObjectsRuntime option to the Prepack Website

### DIFF
--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -48,7 +48,7 @@ var optionsConfig = [
     type: "string",
     name: "lazyObjectsRuntime",
     defaultVal: "",
-    description: "Enable lazy objects feature and specify the JS runtime that support this feature."
+    description: "Enable lazy objects feature and specify the JS runtime that supports this feature."
   },
   {
     type: "boolean",

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -45,6 +45,12 @@ var optionsConfig = [
     description: "The target environment for Prepack"
   },
   {
+    type: "string",
+    name: "lazyObjectsRuntime",
+    defaultVal: "",
+    description: "Enable lazy objects feature and specify the JS runtime that support this feature."
+  },
+  {
     type: "boolean",
     name: "omitInvariants",
     defaultVal: true,


### PR DESCRIPTION
This addresses the issue https://github.com/facebook/prepack/issues/1282 although the issue also requests for --additionalFunctions option which is not part of this commit. User should now be able to see --lazyObjectsRuntime option in the options list on https://prepack.io/repl.html. Ideally this should be an enum but this will accept a freeform string in this revision.