### PR TITLE
Fixes an emitter bug where an AdditionalFunction is a generator body

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -199,7 +199,7 @@ export class Emitter {
     return this._activeGeneratorStack[this._activeGeneratorStack.length - 1] === this._body;
   }
   _isGeneratorBody(body: SerializedBody): boolean {
-    return body.type === "MainGenerator" || body.type === "Generator";
+    return body.type === "MainGenerator" || body.type === "Generator" || body.type === "AdditionalFunction";
   }
   _processCurrentBody() {
     if (!this._isEmittingActiveGenerator()) {


### PR DESCRIPTION
Release notes: none

This seems like a typo as to why this was missed off. Unfortunately, to repro this bug, you'll need to test this with the FB UFI bundle – I was unable to extract the error.