### PR TITLE
Abstract evaluation of switch cases (simple).

### DIFF
--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -52,9 +52,9 @@ function AbstractCaseBlockEvaluation(
     // we start at the case we've been asked to evaluate, and process statements
     // until there is either a break statement or exception thrown (this means we
     // implicitly fall through correctly in the absence of a break statement).
-    while (caseIndex < cases.length && !(result instanceof Completion)) {
+    while (caseIndex < cases.length) {
       let c = cases[caseIndex];
-      for (let i = 0; i < c.consequent.length && !(result instanceof Completion); ++i) {
+      for (let i = 0; i < c.consequent.length; i += 1) {
         let node = c.consequent[i];
         let r = env.evaluateCompletion(node, strictCode);
         invariant(!(r instanceof Reference));

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -103,8 +103,8 @@ function AbstractCaseBlockEvaluation(
       return AbstractCaseEvaluation(caseIndex + 1);
     } else if (caseIndex >= cases.length) {
       // this is the stop condition for our recursive search for a matching case.
-      // we tried every available case index and if nothing matches we return
-      // the default (and since none exists....just empty)
+      // we tried every available case index and since nothing matches we return
+      // the default (and if none exists....just empty)
       if (defaultCaseIndex !== -1) {
         return DefiniteCaseEvaluation(defaultCaseIndex);
       } else {

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -104,7 +104,7 @@ function AbstractCaseBlockEvaluation(
     } else if (caseIndex >= cases.length) {
       // this is the stop condition for our recursive search for a matching case.
       // we tried every available case index and if nothing matches we return
-      // the default (and if none exists....just empty)
+      // the default (and since none exists....just empty)
       if (defaultCaseIndex !== -1) {
         return DefiniteCaseEvaluation(defaultCaseIndex);
       } else {

--- a/test/serializer/abstract/Switch.js
+++ b/test/serializer/abstract/Switch.js
@@ -61,12 +61,11 @@ switch (x) {
   default: throw 2;
 }
 
-// throws introspection error
-switch (x) {
-  case 1: if (z10 === 13) z11 = 12; else throw 3; break;
-  case 0: throw 1; break;
-  case 2: z11 = 13; break;
-  default: throw 2; break;
-}
+// switch (x) {
+//   case 1: if (z10 === 13) z11 = 12; else throw 3; break;
+//   case 0: throw 1; break;
+//   case 2: z11 = 13; break;
+//   default: throw 2; break;
+// }
 
 inspect = function() { return "" + z1 + " " + z2 + " " + z3 + " " + z4 + " " + z5 + " " + z6 + " " + z7 + " " + z8 + " " + z9 + " " + z10 + " "  + z11; }

--- a/test/serializer/abstract/Switch.js
+++ b/test/serializer/abstract/Switch.js
@@ -61,11 +61,12 @@ switch (x) {
   default: throw 2;
 }
 
-// switch (x) {
-//   case 1: if (z10 === 13) z11 = 12; else throw 3; break;
-//   case 0: throw 1; break;
-//   case 2: z11 = 13; break;
-//   default: throw 2; break;
-// }
+// throws introspection error
+switch (x) {
+  case 1: if (z10 === 13) z11 = 12; else throw 3; break;
+  case 0: throw 1; break;
+  case 2: z11 = 13; break;
+  default: throw 2; break;
+}
 
 inspect = function() { return "" + z1 + " " + z2 + " " + z3 + " " + z4 + " " + z5 + " " + z6 + " " + z7 + " " + z8 + " " + z9 + " " + z10 + " "  + z11; }

--- a/test/serializer/abstract/Switch.js
+++ b/test/serializer/abstract/Switch.js
@@ -1,12 +1,72 @@
-// throws introspection error
 let x = global.__abstract ? __abstract("number", "1") : 1;
-z = 10;
+z1 = z2 = z3 = z4 = z5 = z6 = z7 = z8 = z9 = z10 = z11 = 10;
+
+switch (x) {}
 
 switch (x) {
-  case 0: z = 11; break;
-  case 1: z = 12; break;
-  case 2: z = 13; break;
-  default: z = 14; break;
+  case 0: z1 = 11; break;
+  case 1: z1 = 12; break;
+  case 2: z1 = 13; break;
+  default: z1 = 14; break;
 }
 
-inspect = function() { return "" + z; }
+switch (x) {
+  case 2: z2 = 11; break;
+  case 1: z2 = 12; break;
+  case 0: z2 = 13; break;
+  default: z2 = 14; break;
+}
+
+switch (x + 1) {
+  case 0: z3 = 11; break;
+  case 1: z3 = 100; break;
+  case 2: z3 = 12;
+  case 3: z3 = 14;
+  default: z3 = 122; break;
+}
+
+switch (x) {
+  case (x-1): z5 = 11; break;
+  case x: z5 = 12; break;
+}
+
+switch (x) {
+  case 5: z6 = 100; break;
+  case 6: z6 = 101; break;
+}
+
+switch (x) {
+  case 5: z7 = 100; break;
+  case 6: z7 = 101; break;
+  default: z7 = 12; break;
+}
+
+switch (x) {
+  case 5: z8 = 100; break;
+  default: z8 = 12; break;
+  case 6: z8 = 101; break;
+}
+
+switch (x) {
+  case 5: z9 = 100; break;
+  default: z9 = 12;
+  case 6: z9 = 101; break;
+}
+
+// throws introspection error
+switch (x) {
+  case 0: throw 1;
+  case 1: z10 = 12; break;
+  case 2: z10 = 13; break;
+  default: throw 2;
+}
+
+// throws introspection error
+switch (x) {
+  case 1: if (z10 === 13) z11 = 12; else throw 3; break;
+  case 0: throw 1; break;
+  case 2: z11 = 13; break;
+  default: throw 2; break;
+}
+
+inspect = function() { return "" + z1 + " " + z2 + " " + z3 + " " + z4 + " " + z5 + " " + z6 + " " + z7 + " " + z8 + " " + z9 + " " + z10 + " "  + z11; }


### PR DESCRIPTION
Adds abstract evaluation for switch cases. Effectively treats the switch case as a series of if-else statements to achieve the same outcome.

Currently does not support case blocks that result in an abrupt completion through `return/throw/continue`. That is work-to-go in the future.

A future PR will also expand on the tests to provide more coverage (and look for corner cases).

Test plan: Added more tests to serializer/abstract/Switch.js