### PR TITLE
Change how to signal React components for optimization

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -54,7 +54,7 @@ import {
 import { ExpectedBailOut, SimpleClassBailOut, NewComponentTreeBranch } from "./errors.js";
 import { Completion } from "../completions.js";
 import { Logger } from "../utils/logger.js";
-import type { ClassComponentMetadata } from "../types.js";
+import type { ClassComponentMetadata, ReactComponentTreeConfig } from "../types.js";
 
 type RenderStrategy = "NORMAL" | "FRAGMENT" | "RELAY_QUERY_RENDERER";
 
@@ -77,7 +77,8 @@ export class Reconciler {
     realm: Realm,
     moduleTracer: ModuleTracer,
     statistics: ReactStatistics,
-    reactSerializerState: ReactSerializerState
+    reactSerializerState: ReactSerializerState,
+    componentTreeConfig: ReactComponentTreeConfig
   ) {
     this.realm = realm;
     this.moduleTracer = moduleTracer;
@@ -86,6 +87,7 @@ export class Reconciler {
     this.logger = moduleTracer.modules.logger;
     this.componentTreeState = this._createComponentTreeState();
     this.alreadyEvaluatedRootNodes = new Map();
+    this.componentTreeConfig = componentTreeConfig;
   }
 
   realm: Realm;
@@ -95,6 +97,7 @@ export class Reconciler {
   logger: Logger;
   componentTreeState: ComponentTreeState;
   alreadyEvaluatedRootNodes: Map<ECMAScriptSourceFunctionValue, ReactEvaluatedNode>;
+  componentTreeConfig: ReactComponentTreeConfig;
 
   render(
     componentType: ECMAScriptSourceFunctionValue,
@@ -132,7 +135,7 @@ export class Reconciler {
         if (!isRoot) {
           this.logger.logWarning(
             componentType,
-            `__registerReactComponentRoot() React component tree (branch) failed due to - ${error.message}`
+            `__optimizeReactComponentTree() React component tree (branch) failed due to - ${error.message}`
           );
           return this.realm.intrinsics.undefined;
         }
@@ -143,7 +146,7 @@ export class Reconciler {
           throw error;
         } else if (error instanceof ExpectedBailOut) {
           let diagnostic = new CompilerDiagnostic(
-            `__registerReactComponentRoot() React component tree (root) failed due to - ${error.message}`,
+            `__optimizeReactComponentTree() React component tree (root) failed due to - ${error.message}`,
             this.realm.currentLocation,
             "PP0020",
             "FatalError"

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -23,10 +23,11 @@ import {
   StringValue,
   ArrayValue,
   ECMAScriptSourceFunctionValue,
+  UndefinedValue,
 } from "../values/index.js";
 import type { BabelTraversePath } from "babel-traverse";
 import { Generator } from "../utils/generator.js";
-import type { Descriptor, ReactHint, PropertyBinding } from "../types";
+import type { Descriptor, ReactHint, PropertyBinding, ReactComponentTreeConfig } from "../types";
 import { Get, cloneDescriptor } from "../methods/index.js";
 import { computeBinary } from "../evaluators/BinaryExpression.js";
 import type { ReactSerializerState, AdditionalFunctionEffects, ReactEvaluatedNode } from "../serializer/types.js";
@@ -703,4 +704,14 @@ export function getComponentName(
     }
   }
   return "Unknown";
+}
+
+export function convertConfigObjectToReactComponentTreeConfig(
+  realm: Realm,
+  config: ObjectValue | UndefinedValue
+): ReactComponentTreeConfig {
+  // TODO get values from config object
+  return {
+    serverSideRenderOnly: false,
+  };
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -24,6 +24,7 @@ import {
   ArrayValue,
   ECMAScriptSourceFunctionValue,
   UndefinedValue,
+  BooleanValue,
 } from "../values/index.js";
 import type { BabelTraversePath } from "babel-traverse";
 import { Generator } from "../utils/generator.js";
@@ -710,8 +711,26 @@ export function convertConfigObjectToReactComponentTreeConfig(
   realm: Realm,
   config: ObjectValue | UndefinedValue
 ): ReactComponentTreeConfig {
-  // TODO get values from config object
+  // defaults
+  let serverSideRenderOnly = false;
+
+  if (!(config instanceof UndefinedValue)) {
+    for (let [key] of config.properties) {
+      let propValue = getProperty(realm, config, key);
+      invariant(
+        propValue instanceof StringValue || propValue instanceof NumberValue || propValue instanceof BooleanValue
+      );
+      let value = propValue.value;
+
+      // boolean options
+      if (typeof value === "boolean") {
+        if (key === serverSideRenderOnly) {
+          serverSideRenderOnly = value;
+        }
+      }
+    }
+  }
   return {
-    serverSideRenderOnly: false,
+    serverSideRenderOnly,
   };
 }

--- a/src/types.js
+++ b/src/types.js
@@ -326,6 +326,10 @@ export type ClassComponentMetadata = {
 
 export type ReactHint = {| object: ObjectValue, propertyName: string, args: Array<Value> |};
 
+export type ReactComponentTreeConfig = {
+  serverSideRenderOnly: boolean,
+};
+
 export type DebugServerType = {
   checkForActions: BabelNode => void,
   shutdown: () => void,

--- a/test/react/class-components/classes-with-state.js
+++ b/test/react/class-components/classes-with-state.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['render with class with state', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/complex-class-into-functional-root.js
+++ b/test/react/class-components/complex-class-into-functional-root.js
@@ -29,8 +29,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/complex-class-into-functional-root2.js
+++ b/test/react/class-components/complex-class-into-functional-root2.js
@@ -42,8 +42,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/complex-class-into-functional-root3.js
+++ b/test/react/class-components/complex-class-into-functional-root3.js
@@ -53,8 +53,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/complex-class-into-functional-root4.js
+++ b/test/react/class-components/complex-class-into-functional-root4.js
@@ -33,8 +33,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/complex-class-into-functional-root5.js
+++ b/test/react/class-components/complex-class-into-functional-root5.js
@@ -43,8 +43,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/inheritance-chain.js
+++ b/test/react/class-components/inheritance-chain.js
@@ -36,8 +36,8 @@ App.getTrials = function(renderer, Root) {
   return [['inheritance chain', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/simple-classes-2.js
+++ b/test/react/class-components/simple-classes-2.js
@@ -13,8 +13,8 @@ App.getTrials = function(renderer, Root) {
   return [['render simple classes', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/simple-classes-3.js
+++ b/test/react/class-components/simple-classes-3.js
@@ -28,8 +28,8 @@ App.getTrials = function(renderer, Root) {
   return [['render simple classes', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/class-components/simple-classes.js
+++ b/test/react/class-components/simple-classes.js
@@ -40,8 +40,8 @@ var App = (function (superclass) {
   return App;
 }(React.Component));
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/factory-components/simple.js
+++ b/test/react/factory-components/simple.js
@@ -15,8 +15,8 @@ FactoryComponent.getTrials = function(renderer, Root) {
   return [['render simple factory classes', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(FactoryComponent);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(FactoryComponent);
 }
 
 module.exports = FactoryComponent;

--- a/test/react/factory-components/simple2.js
+++ b/test/react/factory-components/simple2.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['render simple factory classes #2', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/additional-function-regression.js
+++ b/test/react/functional-components/additional-function-regression.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/array-twice.js
+++ b/test/react/functional-components/array-twice.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['render array twice', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/circular-reference.js
+++ b/test/react/functional-components/circular-reference.js
@@ -30,8 +30,8 @@ App.getTrials = function(renderer, Root) {
   return [['circular-reference', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/class-root-with-instance-vars-2.js
+++ b/test/react/functional-components/class-root-with-instance-vars-2.js
@@ -38,8 +38,8 @@ var App = (function (superclass) {
   return App;
 }(React.Component));
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/class-root-with-instance-vars.js
+++ b/test/react/functional-components/class-root-with-instance-vars.js
@@ -38,8 +38,8 @@ var App = (function (superclass) {
   return App;
 }(React.Component));
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/class-root-with-props.js
+++ b/test/react/functional-components/class-root-with-props.js
@@ -33,8 +33,8 @@ var App = (function (superclass) {
   return App;
 }(React.Component));
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/class-root-with-refs.js
+++ b/test/react/functional-components/class-root-with-refs.js
@@ -46,8 +46,8 @@ var App = (function (superclass) {
   return App;
 }(React.Component));
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/class-root-with-render-methods.js
+++ b/test/react/functional-components/class-root-with-render-methods.js
@@ -36,8 +36,8 @@ var App = (function (superclass) {
   return App;
 }(React.Component));
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/class-root-with-state.js
+++ b/test/react/functional-components/class-root-with-state.js
@@ -27,8 +27,8 @@ App.getTrials = function(renderer, Root) {
   return [['render with class root and props', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/class-root.js
+++ b/test/react/functional-components/class-root.js
@@ -33,8 +33,8 @@ var App = (function (superclass) {
   return App;
 }(React.Component));
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/clone-element.js
+++ b/test/react/functional-components/clone-element.js
@@ -37,8 +37,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/conditional.js
+++ b/test/react/functional-components/conditional.js
@@ -22,8 +22,8 @@ App.getTrials = function(renderer, Root) {
   return [['conditional render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/delete-element-prop-key.js
+++ b/test/react/functional-components/delete-element-prop-key.js
@@ -33,8 +33,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with delete on props key', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/dynamic-context.js
+++ b/test/react/functional-components/dynamic-context.js
@@ -46,8 +46,8 @@ App.getTrials = function(renderer, Root) {
   return [['render with dynamic context access', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(Child);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(Child);
 }
 
 module.exports = App;

--- a/test/react/functional-components/dynamic-props.js
+++ b/test/react/functional-components/dynamic-props.js
@@ -15,8 +15,8 @@ App.getTrials = function(renderer, Root) {
   return [['render with dynamic prop access', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/event-handlers.js
+++ b/test/react/functional-components/event-handlers.js
@@ -20,8 +20,8 @@ App.getTrials = function(renderer, Root) {
   ];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/key-change-fragments.js
+++ b/test/react/functional-components/key-change-fragments.js
@@ -62,8 +62,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/key-change.js
+++ b/test/react/functional-components/key-change.js
@@ -64,8 +64,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/key-nesting-2.js
+++ b/test/react/functional-components/key-nesting-2.js
@@ -24,8 +24,8 @@ App.getTrials = function(renderer, Root) {
   return [['key nesting 2', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/key-nesting-3.js
+++ b/test/react/functional-components/key-nesting-3.js
@@ -26,8 +26,8 @@ App.getTrials = function(renderer, Root) {
   return [['key nesting 3', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/key-nesting.js
+++ b/test/react/functional-components/key-nesting.js
@@ -71,8 +71,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/key-not-change-fragments.js
+++ b/test/react/functional-components/key-not-change-fragments.js
@@ -62,8 +62,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/nested-array-children.js
+++ b/test/react/functional-components/nested-array-children.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['render nested array children', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/return-text.js
+++ b/test/react/functional-components/return-text.js
@@ -22,8 +22,8 @@ App.getTrials = function(renderer, Root) {
   return [['render text', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/return-undefined.js
+++ b/test/react/functional-components/return-undefined.js
@@ -23,8 +23,8 @@ App.getTrials = function(renderer, Root) {
   return [['error rendering', didError]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-2.js
+++ b/test/react/functional-components/simple-2.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-3.js
+++ b/test/react/functional-components/simple-3.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-4.js
+++ b/test/react/functional-components/simple-4.js
@@ -23,8 +23,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render 4', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-5.js
+++ b/test/react/functional-components/simple-5.js
@@ -25,12 +25,12 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(Child);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(Child);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-6.js
+++ b/test/react/functional-components/simple-6.js
@@ -13,8 +13,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-7.js
+++ b/test/react/functional-components/simple-7.js
@@ -13,8 +13,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-assign.js
+++ b/test/react/functional-components/simple-assign.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with object assign', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-assign2.js
+++ b/test/react/functional-components/simple-assign2.js
@@ -23,8 +23,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with object assign', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-assign3.js
+++ b/test/react/functional-components/simple-assign3.js
@@ -17,8 +17,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with object assign', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-assign4.js
+++ b/test/react/functional-components/simple-assign4.js
@@ -15,8 +15,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with object assign', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-assign5.js
+++ b/test/react/functional-components/simple-assign5.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with object assign', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-children.js
+++ b/test/react/functional-components/simple-children.js
@@ -21,8 +21,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple children', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-fragments.js
+++ b/test/react/functional-components/simple-fragments.js
@@ -29,8 +29,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple fragments render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-refs.js
+++ b/test/react/functional-components/simple-refs.js
@@ -34,8 +34,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-abstract-props.js
+++ b/test/react/functional-components/simple-with-abstract-props.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread.js
+++ b/test/react/functional-components/simple-with-jsx-spread.js
@@ -23,8 +23,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with jsx spread', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread2.js
+++ b/test/react/functional-components/simple-with-jsx-spread2.js
@@ -23,8 +23,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with jsx spread 2', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread3.js
+++ b/test/react/functional-components/simple-with-jsx-spread3.js
@@ -19,8 +19,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with jsx spread 3', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread4.js
+++ b/test/react/functional-components/simple-with-jsx-spread4.js
@@ -17,8 +17,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with jsx spread 4', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread5.js
+++ b/test/react/functional-components/simple-with-jsx-spread5.js
@@ -12,8 +12,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with jsx spread 5', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread6.js
+++ b/test/react/functional-components/simple-with-jsx-spread6.js
@@ -10,8 +10,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render with jsx spread 6', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-with-unary.js
+++ b/test/react/functional-components/simple-with-unary.js
@@ -27,8 +27,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple.js
+++ b/test/react/functional-components/simple.js
@@ -29,8 +29,8 @@ App.getTrials = function(renderer, Root) {
   return [['simple render', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/type-change.js
+++ b/test/react/functional-components/type-change.js
@@ -72,8 +72,8 @@ App.getTrials = function(renderer, Root) {
   return results;
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/type-same.js
+++ b/test/react/functional-components/type-same.js
@@ -16,8 +16,8 @@ App.getTrials = function(renderer, Root) {
   return [['no added keys to child components', childKey]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/mocks/fb1.js
+++ b/test/react/mocks/fb1.js
@@ -32,8 +32,8 @@ module.exports = this.__evaluatePureFunction(() => {
     return [['fb1 mocks', renderer.toJSON()]];
   };
 
-  if (this.__registerReactComponentRoot) {
-    __registerReactComponentRoot(App);
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App);
   }
 
   return App;

--- a/test/react/mocks/fb10.js
+++ b/test/react/mocks/fb10.js
@@ -73,8 +73,8 @@ module.exports = this.__evaluatePureFunction(() => {
     return [['simple render', renderer.toJSON()]];
   };
 
-  if (this.__registerReactComponentRoot) {
-    __registerReactComponentRoot(App);
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App);
   }
 
   return App;

--- a/test/react/mocks/fb11.js
+++ b/test/react/mocks/fb11.js
@@ -83,8 +83,8 @@ module.exports = this.__evaluatePureFunction(() => {
     return [['simple render', renderer.toJSON()]];
   };
 
-  if (this.__registerReactComponentRoot) {
-    __registerReactComponentRoot(App);
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App);
   }
 
   return App;

--- a/test/react/mocks/fb2.js
+++ b/test/react/mocks/fb2.js
@@ -58,8 +58,8 @@ Hello.getTrials = function(renderer, Root) {
   return [['fb2 mocks', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(Hello);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(Hello);
 }
 
 module.exports = Hello;

--- a/test/react/mocks/fb7.js
+++ b/test/react/mocks/fb7.js
@@ -38,8 +38,8 @@ module.exports = this.__evaluatePureFunction(() => {
     },
   })
 
-  if (this.__registerReactComponentRoot) {
-    __registerReactComponentRoot(WrappedApp);
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(WrappedApp);
   }
 
   // this is a mocked out relay mock for this test

--- a/test/react/mocks/fb8.js
+++ b/test/react/mocks/fb8.js
@@ -42,8 +42,8 @@ module.exports = this.__evaluatePureFunction(() => {
     return <span>This contains a ReactRelay container:<WrappedApp /></span>;
   }
 
-  if (this.__registerReactComponentRoot) {
-    __registerReactComponentRoot(App);
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App);
   }
 
   // this is a mocked out relay mock for this test

--- a/test/react/mocks/fb9.js
+++ b/test/react/mocks/fb9.js
@@ -75,8 +75,8 @@ module.exports = this.__evaluatePureFunction(() => {
     return [['simple render', renderer.toJSON()]];
   };
 
-  if (this.__registerReactComponentRoot) {
-    __registerReactComponentRoot(App);
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App);
   }
 
   return App;

--- a/test/react/mocks/hacker-news.js
+++ b/test/react/mocks/hacker-news.js
@@ -212,8 +212,8 @@ module.exports = this.__evaluatePureFunction(() => {
     stories: PropTypes.array.isRequired,
   };
 
-  if (this.__registerReactComponentRoot) {
-  	__registerReactComponentRoot(App);
+  if (this.__optimizeReactComponentTree) {
+  	__optimizeReactComponentTree(App);
   }
 
   return App;

--- a/test/react/mocks/repl-example.js
+++ b/test/react/mocks/repl-example.js
@@ -28,8 +28,8 @@ function Foo(props: {href: string}) {
 
 // this is a special Prepack function hook
 // that tells Prepack the root of a React component tree
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(Foo);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(Foo);
 }
 
 window.Foo = Foo;

--- a/test/react/render-props/relay-query-renderer.js
+++ b/test/react/render-props/relay-query-renderer.js
@@ -20,8 +20,8 @@ App.getTrials = function(renderer, Root) {
   return [['render props relay', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/render-props/relay-query-renderer2.js
+++ b/test/react/render-props/relay-query-renderer2.js
@@ -20,8 +20,8 @@ App.getTrials = function(renderer, Root) {
   return [['render props relay', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/render-props/relay-query-renderer3.js
+++ b/test/react/render-props/relay-query-renderer3.js
@@ -32,8 +32,8 @@ App.getTrials = function(renderer, Root) {
   return [['render props relay', renderer.toJSON()]];
 };
 
-if (this.__registerReactComponentRoot) {
-  __registerReactComponentRoot(App);
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;


### PR DESCRIPTION
Release notes: none

Currently, you register a React component tree with `__registerReactComponent(component)`. 

This PR changes this global to `__optimizeReactComponentTree(rootComponent, config)`. Notice it now supports two arguments `rootComponent` and `config` – although config is optional.

This global now also returns the original component passed in, so it can be added to existing codebase without having to break logic flow.

This config argument allows the user to define how that React component tree will be optimized. More work will be added to this in upcoming PRs, but for now this PR is just a quick rename plus small refactor of the Prepack global.

I've also had to rename the global in all tests. I've also added some doc as to how all this works: https://github.com/facebook/prepack/wiki/React-Compiler