### PR TITLE
Remove react-rest console.error noise

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -632,31 +632,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with JSX input, JSX output Functional component folding Dynamic props 1`] = `
-ReactStatistics {
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
-  "optimizedTrees": 1,
-}
-`;
-
 exports[`Test React with JSX input, JSX output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -2419,31 +2394,6 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 1,
-  "optimizedTrees": 1,
-}
-`;
-
-exports[`Test React with JSX input, create-element output Functional component folding Dynamic props 1`] = `
-ReactStatistics {
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
@@ -4214,31 +4164,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with create-element input, JSX output Functional component folding Dynamic props 1`] = `
-ReactStatistics {
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
-  "optimizedTrees": 1,
-}
-`;
-
 exports[`Test React with create-element input, JSX output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -5971,31 +5896,6 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 1,
-  "optimizedTrees": 1,
-}
-`;
-
-exports[`Test React with create-element input, create-element output Functional component folding Dynamic props 1`] = `
-ReactStatistics {
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "name": "Fn",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;


### PR DESCRIPTION
Release notes: none

We spam the console when running `test-react` and many of the errors are not errors but just noise. Interestingly this also brought about one test that genuinely is failing but before was bringing up an invalid bail-out with `dynamic-props.js`. I'll fix that as a follow up as it's unrelated to this PRs goal.