### PR TITLE
Do not havoc frozen objects

### DIFF
--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -43,7 +43,7 @@ type HavocedFunctionInfo = {
   unboundWrites: Set<string>,
 };
 
-function visitName(path, state, name, read, write) {
+function visitName(path: BabelTraversePath, state: HavocedFunctionInfo, name: string, read: boolean, write: boolean) {
   // Is the name bound to some local identifier? If so, we don't need to do anything
   if (path.scope.hasBinding(name, /*noGlobals*/ true)) return;
 
@@ -154,6 +154,8 @@ class ObjectValueHavocingVisitor {
 
     // prototype
     this.visitObjectPrototype(obj);
+
+    if (TestIntegrityLevel(obj.$Realm, obj, "frozen")) return;
 
     // if this object wasn't already havoced, we need mark it as havoced
     // so that any mutation and property access get tracked after this.
@@ -321,10 +323,6 @@ class ObjectValueHavocingVisitor {
     if (val.isHavocedObject()) {
       return;
     }
-
-    // TODO: if this object is frozen there is no need to havoc it.
-    // TODO: if the object is not extensible, just havoc the known properties
-    // TODO: if a property is readonly and not configurable, leave it alone
 
     let kind = val.getKind();
     this.visitObjectProperties(val, kind);

--- a/test/serializer/pure-functions/AbstractPropertyRead3.js
+++ b/test/serializer/pure-functions/AbstractPropertyRead3.js
@@ -1,0 +1,17 @@
+// abstract effects
+// does contain: "barone"
+
+var __evaluatePureFunction = this.__evaluatePureFunction || (f => f());
+let absFunc = global.__abstract ? __abstract('function', '(x => x)') : x => x;
+
+let x, y;
+__evaluatePureFunction(() => {
+  let obj1 = { foo: "bar" };
+  Object.freeze(obj1);
+  absFunc(obj1);
+  x = obj1.foo + "one";
+});
+
+inspect = function() {
+  return x;
+}

--- a/test/serializer/pure-functions/AbstractPropertyRead4.js
+++ b/test/serializer/pure-functions/AbstractPropertyRead4.js
@@ -1,0 +1,20 @@
+// abstract effects
+// does contain: "barone"
+// does not contain: "23"
+
+var __evaluatePureFunction = this.__evaluatePureFunction || (f => f());
+let absFunc = global.__abstract ? __abstract('function', '(x => x)') : x => x;
+
+let x, y;
+__evaluatePureFunction(() => {
+  let obj1 = { foo: "bar" };
+  Object.freeze(obj1);
+  let obj2 = { one: obj1, two: 2 };
+  absFunc(obj2);
+  x = obj1.foo + "one";
+  y = obj2.two + "3";
+});
+
+inspect = function() {
+  return x + " " + y ;
+}


### PR DESCRIPTION
Release note: Do not havoc leaked objects if they are frozen

This still traverses the object and makes sure that any unfrozen locally created objects that are reachable from it are havoced.

@sebmarkbage What is the rationale for leaving unfrozen objects unhavoced if they were not created in a pure context?