### PR TITLE
Fixes named function bindings in additionalFunction scope

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -147,6 +147,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Event handlers 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Key change 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
@@ -596,6 +603,13 @@ ReactStatistics {
 `;
 
 exports[`Test React with JSX input, create-element output Functional component folding Dynamic props 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
   "optimizedTrees": 1,
@@ -1057,6 +1071,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Event handlers 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Key change 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
@@ -1506,6 +1527,13 @@ ReactStatistics {
 `;
 
 exports[`Test React with create-element input, create-element output Functional component folding Dynamic props 1`] = `
+ReactStatistics {
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
   "optimizedTrees": 1,

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -345,6 +345,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         }
       });
 
+      it("Event handlers", async () => {
+        await runTest(directory, "event-handlers.js");
+      });
+
       it("Class component as root", async () => {
         await runTest(directory, "class-root.js");
       });

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -887,17 +887,16 @@ export class ResidualHeapVisitor {
           this._withScope(functionValue, () => {
             // Also visit the original value of the binding
             residualBinding = this.visitBinding(functionValue, modifiedBinding.name);
+            invariant(residualBinding !== undefined);
             // named functions inside an additional function that have a global binding
             // can be skipped, as we don't want them to bind to the global
             if (
-              residualBinding &&
               residualBinding.declarativeEnvironmentRecord === null &&
               modifiedBinding.value instanceof ECMAScriptSourceFunctionValue
             ) {
               residualBinding = null;
               return;
             }
-            invariant(residualBinding !== undefined);
             // Fixup the binding to have the correct value
             // No previousValue means this is a binding for a nested function
             if (previousValue && previousValue.value)

--- a/test/react/functional-components/event-handlers.js
+++ b/test/react/functional-components/event-handlers.js
@@ -1,0 +1,27 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App(props) {
+  // This being a named function is a regression test for a bug
+  // that emitted a global.onClick assignment.
+  return <div onClick={function onClick(x) {
+    props.onClick(x * 2);
+  }} />
+}
+
+App.getTrials = function(renderer, Root) {
+  let result;
+  renderer.update(<Root onClick={res => { result = res; }} />);
+  renderer.root.findByType('div').props.onClick(10);
+  return [
+    ['onClick gets called', result],
+    ['regression: onClick is not global', typeof this.onClick],
+  ];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/serializer/additional-functions/named-function.js
+++ b/test/serializer/additional-functions/named-function.js
@@ -1,0 +1,15 @@
+function additional1() {
+  return {foo: function foo() {
+    return 123;
+  }};
+}
+
+if (this.__registerAdditionalFunctionToPrepack) {
+  __registerAdditionalFunctionToPrepack(additional1);
+}
+
+inspect = function() {
+  let x = additional1();
+
+  return x.foo();
+}


### PR DESCRIPTION
Release notes: none

This PR fixes a bug where named functions' bindings were being marked as global inside additionalFunctions. This meant that they were incorrectly being assigned to the global.

Fixes https://github.com/facebook/prepack/pull/1432