### PR TITLE
Add a precondition to AbstractValue.createFromUnaryOp

### DIFF
--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -386,12 +386,7 @@ export default class ValuesDomain {
       invariant(typeString !== undefined);
       return new StringValue(realm, typeString);
     } else {
-      invariant(op === "delete");
-      // ECMA262 12.5.3.2
-      // 1. Let ref be the result of evaluating UnaryExpression.
-      // 2. ReturnIfAbrupt(ref).
-      // 3. If Type(ref) is not Reference, return true.
-      return realm.intrinsics.true;
+      invariant(false, `${op} is a state update, not a pure operation, so we don't support it`);
     }
   }
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -552,6 +552,7 @@ export default class AbstractValue extends Value {
     prefix?: boolean,
     loc?: ?BabelNodeSourceLocation
   ): Value {
+    invariant(op !== "delete" && op !== "++" && op !== "--"); // The operation must be pure
     let resultTypes = TypesDomain.unaryOp(op, new TypesDomain(operand.getType()));
     let resultValues = ValuesDomain.unaryOp(realm, op, operand.values);
     let result = new AbstractValue(realm, resultTypes, resultValues, hashUnary(op, operand), [operand], ([x]) =>


### PR DESCRIPTION
Release note: none

AbstractValue.createFromXXX functions create atemporal abstract values that should evaluate at runtime without observable side effects. 

The type declaration for BabelUnaryOperator allows "delete", "++" and "--" which do not meet these conditions. Adding a precondition that excludes these operators clarifies things and enforces the desired behavior.

Likewise for ValuesDomain.computeUnary.