### PR TITLE
Refactored babelExtends code

### DIFF
--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -9,50 +9,24 @@
 
 /* @flow */
 
-import { parseExpression } from "babylon";
 import type { Realm } from "../../realm.js";
 import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import {
+  ArrayValue,
   AbstractValue,
   FunctionValue,
   AbstractObjectValue,
   NativeFunctionValue,
   ObjectValue,
+  StringValue,
+  NumberValue,
 } from "../../values/index.js";
+import { Create } from "../../singletons.js";
+import { Get } from "../../methods/index.js";
 import * as t from "babel-types";
 import invariant from "../../invariant";
-
-// Based on www babelHelpers fork.
-const babelHelpersCode = `
-{
-  inherits(subClass, superClass) {
-    Object.assign(subClass, superClass);
-    subClass.prototype = Object.create(superClass && superClass.prototype);
-    subClass.prototype.constructor = subClass;
-    subClass.__superConstructor__ = superClass;
-    return superClass;
-  },
-  _extends: Object.assign,
-  extends: Object.assign,
-  objectWithoutProperties(obj, keys) {
-    var hasOwn = Object.prototype.hasOwnProperty;
-    var target = {};
-    for (var i in obj) {
-      if (!hasOwn.call(obj, i) || keys.indexOf(i) >= 0) {
-        continue;
-      }
-      target[i] = obj[i];
-    }
-    return target;
-  },
-  taggedTemplateLiteralLoose(strings, raw) {
-    strings.raw = raw;
-    return strings;
-  },
-  bind: Function.prototype.bind,
-}
-`;
-let babelHelpersAST = parseExpression(babelHelpersCode);
+import { Properties } from "../../../lib/singletons.js";
+import { forEachArrayValue } from "../../react/utils.js";
 
 const fbMagicGlobalFunctions = [
   "asset",
@@ -72,6 +46,147 @@ const fbMagicGlobalFunctions = [
 ];
 
 const fbMagicGlobalObjects = ["JSResource", "Bootloader"];
+
+function createBabelHelpers(realm: Realm, global: ObjectValue | AbstractObjectValue) {
+  let babelHelpersValue = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, `babelHelpers`, true);
+  let objectAssign = Get(realm, realm.intrinsics.Object, "assign");
+  let objectCreate = Get(realm, realm.intrinsics.Object, "create");
+
+  //babelHelpers.objectWithoutProperties
+  let inheritsValue = new NativeFunctionValue(realm, undefined, `inherits`, 2, (context, [subClass, superClass]) => {
+    invariant(objectAssign instanceof NativeFunctionValue);
+    let objectAssignCall = objectAssign.$Call;
+    invariant(objectAssignCall !== undefined);
+    objectAssignCall(realm.intrinsics.undefined, [subClass, superClass]);
+
+    invariant(superClass instanceof ObjectValue);
+    let superClassPrototype = Get(realm, superClass, "prototype");
+
+    invariant(objectCreate instanceof NativeFunctionValue);
+    let objectCreateCall = objectCreate.$Call;
+    invariant(typeof objectCreateCall === "function");
+    let newPrototype = objectCreateCall(realm.intrinsics.undefined, [superClassPrototype]);
+
+    invariant(subClass instanceof ObjectValue);
+    invariant(newPrototype instanceof ObjectValue);
+    Properties.Set(realm, subClass, "prototype", newPrototype, true);
+    Properties.Set(realm, newPrototype, "constructor", subClass, true);
+    Properties.Set(realm, subClass, "__superConstructor__", superClass, true);
+
+    return superClass;
+  });
+  babelHelpersValue.$DefineOwnProperty("inherits", {
+    value: inheritsValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  inheritsValue.intrinsicName = `babelHelpers.inherits`;
+
+  //babelHelpers.objectWithoutProperties
+  let objectWithoutPropertiesValue = new NativeFunctionValue(
+    realm,
+    undefined,
+    `objectWithoutProperties`,
+    2,
+    (context, [obj, keys]) => {
+      invariant(obj instanceof ObjectValue || obj instanceof AbstractObjectValue);
+      invariant(keys instanceof ArrayValue);
+      if (obj.isPartialObject() || obj instanceof AbstractObjectValue) {
+        let value = AbstractValue.createTemporalFromBuildFunction(
+          realm,
+          ObjectValue,
+          [objectWithoutPropertiesValue, obj, keys],
+          ([methodNode, objNode, propRemoveNode]) => {
+            return t.callExpression(methodNode, [objNode, propRemoveNode]);
+          }
+        );
+        if (value instanceof AbstractObjectValue) {
+          // as we are returning an abstract object, we mark it as simple
+          value.makeSimple();
+        }
+        return value;
+      } else {
+        let removeKeys = new Set();
+        forEachArrayValue(realm, keys, key => {
+          if (key instanceof StringValue || key instanceof NumberValue) {
+            removeKeys.add(key.value);
+          }
+        });
+        let newObject = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
+        for (let [propName, binding] of obj.properties) {
+          if (!removeKeys.has(propName)) {
+            if (binding && binding.descriptor && binding.descriptor.enumerable) {
+              let value = Get(realm, obj, propName);
+              Properties.Set(realm, newObject, propName, value, true);
+            }
+          }
+        }
+        return newObject;
+      }
+    }
+  );
+  babelHelpersValue.$DefineOwnProperty("objectWithoutProperties", {
+    value: objectWithoutPropertiesValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  objectWithoutPropertiesValue.intrinsicName = `babelHelpers.objectWithoutProperties`;
+
+  //babelHelpers.taggedTemplateLiteralLoose
+  let taggedTemplateLiteralLooseValue = new NativeFunctionValue(
+    realm,
+    undefined,
+    `taggedTemplateLiteralLoose`,
+    2,
+    (context, [strings, raw]) => {
+      invariant(strings instanceof ObjectValue);
+      Properties.Set(realm, strings, "raw", raw, true);
+      return strings;
+    }
+  );
+  babelHelpersValue.$DefineOwnProperty("taggedTemplateLiteralLoose", {
+    value: taggedTemplateLiteralLooseValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  taggedTemplateLiteralLooseValue.intrinsicName = `babelHelpers.taggedTemplateLiteralLoose`;
+
+  //babelHelpers.extends & babelHelpers._extends
+  babelHelpersValue.$DefineOwnProperty("extends", {
+    value: objectAssign,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  babelHelpersValue.$DefineOwnProperty("_extends", {
+    value: objectAssign,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  //babelHelpers.bind
+  let functionBind = Get(realm, realm.intrinsics.FunctionPrototype, "bind");
+
+  babelHelpersValue.$DefineOwnProperty("bind", {
+    value: functionBind,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  global.$DefineOwnProperty("babelHelpers", {
+    value: babelHelpersValue,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  babelHelpersValue.refuseSerialization = false;
+}
 
 function createMagicGlobalFunction(realm: Realm, global: ObjectValue | AbstractObjectValue, functionName: string) {
   global.$DefineOwnProperty(functionName, {
@@ -110,14 +225,7 @@ export function createFbMocks(realm: Realm, global: ObjectValue | AbstractObject
     configurable: true,
   });
 
-  const babelHelpersValue = realm.$GlobalEnv.evaluate(babelHelpersAST, false);
-  invariant(babelHelpersValue instanceof ObjectValue);
-  global.$DefineOwnProperty("babelHelpers", {
-    value: babelHelpersValue,
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  });
+  createBabelHelpers(realm, global);
 
   for (let functionName of fbMagicGlobalFunctions) {
     createMagicGlobalFunction(realm, global, functionName);


### PR DESCRIPTION
Release notes: none

I converted the `babelExtends` code into native Prepack functions, resulting in drastically less emitted artifacts and making output source easier to read. This also allows us to tweak the internals better to help us resolve current bail outs.