### PR TITLE
Adds firstRenderOnly mode

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -290,6 +290,58 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output First render only Simple 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output First render only componentWillMount 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -2053,6 +2105,58 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only Simple 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only componentWillMount 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
 }
 `;
 
@@ -3822,6 +3926,58 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output First render only Simple 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output First render only componentWillMount 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
   "evaluatedRootNodes": Array [
@@ -5555,6 +5711,58 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only Simple 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only componentWillMount 1`] = `
+ReactStatistics {
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -77,23 +77,18 @@ let reactCode = `
       return config.key !== undefined;
     }
 
-    class Component {
-      constructor(props, context) {
-        this.props = props;
-        this.context = context;
-        this.refs = {};
-      }
-      getChildContext() {}
+    function Component(props, context) {
+      this.props = props;
+      this.context = context;
+      this.refs = {};
     }
-
+    
     Component.prototype.isReactComponent = {};
 
-    class PureComponent {
-      constructor(props, context) {
-        this.props = props;
-        this.context = context;
-        this.refs = {};
-      }
+    function PureComponent(props, context) {
+      this.props = props;
+      this.context = context;
+      this.refs = {};
     }
 
     PureComponent.prototype.isReactComponent = {};

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -189,6 +189,7 @@ export function createClassInstanceForFirstRenderOnly(
     }
     return realm.intrinsics.undefined;
   });
+  setState.intrinsicName = "this.setState";
   Properties.Set(realm, instance, "setState", setState, true);
 
   instance.refuseSerialization = false;

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -757,8 +757,8 @@ export function sanitizeReactElementForFirstRenderOnly(realm: Realm, reactElemen
       invariant(propsValue instanceof ObjectValue);
       let value = getProperty(realm, propsValue, propName);
 
-      // skip children
-      if (propName === "children") {
+      // skip children and style
+      if (propName === "children" || propName === "style") {
         continue;
       }
       if (!(value instanceof StringValue || value instanceof NumberValue || value instanceof BooleanValue)) {

--- a/src/types.js
+++ b/src/types.js
@@ -327,7 +327,7 @@ export type ClassComponentMetadata = {
 export type ReactHint = {| object: ObjectValue, propertyName: string, args: Array<Value> |};
 
 export type ReactComponentTreeConfig = {
-  serverSideRenderOnly: boolean,
+  firstRenderOnly: boolean,
 };
 
 export type DebugServerType = {

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -12,7 +12,7 @@ type JSONValue = Array<JSONValue> | string | number | JSON;
 type JSON = { [key: string]: JSONValue };
 
 // this will mutate the original JSON object
-export function mergeAdacentJSONTextNodes(node: JSON, firstRenderOnly: boolean, visitedNodes?: Set<JSON>) {
+export function mergeAdacentJSONTextNodes(node: JSON, includeFunctionBodies: boolean, visitedNodes?: Set<JSON>) {
   if (visitedNodes === undefined) {
     visitedNodes = new Set();
   }
@@ -41,7 +41,7 @@ export function mergeAdacentJSONTextNodes(node: JSON, firstRenderOnly: boolean, 
           arr.push(concatString);
           concatString = null;
         }
-        arr.push(mergeAdacentJSONTextNodes(child, firstRenderOnly, visitedNodes));
+        arr.push(mergeAdacentJSONTextNodes(child, includeFunctionBodies, visitedNodes));
       }
     }
     if (concatString !== null) {
@@ -52,13 +52,13 @@ export function mergeAdacentJSONTextNodes(node: JSON, firstRenderOnly: boolean, 
     for (let key in node) {
       let value = node[key];
       if (typeof value === "function") {
-        if (!firstRenderOnly) {
+        if (!includeFunctionBodies) {
           node[key] = value.toString();
         } else {
           delete node[key];
         }
       } else if (typeof value === "object" && value !== null) {
-        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), firstRenderOnly, visitedNodes);
+        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), includeFunctionBodies, visitedNodes);
       }
     }
   }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -12,7 +12,7 @@ type JSONValue = Array<JSONValue> | string | number | JSON;
 type JSON = { [key: string]: JSONValue };
 
 // this will mutate the original JSON object
-export function mergeAdacentJSONTextNodes(node: JSON, visitedNodes?: Set<JSON>) {
+export function mergeAdacentJSONTextNodes(node: JSON, firstRenderOnly: boolean, visitedNodes?: Set<JSON>) {
   if (visitedNodes === undefined) {
     visitedNodes = new Set();
   }
@@ -41,7 +41,7 @@ export function mergeAdacentJSONTextNodes(node: JSON, visitedNodes?: Set<JSON>) 
           arr.push(concatString);
           concatString = null;
         }
-        arr.push(mergeAdacentJSONTextNodes(child, visitedNodes));
+        arr.push(mergeAdacentJSONTextNodes(child, firstRenderOnly, visitedNodes));
       }
     }
     if (concatString !== null) {
@@ -52,9 +52,13 @@ export function mergeAdacentJSONTextNodes(node: JSON, visitedNodes?: Set<JSON>) 
     for (let key in node) {
       let value = node[key];
       if (typeof value === "function") {
-        node[key] = value.toString();
+        if (!firstRenderOnly) {
+          node[key] = value.toString();
+        } else {
+          delete node[key];
+        }
       } else if (typeof value === "object" && value !== null) {
-        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), visitedNodes);
+        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), firstRenderOnly, visitedNodes);
       }
     }
   }

--- a/test/react/first-render-only/simple.js
+++ b/test/react/first-render-only/simple.js
@@ -1,0 +1,68 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Child3(props) {
+  return <span>{props.data.text}</span>;
+}
+
+class Child2 extends React.Component {
+  constructor() {
+    super();
+    this.randomVar = {
+      text: "Hello world",
+    };
+  }
+  render() {
+    return (
+      <React.Fragment>
+        {Array.from(this.props.items).map(item =>
+          <Child3 data={item} key={item.id} />
+        )}
+        <span>{this.randomVar.text}</span>
+      </React.Fragment>
+    );
+  }
+}
+
+class Child1 extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      counter: 0,
+    };
+    this.handleClick = () => {
+      this.setState({ counter: this.state.counter + 1 });
+    };
+  }
+  render() {
+    return (
+      <div onClick={this.handleClick}>
+        <Child2  items={this.props.items} />
+        <span>Counter is at: {this.state.counter}</span>
+      </div>
+    );
+  }
+}
+
+function App(props) {
+  return <Child1 {...props} />
+}
+
+App.getTrials = function(renderer, Root) {
+  var items = [
+    {id: 0, text: "Item 1"},
+    {id: 1, text: "Item 2"},
+    {id: 2, text: "Item 3"},
+  ];
+  renderer.update(<Root items={items} />);
+  return [['render simple first render only tree', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;

--- a/test/react/first-render-only/will-mount.js
+++ b/test/react/first-render-only/will-mount.js
@@ -1,0 +1,76 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Child3(props) {
+  return <span>{props.data.text}</span>;
+}
+
+class Child2 extends React.Component {
+  constructor() {
+    super();
+    this.randomVar = {
+      text: "Hello world",
+    };
+  }
+  render() {
+    return (
+      <React.Fragment>
+        {Array.from(this.props.items).map(item =>
+          <Child3 data={item} key={item.id} />
+        )}
+        <span>{this.randomVar.text}</span>
+      </React.Fragment>
+    );
+  }
+  componentWillMount() {
+    this.randomVar.text = "It worked!";
+  }
+}
+
+class Child1 extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      counter: 0,
+    };
+    this.handleClick = () => {
+      this.setState({ counter: this.state.counter + 1 });
+    };
+  }
+  render() {
+    return (
+      <div onClick={this.handleClick}>
+        <Child2  items={this.props.items} />
+        <span>Counter is at: {this.state.counter}</span>
+      </div>
+    );
+  }
+  componentWillMount() {
+    this.setState({
+      counter: this.state.counter + 1,
+    });
+  }
+}
+
+function App(props) {
+  return <Child1 {...props} />
+}
+
+App.getTrials = function(renderer, Root) {
+  var items = [
+    {id: 0, text: "Item 1"},
+    {id: 1, text: "Item 2"},
+    {id: 2, text: "Item 3"},
+  ];
+  renderer.update(<Root items={items} />);
+  return [['render simple first render only tree', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

Adds a new React reconciler rendering mode called `firstRenderOnly`, activated by in the config passed to `__optimizeReactComponentTree`. Will add documentation to the wiki once this PR is ready to land.