### PR TITLE
Fix _getTarget to deal with abstract values that are referenced from more than one additional function

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -87,6 +87,7 @@ function runTest(name: string, code: string): boolean {
   } catch (e) {
     if (!(e instanceof FatalError)) {
       console.error(chalk.red(`Unexpected error: ${e.message}`));
+      return false;
     }
   }
   if (errors.length !== expectedErrors.length) {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -715,7 +715,12 @@ export class ResidualHeapSerializer {
         if (this.additionalFunctionGeneratorsInverse.has(g)) return false;
       return true;
     });
-    invariant(generators.length > 0);
+    if (generators.length === 0) {
+      // This means that the value was referenced by multiple additional functions, and thus it must have existed at the end of global code execution.
+      // TODO: Emit to the end, not somewhere in the middle of the mainBody.
+      // TODO: Revisit for nested additional functions
+      return { body: this.mainBody };
+    }
 
     // This value is referenced from more than one generator or function.
     // Let's find the body associated with their common ancestor.


### PR DESCRIPTION
Release note: none

Abstract values from the global scope are not registered as additional roots, so the usual common ancestor logic fails in this case.

Also fix a bug in test-error-handler.js that allowed this regression to go undetected.