### PR TITLE
Handle Completions differently in _generateWriteEffectsForReactComponentTree

### DIFF
--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -143,6 +143,11 @@ export class Functions {
       // in the reconciler
       return;
     }
+    if (value instanceof Completion) {
+      // TODO we don't support this yet, but will do very soon
+      // to unblock work, we'll just return at this point right now
+      return;
+    }
     invariant(value instanceof Value);
     if (simpleClassComponents.has(value)) {
       // if the root component was a class and is now simple, we can convert it from a class


### PR DESCRIPTION
Release notes: none

When we encounter a Completion during _generateWriteEffectsForReactComponentTree, we should return for now, instead of causing an invariant. This is a temporary thing until https://github.com/facebook/prepack/pull/1455 lands and is purely meant to unblock work by not having the invariant block UFI work.