### PR TITLE
Small tidy up of ReactElement logic

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -133,6 +133,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Delete element prop key 1`] = `
+ReactStatistics {
+  "inlinedComponents": 3,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
@@ -598,6 +605,13 @@ ReactStatistics {
 exports[`Test React with JSX input, create-element output Functional component folding Conditional 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Delete element prop key 1`] = `
+ReactStatistics {
+  "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
 `;
@@ -1071,6 +1085,13 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Delete element prop key 1`] = `
+ReactStatistics {
+  "inlinedComponents": 3,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
@@ -1536,6 +1557,13 @@ ReactStatistics {
 exports[`Test React with create-element input, create-element output Functional component folding Conditional 1`] = `
 ReactStatistics {
   "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Delete element prop key 1`] = `
+ReactStatistics {
+  "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
 `;

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -297,6 +297,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "key-change.js");
       });
 
+      it("Delete element prop key", async () => {
+        await runTest(directory, "delete-element-prop-key.js");
+      });
+
       it("Key change with fragments", async () => {
         await runTest(directory, "key-change-fragments.js");
       });

--- a/src/realm.js
+++ b/src/realm.js
@@ -188,6 +188,7 @@ export class Realm {
       output: opts.reactOutput || "create-element",
       hoistableFunctions: new WeakMap(),
       hoistableReactElements: new WeakMap(),
+      reactElements: new Set(),
       symbols: new Map(),
     };
 
@@ -255,6 +256,7 @@ export class Realm {
     hoistableFunctions: WeakMap<FunctionValue, boolean>,
     hoistableReactElements: WeakMap<ObjectValue, boolean>,
     output?: ReactOutputTypes,
+    reactElements: Set<ObjectValue>,
     symbols: Map<ReactSymbolTypes, SymbolValue>,
   };
   stripFlow: boolean;

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -131,9 +131,8 @@ export class ResidualHeapInspector {
         return true;
       }
     } else if (isReactElement(val)) {
-      // we don't want to the $$typeof or _owner/_store properties
-      // as this is contained within the JSXElement, otherwise
-      // they we be need to be emitted during serialization
+      // we don't want to visit/serialize $$typeof, _owner and _store properties
+      // as these are all internals of JSX/createElement
       if (key === "$$typeof" || key === "_owner" || key === "_store") {
         return true;
       }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -174,7 +174,7 @@ export class ResidualHeapVisitor {
     let { skipPrototype, constructor } = getObjectPrototypeMetadata(this.realm, obj);
 
     // visit properties
-    if (kind !== "ReactElement") {
+    if (!isReactElement(obj)) {
       for (let [symbol, propertyBinding] of obj.symbols) {
         invariant(propertyBinding);
         let desc = propertyBinding.descriptor;
@@ -186,15 +186,6 @@ export class ResidualHeapVisitor {
 
     // visit properties
     for (let [propertyBindingKey, propertyBindingValue] of obj.properties) {
-      // we don't want to the $$typeof or _owner/_store properties
-      // as this is contained within the JSXElement, otherwise
-      // they we be need to be emitted during serialization
-      if (
-        kind === "ReactElement" &&
-        (propertyBindingKey === "$$typeof" || propertyBindingKey === "_owner" || propertyBindingKey === "_store")
-      ) {
-        continue;
-      }
       // we don't want to visit these as we handle the serialization ourselves
       // via a different logic route for classes
       let descriptor = propertyBindingValue.descriptor;
@@ -221,7 +212,7 @@ export class ResidualHeapVisitor {
     }
 
     // prototype
-    if (kind !== "ReactElement" && !skipPrototype) {
+    if (!isReactElement(obj) && !skipPrototype) {
       // we don't want to the ReactElement prototype visited
       // as this is contained within the JSXElement, otherwise
       // they we be need to be emitted during serialization

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -53,30 +53,24 @@ export class ResidualReactElementSerializer {
     let propsValue = getProperty(this.realm, val, "props");
     let waitForProperties = [val, typeValue, keyValue, refValue, propsValue];
 
-    invariant(typeValue !== null, "ReactElement type of null");
-
     let attributes = [];
     let children = [];
 
-    if (keyValue !== null) {
+    if (keyValue !== this.realm.intrinsics.null) {
       let keyExpr = this.residualHeapSerializer.serializeValue(keyValue);
-      if (keyExpr.type !== "NullLiteral") {
-        if (this.reactOutput === "jsx") {
-          this._addSerializedValueToJSXAttriutes("key", keyExpr, attributes);
-        } else if (this.reactOutput === "create-element") {
-          this._addSerializedValueToObjectProperty("key", keyExpr, attributes);
-        }
+      if (this.reactOutput === "jsx") {
+        this._addSerializedValueToJSXAttriutes("key", keyExpr, attributes);
+      } else if (this.reactOutput === "create-element") {
+        this._addSerializedValueToObjectProperty("key", keyExpr, attributes);
       }
     }
 
-    if (refValue !== null) {
+    if (refValue !== this.realm.intrinsics.null) {
       let refExpr = this.residualHeapSerializer.serializeValue(refValue);
-      if (refExpr.type !== "NullLiteral") {
-        if (this.reactOutput === "jsx") {
-          this._addSerializedValueToJSXAttriutes("ref", refExpr, attributes);
-        } else if (this.reactOutput === "create-element") {
-          this._addSerializedValueToObjectProperty("ref", refExpr, attributes);
-        }
+      if (this.reactOutput === "jsx") {
+        this._addSerializedValueToJSXAttriutes("ref", refExpr, attributes);
+      } else if (this.reactOutput === "create-element") {
+        this._addSerializedValueToObjectProperty("ref", refExpr, attributes);
       }
     }
 

--- a/test/react/functional-components/delete-element-prop-key.js
+++ b/test/react/functional-components/delete-element-prop-key.js
@@ -1,0 +1,40 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>Hello {props.x.b}</div>;
+}
+
+function B() {
+  return <div>World</div>;
+}
+
+function C() {
+  return "!";
+}
+
+function App() {
+  var x = { a: 1, b: "World" };
+
+  delete x.a;
+
+  return (
+    <div>
+      <A x={x} />
+      <B />
+      <C />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render with delete on props key', renderer.toJSON()]];
+};
+
+if (this.__registerReactComponentRoot) {
+  __registerReactComponentRoot(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This PR cleans up the logic in how ReactElement properties are visited, moving them to the right place in the codebase. `react/utils/getProperty` also now properly deals with missing properties and throws an introspection error for getters/setters.