### PR TITLE
When Object.assign bails out, resolve to an AbstractObjectValue

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -285,6 +285,28 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
+  // Internal helper function for tests.
+  // __isAbstractObject(value) checks if a given value is abstract.
+  global.$DefineOwnProperty("__isAbstractObject", {
+    value: new NativeFunctionValue(realm, "global.__isAbstractObject", "__isAbstractObject", 1, (context, [value]) => {
+      return new BooleanValue(realm, value instanceof AbstractObjectValue);
+    }),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
+  // Internal helper function for tests.
+  // __isSimpleObject(value) checks if a given value is abstract.
+  global.$DefineOwnProperty("__isSimpleObject", {
+    value: new NativeFunctionValue(realm, "global.__isSimpleObject", "__isSimpleObject", 1, (context, [value]) => {
+      return new BooleanValue(realm, value.isSimpleObject());
+    }),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+
   // __makePartial(object) marks an (abstract) object as partial.
   global.$DefineOwnProperty("__makePartial", {
     value: new NativeFunctionValue(realm, "global.__makePartial", "__makePartial", 1, (context, [object]) => {

--- a/test/serializer/pure-functions/ObjectAssign2.js
+++ b/test/serializer/pure-functions/ObjectAssign2.js
@@ -1,0 +1,30 @@
+// additional functions
+// abstract effects
+
+var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
+var objSimple = global.__abstract && global.__makePartial && global.__makeSimple ? __makeSimple(__makePartial(__abstract({}, "({foo:2})"))) : {foo:2};
+
+function additional1() {
+  var o = Object.assign(obj, {get bar() {}});
+  // Object.assign should fail by returning a non-simple AbstractObjectValue
+  return global.__isAbstractObject && global.__isSimpleObject ?
+    [__isAbstractObject(o), __isSimpleObject(o)] :
+    [true, false];
+}
+
+function additional2() {
+  var o = Object.assign(objSimple, global.__abstract ? __abstract("empty") : false);
+  // Object.assign should fail by returning a simple AbstractObjectValue
+  return global.__isAbstractObject && global.__isSimpleObject ?
+    [__isAbstractObject(o), __isSimpleObject(o)] :
+    [true, true];
+}
+
+inspect = function() {
+  var res1 = additional1();
+  var res2 = additional2();
+  return JSON.stringify({
+    res1,
+    res2,
+  });
+}


### PR DESCRIPTION
Release notes: none

This will allow Put to execute successfully on something that has come from an object literal with spread.