### PR TITLE
Add "node-react" compatibility mode

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -20,7 +20,7 @@ export default function(realm: Realm): Realm {
   if (realm.isCompatibleWith("browser")) {
     initializeDOMGlobals(realm);
   }
-  if (realm.isCompatibleWith("fb-www")) {
+  if (realm.isCompatibleWith("fb-www") || realm.isCompatibleWith("node-react")) {
     initializeDOMGlobals(realm);
     initializeReactMocks(realm);
   }

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -86,5 +86,7 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
-  createFbMocks(realm, global);
+  if (realm.isCompatibleWith("fb-www")) {
+    createFbMocks(realm, global);
+  }
 }

--- a/src/options.js
+++ b/src/options.js
@@ -11,8 +11,23 @@
 
 import type { ErrorHandler } from "./errors.js";
 
-export type Compatibility = "browser" | "jsc-600-1-4-17" | "mobile" | "node-source-maps" | "node-cli" | "fb-www";
-export const CompatibilityValues = ["browser", "jsc-600-1-4-17", "mobile", "node-source-maps", "node-cli", "fb-www"];
+export type Compatibility =
+  | "browser"
+  | "jsc-600-1-4-17"
+  | "mobile"
+  | "node-source-maps"
+  | "node-cli"
+  | "fb-www"
+  | "node-react";
+export const CompatibilityValues = [
+  "browser",
+  "jsc-600-1-4-17",
+  "mobile",
+  "node-source-maps",
+  "node-cli",
+  "fb-www",
+  "node-react",
+];
 
 export type ReactOutputTypes = "create-element" | "jsx" | "bytecode";
 export const ReactOutputValues = ["create-element", "jsx", "bytecode"];

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -40,8 +40,8 @@ var optionsConfig = [
   {
     type: "choice",
     name: "compatibility",
-    choices: ["browser", "jsc-600-1-4-17", "node-source-maps", "node-cli", "fb-wwww"],
-    defaultVal: "browser",
+    choices: ["browser", "jsc-600-1-4-17", "node-source-maps", "node-cli", "node-react"],
+    defaultVal: "node-react",
     description: "The target environment for Prepack"
   },
   {


### PR DESCRIPTION
Release notes: adds "node-react" compatibility mode

Adds the "node-react" compatibility mode, which is like "fb-www", but doesn't contain the internal FB mocks. This mode is ideal for library authors who might want to experiment with the features of the React compiler in an environment that has basic React/Relay mocks as well as `require` and `module.exports` partial support.

I'll be adding relevant documentation for this on the wiki too.