### PR TITLE
Support more unary expression cases in pure scope

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -385,6 +385,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple with unary expressions 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
   "inlinedComponents": 3,
@@ -843,6 +850,13 @@ ReactStatistics {
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple with unary expressions 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
 `;
@@ -1309,6 +1323,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Simple with unary expressions 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
   "inlinedComponents": 3,
@@ -1767,6 +1788,13 @@ ReactStatistics {
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with unary expressions 1`] = `
+ReactStatistics {
+  "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
 `;

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -33,7 +33,7 @@ let prepackOptions = {
   abstractEffectsInAdditionalFunctions: true,
   simpleClosures: true,
 };
-let inputPath = path.resolve("fb-www/input.js");
+let inputPath = path.resolve("fb-www/input3.js");
 let outputPath = path.resolve("fb-www/output.js");
 
 function compileSource(source) {

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -33,7 +33,7 @@ let prepackOptions = {
   abstractEffectsInAdditionalFunctions: true,
   simpleClosures: true,
 };
-let inputPath = path.resolve("fb-www/input3.js");
+let inputPath = path.resolve("fb-www/input.js");
 let outputPath = path.resolve("fb-www/output.js");
 
 function compileSource(source) {

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -225,6 +225,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-with-abstract-props.js");
       });
 
+      it("Simple with unary expressions", async () => {
+        await runTest(directory, "simple-with-unary.js");
+      });
+
       it("Simple with multiple JSX spreads", async () => {
         await runTest(directory, "simple-with-jsx-spread.js");
       });

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -116,6 +116,7 @@ function generateRuntimeCall(ref: Reference | Value, ast: BabelNodeUnaryExpressi
   } else {
     value = Environment.GetValue(realm, ref);
     invariant(value instanceof Value);
+    Leak.leakValue(realm, value, ast.loc);
   }
 
   return AbstractValue.createTemporalFromBuildFunction(realm, Value, [value], nodes => {

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -113,10 +113,7 @@ function tryToEvaluateOperationOrLeaveAsAbstract(
   } catch (error) {
     if (error instanceof FatalError) {
       return realm.evaluateWithPossibleThrowCompletion(
-        () => {
-          invariant(expr instanceof Reference);
-          return generateRuntimeCall(expr, ast, realm);
-        },
+        () => generateRuntimeCall(expr, ast, realm),
         TypesDomain.topVal,
         ValuesDomain.topVal
       );

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -68,6 +68,10 @@ function evaluateDeleteOperation(expr: Value | Reference, realm: Realm) {
 
     // b. Let baseObj be ! ToObject(GetBase(ref)).
     let base = Environment.GetBase(realm, ref);
+    if (base instanceof AbstractValue && !(base instanceof AbstractObjectValue)) {
+      // if the base is abstract but not an abstract object, we have a type error
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    }
     // Constructing the reference checks that base is coercible to an object hence
     invariant(base instanceof ConcreteValue || base instanceof AbstractObjectValue);
     let baseObj = base instanceof ConcreteValue ? To.ToObject(realm, base) : base;

--- a/test/react/functional-components/simple-with-unary.js
+++ b/test/react/functional-components/simple-with-unary.js
@@ -1,0 +1,34 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Child({ targetNumCommentsToDisplay, pageSize, offset }) {
+  return (
+    <span>
+      {~targetNumCommentsToDisplay + +pageSize + -offset}
+    </span>
+  );
+}
+
+function App(props) {
+  return (
+    <div>
+      <Child {...props} />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  let results = [];
+  renderer.update(<Root targetNumCommentsToDisplay={1} pageSize={2} offset={3} />);
+  results.push(["simple render", renderer.toJSON()]);
+  renderer.update(<Root targetNumCommentsToDisplay={3} pageSize={2} offset={1} />);
+  results.push(["update render", renderer.toJSON()]);
+  return results;
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;

--- a/test/serializer/pure-functions/UnaryExpressions.js
+++ b/test/serializer/pure-functions/UnaryExpressions.js
@@ -1,0 +1,19 @@
+// additional functions
+// abstract effects
+
+let obj1 = global.__abstract ? __abstract('object', '({foo: {valueOf() { return 42; }}})') : {foo: {valueOf() { return 42; }}};
+let obj2 = global.__abstract ? __abstract('object', '({foo: {bar: {valueOf() { return 42; }}}})') : {foo: {bar: {valueOf() { return 42; }}}};
+
+function additional1() {
+  return '' + +obj1.foo + -obj1.foo;
+}
+
+function additional2() {
+  return ~obj2.foo.bar + 10;
+}
+
+inspect = function() {
+  let ret1 = additional1();
+  let ret2 = additional2();
+  return JSON.stringify({ ret1, ret2 });
+}


### PR DESCRIPTION
Release notes: none

Support was added for delete unary expression cases a few days ago. This PR ensures all the other unary expression cases are also handled now too. The abstract temporal logic has been extended to support cases where the BaseValue of a reference was a EnvironmentRecord (when you destructure an object, this occurs).