### PR TITLE
Allowing specifying abstract function result type

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -16,7 +16,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { EnvironmentRecord } from "../environment.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { Value } from "../values/index.js";
-import { AbstractValue, BooleanValue, ConcreteValue, FunctionValue } from "../values/index.js";
+import { AbstractValue, AbstractObjectValue, BooleanValue, ConcreteValue, FunctionValue } from "../values/index.js";
 import { Reference } from "../environment.js";
 import { Environment, Functions, Join, Leak } from "../singletons.js";
 import {
@@ -116,7 +116,8 @@ function generateRuntimeCall(
       Leak.leakValue(realm, arg, ast.loc);
     }
   }
-  return AbstractValue.createTemporalFromBuildFunction(realm, Value, args, nodes => {
+  let resultType = (func instanceof AbstractObjectValue ? func.functionResultType : undefined) || Value;
+  return AbstractValue.createTemporalFromBuildFunction(realm, resultType, args, nodes => {
     let callFunc;
     let argStart = 1;
     if (thisArg instanceof Value) {

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -52,13 +52,14 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 5. Repeat, while items is not empty
     while (items.length) {
       // a. Remove the first element from items and let E be the value of the element.
-      let E = items.shift().throwIfNotConcrete();
+      let E = items.shift();
 
       // b. Let spreadable be ? IsConcatSpreadable(E).
       let spreadable = IsConcatSpreadable(realm, E);
 
       // c. If spreadable is true, then
       if (spreadable) {
+        E = E.throwIfNotConcrete();
         invariant(E instanceof ObjectValue);
         // i. Let k be 0.
         let k = 0;

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -59,8 +59,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
       // c. If spreadable is true, then
       if (spreadable) {
-        E = E.throwIfNotConcrete();
-        invariant(E instanceof ObjectValue);
+        E = E.throwIfNotConcreteObject();
+
         // i. Let k be 0.
         let k = 0;
 

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -58,7 +58,11 @@ export default function(realm: Realm): void {
   // Helper function to model values that are obtained from the environment,
   // and whose concrete values are not known at Prepack-time.
   // __abstract(typeNameOrTemplate, name, options) creates a new abstract value
-  // where typeNameOrTemplate either either 'string', 'boolean', 'number', 'object', or an actual object defining known properties.
+  // where typeNameOrTemplate can be...
+  // - 'string', 'boolean', 'number', 'object', 'function' or
+  // - ':string', ':boolean', ':number', ':object', ':function' to indicate that
+  //   the abstract value represents a function that only returns values of the specified type, or
+  // - an actual object defining known properties.
   // If the abstract value gets somehow embedded in the final heap,
   // it will be referred to by the supplied name in the generated code.
   global.$DefineOwnProperty("__abstract", {

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -27,6 +27,7 @@ import AbstractObjectValue from "../../values/AbstractObjectValue";
 import { CompilerDiagnostic, FatalError } from "../../errors.js";
 import { Utils } from "../../singletons";
 import type { BabelNodeSourceLocation } from "babel-types";
+import invariant from "../../invariant.js";
 
 const throwTemplateSrc = "(function(){throw new global.Error('abstract value defined at ' + A);})()";
 const throwTemplate = buildExpressionTemplate(throwTemplateSrc);
@@ -127,7 +128,10 @@ export function createAbstract(
     template.makePartial();
     if (name) realm.rebuildNestedProperties(result, name);
   }
-  if (functionResultType) result.functionResultType = functionResultType;
+  if (functionResultType) {
+    invariant(result instanceof AbstractObjectValue);
+    result.functionResultType = functionResultType;
+  }
 
   if (additionalValues.length > 0)
     result = AbstractValue.createAbstractConcreteUnion(realm, result, ...additionalValues);

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -34,7 +34,7 @@ const throwTemplate = buildExpressionTemplate(throwTemplateSrc);
 export function parseTypeNameOrTemplate(
   realm: Realm,
   typeNameOrTemplate: void | Value | string
-): { type: typeof Value, template: void | ObjectValue } {
+): { type: typeof Value, template: void | ObjectValue, functionResultType?: typeof Value } {
   if (typeNameOrTemplate === undefined || typeNameOrTemplate instanceof UndefinedValue) {
     return { type: Value, template: undefined };
   } else if (typeof typeNameOrTemplate === "string") {
@@ -45,11 +45,15 @@ export function parseTypeNameOrTemplate(
     return { type, template: undefined };
   } else if (typeNameOrTemplate instanceof StringValue) {
     let typeNameString = To.ToStringPartial(realm, typeNameOrTemplate);
+    let hasFunctionResultType = typeNameString.startsWith(":");
+    if (hasFunctionResultType) typeNameString = typeNameString.substring(1);
     let type = Utils.getTypeFromName(typeNameString);
     if (type === undefined) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown typeNameOrTemplate");
     }
-    return { type, template: undefined };
+    return hasFunctionResultType
+      ? { type: FunctionValue, template: undefined, functionResultType: type }
+      : { type, template: undefined };
   } else if (typeNameOrTemplate instanceof FunctionValue) {
     return { type: FunctionValue, template: typeNameOrTemplate };
   } else if (typeNameOrTemplate instanceof ObjectValue) {
@@ -84,7 +88,7 @@ export function createAbstract(
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
   }
 
-  let { type, template } = parseTypeNameOrTemplate(realm, typeNameOrTemplate);
+  let { type, template, functionResultType } = parseTypeNameOrTemplate(realm, typeNameOrTemplate);
 
   let result;
   let locString,
@@ -123,6 +127,7 @@ export function createAbstract(
     template.makePartial();
     if (name) realm.rebuildNestedProperties(result, name);
   }
+  if (functionResultType) result.functionResultType = functionResultType;
 
   if (additionalValues.length > 0)
     result = AbstractValue.createAbstractConcreteUnion(realm, result, ...additionalValues);

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -477,10 +477,10 @@ export function EvaluateDirectCallWithArgList(
   argList: Array<Value>,
   tailPosition?: boolean
 ): Value {
-  if (func instanceof AbstractValue && Value.isTypeCompatibleWith(func.getType(), FunctionValue)) {
+  if (func instanceof AbstractObjectValue && Value.isTypeCompatibleWith(func.getType(), FunctionValue)) {
     return AbstractValue.createTemporalFromBuildFunction(
       realm,
-      Value,
+      func.functionResultType || Value,
       [func].concat(argList),
       (nodes: Array<BabelNodeExpression>) => {
         let fun_args = nodes.slice(1);

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -38,6 +38,7 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   cachedIsSimpleObject: void | boolean;
+  functionResultType: void | typeof Value;
 
   getTemplate(): ObjectValue {
     for (let element of this.values.getElements()) {

--- a/test/serializer/abstract/AbstractFunctionWithResultType.js
+++ b/test/serializer/abstract/AbstractFunctionWithResultType.js
@@ -1,0 +1,6 @@
+// add at runtime:function __nextComponentID() { return 42; }
+(function() {
+    let f = global.__abstract ? __abstract(":number", "__nextComponentID") : __nextComponentID;
+    let t = typeof f();
+    inspect = function() { return t; }
+})();

--- a/test/serializer/abstract/ArrayConcat.js
+++ b/test/serializer/abstract/ArrayConcat.js
@@ -1,0 +1,8 @@
+// add at runtime:function __nextComponentID() { return 42; }
+(function() {
+    let f = global.__abstract ? __abstract(":number", "__nextComponentID") : __nextComponentID;
+    let n = f();
+    let a = [].concat([n]);;
+    
+    inspect = function() { return a[0]; }
+})();


### PR DESCRIPTION
Release notes: None

In calls to __abstract, the first argument represents a type name or a template object.
Adding a new kind of type name: A colon followed by a simple type name.
This indicates that the abstract value is a function with the given known result type.

Also tweaked handling of Array concat so that it doesn't require knowing the exact elements
being concatenated (this is what motivated the abstract function result type change for me...)