### PR TITLE
Add test cases that are broken in first render mode

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -336,6 +336,66 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output First render only Class component as root with instance variables 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output First render only Simple 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -2463,6 +2523,66 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only Class component as root with instance variables 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
 }
 `;
 
@@ -4596,6 +4716,66 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output First render only Class component as root with instance variables 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output First render only Simple 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -6688,6 +6868,66 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only Class component as root with instance variables 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -498,6 +498,18 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple.js", true);
       });
 
+      it("Simple #2", async () => {
+        await runTest(directory, "simple-2.js", true);
+      });
+
+      it("Class component as root with instance variables", async () => {
+        await runTest(directory, "class-root-with-instance-vars.js", true);
+      });
+
+      it("Class component as root with refs", async () => {
+        await runTest(directory, "class-root-with-refs.js", true);
+      });
+
       it("componentWillMount", async () => {
         await runTest(directory, "will-mount.js", true);
       });

--- a/test/react/first-render-only/class-root-with-instance-vars.js
+++ b/test/react/first-render-only/class-root-with-instance-vars.js
@@ -1,0 +1,47 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+this['abstractVal'] = null;
+
+function SubChild(props) {
+  return <span>{props.title}<div>{props.abstractVal}</div></span>;
+}
+
+function Child(props) {
+  return <span><SubChild title={props.title} abstractVal={props.abstractVal} /></span>;
+}
+
+// we can't use ES2015 classes in Prepack yet (they don't serialize)
+// so we have to use ES5 instead
+var App = (function (superclass) {
+  function App (props) {
+    superclass.apply(this, arguments);
+    this.title = props.title;
+    // side-effectful
+    this.abstractVal = abstractVal;
+  }
+
+  if ( superclass ) {
+    App.__proto__ = superclass;
+  }
+  App.prototype = Object.create( superclass && superclass.prototype );
+  App.prototype.constructor = App;
+  App.prototype.render = function render () {
+    return <Child title={this.title} abstractVal={this.abstractVal} />;
+  };
+  App.getTrials = function(renderer, Root) {
+    abstractVal = "It works!";
+    renderer.update(<Root title="Hello world" />);
+    return [['render with class root and instance vars', renderer.toJSON()]]; 
+  };
+
+  return App;
+}(React.Component));
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true
+  });
+}
+
+module.exports = App;

--- a/test/react/first-render-only/class-root-with-refs.js
+++ b/test/react/first-render-only/class-root-with-refs.js
@@ -1,0 +1,55 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function SubChild() {
+  return <span>Hello world</span>;
+}
+
+function Child() {
+  return <span><SubChild /></span>;
+}
+
+let instance = null;
+
+// we can't use ES2015 classes in Prepack yet (they don't serialize)
+// so we have to use ES5 instead
+var App = (function (superclass) {
+  function App () {
+    superclass.apply(this, arguments);
+    this.divRefWorked = null;
+    instance = this;
+  }
+
+  if ( superclass ) {
+    App.__proto__ = superclass;
+  }
+  App.prototype = Object.create( superclass && superclass.prototype );
+  App.prototype.constructor = App;
+  App.prototype._renderChild = function () {
+    return <Child />;
+  };
+  App.prototype.divRefFunc = function divRefFunc (ref) {
+    this.divRefWorked = true;
+  };
+  App.prototype.render = function render () {
+    return <div ref={this.divRefFunc}>{this._renderChild()}</div>;
+  };
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root />);
+    let results = [];
+    results.push(['render with class root', renderer.toJSON()]);
+    results.push(['get the ref', instance.divRefWorked]);
+    return results;
+  };
+
+  return App;
+}(React.Component));
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true
+  });
+}
+
+module.exports = App;

--- a/test/react/first-render-only/simple-2.js
+++ b/test/react/first-render-only/simple-2.js
@@ -1,0 +1,40 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+class Child extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      id: 5,
+    };
+  }
+  render() {
+    return <span>{this.state.id}</span>
+  }
+}
+
+function App() {
+  return (
+    <div><Child /></div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true
+  });
+}
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(Child, {
+    firstRenderOnly: true
+  });
+}
+
+module.exports = App;


### PR DESCRIPTION
My methodology for finding these:

* Switch `firstRenderMode` to be the default
* Remove rendering of updates from all tests
* Run all tests
* Find those that fail and copy them into this folder with `firstRenderMode` explicitly set to true

These specific failures look very similar to the issues I’ve seen in the UFI so I’m posting them first.

----

For the reference, the failures look like this:

```
● Test React with JSX input, JSX output › First render only › Simple #2

    Invariant Violation: undefined
    This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.

      14 |   const message = `${format}
      15 | This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.`;
    > 16 |   let error = new Error(message);
      17 |   error.name = "Invariant Violation";
      18 |   throw error;
      19 | }
      
      at invariant (src/invariant.js:16:15)
      at ResidualHeapSerializer._serializeAdditionalFunctionEffects (src/serializer/ResidualHeapSerializer.js:1837:3)
      at _withGeneratorScope.newBody (src/serializer/ResidualHeapSerializer.js:1810:3)
      at ResidualHeapSerializer._withGeneratorScope (src/serializer/ResidualHeapSerializer.js:1738:5)
      at ResidualHeapSerializer._serializeAdditionalFunctionGeneratorAndEffects (src/serializer/ResidualHeapSerializer.js:1805:3)
      at evaluateForEffectsInGlobalEnv (src/realm.js:592:17)
      at Realm.evaluateForEffects (src/realm.js:641:11)
```

```
● Test React with JSX input, JSX output › First render only › Class component as root with instance variables

    expect(received).toEqual(expected)
    
    Expected value to equal:
      <span><span>Hello world<div>It works!</div></span></span>
    Received:
      <span><span>Hello world<div /></span></span>
    
    Difference:
    
    - Expected
    + Received
    
      <span>
        <span>
          Hello world
    -     <div>
    -       It works!
    -     </div>
    +     <div />
        </span>
      </span>
```

```
 ● Test React with JSX input, JSX output › First render only › Class component as root with refs

    TypeError: Cannot read property 'setState' of undefined
      
      at eval (eval at runSource (scripts/test-react.js:179:14), <anonymous>:30:16)
      at eval (eval at runSource (scripts/test-react.js:179:14), <anonymous>:136:4)
      at runSource (scripts/test-react.js:201:7)
      at scripts/test-react.js:63:15
      at step (scripts/test-react.js:3:191)
      at scripts/test-react.js:3:437
```

----

PS. Ideally I think we should run all tests in both modes. To do this, we can dynamically adjust the default, and we could `render(null)` before every step in that mode (both for real and Prepacked versions) to ensure "updates" become "mounts" in tests. The only thing that wouldn't work this way is `componentDidMount`. Regardless, it's out of the scope of this PR.