### PR TITLE
Fixes a range of issues with ReactElement serialization

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -34,6 +34,7 @@ import {
   valueIsKnownReactAbstraction,
   getReactSymbol,
   flattenChildren,
+  getProperty,
 } from "./utils";
 import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
@@ -404,7 +405,7 @@ export class Reconciler {
       const resolveChildren = () => {
         // terminal host component. Start evaluating its children.
         if (propsValue instanceof ObjectValue && propsValue.properties.has("children")) {
-          let childrenValue = Get(this.realm, propsValue, "children");
+          let childrenValue = getProperty(this.realm, propsValue, "children");
 
           if (childrenValue instanceof Value) {
             let resolvedChildren = this._resolveDeeply(childrenValue, context, branchStatus, branchState);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -374,3 +374,24 @@ export function flattenChildren(realm: Realm, array: ArrayValue): ArrayValue {
   recursivelyFlattenArray(realm, array, flattenedChildren);
   return flattenedChildren;
 }
+
+export function getProperty(realm: Realm, object: ObjectValue, property: string | SymbolValue): Value {
+  let binding;
+  if (typeof property === "string") {
+    binding = object.properties.get(property);
+  } else {
+    binding = object.symbols.get(property);
+  }
+  invariant(binding);
+  let descriptor = binding.descriptor;
+
+  if (!descriptor) {
+    return realm.intrinsics.undefined;
+  }
+  let value;
+  if (descriptor.value) {
+    value = descriptor.value;
+  }
+  invariant(value instanceof Value, `ReactElementSet could not get value for`, object, property);
+  return value;
+}


### PR DESCRIPTION
Release notes: none

There are range of things this PR fixes, but ultimately it allows for the UFI to be serialized without any invariants being fired (apart from known issue ones covered in other PRs).

This PR fixes issues around ReactElement objects:

- Rather than use `Get` to access properties on the ReactElement during serialization and visiting, we instead access the binding and the descriptor directly to get the value like all other code paths do in the serialization process (and how ReactElement serialization used to work). This was causing many invariants to get triggered and was almost impossible to debug. Switching back to accessing the value removed all these issues.
- ReactElement serialization never waited for dependencies, it does now.

I couldn't recreate the issues in standalone tests, they were only apparent when using the UFI. :(