### PR TITLE
Fix additional functions refactor

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -780,10 +780,12 @@ export class ResidualHeapVisitor {
     } else if (val instanceof FunctionValue) {
       // Function declarations should get hoisted in common scope so that instances only get allocated once
       let parentScope = this.scope;
-      this._withScope(this.commonScope, () => {
-        invariant(val instanceof FunctionValue);
-        if (this.preProcessValue(val)) this.visitValueFunction(val, parentScope);
-      });
+      // Every function references itself through arguments, prevent the recursive double-visit
+      if (this.scope !== val && this.commonScope !== val)
+        this._withScope(this.commonScope, () => {
+          invariant(val instanceof FunctionValue);
+          if (this.preProcessValue(val)) this.visitValueFunction(val, parentScope);
+        });
     } else if (val instanceof SymbolValue) {
       if (this.preProcessValue(val)) this.visitValueSymbol(val);
     } else {

--- a/test/serializer/additional-functions/self_referential.js
+++ b/test/serializer/additional-functions/self_referential.js
@@ -1,0 +1,15 @@
+// does not contain:x = 5;
+
+function func1() {
+  let x = 5;
+  let z = [ func1 ];
+  return z;
+}
+
+if (global.__registerAdditionalFunctionToPrepack) {
+  __registerAdditionalFunctionToPrepack(func1);
+}
+
+inspect = function() {
+  return func1()[0] === func1()[0];
+}


### PR DESCRIPTION
Fix for bug @NTillmann encountered with the additional functions refactor.

Every function references itself through its `arguments`, so additional functions were recursively trying to visit themselves while visiting their arguments. It doesn't make sense to visit a function from its own scope, so we add a check to the visitor preventing this.