### PR TITLE
All generators now have a proper name.

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -205,7 +205,7 @@ export function computeBinary(
     };
     let effects;
     try {
-      effects = realm.evaluateForEffects(compute);
+      effects = realm.evaluateForEffects(compute, undefined, "computeBinary");
     } catch (x) {
       if (x instanceof FatalError) {
         isPure = false;

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -65,12 +65,16 @@ function callBothFunctionsAndJoinTheirEffects(
   invariant(Value.isTypeCompatibleWith(func1.getType(), FunctionValue));
   invariant(Value.isTypeCompatibleWith(func2.getType(), FunctionValue));
 
-  let [compl1, gen1, bindings1, properties1, createdObj1] = realm.evaluateForEffects(() =>
-    EvaluateCall(func1, func1, ast, strictCode, env, realm)
+  let [compl1, gen1, bindings1, properties1, createdObj1] = realm.evaluateForEffects(
+    () => EvaluateCall(func1, func1, ast, strictCode, env, realm),
+    undefined,
+    "callBothFunctionsAndJoinTheirEffects/1"
   );
 
-  let [compl2, gen2, bindings2, properties2, createdObj2] = realm.evaluateForEffects(() =>
-    EvaluateCall(func2, func2, ast, strictCode, env, realm)
+  let [compl2, gen2, bindings2, properties2, createdObj2] = realm.evaluateForEffects(
+    () => EvaluateCall(func2, func2, ast, strictCode, env, realm),
+    undefined,
+    "callBothFunctionsAndJoinTheirEffects/2"
   );
 
   let joinedEffects = Join.joinEffects(
@@ -154,8 +158,10 @@ function tryToEvaluateCallOrLeaveAsAbstract(
 ): Value {
   let effects;
   try {
-    effects = realm.evaluateForEffects(() =>
-      EvaluateDirectCall(realm, strictCode, env, ref, func, thisValue, ast.arguments, tailCall)
+    effects = realm.evaluateForEffects(
+      () => EvaluateDirectCall(realm, strictCode, env, ref, func, thisValue, ast.arguments, tailCall),
+      undefined,
+      "tryToEvaluateCallOrLeaveAsAbstract"
     );
   } catch (error) {
     if (error instanceof FatalError) {

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -133,15 +133,23 @@ function AbstractCaseBlockEvaluation(
       // so we evaluate the case in the abstract as an if-else with the else
       // leading to the next case statement
       let trueEffects = Path.withCondition(selectionResult, () => {
-        return realm.evaluateForEffects(() => {
-          return DefiniteCaseEvaluation(caseIndex);
-        });
+        return realm.evaluateForEffects(
+          () => {
+            return DefiniteCaseEvaluation(caseIndex);
+          },
+          undefined,
+          "AbstractCaseEvaluation/1"
+        );
       });
 
       let falseEffects = Path.withInverseCondition(selectionResult, () => {
-        return realm.evaluateForEffects(() => {
-          return AbstractCaseEvaluation(caseIndex + 1);
-        });
+        return realm.evaluateForEffects(
+          () => {
+            return AbstractCaseEvaluation(caseIndex + 1);
+          },
+          undefined,
+          "AbstractCaseEvaluation/2"
+        );
       });
 
       let joinedEffects = Join.joinEffects(realm, selectionResult, trueEffects, falseEffects);

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -111,11 +111,15 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
     if (consequent instanceof JoinedAbruptCompletions || consequent instanceof PossiblyNormalCompletion) {
       consequentEffects = composeNestedThrowEffectsWithHandler(consequent, priorEffects);
     } else if (consequent instanceof ThrowCompletion) {
-      consequentEffects = realm.evaluateForEffects(() => {
-        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
-        invariant(ast.handler);
-        return env.evaluateCompletionDeref(ast.handler, strictCode, consequent);
-      });
+      consequentEffects = realm.evaluateForEffects(
+        () => {
+          for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+          invariant(ast.handler);
+          return env.evaluateCompletionDeref(ast.handler, strictCode, consequent);
+        },
+        undefined,
+        "composeNestedThrowEffectsWithHandler/1"
+      );
     }
     priorEffects.pop();
     let alternate = c.alternate;
@@ -124,11 +128,15 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
     if (alternate instanceof PossiblyNormalCompletion || alternate instanceof JoinedAbruptCompletions) {
       alternateEffects = composeNestedThrowEffectsWithHandler(alternate, priorEffects);
     } else if (alternate instanceof ThrowCompletion) {
-      alternateEffects = realm.evaluateForEffects(() => {
-        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
-        invariant(ast.handler);
-        return env.evaluateCompletionDeref(ast.handler, strictCode, alternate);
-      });
+      alternateEffects = realm.evaluateForEffects(
+        () => {
+          for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+          invariant(ast.handler);
+          return env.evaluateCompletionDeref(ast.handler, strictCode, alternate);
+        },
+        undefined,
+        "composeNestedThrowEffectsWithHandler/2"
+      );
     }
     priorEffects.pop();
     return Join.joinEffects(realm, c.joinCondition, consequentEffects, alternateEffects);
@@ -148,11 +156,15 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
     if (consequent instanceof JoinedAbruptCompletions || consequent instanceof PossiblyNormalCompletion) {
       consequentEffects = composeNestedThrowEffectsWithHandler(consequent, priorEffects);
     } else {
-      consequentEffects = realm.evaluateForEffects(() => {
-        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
-        invariant(ast.finalizer);
-        return env.evaluateCompletionDeref(ast.finalizer, strictCode);
-      });
+      consequentEffects = realm.evaluateForEffects(
+        () => {
+          for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+          invariant(ast.finalizer);
+          return env.evaluateCompletionDeref(ast.finalizer, strictCode);
+        },
+        undefined,
+        "composeNestedEffectsWithFinalizer/1"
+      );
       if (!(consequentEffects[0] instanceof AbruptCompletion)) consequentEffects[0] = consequent;
     }
     priorEffects.pop();
@@ -162,11 +174,15 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
     if (alternate instanceof PossiblyNormalCompletion || alternate instanceof JoinedAbruptCompletions) {
       alternateEffects = composeNestedThrowEffectsWithHandler(alternate, priorEffects);
     } else {
-      alternateEffects = realm.evaluateForEffects(() => {
-        for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
-        invariant(ast.finalizer);
-        return env.evaluateCompletionDeref(ast.finalizer, strictCode);
-      });
+      alternateEffects = realm.evaluateForEffects(
+        () => {
+          for (let priorEffect of priorEffects) realm.applyEffects(priorEffect);
+          invariant(ast.finalizer);
+          return env.evaluateCompletionDeref(ast.finalizer, strictCode);
+        },
+        undefined,
+        "composeNestedThrowEffectsWithHandler"
+      );
       if (!(alternateEffects[0] instanceof AbruptCompletion)) alternateEffects[0] = alternate;
     }
     priorEffects.pop();

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -100,10 +100,14 @@ function tryToEvaluateOperationOrLeaveAsAbstract(
   func: (ast: BabelNodeUnaryExpression, expr: Value | Reference, strictCode: boolean, realm: Realm) => Value,
   strictCode: boolean,
   realm: Realm
-) {
+): Value {
   let effects;
   try {
-    effects = realm.evaluateForEffects(() => func(ast, expr, strictCode, realm));
+    effects = realm.evaluateForEffects(
+      () => func(ast, expr, strictCode, realm),
+      undefined,
+      "tryToEvaluateOperationOrLeaveAsAbstract"
+    );
   } catch (error) {
     if (error instanceof FatalError) {
       return realm.evaluateWithPossibleThrowCompletion(

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -331,7 +331,7 @@ export function OrdinaryCallEvaluateBody(
       let savedIsSelfRecursive = F.isSelfRecursive;
       try {
         F.isSelfRecursive = false;
-        let effects = realm.evaluateForEffects(guardedCall);
+        let effects = realm.evaluateForEffects(guardedCall, undefined, "OrdinaryCallEvaluateBody");
         if (F.isSelfRecursive) {
           AbstractValue.reportIntrospectionError(F, "call to function that calls itself");
           throw new FatalError();

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -103,13 +103,13 @@ export function OrdinaryGet(
       desc = desc.descriptor1;
       let [compl1, gen1, bindings1, properties1, createdObj1] = Path.withCondition(joinCondition, () => {
         return desc !== undefined
-          ? realm.evaluateForEffects(() => OrdinaryGetHelper())
+          ? realm.evaluateForEffects(() => OrdinaryGetHelper(), undefined, "OrdinaryGet/1")
           : construct_empty_effects(realm);
       });
       desc = descriptor2;
       let [compl2, gen2, bindings2, properties2, createdObj2] = Path.withInverseCondition(joinCondition, () => {
         return desc !== undefined
-          ? realm.evaluateForEffects(() => OrdinaryGetHelper())
+          ? realm.evaluateForEffects(() => OrdinaryGetHelper(), undefined, "OrdinaryGet/2")
           : construct_empty_effects(realm);
       });
 

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -47,7 +47,7 @@ function joinGenerators(
   generator1: Generator,
   generator2: Generator
 ): Generator {
-  let result = new Generator(realm);
+  let result = new Generator(realm, "joined");
   if (!generator1.empty() || !generator2.empty()) {
     result.joinGenerators(joinCondition, generator1, generator2);
   }
@@ -712,7 +712,7 @@ export class JoinImplementation {
   }
 
   composeGenerators(realm: Realm, generator1: Generator, generator2: Generator): Generator {
-    let result = new Generator(realm);
+    let result = new Generator(realm, "composed");
     if (!generator1.empty() || !generator2.empty()) {
       result.composeGenerators(generator1, generator2);
     }

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -303,13 +303,13 @@ export class PropertiesImplementation {
       ownDesc = ownDesc.descriptor1;
       let [compl1, gen1, bindings1, properties1, createdObj1] = Path.withCondition(joinCondition, () => {
         return ownDesc !== undefined
-          ? realm.evaluateForEffects(() => new BooleanValue(realm, OrdinarySetHelper()))
+          ? realm.evaluateForEffects(() => new BooleanValue(realm, OrdinarySetHelper()), undefined, "OrdinarySet/1")
           : construct_empty_effects(realm);
       });
       ownDesc = descriptor2;
       let [compl2, gen2, bindings2, properties2, createdObj2] = Path.withInverseCondition(joinCondition, () => {
         return ownDesc !== undefined
-          ? realm.evaluateForEffects(() => new BooleanValue(realm, OrdinarySetHelper()))
+          ? realm.evaluateForEffects(() => new BooleanValue(realm, OrdinarySetHelper()), undefined, "OrdinarySet/2")
           : construct_empty_effects(realm);
       });
 

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -101,12 +101,16 @@ function callBothFunctionsAndJoinTheirEffects(
   invariant(Value.isTypeCompatibleWith(func1.getType(), FunctionValue));
   invariant(Value.isTypeCompatibleWith(func2.getType(), FunctionValue));
 
-  let [compl1, gen1, bindings1, properties1, createdObj1] = realm.evaluateForEffects(() =>
-    EvaluateCall(func1, func1, ast, argVals, strictCode, env, realm)
+  let [compl1, gen1, bindings1, properties1, createdObj1] = realm.evaluateForEffects(
+    () => EvaluateCall(func1, func1, ast, argVals, strictCode, env, realm),
+    undefined,
+    "callBothFunctionsAndJoinTheirEffects/1"
   );
 
-  let [compl2, gen2, bindings2, properties2, createdObj2] = realm.evaluateForEffects(() =>
-    EvaluateCall(func2, func2, ast, argVals, strictCode, env, realm)
+  let [compl2, gen2, bindings2, properties2, createdObj2] = realm.evaluateForEffects(
+    () => EvaluateCall(func2, func2, ast, argVals, strictCode, env, realm),
+    undefined,
+    "callBothFunctionsAndJoinTheirEffects/2"
   );
 
   let joinedEffects = Join.joinEffects(

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -549,7 +549,13 @@ export function evaluateComponentTreeBranch(
     createdObjects,
   ] = effects;
   if (nested) {
-    realm.applyEffects([value, new Generator(realm), modifiedBindings, modifiedProperties, createdObjects]);
+    realm.applyEffects([
+      value,
+      new Generator(realm, "evaluateComponentTreeBranch"),
+      modifiedBindings,
+      modifiedProperties,
+      createdObjects,
+    ]);
   }
   try {
     return f(generator, value);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -770,6 +770,7 @@ export class ResidualHeapSerializer {
     this.emitter.dependenciesVisitor(val, {
       onAbstractValueWithIdentifier: dependency => {
         if (trace) console.log(`  depending on abstract value with identifier ${dependency.intrinsicName || "?"}`);
+        invariant(referencingOnlyAdditionalFunction === undefined || this.emitter.emittingToAdditionalFunction());
         let declarationBody = this.emitter.getDeclarationBody(dependency);
         if (declarationBody !== undefined) {
           if (trace) console.log(`    has declaration body`);
@@ -1806,7 +1807,7 @@ export class ResidualHeapSerializer {
       this._serializedValueWithIdentifiers = new Set(Array.from(this._serializedValueWithIdentifiers));
       try {
         generator.serialize(context);
-        if (postGeneratorCallback) postGeneratorCallback();
+        postGeneratorCallback();
       } finally {
         this._serializedValueWithIdentifiers = oldSerialiedValueWithIdentifiers;
       }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -85,7 +85,7 @@ function serializeBody(generator: Generator, context: SerializationContext): Bab
 }
 
 export class Generator {
-  constructor(realm: Realm, name: void | string) {
+  constructor(realm: Realm, name: string) {
     invariant(realm.useAbstractInterpretation);
     let realmPreludeGenerator = realm.preludeGenerator;
     invariant(realmPreludeGenerator);
@@ -101,10 +101,10 @@ export class Generator {
   preludeGenerator: PreludeGenerator;
 
   id: number;
-  _name: void | string;
+  _name: string;
 
   getName(): string {
-    return this._name || `#${this.id}`;
+    return `${this._name}(#${this.id})`;
   }
 
   getAsPropertyNameExpression(key: string, canBeIdentifier: boolean = true): BabelNodeExpression {

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -46,20 +46,24 @@ export class Logger {
     };
     try {
       let result;
-      let effects = realm.evaluateForEffects(() => {
-        try {
-          result = f();
-        } catch (e) {
-          if (e instanceof Completion) {
-            result = defaultValue;
-          } else if (e instanceof FatalError) {
-            result = defaultValue;
-          } else {
-            throw e;
+      let effects = realm.evaluateForEffects(
+        () => {
+          try {
+            result = f();
+          } catch (e) {
+            if (e instanceof Completion) {
+              result = defaultValue;
+            } else if (e instanceof FatalError) {
+              result = defaultValue;
+            } else {
+              throw e;
+            }
           }
-        }
-        return realm.intrinsics.undefined;
-      });
+          return realm.intrinsics.undefined;
+        },
+        undefined,
+        "tryQuery"
+      );
       invariant(effects[0] === realm.intrinsics.undefined);
       return ((result: any): T);
     } finally {

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -145,7 +145,7 @@ export class ModuleTracer extends Tracer {
     let acceleratedModuleIds, effects;
     do {
       try {
-        effects = realm.evaluateForEffects(() => performCall(), this);
+        effects = realm.evaluateForEffects(() => performCall(), this, "_callRequireAndAccelerate");
       } catch (e) {
         e;
       }


### PR DESCRIPTION
Release notes: None

Keeping track of the origin of a Generator greatly improves debuggability, especially with the --debugScopes option.