### PR TITLE
Fix hasOwnProperty invariant failure

### DIFF
--- a/src/intrinsics/ecma262/ObjectPrototype.js
+++ b/src/intrinsics/ecma262/ObjectPrototype.js
@@ -38,13 +38,15 @@ export default function(realm: Realm, obj: ObjectValue): void {
         // leaving the call in place which we do by default, but we don't
         // have to havoc the state of any arguments since this function is pure.
         // This also lets us define the return type properly.
-        return AbstractValue.createTemporalFromBuildFunction(
-          realm,
-          BooleanValue,
-          [ObjectPrototypeHasOwnPrototype, context, V],
-          ([methodNode, objectNode, nameNode]: Array<BabelNodeExpression>) => {
-            return t.callExpression(t.memberExpression(methodNode, t.identifier("call")), [objectNode, nameNode]);
-          }
+        return realm.evaluateWithPossibleThrowCompletion(() =>
+          AbstractValue.createTemporalFromBuildFunction(
+            realm,
+            BooleanValue,
+            [ObjectPrototypeHasOwnPrototype, context, V],
+            ([methodNode, objectNode, nameNode]: Array<BabelNodeExpression>) => {
+              return t.callExpression(t.memberExpression(methodNode, t.identifier("call")), [objectNode, nameNode]);
+            }
+          )
         );
       }
       throw x;

--- a/src/intrinsics/ecma262/ObjectPrototype.js
+++ b/src/intrinsics/ecma262/ObjectPrototype.js
@@ -10,24 +10,45 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { NativeFunctionValue, ObjectValue, BooleanValue, NullValue } from "../../values/index.js";
+import { AbstractValue, NativeFunctionValue, ObjectValue, BooleanValue, NullValue } from "../../values/index.js";
 import { SameValuePartial, RequireObjectCoercible } from "../../methods/abstract.js";
 import { HasOwnProperty, HasSomeCompatibleType } from "../../methods/has.js";
 import { Invoke } from "../../methods/call.js";
 import { Properties, To } from "../../singletons.js";
+import { FatalError } from "../../errors.js";
+import type { BabelNodeExpression } from "babel-types";
+import * as t from "babel-types";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 19.1.3.2
-  obj.defineNativeMethod("hasOwnProperty", 1, (context, [V]) => {
-    // 1. Let P be ? ToPropertyKey(V).
-    let P = To.ToPropertyKey(realm, V.throwIfNotConcrete());
+  const ObjectPrototypeHasOwnPrototype = obj.defineNativeMethod("hasOwnProperty", 1, (context, [V]) => {
+    try {
+      // 1. Let P be ? ToPropertyKey(V).
+      let P = To.ToPropertyKey(realm, V.throwIfNotConcrete());
 
-    // 2. Let O be ? ToObject(this value).
-    let O = To.ToObjectPartial(realm, context);
+      // 2. Let O be ? ToObject(this value).
+      let O = To.ToObjectPartial(realm, context);
 
-    // 3. Return ? HasOwnProperty(O, P).
-    return new BooleanValue(realm, HasOwnProperty(realm, O, P));
+      // 3. Return ? HasOwnProperty(O, P).
+      return new BooleanValue(realm, HasOwnProperty(realm, O, P));
+    } catch (x) {
+      if (realm.isInPureScope() && x instanceof FatalError) {
+        // If we're in pure scope we can try to recover from any fatals by
+        // leaving the call in place which we do by default, but we don't
+        // have to havoc the state of any arguments since this function is pure.
+        // This also lets us define the return type properly.
+        return AbstractValue.createTemporalFromBuildFunction(
+          realm,
+          BooleanValue,
+          [ObjectPrototypeHasOwnPrototype, context, V],
+          ([methodNode, objectNode, nameNode]: Array<BabelNodeExpression>) => {
+            return t.callExpression(t.memberExpression(methodNode, t.identifier("call")), [objectNode, nameNode]);
+          }
+        );
+      }
+      throw x;
+    }
   });
 
   // ECMA262 19.1.3.3

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -173,6 +173,11 @@ export default class AbstractObjectValue extends AbstractValue {
   $GetOwnProperty(P: PropertyKeyValue): Descriptor | void {
     if (P instanceof StringValue) P = P.value;
 
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this, P);
+      throw new FatalError();
+    }
+
     let elements = this.values.getElements();
     if (elements.size === 1) {
       for (let cv of elements) {

--- a/test/serializer/pure-functions/hasOwnProperty.js
+++ b/test/serializer/pure-functions/hasOwnProperty.js
@@ -10,6 +10,13 @@ function additional1() {
 }
 
 function additional2() {
+  var foo = obj.foo;
+  var dontHavocThis = { bar: 2, toString: function() { return 'bar'; } };
+  Object.prototype.hasOwnProperty.call(foo, dontHavocThis);
+  if (global.__isAbstract && __isAbstract(dontHavocThis.bar)) {
+    return 'This should not be abstract.';
+  }
+  return dontHavocThis.bar;
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/hasOwnProperty.js
+++ b/test/serializer/pure-functions/hasOwnProperty.js
@@ -1,0 +1,19 @@
+// additional functions
+// abstract effects
+
+var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
+if (global.__makeSimple) __makeSimple(obj);
+
+function additional1() {
+  var foo = obj.foo;
+  return Object.prototype.hasOwnProperty.call(foo, 'bar');
+}
+
+function additional2() {
+}
+
+inspect = function() {
+  var obj1 = additional1();
+  var obj2 = additional2();
+  return JSON.stringify({ obj1, obj2 });
+}

--- a/test/serializer/pure-functions/hasOwnProperty2.js
+++ b/test/serializer/pure-functions/hasOwnProperty2.js
@@ -1,0 +1,43 @@
+// additional functions
+// abstract effects
+
+var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
+if (global.__makeSimple) __makeSimple(obj);
+
+function additional1() {
+  var foo = obj.foo;
+  var hasOwn = Object.prototype.hasOwnProperty;
+  var dontHavocThis = { bar: 2, toString: function() { return 'bar'; } };
+  var x = 0;
+  if (hasOwn.call(foo, dontHavocThis)) {
+    x = 1;
+  } else {
+    x = 2;
+  }
+  if (global.__isAbstract && __isAbstract(dontHavocThis.bar)) {
+    return 'This should not be abstract.';
+  }
+  return x;
+}
+
+function additional2() {
+  var foo = obj.foo;
+  var hasOwn = Object.prototype.hasOwnProperty.bind(foo);
+  var dontHavocThis = { bar: 2, toString: function() { return 'bar'; } };
+  var x = 0;
+  if (hasOwn(dontHavocThis)) {
+    x = 1;
+  } else {
+    x = 2;
+  }
+  if (global.__isAbstract && __isAbstract(dontHavocThis.bar)) {
+    return 'This should not be abstract.';
+  }
+  return x;
+}
+
+inspect = function() {
+  var obj1 = additional1();
+  var obj2 = additional2();
+  return JSON.stringify({ obj1, obj2 });
+}


### PR DESCRIPTION
Release notes: none

This fatals in the case we try to extract a descriptor from a topVal which can happen.

This lets the CallExpression fallback to leaving the call inact.

Unfortunately that havocs the arguments unnecessarily. So I also special cased it. I guess we should just make this a common pattern for pure built-ins.
