### PR TITLE
Allow simple object property access with an abstract dynamic key

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -632,6 +632,26 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Dynamic props 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -2390,6 +2410,26 @@ ReactStatistics {
         },
       ],
       "name": "Child",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Dynamic props 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
       "status": "ROOT",
     },
   ],
@@ -4164,6 +4204,26 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Dynamic props 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -5892,6 +5952,26 @@ ReactStatistics {
         },
       ],
       "name": "Child",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Dynamic props 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "name": "Fn",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
       "status": "ROOT",
     },
   ],

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -350,7 +350,7 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
       });
 
       it("Dynamic props", async () => {
-        // await runTest(directory, "dynamic-props.js");
+        await runTest(directory, "dynamic-props.js");
       });
 
       it("Dynamic context", async () => {

--- a/src/environment.js
+++ b/src/environment.js
@@ -1380,7 +1380,7 @@ export class Reference {
           refName.mightNotBeString() &&
           refName.mightNotBeNumber() &&
           !refName.isSimpleObject() &&
-          // if the base is a simple abstract object we but
+          // if the base is a simple abstract object but
           // the refName is not simple, this is also okay
           (base instanceof AbstractValue && !base.isSimpleObject())
         )

--- a/src/environment.js
+++ b/src/environment.js
@@ -1380,6 +1380,8 @@ export class Reference {
           refName.mightNotBeString() &&
           refName.mightNotBeNumber() &&
           !refName.isSimpleObject() &&
+          // if the base is a simple abstract object we but
+          // the refName is not simple, this is also okay
           (base instanceof AbstractValue && !base.isSimpleObject())
         )
     );

--- a/src/environment.js
+++ b/src/environment.js
@@ -1376,7 +1376,12 @@ export class Reference {
     this.referencedName = refName;
     invariant(
       !(refName instanceof AbstractValue) ||
-        !(refName.mightNotBeString() && refName.mightNotBeNumber() && !refName.isSimpleObject())
+        !(
+          refName.mightNotBeString() &&
+          refName.mightNotBeNumber() &&
+          !refName.isSimpleObject() &&
+          (base instanceof AbstractValue && !base.isSimpleObject())
+        )
     );
     this.strict = strict;
     this.thisValue = thisValue;

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -780,8 +780,8 @@ export class ToImplementation {
 
   ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */ {
     if (arg instanceof ConcreteValue) return this.ToPropertyKey(realm, arg);
-    // if we are in pure scope, we can assume that the property
-    // won't cause side-effects if it's not simple
+    // if we are in pure scope, we can assume that ToPropertyKey
+    // won't cause side-effects even if it's not simple
     if (arg.mightNotBeString() && arg.mightNotBeNumber() && !arg.isSimpleObject() && !realm.isInPureScope()) {
       arg.throwIfNotConcrete();
     }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -782,6 +782,8 @@ export class ToImplementation {
   ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */ {
     if (arg instanceof ConcreteValue) return this.ToPropertyKey(realm, arg);
     if (arg.mightNotBeString() && arg.mightNotBeNumber() && !arg.isSimpleObject()) {
+      // if we are in pure scope, we can assume that the property
+      // won't cause side-effects if it's not simple
       if (!realm.isInPureScope()) {
         arg.throwIfNotConcrete();
       }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -34,7 +34,6 @@ import {
   Value,
 } from "../values/index.js";
 import invariant from "../invariant.js";
-import { Havoc } from "../singletons.js";
 
 type ElementConvType = {
   Int8: (Realm, numberOrValue) => number,
@@ -781,13 +780,10 @@ export class ToImplementation {
 
   ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */ {
     if (arg instanceof ConcreteValue) return this.ToPropertyKey(realm, arg);
-    if (arg.mightNotBeString() && arg.mightNotBeNumber() && !arg.isSimpleObject()) {
-      // if we are in pure scope, we can assume that the property
+    // if we are in pure scope, we can assume that the property
       // won't cause side-effects if it's not simple
-      if (!realm.isInPureScope()) {
-        arg.throwIfNotConcrete();
-      }
-      Havoc.value(realm, arg);
+    if (arg.mightNotBeString() && arg.mightNotBeNumber() && !arg.isSimpleObject() && !realm.isInPureScope()) {
+      arg.throwIfNotConcrete();
     }
     invariant(arg instanceof AbstractValue);
     return arg;

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -34,6 +34,7 @@ import {
   Value,
 } from "../values/index.js";
 import invariant from "../invariant.js";
+import { Havoc } from "../singletons.js";
 
 type ElementConvType = {
   Int8: (Realm, numberOrValue) => number,
@@ -780,7 +781,12 @@ export class ToImplementation {
 
   ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */ {
     if (arg instanceof ConcreteValue) return this.ToPropertyKey(realm, arg);
-    if (arg.mightNotBeString() && arg.mightNotBeNumber() && !arg.isSimpleObject()) arg.throwIfNotConcrete();
+    if (arg.mightNotBeString() && arg.mightNotBeNumber() && !arg.isSimpleObject()) {
+      if (!realm.isInPureScope()) {
+        arg.throwIfNotConcrete();
+      }
+      Havoc.value(realm, arg);
+    }
     invariant(arg instanceof AbstractValue);
     return arg;
   }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -781,7 +781,7 @@ export class ToImplementation {
   ToPropertyKeyPartial(realm: Realm, arg: Value): AbstractValue | SymbolValue | string /* but not StringValue */ {
     if (arg instanceof ConcreteValue) return this.ToPropertyKey(realm, arg);
     // if we are in pure scope, we can assume that the property
-      // won't cause side-effects if it's not simple
+    // won't cause side-effects if it's not simple
     if (arg.mightNotBeString() && arg.mightNotBeNumber() && !arg.isSimpleObject() && !realm.isInPureScope()) {
       arg.throwIfNotConcrete();
     }

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -29,8 +29,6 @@ function createPropsObject(
   let props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
   // start by having key and ref deleted, if they actually exist, they will be add later
   deleteRefAndKeyFromProps(realm, props);
-  // props can never have getters or setters on them
-  props.makeSimple();
   let key = realm.intrinsics.null;
   let ref = realm.intrinsics.null;
 

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -29,6 +29,8 @@ function createPropsObject(
   let props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
   // start by having key and ref deleted, if they actually exist, they will be add later
   deleteRefAndKeyFromProps(realm, props);
+  // props can never have getters or setters on them
+  props.makeSimple();
   let key = realm.intrinsics.null;
   let ref = realm.intrinsics.null;
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -48,6 +48,7 @@ import {
 import { Join, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { typeAnnotation } from "babel-types";
+import { Havoc } from "../singletons.js";
 import * as t from "babel-types";
 
 function isWidenedValue(v: void | Value) {
@@ -585,8 +586,12 @@ export default class ObjectValue extends ConcreteValue {
       !this.isSimpleObject() ||
       (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject())
     ) {
-      AbstractValue.reportIntrospectionError(P, "TODO: #1021");
-      throw new FatalError();
+      if (this.$Realm.isInPureScope() && !this.isPartialObject() && this.isSimpleObject() && this === Receiver) {
+        Havoc.value(this.$Realm, P);
+      } else {
+        AbstractValue.reportIntrospectionError(P, "TODO: #1021");
+        throw new FatalError();
+      }
     }
     // If all else fails, use this expression
     let result;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -48,7 +48,6 @@ import {
 import { Join, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { typeAnnotation } from "babel-types";
-import { Havoc } from "../singletons.js";
 import * as t from "babel-types";
 
 function isWidenedValue(v: void | Value) {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -587,7 +587,8 @@ export default class ObjectValue extends ConcreteValue {
     ) {
       // if P is an abstract value that we don't know about, but we're in pure scope
       // then if the object is simple, then we can safely continue without throwing
-      // the below introspection error
+      // the introspection error below, since converting P to a string is assumed to
+      // be well behaved in a pure scope
       if (!(this.$Realm.isInPureScope() && this.isSimpleObject() && this === Receiver)) {
         AbstractValue.reportIntrospectionError(P, "TODO: #1021");
         throw new FatalError();

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -586,12 +586,10 @@ export default class ObjectValue extends ConcreteValue {
       !this.isSimpleObject() ||
       (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject())
     ) {
-      // if P is an abstract value that we don't know about, but wee're in pure scope
-      // then if the object is **not** partial, but is simple, then we can
-      // safely continue without throwing the beelow introspection error
-      if (this.$Realm.isInPureScope() && !this.isPartialObject() && this.isSimpleObject() && this === Receiver) {
-        Havoc.value(this.$Realm, P);
-      } else {
+      // if P is an abstract value that we don't know about, but we're in pure scope
+      // then if the object is simple, then we can safely continue without throwing
+      // the below introspection error
+      if (!(this.$Realm.isInPureScope() && this.isSimpleObject() && this === Receiver)) {
         AbstractValue.reportIntrospectionError(P, "TODO: #1021");
         throw new FatalError();
       }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -586,6 +586,9 @@ export default class ObjectValue extends ConcreteValue {
       !this.isSimpleObject() ||
       (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject())
     ) {
+      // if P is an abstract value that we don't know about, but wee're in pure scope
+      // then if the object is **not** partial, but is simple, then we can
+      // safely continue without throwing the beelow introspection error
       if (this.$Realm.isInPureScope() && !this.isPartialObject() && this.isSimpleObject() && this === Receiver) {
         Havoc.value(this.$Realm, P);
       } else {


### PR DESCRIPTION
Release notes: Allow simple object computed property access with abstract property keys

The aim of this PR is to provide object computed property access when the property key is an abstract value and the object is a simple object. Furthermore, given the key is abstract, and converting it to a key might involve side-effects, this is only handled in a pure scope.