### PR TITLE
Git rid of calls to Object.setPrototypeOf in the Prepack code base.

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -35,12 +35,10 @@ export class CompilerDiagnostic extends Error {
 // This error is thrown to exit Prepack when an ErrorHandler returns 'FatalError'
 // This should just be a class but Babel classes doesn't work with
 // built-in super classes.
-export function FatalError(message?: string) {
-  let self = new Error(message || "A fatal error occurred while prepacking.");
-  Object.setPrototypeOf(self, FatalError.prototype);
-  return self;
+export class FatalError extends Error {
+  constructor(message?: string) {
+    super(message || "A fatal error occurred while prepacking.");
+  }
 }
-Object.setPrototypeOf(FatalError, Error);
-Object.setPrototypeOf(FatalError.prototype, Error.prototype);
 
 export type ErrorHandler = (error: CompilerDiagnostic) => ErrorHandlerResult;

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -33,17 +33,6 @@ import { Logger } from "./utils/logger.js";
 import { Generator } from "./utils/generator.js";
 import { AbstractObjectValue, AbstractValue, ObjectValue } from "./values/index.js";
 
-// IMPORTANT: This function is now deprecated and will go away in a future release.
-// Please use FatalError instead.
-export function InitializationError() {
-  let self = new Error("An error occurred while prepacking. See the error logs.");
-  Object.setPrototypeOf(self, InitializationError.prototype);
-  return self;
-}
-Object.setPrototypeOf(InitializationError, Error);
-Object.setPrototypeOf(InitializationError.prototype, Error.prototype);
-Object.setPrototypeOf(FatalError.prototype, InitializationError.prototype);
-
 export function prepackSources(
   sources: Array<SourceFile>,
   options: PrepackOptions = defaultOptions,

--- a/src/react/errors.js
+++ b/src/react/errors.js
@@ -14,40 +14,13 @@
 // given to ExpectedBailOut will be assigned to the value.$BailOutReason property and serialized
 // as a comment in the output source to give the user hints as to what they need to do
 // to fix the bail-out case
-export class ExpectedBailOut {
-  message: string;
-  constructor(message: string) {
-    this.message = message;
-    let self = new Error(message);
-    Object.setPrototypeOf(self, ExpectedBailOut.prototype);
-    return self;
-  }
-}
-Object.setPrototypeOf(ExpectedBailOut, Error);
-Object.setPrototypeOf(ExpectedBailOut.prototype, Error.prototype);
+export class ExpectedBailOut extends Error {}
 
 // SimpleClassBailOuts only occur when a simple class instance is created and used
 // bailing out here will result in a complex class instance being created after
 // and an alternative complex class component route being used
-export class SimpleClassBailOut {
-  message: string;
-  constructor(message: string) {
-    let self = new Error(message);
-    Object.setPrototypeOf(self, SimpleClassBailOut.prototype);
-    return self;
-  }
-}
-Object.setPrototypeOf(SimpleClassBailOut, Error);
-Object.setPrototypeOf(SimpleClassBailOut.prototype, Error.prototype);
+export class SimpleClassBailOut extends Error {}
 
 // NewComponentTreeBranch only occur when a complex class is found in a
 // component tree and the reconciler can no longer fold the component of that branch
-export class NewComponentTreeBranch {
-  constructor() {
-    let self = new Error();
-    Object.setPrototypeOf(self, NewComponentTreeBranch.prototype);
-    return self;
-  }
-}
-Object.setPrototypeOf(NewComponentTreeBranch, Error);
-Object.setPrototypeOf(NewComponentTreeBranch.prototype, Error.prototype);
+export class NewComponentTreeBranch extends Error {}


### PR DESCRIPTION
Release note: Adapted Prepack source code to latest Flow

The latest version of Flow has a bug where it does not know about Object.setPrototypeOf. It turns out that we don't really need to call it anymore, so we may as well get rid of it.
