### PR TITLE
Set eslint to ignore fb-www directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 test262
 lib
+fb-www
 underscore-with-tests.js
 flow-typed
 test/**/*.js


### PR DESCRIPTION
Release notes: none

Ignore fb-www with eslint.