### PR TITLE
[WIP]: Support for abstract interpretation of switches

### DIFF
--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -33,6 +33,19 @@ function CaseSelectorEvaluation(
   return Environment.GetValue(realm, exprRef);
 }
 
+function AbstractCaseBlockEvaluation(
+  cases: Array<BabelNodeSwitchCase>,
+  defaultCaseNum: number,
+  input: Value,
+  strictCode: boolean,
+  env: LexicalEnvironment,
+  realm: Realm
+): Value {
+  invariant(realm.useAbstractInterpretation);
+
+  invariant(false, "Can't do abstract interpretation of switch blocks yet.");
+}
+
 function CaseBlockEvaluation(
   cases: Array<BabelNodeSwitchCase>,
   input: Value,
@@ -98,6 +111,12 @@ function CaseBlockEvaluation(
   let default_case_num = cases.findIndex(clause => {
     return clause.test === null;
   });
+
+  // Abstract interpretation of case blocks is a significantly different process
+  // from regular interpretation, so we fork off early to keep things tidily separated.
+  if (realm.useAbstractInterpretation) {
+    return AbstractCaseBlockEvaluation(cases, default_case_num, input, strictCode, env, realm);
+  }
 
   if (default_case_num !== -1) {
     // 2. Let A be the List of CaseClause items in the first CaseClauses, in source text order. If the first CaseClauses is not present, A is « ».

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -13,9 +13,10 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { AbruptCompletion, BreakCompletion } from "../completions.js";
 import { InternalGetResultValue } from "./ForOfStatement.js";
-import { EmptyValue, Value } from "../values/index.js";
+import { EmptyValue, AbstractValue, Value } from "../values/index.js";
 import { StrictEqualityComparisonPartial, UpdateEmpty } from "../methods/index.js";
 import { Environment } from "../singletons.js";
+import { FatalError } from "../errors.js";
 import type { BabelNodeSwitchStatement, BabelNodeSwitchCase, BabelNodeExpression } from "babel-types";
 import invariant from "../invariant.js";
 
@@ -43,7 +44,8 @@ function AbstractCaseBlockEvaluation(
 ): Value {
   invariant(realm.useAbstractInterpretation);
 
-  invariant(false, "Can't do abstract interpretation of switch blocks yet.");
+  AbstractValue.reportIntrospectionError(input);
+  throw new FatalError();
 }
 
 function CaseBlockEvaluation(
@@ -114,7 +116,7 @@ function CaseBlockEvaluation(
 
   // Abstract interpretation of case blocks is a significantly different process
   // from regular interpretation, so we fork off early to keep things tidily separated.
-  if (realm.useAbstractInterpretation) {
+  if (input instanceof AbstractValue) {
     return AbstractCaseBlockEvaluation(cases, default_case_num, input, strictCode, env, realm);
   }
 

--- a/test/serializer/abstract/Switch.js
+++ b/test/serializer/abstract/Switch.js
@@ -1,3 +1,4 @@
+// throws introspection error
 let x = global.__abstract ? __abstract("number", "1") : 1;
 z = 10;
 

--- a/test/serializer/abstract/Switch.js
+++ b/test/serializer/abstract/Switch.js
@@ -1,0 +1,11 @@
+let x = global.__abstract ? __abstract("number", "1") : 1;
+z = 10;
+
+switch (x) {
+  case 0: z = 11; break;
+  case 1: z = 12; break;
+  case 2: z = 13; break;
+  default: z = 14; break;
+}
+
+inspect = function() { return "" + z; }


### PR DESCRIPTION
Thought I'd (re)start by just adding a hook point to the existing interpreter code to branch off in case of abstract interpretation. The two are likely to look quite different and keeping them separate will be tidier. Also added a basic test case to ensure that it fails when abstract interpretation is required for a switch.

Looking for feedback if this looks repulsive. If not, then I'll go make it do something basic as the next step (and add more tests) ;-)