### PR TITLE
Fixes StringLiterals as JSX text

### DIFF
--- a/src/react/jsx.js
+++ b/src/react/jsx.js
@@ -16,6 +16,7 @@ import type {
   BabelNodeJSXIdentifier,
   BabelNodeIdentifier,
   BabelNodeMemberExpression,
+  BabelNodeStringLiteral,
 } from "babel-types";
 import invariant from "../invariant.js";
 import { isReactComponent } from "./utils";
@@ -74,5 +75,14 @@ export function convertJSXExpressionToIdentifier(
 }
 
 export function convertKeyValueToJSXAttribute(key: string, expr: BabelNodeExpression) {
-  return t.jSXAttribute(t.jSXIdentifier(key), expr.type === "StringLiteral" ? expr : t.jSXExpressionContainer(expr));
+  let wrapInContainer = true;
+
+  if (expr && t.isStringLiteral(expr) && typeof expr.value === "string") {
+    let value = expr.value;
+    wrapInContainer = !value.includes('"') && !value.includes("'");
+  }
+  return t.jSXAttribute(
+    t.jSXIdentifier(key),
+    wrapInContainer ? ((expr: any): BabelNodeStringLiteral) : t.jSXExpressionContainer(expr)
+  );
 }

--- a/src/react/jsx.js
+++ b/src/react/jsx.js
@@ -79,10 +79,10 @@ export function convertKeyValueToJSXAttribute(key: string, expr: BabelNodeExpres
 
   if (expr && t.isStringLiteral(expr) && typeof expr.value === "string") {
     let value = expr.value;
-    wrapInContainer = !value.includes('"') && !value.includes("'");
+    wrapInContainer = value.includes('"') || value.includes("'");
   }
   return t.jSXAttribute(
     t.jSXIdentifier(key),
-    wrapInContainer ? ((expr: any): BabelNodeStringLiteral) : t.jSXExpressionContainer(expr)
+    wrapInContainer ? t.jSXExpressionContainer(expr) : ((expr: any): BabelNodeStringLiteral)
   );
 }

--- a/test/react/mocks/fb6.js
+++ b/test/react/mocks/fb6.js
@@ -2,6 +2,10 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
+var div = (
+  <div data-ft={'{"tn": "O"}'} />
+);
+
 function App(props) {
   return (
     <div className={cx("yar/Jar")}>
@@ -17,6 +21,7 @@ function App(props) {
         >
           I am a link
         </a>
+        {div}
       </span>
     </div>
   );


### PR DESCRIPTION
Release notes: none

This PR fixes an issue where a StringLiteral that contained quotes, which resulted in being escaped on output, should have been wrapped in JSXExpressionContainer, otherwise the output becomes invalid.