### PR TITLE
Fix environment record bindings in serializer

### DIFF
--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -60,6 +60,9 @@ function runTest(name: string, code: string): boolean {
     let modelCode = fs.existsSync(modelName) ? fs.readFileSync(modelName, "utf8") : undefined;
     let sourceMap = fs.existsSync(sourceMapName) ? fs.readFileSync(sourceMapName, "utf8") : undefined;
     let sources = [];
+    if (modelCode) {
+      sources.push({ filePath: modelName, fileContents: modelCode });
+    }
     sources.push({ filePath: name, fileContents: sourceCode, sourceMapContents: sourceMap });
 
     let options = {

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -301,7 +301,6 @@ function runTest(name, code, options: PrepackOptions, args) {
         initializeMoreModules,
         delayUnsupportedRequires,
         internalDebug: true,
-        additionalFunctions: options.additionalFunctions,
         lazyObjectsRuntime: options.lazyObjectsRuntime,
       };
       let serializer = new Serializer(realm, serializerOptions);
@@ -559,7 +558,7 @@ function run(args) {
     if (args.es5 && test.file.includes("// es6")) continue;
     //only run specific tests if desired
     if (!test.name.includes(args.filter)) continue;
-    const isAdditionalFunctionTest = test.name.includes("additional-functions");
+    const isAdditionalFunctionTest = test.file.includes("__optimize");
     const isPureFunctionTest = test.name.includes("pure-functions");
     const isCaptureTest = test.name.includes("Closure") || test.name.includes("Capture");
     const isSimpleClosureTest = test.file.includes("// simple closures");

--- a/src/environment.js
+++ b/src/environment.js
@@ -77,11 +77,15 @@ export class EnvironmentRecord {
   realm: Realm;
   isReadOnly: boolean;
   $NewTarget: void | ObjectValue;
+  id: number;
+
+  static nextId: number = 0;
 
   constructor(realm: Realm) {
     invariant(realm, "expected realm");
     this.realm = realm;
     this.isReadOnly = false;
+    this.id = EnvironmentRecord.nextId++;
   }
 
   +HasBinding: (N: string) => boolean;

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -16,7 +16,6 @@ import invariant from "./invariant.js";
 
 export type PrepackOptions = {|
   additionalGlobals?: Realm => void,
-  additionalFunctions?: Array<string>,
   abstractEffectsInAdditionalFunctions?: boolean,
   lazyObjectsRuntime?: string,
   heapGraphFormat?: "DotLanguage" | "VISJS",
@@ -98,7 +97,6 @@ export function getRealmOptions({
 }
 
 export function getSerializerOptions({
-  additionalFunctions,
   lazyObjectsRuntime,
   heapGraphFormat,
   delayInitializations = false,

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -735,7 +735,7 @@ export class ResidualHeapSerializer {
       (x, y) => commonAncestorOf(x, y, this.getGeneratorParent),
       generators[0]
     );
-    invariant(commonAncestor);
+    invariant(commonAncestor !== undefined);
     if (trace) console.log(`  common ancestor: ${commonAncestor.getName()}`);
 
     let body;

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord, EnvironmentRecord } from "../environment.js";
-import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import type { Effects } from "../realm.js";
 import type { Descriptor, PropertyBinding, ObjectKind } from "../types.js";
@@ -525,9 +524,6 @@ export class ResidualHeapVisitor {
       invariant(!Environment.IsUnresolvableReference(this.realm, reference));
       let referencedBase = reference.base;
       let referencedName: string = (reference.referencedName: any);
-      if (typeof referencedName !== "string") {
-        throw new FatalError("TODO: do not know how to visit reference with symbol");
-      }
       invariant(referencedName === name);
       invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
       return referencedBase;
@@ -570,6 +566,7 @@ export class ResidualHeapVisitor {
       residualFunctionBinding = getFromMap(residualFunctionBindings, name, (): ResidualFunctionBinding => {
         invariant(environment instanceof DeclarativeEnvironmentRecord);
         let binding = environment.bindings[name];
+        invariant(binding !== undefined);
         invariant(!binding.deletable);
         return {
           value: (binding.initialized && binding.value) || this.realm.intrinsics.undefined,

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../environment.js";
+import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord, EnvironmentRecord } from "../environment.js";
 import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import type { Effects } from "../realm.js";
@@ -83,7 +83,8 @@ export class ResidualHeapVisitor {
     modules: Modules,
     additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
     // Referentializer is null if we're just checking what values exist
-    referentializer: Referentializer | "NO_REFERENTIALIZE"
+    referentializer: Referentializer | "NO_REFERENTIALIZE",
+    environmentRecordIdAfterGlobalCode: number = 0
   ) {
     invariant(realm.useAbstractInterpretation);
     this.realm = realm;
@@ -113,6 +114,10 @@ export class ResidualHeapVisitor {
     this.inClass = false;
     this.functionToCapturedScopes = new Map();
     this.generatorParents = new Map();
+    this.environmentRecordIdAfterGlobalCode = environmentRecordIdAfterGlobalCode;
+    let environment = realm.$GlobalEnv.environmentRecord;
+    invariant(environment instanceof GlobalEnvironmentRecord);
+    this.globalEnvironmentRecord = environment;
   }
 
   realm: Realm;
@@ -150,6 +155,9 @@ export class ResidualHeapVisitor {
   // identity to work).
   additionalRoots: Map<ObjectValue, Set<FunctionValue>>;
   inClass: boolean;
+  environmentRecordIdAfterGlobalCode: number;
+
+  globalEnvironmentRecord: GlobalEnvironmentRecord;
 
   _registerAdditionalRoot(value: ObjectValue) {
     let additionalFunction = this.containingAdditionalFunction;
@@ -440,7 +448,8 @@ export class ResidualHeapVisitor {
       this._withScope(val, () => {
         invariant(functionInfo);
         for (let innerName of functionInfo.unbound) {
-          let residualBinding = this.visitBinding(val, innerName);
+          let environment = this.resolveBinding(val, innerName);
+          let residualBinding = this.visitBinding(val, environment, innerName);
           invariant(residualBinding !== undefined);
           residualFunctionBindings.set(innerName, residualBinding);
           if (functionInfo.modified.has(innerName)) {
@@ -499,21 +508,45 @@ export class ResidualHeapVisitor {
     }
   }
 
-  // Visits a binding, if createBinding is true, will always return a ResidualFunctionBinding
-  // otherwise visits + returns the binding only if one already exists.
-  visitBinding(val: FunctionValue, name: string, createBinding: boolean = true): ResidualFunctionBinding | void {
-    let residualFunctionBinding;
+  resolveBinding(val: FunctionValue, name: string): EnvironmentRecord {
     let doesNotMatter = true;
     let reference = this.logger.tryQuery(
       () => Environment.ResolveBinding(this.realm, name, doesNotMatter, val.$Environment),
       undefined
     );
-    let getFromMap = createBinding ? getOrDefault : (map, key, defaultFn) => map.get(key);
     if (
       reference === undefined ||
       Environment.IsUnresolvableReference(this.realm, reference) ||
-      reference.base instanceof GlobalEnvironmentRecord
+      reference.base === this.globalEnvironmentRecord ||
+      reference.base === this.globalEnvironmentRecord.$DeclarativeRecord
     ) {
+      return this.globalEnvironmentRecord;
+    } else {
+      invariant(!Environment.IsUnresolvableReference(this.realm, reference));
+      let referencedBase = reference.base;
+      let referencedName: string = (reference.referencedName: any);
+      if (typeof referencedName !== "string") {
+        throw new FatalError("TODO: do not know how to visit reference with symbol");
+      }
+      invariant(referencedName === name);
+      invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
+      return referencedBase;
+    }
+  }
+
+  // Visits a binding, if createBinding is true, will always return a ResidualFunctionBinding
+  // otherwise visits + returns the binding only if one already exists.
+  visitBinding(
+    val: FunctionValue,
+    environment: EnvironmentRecord,
+    name: string,
+    createBinding: boolean = true
+  ): ResidualFunctionBinding | void {
+    if (environment === this.globalEnvironmentRecord.$DeclarativeRecord) environment = this.globalEnvironmentRecord;
+
+    let residualFunctionBinding;
+    let getFromMap = createBinding ? getOrDefault : (map, key, defaultFn) => map.get(key);
+    if (environment === this.globalEnvironmentRecord) {
       // Global Binding
       residualFunctionBinding = getFromMap(
         this.globalBindings,
@@ -526,28 +559,22 @@ export class ResidualHeapVisitor {
           }: ResidualFunctionBinding)
       );
     } else {
+      invariant(environment instanceof DeclarativeEnvironmentRecord);
       // DeclarativeEnvironmentRecord binding
-      invariant(!Environment.IsUnresolvableReference(this.realm, reference));
-      let referencedBase = reference.base;
-      let referencedName: string = (reference.referencedName: any);
-      if (typeof referencedName !== "string") {
-        throw new FatalError("TODO: do not know how to visit reference with symbol");
-      }
-      invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
       let residualFunctionBindings = getOrDefault(
         this.declarativeEnvironmentRecordsBindings,
-        referencedBase,
+        environment,
         () => new Map()
       );
-      let createdBinding = !residualFunctionBindings.has(referencedName);
-      residualFunctionBinding = getFromMap(residualFunctionBindings, referencedName, (): ResidualFunctionBinding => {
-        invariant(referencedBase instanceof DeclarativeEnvironmentRecord);
-        let binding = referencedBase.bindings[referencedName];
+      let createdBinding = !residualFunctionBindings.has(name);
+      residualFunctionBinding = getFromMap(residualFunctionBindings, name, (): ResidualFunctionBinding => {
+        invariant(environment instanceof DeclarativeEnvironmentRecord);
+        let binding = environment.bindings[name];
         invariant(!binding.deletable);
         return {
           value: (binding.initialized && binding.value) || this.realm.intrinsics.undefined,
           modified: false,
-          declarativeEnvironmentRecord: referencedBase,
+          declarativeEnvironmentRecord: environment,
         };
       });
       if (residualFunctionBinding) {
@@ -860,13 +887,17 @@ export class ResidualHeapVisitor {
       if (object.intrinsicName === "global") continue; // Avoid double-counting
       this.visitObjectProperty(propertyBinding);
     }
-    // Handing of ModifiedBindings
+    // Handling of ModifiedBindings
     for (let [additionalBinding, previousValue] of modifiedBindings) {
       let modifiedBinding = additionalBinding;
+      // TODO: Instead of looking at the environment ids, keep instead track of a createdEnvironmentRecords set,
+      // and only consider bindings here from environment records that already existed, or even better,
+      // ensure upstream that only such bindings are ever added to the modified-bindings set.
+      if (modifiedBinding.environment.id >= this.environmentRecordIdAfterGlobalCode) continue;
       let residualBinding;
       this._withScope(functionValue, () => {
         // Also visit the original value of the binding
-        residualBinding = this.visitBinding(functionValue, modifiedBinding.name);
+        residualBinding = this.visitBinding(functionValue, modifiedBinding.environment, modifiedBinding.name);
         invariant(residualBinding !== undefined);
         // named functions inside an additional function that have a global binding
         // can be skipped, as we don't want them to bind to the global
@@ -983,7 +1014,8 @@ export class ResidualHeapVisitor {
           this.visitValue(value);
         }
         for (let innerName of functionInfo.unbound) {
-          let residualBinding = this.visitBinding(functionValue, innerName, false);
+          let environment = this.resolveBinding(functionValue, innerName);
+          let residualBinding = this.visitBinding(functionValue, environment, innerName, false);
           if (residualBinding) {
             funcInstance.residualFunctionBindings.set(innerName, residualBinding);
             delete residualBinding.referencedOnlyFromAdditionalFunctions;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { EnvironmentRecord } from "../environment.js";
 import { Realm, ExecutionContext } from "../realm.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { SourceFile } from "../types.js";
@@ -105,6 +106,7 @@ export class Serializer {
       timingStats.globalCodeTime = Date.now();
     }
     let code = this._execute(sources);
+    let environmentRecordIdAfterGlobalCode = EnvironmentRecord.nextId;
     if (timingStats !== undefined) timingStats.globalCodeTime = Date.now() - timingStats.globalCodeTime;
     if (this.logger.hasErrors()) return undefined;
     this.modules.resolveInitializedModules();
@@ -141,7 +143,8 @@ export class Serializer {
       this.logger,
       this.modules,
       additionalFunctionValuesAndEffects,
-      referentializer
+      referentializer,
+      environmentRecordIdAfterGlobalCode
     );
     residualHeapVisitor.visitRoots();
     if (this.logger.hasErrors()) return undefined;


### PR DESCRIPTION
Release notes: None

- Removed --additionalFunctions CLI argument as well as `// additional functions` comment from test runner, rewriting tests instead to use `__registerAdditionalFunctionToPrepack` everywhere.
- Turns out that too many modified bindings reach the serializer's visitor. As a short-term hack, introduced a global id counter for environment records to identify and filter out environment records created after global code. (Long term a `createdEnvironmentRecords` set just like `createdObjects` might be the proper solution.)
- There was some confusion around the global environment, as there's the `GlobalEnvironmentRecord`, but it in fact defers to its `.$DeclarativeRecord`, which ended up in a binding. This is now normalized.
- Separated out `resolveBinding` from `visitBinding`, to avoid the unnecessary (and error-prone) binding resolution step when possible
- Removed what looked like an unmotivated `residualBinding.modified = true;` statement.