### PR TITLE
Add missing fb tests

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -1460,6 +1460,100 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 10 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 11 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 9,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -2968,6 +3062,100 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 10 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 11 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 9,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -4446,6 +4634,100 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 10 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 11 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 9,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -5920,6 +6202,100 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 6,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 10 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 11 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "B",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "name": "C",
+              "status": "INLINED",
+            },
+          ],
+          "name": "A",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 9,
   "optimizedTrees": 1,
 }
 `;

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -483,6 +483,14 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb9.js");
       });
 
+      it("fb-www 10", async () => {
+        await runTest(directory, "fb10.js");
+      });
+
+      it("fb-www 11", async () => {
+        await runTest(directory, "fb11.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/test/react/mocks/fb11.js
+++ b/test/react/mocks/fb11.js
@@ -1,0 +1,91 @@
+var React = require('React');
+this['React'] = React;
+
+// FB www polyfill
+if (!this.babelHelpers) {
+  this.babelHelpers = {
+    inherits(subClass, superClass) {
+      Object.assign(subClass, superClass);
+      subClass.prototype = Object.create(superClass && superClass.prototype);
+      subClass.prototype.constructor = subClass;
+      subClass.__superConstructor__ = superClass;
+      return superClass;
+    },
+    _extends: Object.assign,
+    extends: Object.assign,
+    objectWithoutProperties(obj, keys) {
+      var target = {};
+      var hasOwn = Object.prototype.hasOwnProperty;
+      for (var i in obj) {
+        if (!hasOwn.call(obj, i) || keys.indexOf(i) >= 0) {
+          continue;
+        }
+        target[i] = obj[i];
+      }
+      return target;
+    },
+    taggedTemplateLiteralLoose(strings, raw) {
+      strings.raw = raw;
+      return strings;
+    },
+    bind: Function.prototype.bind,
+  };
+}
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = this.__evaluatePureFunction(() => {  
+  function A(props) {
+    return (
+      <React.Fragment>
+        <div>Hello {props.x} {props.y}</div>
+        <B />
+        <C />
+      </React.Fragment>
+    );
+  }
+
+  function B() {
+    return <div>World</div>;
+  }
+
+  function C() {
+    return "!";
+  }
+
+  function App(props) {
+    const propsCopyWithDeletedProp = babelHelpers.extends({}, props);
+    delete propsCopyWithDeletedProp.y;
+    return React.createElement('div', null,
+      // Feel free to comment out either of these children
+      // individually when debugging specific cases.
+      React.createElement(
+        A,
+        babelHelpers.objectWithoutProperties(props, ['x'])
+      ),
+      React.createElement(
+        A,
+        babelHelpers.extends({}, props, {x: 30})
+      ),
+      React.createElement(
+        A,
+        propsCopyWithDeletedProp
+      ),
+    );
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root x={10} y={20} />);
+    return [['simple render', renderer.toJSON()]];
+  };
+
+  if (this.__registerReactComponentRoot) {
+    __registerReactComponentRoot(App);
+  }
+
+  return App;
+});


### PR DESCRIPTION
Release notes: none

This PR enables fb10.js and adds fb11.js from https://github.com/facebook/prepack/pull/1434, thus closing that PR.