### PR TITLE
Treat transitively simple objects as frozen

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -109,7 +109,7 @@ export class Generator {
     return this._name || `#${this.id}`;
   }
 
-  getAsPropertyNameExpression(key: string, canBeIdentifier: boolean = true) {
+  getAsPropertyNameExpression(key: string, canBeIdentifier: boolean = true): BabelNodeExpression {
     // If key is a non-negative numeric string literal, parse it and set it as a numeric index instead.
     let index = Number.parseInt(key, 10);
     if (index >= 0 && index.toString() === key) {


### PR DESCRIPTION
Release note: Transitive simple partial objects are now assumed to be frozen

The effect of the assumption is that there is no need to create temporal values when accessing properties of transitive simple objects. This leads to simpler/smaller/faster code.