### PR TITLE
A round of additional function serialization refactoring

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -509,8 +509,8 @@ export class Realm {
     return this.evaluateForEffects(() => env.evaluateCompletionDeref(ast, strictCode), state, generatorName);
   }
 
-  evaluateForEffectsInGlobalEnv(func: () => Value): Effects {
-    return this.wrapInGlobalEnv(() => this.evaluateForEffects(func));
+  evaluateForEffectsInGlobalEnv(func: () => Value, state?: any, generatorName?: string): Effects {
+    return this.wrapInGlobalEnv(() => this.evaluateForEffects(func, state, generatorName));
   }
 
   // NB: does not apply generators because there's no way to cleanly revert them.

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -58,7 +58,10 @@ type EmitterDependenciesVisitorCallbacks<T> = {
 //    the lower body entry is finished.
 //    To this end, the emitter maintains the `_activeGeneratorStack` and `_waitingForBodies` datastructures.
 export class Emitter {
-  constructor(residualFunctions: ResidualFunctions) {
+  constructor(
+    residualFunctions: ResidualFunctions,
+    referencedDeclaredValues: Map<AbstractValue, void | FunctionValue>
+  ) {
     this._mainBody = { type: "MainGenerator", parentBody: undefined, entries: [], done: false };
     this._waitingForValues = new Map();
     this._waitingForBodies = new Map();
@@ -77,7 +80,12 @@ export class Emitter {
       },
       onAbstractValueWithIdentifier: val => {
         // If the value hasn't been declared yet, then we should wait for it.
-        if (!this.cannotDeclare() && !this.hasBeenDeclared(val)) return val;
+        if (
+          !this.cannotDeclare() &&
+          !this.hasBeenDeclared(val) &&
+          (!this.emittingToAdditionalFunction() || referencedDeclaredValues.get(val) !== undefined)
+        )
+          return val;
         else return undefined;
       },
     };

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -402,6 +402,11 @@ export class Emitter {
     this._body.declaredAbstractValues.set(value, this._body);
     this._processValue(value);
   }
+  emittingToAdditionalFunction() {
+    // Whether we are directly or indirectly emitting to an additional function
+    for (let b = this._body; b !== undefined; b = b.parentBody) if (b.type === "AdditionalFunction") return true;
+    return false;
+  }
   cannotDeclare(): boolean {
     // Bodies of the following types will never contain any (temporal) abstract value declarations.
     return this._body.type === "DelayInitializations" || this._body.type === "LazyObjectInitializer";

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -41,6 +41,7 @@ import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { getOrDefault } from "./utils.js";
 import type { DeclarativeEnvironmentRecord } from "../environment.js";
 import type { Referentializer } from "./Referentializer.js";
+import { Generator } from "../utils/generator.js";
 
 const LAZY_OBJECTS_SERIALIZER_BODY_TYPE = "LazyObjectInitializer";
 
@@ -72,7 +73,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>,
     statistics: SerializerStatistics,
     react: ReactSerializerState,
-    referentializer: Referentializer
+    referentializer: Referentializer,
+    generatorParents: Map<Generator, Generator>
   ) {
     super(
       realm,
@@ -91,7 +93,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       declarativeEnvironmentRecordsBindings,
       statistics,
       react,
-      referentializer
+      referentializer,
+      generatorParents
     );
     this._lazyObjectIdSeed = 1;
     this._valueLazyIds = new Map();

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -67,7 +67,7 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     residualClassMethodInstances: Map<FunctionValue, ClassMethodInstance>,
     residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>,
     options: SerializerOptions,
-    referencedDeclaredValues: Set<AbstractValue>,
+    referencedDeclaredValues: Map<AbstractValue, void | FunctionValue>,
     additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects> | void,
     additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
     declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>,

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -99,7 +99,7 @@ export class ResidualHeapSerializer {
     residualClassMethodInstances: Map<FunctionValue, ClassMethodInstance>,
     residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>,
     options: SerializerOptions,
-    referencedDeclaredValues: Set<AbstractValue>,
+    referencedDeclaredValues: Map<AbstractValue, void | FunctionValue>,
     additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects> | void,
     additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
     declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>,
@@ -162,7 +162,7 @@ export class ResidualHeapSerializer {
       this.additionalFunctionValueNestedFunctions,
       referentializer
     );
-    this.emitter = new Emitter(this.residualFunctions);
+    this.emitter = new Emitter(this.residualFunctions, referencedDeclaredValues);
     this.mainBody = this.emitter.getBody();
     this.residualHeapInspector = residualHeapInspector;
     this.residualValues = residualValues;
@@ -213,7 +213,7 @@ export class ResidualHeapSerializer {
   _serializedValueWithIdentifiers: Set<Value>;
   residualFunctions: ResidualFunctions;
   _options: SerializerOptions;
-  referencedDeclaredValues: Set<AbstractValue>;
+  referencedDeclaredValues: Map<AbstractValue, void | FunctionValue>;
   activeGeneratorBodies: Map<Generator, SerializedBody>;
   additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects> | void;
   additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>;
@@ -1604,7 +1604,7 @@ export class ResidualHeapSerializer {
         !this.preludeGenerator.derivedIds.has(id.name) ||
           this.emitter.cannotDeclare() ||
           this.emitter.hasBeenDeclared(val) ||
-          this.emitter.emittingToAdditionalFunction()
+          (this.emitter.emittingToAdditionalFunction() && this.referencedDeclaredValues.get(val) === undefined)
       );
     }
     return serializedValue;

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -100,7 +100,7 @@ export class ResidualHeapVisitor {
     invariant(generator);
     this.scope = this.commonScope = generator;
     this.inspector = new ResidualHeapInspector(realm, logger);
-    this.referencedDeclaredValues = new Set();
+    this.referencedDeclaredValues = new Map();
     this.delayedVisitGeneratorEntries = [];
     this.someReactElement = undefined;
     this.additionalFunctionValuesAndEffects = additionalFunctionValuesAndEffects;
@@ -130,7 +130,7 @@ export class ResidualHeapVisitor {
   commonScope: Scope;
   values: Map<Value, Set<Scope>>;
   inspector: ResidualHeapInspector;
-  referencedDeclaredValues: Set<AbstractValue>;
+  referencedDeclaredValues: Map<AbstractValue, void | FunctionValue>;
   delayedVisitGeneratorEntries: Array<{| commonScope: Scope, generator: Generator, entry: GeneratorEntry |}>;
   additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>;
   functionInstances: Map<FunctionValue, FunctionInstance>;
@@ -833,7 +833,7 @@ export class ResidualHeapVisitor {
         return !this.referencedDeclaredValues.has(value) && !this.values.has(value);
       },
       recordDeclaration: (value: AbstractValue) => {
-        this.referencedDeclaredValues.add(value);
+        this.referencedDeclaredValues.set(value, this.containingAdditionalFunction);
       },
       recordDelayedEntry: (generator, entry: GeneratorEntry) => {
         this.delayedVisitGeneratorEntries.push({ commonScope, generator, entry });

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -150,7 +150,7 @@ export class ResidualReactElementSerializer {
 
     let reactLibraryObject = this.realm.fbLibraries.react;
     let shouldHoist =
-      this.residualHeapSerializer.currentFunctionBody !== this.residualHeapSerializer.mainBody &&
+      this.residualHeapSerializer.isReferencedOnlyByAdditionalFunction(val) !== undefined &&
       canHoistReactElement(this.realm, val);
 
     let id = this.residualHeapSerializer.getSerializeObjectIdentifier(val);

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -270,7 +270,9 @@ export class Functions {
     for (let funcValue of additionalFunctions) {
       invariant(funcValue instanceof FunctionValue);
       let call = this._callOfFunction(funcValue);
-      let effects = this.realm.evaluatePure(() => this.realm.evaluateForEffectsInGlobalEnv(call));
+      let effects = this.realm.evaluatePure(() =>
+        this.realm.evaluateForEffectsInGlobalEnv(call, undefined, "additional function")
+      );
       invariant(effects);
       let additionalFunctionEffects = this._createAdditionalEffects(effects);
       this.writeEffects.set(funcValue, additionalFunctionEffects);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -124,13 +124,6 @@ export class Serializer {
     }
 
     let additionalFunctionValuesAndEffects = this.functions.getAdditionalFunctionValuesToEffects();
-    for (let [functionValue, effectsAndTransforms] of additionalFunctionValuesAndEffects) {
-      // Need to do this fixup because otherwise we will skip over this function's
-      // generator in the _getTarget scope lookup
-      let generator = effectsAndTransforms.effects[1];
-      generator.parent = functionValue.parent;
-      functionValue.parent = generator;
-    }
 
     // Deep traversal of the heap to identify the necessary scope of residual functions
     if (timingStats !== undefined) timingStats.deepTraversalTime = Date.now();
@@ -150,7 +143,7 @@ export class Serializer {
       additionalFunctionValuesAndEffects,
       referentializer
     );
-    residualHeapVisitor.visitRoots(true);
+    residualHeapVisitor.visitRoots();
     if (this.logger.hasErrors()) return undefined;
     if (timingStats !== undefined) timingStats.deepTraversalTime = Date.now() - timingStats.deepTraversalTime;
 
@@ -209,7 +202,8 @@ export class Serializer {
         residualHeapVisitor.declarativeEnvironmentRecordsBindings,
         this.statistics,
         this.react,
-        referentializer
+        referentializer,
+        residualHeapVisitor.generatorParents
       ).serialize();
       if (this.logger.hasErrors()) return undefined;
       if (timingStats !== undefined) timingStats.referenceCountsTime = Date.now() - timingStats.referenceCountsTime;
@@ -236,7 +230,8 @@ export class Serializer {
       residualHeapVisitor.declarativeEnvironmentRecordsBindings,
       this.statistics,
       this.react,
-      referentializer
+      referentializer,
+      residualHeapVisitor.generatorParents
     );
 
     let ast = residualHeapSerializer.serialize();

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -23,6 +23,7 @@ export type TryQuery<T> = (f: () => T, defaultValue: T) => T;
 export type SerializedBodyType =
   | "MainGenerator"
   | "Generator"
+  | "AdditionalFunction"
   | "DelayInitializations"
   | "ConditionalAssignmentBranch"
   | "LazyObjectInitializer";

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -33,9 +33,7 @@ export function getSuggestedArrayLiteralLength(realm: Realm, val: ObjectValue): 
   return length;
 }
 
-interface HasParent { getParent(): void | HasParent }
-
-export function commonAncestorOf<T: HasParent>(node1: void | T, node2: void | T): void | T {
+export function commonAncestorOf<T>(node1: void | T, node2: void | T, getParent: T => void | T): void | T {
   if (node1 === node2) return node1;
   // First get the path length to the root node for both nodes while also checking if
   // either node is the parent of the other.
@@ -44,8 +42,8 @@ export function commonAncestorOf<T: HasParent>(node1: void | T, node2: void | T)
     count1 = 0,
     count2 = 0;
   while (true) {
-    let p1 = n1 && n1.getParent();
-    let p2 = n2 && n2.getParent();
+    let p1 = n1 && getParent(n1);
+    let p2 = n2 && getParent(n2);
     if (p1 === node2) return node2;
     if (p2 === node1) return node1;
     if (p1) count1++;
@@ -58,21 +56,21 @@ export function commonAncestorOf<T: HasParent>(node1: void | T, node2: void | T)
   n1 = node1;
   while (count1 > count2) {
     invariant(n1 !== undefined);
-    n1 = n1.getParent();
+    n1 = getParent(n1);
     count1--;
   }
   n2 = node2;
   while (count1 < count2) {
     invariant(n2 !== undefined);
-    n2 = n2.getParent();
+    n2 = getParent(n2);
     count2--;
   }
   // Now run up both paths in tandem, stopping at the first common entry
   while (n1 !== n2) {
     invariant(n1 !== undefined);
-    n1 = n1.getParent();
+    n1 = getParent(n1);
     invariant(n2 !== undefined);
-    n2 = n2.getParent();
+    n2 = getParent(n2);
   }
   return n1;
 }

--- a/src/values/FunctionValue.js
+++ b/src/values/FunctionValue.js
@@ -13,17 +13,14 @@ import type { ObjectKind } from "../types.js";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
 import { ObjectValue, NumberValue } from "./index.js";
-import { Generator } from "../utils/generator.js";
 import invariant from "../invariant.js";
 
 /* Abstract base class for all function objects */
 export default class FunctionValue extends ObjectValue {
   constructor(realm: Realm, intrinsicName?: string) {
     super(realm, realm.intrinsics.FunctionPrototype, intrinsicName);
-    this.parent = realm.generator;
   }
 
-  parent: void | Generator;
   $Environment: LexicalEnvironment;
   $ScriptOrModule: any;
 
@@ -51,10 +48,6 @@ export default class FunctionValue extends ObjectValue {
     let value = desc.value;
     if (!(value instanceof NumberValue)) return undefined;
     return value.value;
-  }
-
-  getParent(): void | Generator {
-    return this.parent;
   }
 
   hasDefaultLength(): boolean {


### PR DESCRIPTION
Release notes: None

What motivated me to start this refactoring (it became bigger as I kept uncovering strange things) is that the .parent properties of Generators were all getting messed up.

So, I removed the .parent properties of Generator and FunctionValue. Instead, compute this information from the Generator's dependencies.
Added TODO where we can detect if a Generator is used in more than dependency chain. (However, don't do anything about that yet, as there are a few test cases that would fail.)

Without the .parent properties for FunctionValues (and what did it mean anyway?), I reworked the logic that looks up the target body of values (getTarget).
This uncovered a few interesting things:
- There are special generators for additional functions. They are now tagged as such. Also, 1-to-1 mappings in both directions are maintained (additionalFunctionGenerators and additionalFunctionGeneratorsInverse). I hope that we can further simplify this in the future.
- The visitRoots function in the ResidualHeapVisitor used to do a strange adjustRoots operation to indirectly affect which target body values only referenced from residual functions are emitted to. This special handling is no longer needed, as getTarget now figures out the right scope from the available information.

Removed some of the more stateful aspects of the additional function serialization: currentFunctionBody and currentAdditionalFunction. Instead, there's now isReferencedOnlyByAdditionalFunction(val) which goes off a value.