### PR TITLE
Add evaluated tree graph to React reconciler stats

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2,6 +2,13 @@
 
 exports[`Test React with JSX input, JSX output Class component folding Classes with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -9,6 +16,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Class component folding Inheritance chaining 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -16,6 +36,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Class component folding Simple classes #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -23,6 +50,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Class component folding Simple classes #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -30,6 +70,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Class component folding Simple classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -37,6 +90,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "FactoryComponent",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -44,6 +104,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Factory class component folding Simple factory classes 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -51,6 +129,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -58,6 +143,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Circular reference 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -65,6 +157,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Class component as root 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -72,6 +183,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Class component as root with instance variables #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -79,6 +209,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Class component as root with instance variables 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -86,6 +235,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Class component as root with multiple render methods 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -93,6 +261,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Class component as root with props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -100,6 +287,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Class component as root with refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -107,6 +313,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Class component as root with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -114,6 +339,36 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Component type change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -121,6 +376,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Component type same 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -128,6 +401,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Conditional 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "MaybeShow",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -135,6 +421,29 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Delete element prop key 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -142,6 +451,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "SubChild",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Child",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -149,6 +471,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Dynamic props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -156,6 +496,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Event handlers 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -163,6 +510,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Key change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -170,6 +535,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Key change with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -177,6 +560,36 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Key nesting 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -184,6 +597,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Key nesting 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -191,6 +622,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Key nesting 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -198,6 +647,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Key not changing with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -205,6 +672,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding React.cloneElement 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "MaybeShow",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Override",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -212,6 +698,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Render array twice 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -219,6 +718,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Render nested array children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -226,6 +738,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Return text 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -233,13 +763,49 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Return undefined 1`] = `
 ReactStatistics {
-  "inlinedComponents": 0,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -247,6 +813,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -254,6 +833,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -261,6 +853,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -268,6 +873,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 3,
 }
@@ -275,6 +898,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -282,6 +912,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -289,6 +926,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -296,6 +952,29 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -303,6 +982,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -310,6 +1002,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with Object.assign #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -317,6 +1022,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with Object.assign #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -324,6 +1036,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with Object.assign #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -331,6 +1050,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with Object.assign #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -338,6 +1064,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with Object.assign 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -345,6 +1084,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with abstract props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -352,6 +1110,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -359,6 +1136,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -366,6 +1156,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -373,6 +1170,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -380,6 +1184,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -387,6 +1198,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -394,6 +1224,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple with unary expressions 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -401,6 +1244,30 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "HeaderBar",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "StoryList",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Unknown",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -408,13 +1275,33 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 1`] = `
 ReactStatistics {
-  "inlinedComponents": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "RENDER_PROPS",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Hello",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -422,6 +1309,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -429,6 +1317,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -436,6 +1325,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -443,6 +1333,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -450,6 +1341,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -457,6 +1355,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 8 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "WrappedApp",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -464,6 +1375,46 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 9 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }
@@ -471,6 +1422,47 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Foo",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }
@@ -478,6 +1470,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Class component folding Classes with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -485,6 +1484,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Class component folding Inheritance chaining 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -492,6 +1504,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Class component folding Simple classes #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -499,6 +1518,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Class component folding Simple classes #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -506,6 +1538,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Class component folding Simple classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -513,6 +1558,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "FactoryComponent",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -520,6 +1572,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Factory class component folding Simple factory classes 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -527,6 +1597,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -534,6 +1611,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Circular reference 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -541,6 +1625,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Class component as root 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -548,6 +1651,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Class component as root with instance variables #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -555,6 +1677,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Class component as root with instance variables 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -562,6 +1703,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Class component as root with multiple render methods 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -569,6 +1729,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Class component as root with props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -576,6 +1755,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Class component as root with refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -583,6 +1781,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Class component as root with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -590,6 +1807,36 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Component type change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -597,6 +1844,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Component type same 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -604,6 +1869,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Conditional 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "MaybeShow",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -611,6 +1889,29 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Delete element prop key 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -618,6 +1919,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "SubChild",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Child",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -625,6 +1939,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Dynamic props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -632,6 +1964,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Event handlers 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -639,6 +1978,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Key change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -646,6 +2003,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Key change with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -653,6 +2028,36 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Key nesting 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -660,6 +2065,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Key nesting 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -667,6 +2090,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Key nesting 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -674,6 +2115,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Key not changing with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -681,6 +2140,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding React.cloneElement 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "MaybeShow",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Override",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -688,6 +2166,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Render array twice 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -695,6 +2186,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Render nested array children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -702,6 +2206,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Return text 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -709,13 +2231,49 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Return undefined 1`] = `
 ReactStatistics {
-  "inlinedComponents": 0,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -723,6 +2281,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -730,6 +2301,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -737,6 +2321,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -744,6 +2341,24 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 3,
 }
@@ -751,6 +2366,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -758,6 +2380,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -765,6 +2394,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -772,6 +2420,29 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -779,6 +2450,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -786,6 +2470,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with Object.assign #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -793,6 +2490,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with Object.assign #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -800,6 +2504,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with Object.assign #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -807,6 +2518,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with Object.assign #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -814,6 +2532,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with Object.assign 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -821,6 +2552,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with abstract props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -828,6 +2578,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -835,6 +2604,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -842,6 +2624,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -849,6 +2638,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -856,6 +2652,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -863,6 +2666,25 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -870,6 +2692,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple with unary expressions 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -877,6 +2712,30 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "HeaderBar",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "StoryList",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Unknown",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -884,13 +2743,33 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 1`] = `
 ReactStatistics {
-  "inlinedComponents": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "RENDER_PROPS",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Hello",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -898,6 +2777,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -905,6 +2785,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -912,6 +2793,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -919,6 +2801,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -926,6 +2809,13 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -933,6 +2823,19 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 8 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "WrappedApp",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -940,6 +2843,46 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 9 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }
@@ -947,6 +2890,47 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Foo",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }
@@ -954,6 +2938,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Class component folding Classes with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -961,6 +2952,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Class component folding Inheritance chaining 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -968,6 +2972,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Class component folding Simple classes #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -975,6 +2986,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Class component folding Simple classes #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -982,6 +3006,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Class component folding Simple classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -989,6 +3026,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "FactoryComponent",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -996,6 +3040,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Factory class component folding Simple factory classes 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1003,6 +3065,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1010,6 +3079,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Circular reference 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1017,6 +3093,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Class component as root 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1024,6 +3119,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Class component as root with instance variables #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1031,6 +3145,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Class component as root with instance variables 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1038,6 +3171,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Class component as root with multiple render methods 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1045,6 +3197,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Class component as root with props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1052,6 +3223,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Class component as root with refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1059,6 +3249,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Class component as root with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1066,6 +3275,36 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Component type change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -1073,6 +3312,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Component type same 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1080,6 +3337,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Conditional 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "MaybeShow",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1087,6 +3357,29 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Delete element prop key 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1094,6 +3387,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "SubChild",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Child",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1101,6 +3407,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Dynamic props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1108,6 +3432,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Event handlers 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1115,6 +3446,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Key change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1122,6 +3471,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Key change with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1129,6 +3496,36 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Key nesting 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -1136,6 +3533,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Key nesting 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1143,6 +3558,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Key nesting 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1150,6 +3583,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Key not changing with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1157,6 +3608,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding React.cloneElement 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "MaybeShow",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Override",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1164,6 +3634,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Render array twice 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1171,6 +3654,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Render nested array children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1178,6 +3674,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Return text 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1185,13 +3699,49 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Return undefined 1`] = `
 ReactStatistics {
-  "inlinedComponents": 0,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1199,6 +3749,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1206,6 +3769,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1213,6 +3789,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1220,6 +3809,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 3,
 }
@@ -1227,6 +3834,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1234,6 +3848,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1241,6 +3862,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1248,6 +3888,29 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1255,6 +3918,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1262,6 +3938,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with Object.assign #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1269,6 +3958,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with Object.assign #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1276,6 +3972,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with Object.assign #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1283,6 +3986,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with Object.assign #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1290,6 +4000,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with Object.assign 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1297,6 +4020,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with abstract props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1304,6 +4046,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1311,6 +4060,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1318,6 +4074,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1325,6 +4088,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1332,6 +4102,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1339,6 +4116,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1346,6 +4130,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple with unary expressions 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1353,6 +4150,30 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "HeaderBar",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "StoryList",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Unknown",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1360,13 +4181,33 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 1`] = `
 ReactStatistics {
-  "inlinedComponents": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "RENDER_PROPS",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Hello",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1374,6 +4215,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1381,6 +4223,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1388,6 +4231,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1395,6 +4239,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1402,6 +4247,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1409,6 +4261,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 8 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "WrappedApp",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1416,6 +4281,46 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 9 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }
@@ -1423,6 +4328,47 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Foo",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }
@@ -1430,6 +4376,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Class component folding Classes with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1437,6 +4390,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Class component folding Inheritance chaining 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1444,6 +4410,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Class component folding Simple classes #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1451,6 +4424,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Class component folding Simple classes #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1458,6 +4444,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Class component folding Simple classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1465,6 +4464,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "FactoryComponent",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1472,6 +4478,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Factory class component folding Simple factory classes 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "FactoryComponent",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1479,6 +4503,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1486,6 +4517,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Circular reference 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1493,6 +4531,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Class component as root 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1500,6 +4557,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Class component as root with instance variables #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1507,6 +4583,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Class component as root with instance variables 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1514,6 +4609,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Class component as root with multiple render methods 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1521,6 +4635,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Class component as root with props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1528,6 +4661,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Class component as root with refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1535,6 +4687,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Class component as root with state 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1542,6 +4713,36 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Component type change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -1549,6 +4750,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Component type same 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Foo",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1556,6 +4775,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Conditional 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "MaybeShow",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1563,6 +4795,29 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Delete element prop key 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1570,6 +4825,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "SubChild",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Child",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1577,6 +4845,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Dynamic props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1584,6 +4870,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Event handlers 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1591,6 +4884,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Key change 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1598,6 +4909,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Key change with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1605,6 +4934,36 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Key nesting 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "MessagePane",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Stateful",
+              "status": "NEW_TREE",
+            },
+          ],
+          "name": "SettingsPane",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 2,
 }
@@ -1612,6 +4971,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Key nesting 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1619,6 +4996,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Key nesting 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1626,6 +5021,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Key not changing with fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1633,6 +5046,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding React.cloneElement 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "MaybeShow",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Override",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1640,6 +5072,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Render array twice 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1647,6 +5092,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Render nested array children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1654,6 +5112,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Return text 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1661,13 +5137,49 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Return undefined 1`] = `
 ReactStatistics {
-  "inlinedComponents": 0,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1675,6 +5187,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1682,6 +5207,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1689,6 +5227,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1696,6 +5247,24 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [],
+      "name": "Unknown",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 3,
 }
@@ -1703,6 +5272,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1710,6 +5286,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1717,6 +5300,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple children 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1724,6 +5326,29 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple fragments 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1731,6 +5356,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple refs 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1738,6 +5376,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with Object.assign #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1745,6 +5396,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with Object.assign #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1752,6 +5410,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with Object.assign #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1759,6 +5424,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with Object.assign #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1766,6 +5438,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with Object.assign 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1773,6 +5458,25 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with abstract props 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "IWantThisToBeInlined",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 2,
   "optimizedTrees": 1,
 }
@@ -1780,6 +5484,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1787,6 +5498,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1794,6 +5512,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1801,6 +5526,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1808,6 +5540,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1815,6 +5554,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1822,6 +5568,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with unary expressions 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 1,
   "optimizedTrees": 1,
 }
@@ -1829,6 +5588,30 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "HeaderBar",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "StoryList",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Unknown",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 3,
   "optimizedTrees": 1,
 }
@@ -1836,13 +5619,33 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 1`] = `
 ReactStatistics {
-  "inlinedComponents": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Unknown",
+          "status": "RENDER_PROPS",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 2 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "Hello",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1850,6 +5653,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 3 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1857,6 +5661,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 4 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1864,6 +5669,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 5 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1871,6 +5677,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 6 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [],
   "inlinedComponents": 0,
   "optimizedTrees": 0,
 }
@@ -1878,6 +5685,13 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 7 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
@@ -1885,6 +5699,19 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 8 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "WrappedApp",
+          "status": "NEW_TREE",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
 }
@@ -1892,6 +5719,46 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 9 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }
@@ -1899,6 +5766,47 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Yar",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "name": "Foo",
+      "status": "ROOT",
+    },
+  ],
   "inlinedComponents": 6,
   "optimizedTrees": 1,
 }

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -52,11 +52,25 @@ async function compileFile() {
   return stats;
 }
 
+function printReactEvaluationGraph(evaluatedRootNode, depth) {
+  if (Array.isArray(evaluatedRootNode)) {
+    for (let child of evaluatedRootNode) {
+      printReactEvaluationGraph(child, depth);
+    }
+  } else {
+    let line = `- ${evaluatedRootNode.name} (${evaluatedRootNode.status.toLowerCase()})`;
+    console.log(line.padStart(line.length + depth));
+    printReactEvaluationGraph(evaluatedRootNode.children, depth + 2);
+  }
+}
+
 compileFile()
   .then(result => {
     console.log("\nCompilation complete!");
     console.log(`Optimized Trees: ${result.optimizedTrees}`);
-    console.log(`Inlined Components: ${result.inlinedComponents}`);
+    console.log(`Inlined Components: ${result.inlinedComponents}\n`);
+    console.log(`Evaluated Tree:`);
+    printReactEvaluationGraph(result.evaluatedRootNodes, 0);
   })
   .catch(e => {
     console.error(e.natickStack || e.stack);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -25,7 +25,7 @@ import {
 import type { Descriptor, ReactHint } from "../types";
 import { Get } from "../methods/index.js";
 import { computeBinary } from "../evaluators/BinaryExpression.js";
-import { type ReactSerializerState, type AdditionalFunctionEffects } from "../serializer/types.js";
+import type { ReactSerializerState, AdditionalFunctionEffects, ReactEvaluatedNode } from "../serializer/types.js";
 import invariant from "../invariant.js";
 import { Create, Properties } from "../singletons.js";
 import traverse from "babel-traverse";
@@ -413,4 +413,25 @@ export function getProperty(realm: Realm, object: ObjectValue, property: string 
   }
   invariant(value instanceof Value, `react/utils/getProperty should not be called on internal properties`);
   return value;
+}
+
+export function createReactEvaluatedNode(
+  status: "ROOT" | "NEW_TREE" | "INLINED" | "BAIL-OUT" | "RENDER_PROPS",
+  name: string
+): ReactEvaluatedNode {
+  return {
+    name,
+    status,
+    children: [],
+  };
+}
+
+export function getComponentName(
+  realm: Realm,
+  componentType: ECMAScriptSourceFunctionValue | AbstractObjectValue
+): string {
+  if (componentType.__originalName) {
+    return componentType.__originalName;
+  }
+  return "Unknown";
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -188,7 +188,7 @@ export class Realm {
       output: opts.reactOutput || "create-element",
       hoistableFunctions: new WeakMap(),
       hoistableReactElements: new WeakMap(),
-      reactElements: new Set(),
+      reactElements: new WeakSet(),
       symbols: new Map(),
     };
 
@@ -256,7 +256,7 @@ export class Realm {
     hoistableFunctions: WeakMap<FunctionValue, boolean>,
     hoistableReactElements: WeakMap<ObjectValue, boolean>,
     output?: ReactOutputTypes,
-    reactElements: Set<ObjectValue>,
+    reactElements: WeakSet<ObjectValue>,
     symbols: Map<ReactSymbolTypes, SymbolValue>,
   };
   stripFlow: boolean;

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -150,13 +150,21 @@ export class TimingStatistics {
   serializePassTime: number;
 }
 
+export type ReactEvaluatedNode = {
+  name: string,
+  status: "ROOT" | "NEW_TREE" | "INLINED" | "BAIL-OUT" | "RENDER_PROPS",
+  children: Array<ReactEvaluatedNode>,
+};
+
 export class ReactStatistics {
   constructor() {
     this.optimizedTrees = 0;
     this.inlinedComponents = 0;
+    this.evaluatedRootNodes = [];
   }
   optimizedTrees: number;
   inlinedComponents: number;
+  evaluatedRootNodes: Array<ReactEvaluatedNode>;
 }
 
 export class SerializerStatistics {


### PR DESCRIPTION
Release notes: none

This generates a tree graph of how all the components in the React reconciliation process get handled. It will massively help debugging what did or did not get inlined/evaluated. The data is also added to snapshots to further improve regression testing too.