### PR TITLE
Change an invariant in Properties.PutValue to a FatalError

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1007,7 +1007,7 @@ export class PropertiesImplementation {
       }
       if (!(base instanceof ObjectValue || base instanceof AbstractObjectValue)) {
         let diagnostic = new CompilerDiagnostic(
-          "cannot PutValue on a base value that is not an object or abstract object",
+          "cannot put a value on a base value that is not an object or abstract object",
           realm.currentLocation,
           "PP0027",
           "FatalError"

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1005,7 +1005,16 @@ export class PropertiesImplementation {
         // ii. Set base to ToObject(base).
         base = To.ToObjectPartial(realm, base);
       }
-      invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
+      if (!(base instanceof ObjectValue || base instanceof AbstractObjectValue)) {
+        let diagnostic = new CompilerDiagnostic(
+          "cannot PutValue on a base value that is not an object or abstract object",
+          realm.currentLocation,
+          "PP0027",
+          "FatalError"
+        );
+        realm.handleError(diagnostic);
+        throw new FatalError();
+      }
 
       // b. Let succeeded be ? base.[[Set]](GetReferencedName(V), W, GetThisValue(V)).
       let succeeded = base.$SetPartial(Environment.GetReferencedNamePartial(realm, V), W, GetThisValue(realm, V));

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1005,16 +1005,17 @@ export class PropertiesImplementation {
         // ii. Set base to ToObject(base).
         base = To.ToObjectPartial(realm, base);
       }
-      if (!(base instanceof ObjectValue || base instanceof AbstractObjectValue)) {
+      if (!(base instanceof AbstractObjectValue) && base instanceof AbstractValue) {
         let diagnostic = new CompilerDiagnostic(
-          "cannot put a value on a base value that is not an object or abstract object",
+          `member expression object ${AbstractValue.describe(base)} is unknown`,
           realm.currentLocation,
-          "PP0027",
+          "PP0012",
           "FatalError"
         );
         realm.handleError(diagnostic);
         throw new FatalError();
       }
+      invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
 
       // b. Let succeeded be ? base.[[Set]](GetReferencedName(V), W, GetThisValue(V)).
       let succeeded = base.$SetPartial(Environment.GetReferencedNamePartial(realm, V), W, GetThisValue(realm, V));

--- a/test/error-handler/put-value-on-abstract-base.js
+++ b/test/error-handler/put-value-on-abstract-base.js
@@ -1,6 +1,6 @@
 // recover-from-errors
 // abstract effects
-// expected errors: [{"location":{"start":{"line":7,"column":25},"end":{"line":7,"column":28},"source":"test/error-handler/put-value-on-abstract-base.js"},"severity":"FatalError","errorCode":"PP0027"}]
+// expected errors: [{"location":{"start":{"line":7,"column":25},"end":{"line":7,"column":28},"source":"test/error-handler/put-value-on-abstract-base.js"},"severity":"FatalError","errorCode":"PP0012"}]
 
 __evaluatePureFunction(() => {
   var somethingUnknown = global.__abstract();

--- a/test/error-handler/put-value-on-abstract-base.js
+++ b/test/error-handler/put-value-on-abstract-base.js
@@ -1,0 +1,8 @@
+// recover-from-errors
+// abstract effects
+// expected errors: [{"location":{"start":{"line":7,"column":25},"end":{"line":7,"column":28},"source":"test/error-handler/put-value-on-abstract-base.js"},"severity":"FatalError","errorCode":"PP0027"}]
+
+__evaluatePureFunction(() => {
+  var somethingUnknown = global.__abstract();
+  somethingUnknown.foo = 123;
+});


### PR DESCRIPTION
Release notes: none

Whilst running the UFI code, we encountered this invariant being triggered where the base value was not an ObjectValue or AbstractObjectValue (it was an AbstractValue). I changed the invariant for a FatalError along with a relevant message and PP code.