### PR TITLE
Removing dead code.

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -258,14 +258,6 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
-  // TODO #1023: Remove this property. It's just here as some existing internal test cases assume that the __annotate property is exists and is readable.
-  global.$DefineOwnProperty("__annotate", {
-    value: realm.intrinsics.undefined,
-    writable: true,
-    enumerable: false,
-    configurable: true,
-  });
-
   // Internal helper function for tests.
   // __isAbstract(value) checks if a given value is abstract.
   global.$DefineOwnProperty("__isAbstract", {


### PR DESCRIPTION
Release notes: None

This addresses #1023.
__annotate doesn't seem to be used by any internal code anymore.