### PR TITLE
[WIP] Get correct JSX children when props are partial

### DIFF
--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -127,7 +127,23 @@ export class ResidualReactElementSerializer {
       }
       // handle children
       if (propsValue.properties.has("children")) {
-        let childrenValue = Get(this.realm, propsValue, "children");
+        let childrenValue;
+        // if the props are partial, we need to not use the normal Get
+        // as this will lead to returing a new abstract if the original
+        // children property is also abstract
+        if (propsValue.isPartialObject()) {
+          let childrenBinding = propsValue.properties.get("children");
+
+          if (childrenBinding && childrenBinding.descriptor) {
+            let descriptor = childrenBinding.descriptor;
+
+            childrenValue = descriptor.value;
+          }
+          invariant(childrenValue instanceof Value);
+        } else {
+          childrenValue = Get(this.realm, propsValue, "children");
+        }
+
         this.residualHeapSerializer.serializedValues.add(childrenValue);
 
         if (childrenValue !== this.realm.intrinsics.undefined && childrenValue !== this.realm.intrinsics.null) {


### PR DESCRIPTION
Release notes: none

Whilst processing the UFI, I noticed a lot of invariants on the code path from JSX elements having abstract children when the props were partial. I looked deeper into it and it turns out that the `Get` was returning a **new** `children` value from props, rather than the existing one there.

[Where `O` was the `props` object and `value` was the abstract children](https://github.com/facebook/prepack/blob/master/src/methods/properties.js#L1242).

This meant that we create a new abstract value that never gets declared. What we really want, is to use the existing `children` value. By doing so, we no longer get any errors on the UFI (with the other fixes in place) for one of the core paths.

I'm not 100% sure about this strategy yet, I'll keep digging to see if there's a better way.