### PR TITLE
Handle property bindings on newly created objects in fixed point logic

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -555,7 +555,7 @@ function run(args) {
     // filter hidden files
     if (path.basename(test.name)[0] === ".") continue;
     if (test.name.endsWith("~")) continue;
-    if (test.file.includes("// skip")) continue;
+    if (test.file.includes("// skip this test for now")) continue;
     if (args.es5 && test.file.includes("// es6")) continue;
     //only run specific tests if desired
     if (!test.name.includes(args.filter)) continue;

--- a/test/serializer/abstract/DoWhile9.js
+++ b/test/serializer/abstract/DoWhile9.js
@@ -1,0 +1,11 @@
+// skip lazy objects
+
+let n = global.__abstract ? __abstract("number", "(3)") : 3;
+let i = 0;
+let o = null;
+do {
+  o = {i};
+  i++;
+} while (i < n);
+
+inspect = function() { return JSON.stringify(o); }


### PR DESCRIPTION
Release notes: none

First we need to ignore the differences in properties of newly created objects when we compare. Since widening doesn't preserve any knowledge of newly created objects (they just go to topVal), we don't have to be smarter than this.

Second, since all effects including property mutation of newly created objects gets reverted, this always yields empty objects. We need to apply the effects of newly created objects so that the serializer knows how to serialize these objects.

We should also avoid emitting property assignments to these objects since we've already applied them to the object value.