### PR TITLE
Fixes a React first render issue with component instance

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -336,6 +336,36 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output First render only Simple 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -2463,6 +2493,36 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
 }
 `;
 
@@ -4596,6 +4656,36 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output First render only Simple 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -6688,6 +6778,36 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only Class component as root with refs 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "SubChild",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -498,6 +498,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple.js", true);
       });
 
+      it("Class component as root with refs", async () => {
+        await runTest(directory, "class-root-with-refs.js", true);
+      });
+
       it("componentWillMount", async () => {
         await runTest(directory, "will-mount.js", true);
       });

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -162,6 +162,7 @@ export function createClassInstanceForFirstRenderOnly(
 ): ObjectValue {
   let instance = Construct(realm, componentType, [props, context]);
   invariant(instance instanceof ObjectValue);
+  instance.intrinsicName = "this";
   instance.refuseSerialization = true;
   // assign props
   Properties.Set(realm, instance, "props", props, true);

--- a/test/react/first-render-only/class-root-with-refs.js
+++ b/test/react/first-render-only/class-root-with-refs.js
@@ -1,0 +1,55 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function SubChild() {
+  return <span>Hello world</span>;
+}
+
+function Child() {
+  return <span><SubChild /></span>;
+}
+
+let instance = null;
+
+// we can't use ES2015 classes in Prepack yet (they don't serialize)
+// so we have to use ES5 instead
+var App = (function (superclass) {
+  function App () {
+    superclass.apply(this, arguments);
+    this.divRefWorked = null;
+    instance = this;
+  }
+
+  if ( superclass ) {
+    App.__proto__ = superclass;
+  }
+  App.prototype = Object.create( superclass && superclass.prototype );
+  App.prototype.constructor = App;
+  App.prototype._renderChild = function () {
+    return <Child />;
+  };
+  App.prototype.divRefFunc = function divRefFunc (ref) {
+    this.divRefWorked = true;
+  };
+  App.prototype.render = function render () {
+    return <div ref={this.divRefFunc}>{this._renderChild()}</div>;
+  };
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root />);
+    let results = [];
+    results.push(['render with class root', renderer.toJSON()]);
+    results.push(['get the ref', instance.divRefWorked]);
+    return results;
+  };
+
+  return App;
+}(React.Component));
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

When rendering a class component on first render, we need to ensure it's instance is intrinsic otherwise it will serialize out incorrectly. 