### PR TITLE
Rename __registerAdditionalFunction -> __optimize

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -54,7 +54,6 @@ function runTest(name: string, code: string): boolean {
   console.log(chalk.inverse(name));
 
   let recover = code.includes("// recover-from-errors");
-  let additionalFunctions = code.includes("// additional functions");
   let delayUnsupportedRequires = code.includes("// delay unsupported requires");
   let abstractEffects = code.includes("// abstract effects");
   let compatibility = code.includes("// jsc") ? "jsc-600-1-4-17" : undefined;
@@ -78,7 +77,6 @@ function runTest(name: string, code: string): boolean {
       abstractEffectsInAdditionalFunctions: abstractEffects,
       compatibility,
     };
-    if (additionalFunctions) (options: any).additionalFunctions = ["global.additional1", "global['additional2']"];
     prepackFileSync([name], options);
     if (!recover) {
       console.error(chalk.red("Serialization succeeded though it should have failed"));

--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -60,19 +60,6 @@ function runTest(name: string, code: string): boolean {
     let modelCode = fs.existsSync(modelName) ? fs.readFileSync(modelName, "utf8") : undefined;
     let sourceMap = fs.existsSync(sourceMapName) ? fs.readFileSync(sourceMapName, "utf8") : undefined;
     let sources = [];
-    let additionalFunctions;
-    if (modelCode) {
-      /* allows specifying additional functions by a comment of the form:
-      // additional function: additional1, additional2
-      */
-      let marker = "// additional functions:";
-      if (modelCode.includes(marker)) {
-        let i = modelCode.indexOf(marker);
-        let value = modelCode.substring(i + marker.length, modelCode.indexOf("\n", i));
-        additionalFunctions = value.split(",").map(funcStr => funcStr.trim());
-      }
-      sources.push({ filePath: modelName, fileContents: modelCode });
-    }
     sources.push({ filePath: name, fileContents: sourceCode, sourceMapContents: sourceMap });
 
     let options = {
@@ -85,7 +72,6 @@ function runTest(name: string, code: string): boolean {
       serialize: true,
       initializeMoreModules: !modelCode,
       sourceMaps: !!sourceMap,
-      additionalFunctions: additionalFunctions,
     };
     let serialized = prepackSources(sources, options);
     let new_map = serialized.map; // force source maps to get computed

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -268,7 +268,6 @@ function runTest(name, code, options: PrepackOptions, args) {
   if (code.includes("// do not inline expressions")) options.inlineExpressions = false;
   if (code.includes("// omit invariants")) options.omitInvariants = true;
   if (code.includes("// emit concrete model")) options.emitConcreteModel = true;
-  if (code.includes("// additional functions")) options.additionalFunctions = ["additional1", "additional2"];
   if (code.includes("// abstract effects")) options.abstractEffectsInAdditionalFunctions = true;
   if (code.includes("// exceeds stack limit")) options.maxStackDepth = 10;
   if (code.includes("// react")) {

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -93,37 +93,33 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
-  global.$DefineOwnProperty("__additionalFunctions", {
-    value: new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "__additionalFunctions", true),
+  global.$DefineOwnProperty("__optimizedFunctions", {
+    value: new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "__optimizedFunctions", true),
     writable: true,
     enumerable: false,
     configurable: true,
   });
 
   let additonalFunctionUid = 0;
-  // Allows dynamically registering additional functions.
+  // Allows dynamically registering optimized functions.
   // WARNING: these functions will get exposed at global scope and called there.
   // NB: If we interpret one of these calls in an evaluateForEffects context
   //     that is not subsequently applied, the function will not be registered
   //     (because prepack won't have a correct value for the FunctionValue itself)
-  global.$DefineOwnProperty("__registerAdditionalFunctionToPrepack", {
-    value: new NativeFunctionValue(
-      realm,
-      "global.__registerAdditionalFunctionToPrepack",
-      "__registerAdditionalFunctionToPrepack",
-      0,
-      (context, [functionValue]) => {
-        invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
+  global.$DefineOwnProperty("__optimize", {
+    value: new NativeFunctionValue(realm, "global.__optimize", "__optimize", 0, (context, [value, config]) => {
+      // only optimize functions for now
+      if (value instanceof ECMAScriptSourceFunctionValue) {
         realm.assignToGlobal(
           t.memberExpression(
-            t.memberExpression(t.identifier("global"), t.identifier("__additionalFunctions")),
+            t.memberExpression(t.identifier("global"), t.identifier("__optimizedFunctions")),
             t.identifier("" + additonalFunctionUid++)
           ),
-          functionValue
+          value
         );
-        return realm.intrinsics.undefined;
       }
-    ),
+      return value;
+    }),
     writable: true,
     enumerable: false,
     configurable: true,

--- a/src/options.js
+++ b/src/options.js
@@ -53,7 +53,6 @@ export type RealmOptions = {
 };
 
 export type SerializerOptions = {
-  additionalFunctions?: Array<string>,
   lazyObjectsRuntime?: string,
   delayInitializations?: boolean,
   delayUnsupportedRequires?: boolean,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -48,7 +48,6 @@ function run(
     --srcmapOut              The output sourcemap filename.
     --maxStackDepth          Specify the maximum call stack depth.
     --timeout                The amount of time in seconds until Prepack should time out.
-    --additionalFunctions    Additional functions that should be prepacked (comma separated).
     --abstractEffectsInAdditionalFunctions Experimental flag to allow abstract effectful function calls.
     --lazyObjectsRuntime     Enable lazy objects feature and specify the JS runtime that support this feature.
     --debugNames             Changes the output of Prepack so that for named functions and variables that get emitted into
@@ -83,7 +82,6 @@ function run(
   let statsFileName;
   let maxStackDepth: number;
   let timeout: number;
-  let additionalFunctions: void | Array<string>;
   let debugIdentifiers: void | Array<string>;
   let lazyObjectsRuntime: string;
   let heapGraphFilePath: void | string;
@@ -175,11 +173,6 @@ function run(
           timeout = parseInt(seconds, 10) * 1000;
           reproArguments.push("--timeout", timeout.toString());
           break;
-        case "additionalFunctions":
-          let additionalFunctionsString = args.shift();
-          additionalFunctions = additionalFunctionsString.split(",");
-          reproArguments.push("--additionalFunctions", additionalFunctionsString);
-          break;
         case "debugIdentifiers":
           let debugIdentifiersString = args.shift();
           debugIdentifiers = debugIdentifiersString.split(",");
@@ -245,7 +238,6 @@ function run(
             "--srcmapOut outputMap",
             "--maxStackDepth depthValue",
             "--timeout seconds",
-            "--additionalFunctions fnc1,fnc2,...",
             "--debugIdentifiers id1,id2,...",
             "--check [start[, number]]",
             "--lazyObjectsRuntime lazyObjectsRuntimeName",
@@ -308,7 +300,6 @@ fi
       sourceMaps: !!outputSourceMap,
       maxStackDepth,
       timeout,
-      additionalFunctions,
       debugIdentifiers,
       check,
       lazyObjectsRuntime,
@@ -319,13 +310,8 @@ fi
     flags
   );
   if (heapGraphFilePath) resolvedOptions.heapGraphFormat = "DotLanguage";
-  if (
-    lazyObjectsRuntime &&
-    (resolvedOptions.additionalFunctions || resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)
-  ) {
-    console.error(
-      "lazy objects feature is incompatible with additionalFunctions, delayInitializations and inlineExpressions options"
-    );
+  if (lazyObjectsRuntime && (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)) {
+    console.error("lazy objects feature is incompatible with delayInitializations and inlineExpressions options");
     process.exit(1);
   }
 

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -130,7 +130,6 @@ export function getSerializerOptions({
     simpleClosures,
     trace,
   };
-  if (additionalFunctions) result.additionalFunctions = additionalFunctions;
   if (lazyObjectsRuntime !== undefined) {
     result.lazyObjectsRuntime = lazyObjectsRuntime;
   }

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { BabelNodeCallExpression, BabelNodeSourceLocation } from "babel-types";
-import { Completion, ThrowCompletion } from "../completions.js";
+import { Completion } from "../completions.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import invariant from "../invariant.js";
 import { type Effects, type PropertyBindings, Realm } from "../realm.js";
@@ -27,7 +27,6 @@ import {
 } from "../values/index.js";
 import { Get } from "../methods/index.js";
 import { ModuleTracer } from "../utils/modules.js";
-import buildTemplate from "babel-template";
 import {
   ReactStatistics,
   type ReactSerializerState,
@@ -51,50 +50,18 @@ import * as t from "babel-types";
 import { createAbstractArgument } from "../intrinsics/prepack/utils.js";
 
 export class Functions {
-  constructor(realm: Realm, functions: ?Array<string>, moduleTracer: ModuleTracer) {
+  constructor(realm: Realm, moduleTracer: ModuleTracer) {
     this.realm = realm;
-    this.functions = functions;
     this.moduleTracer = moduleTracer;
     this.writeEffects = new Map();
     this.functionExpressions = new Map();
   }
 
   realm: Realm;
-  functions: ?Array<string>;
   // maps back from FunctionValue to the expression string
   functionExpressions: Map<FunctionValue, string>;
   moduleTracer: ModuleTracer;
   writeEffects: Map<FunctionValue, AdditionalFunctionEffects>;
-
-  _generateAdditionalFunctionCallsFromInput(): Array<FunctionValue> {
-    // lookup functions
-    let additionalFunctions = [];
-    for (let fname of this.functions || []) {
-      let fun;
-      let fnameAst = buildTemplate(fname)({}).expression;
-      if (fnameAst) {
-        try {
-          let e = ignoreErrorsIn(this.realm, () => this.realm.evaluateNodeForEffectsInGlobalEnv(fnameAst));
-          fun = e ? e[0] : undefined;
-        } catch (ex) {
-          if (!(ex instanceof ThrowCompletion)) throw ex;
-        }
-      }
-      if (!(fun instanceof FunctionValue)) {
-        let error = new CompilerDiagnostic(
-          `Additional function ${fname} not defined in the global environment`,
-          null,
-          "PP1001",
-          "FatalError"
-        );
-        this.realm.handleError(error);
-        throw new FatalError();
-      }
-      this.functionExpressions.set(fun, fname);
-      additionalFunctions.push(fun);
-    }
-    return additionalFunctions;
-  }
 
   __generateAdditionalFunctionsMap(globalKey: string) {
     let recordedAdditionalFunctions: Map<
@@ -262,10 +229,10 @@ export class Functions {
   }
 
   _generateAdditionalFunctionCallsFromDirective(): Array<[FunctionValue, BabelNodeCallExpression]> {
-    let recordedAdditionalFunctions = this.__generateAdditionalFunctionsMap("__additionalFunctions");
+    let recordedAdditionalFunctions = this.__generateAdditionalFunctionsMap("__optimizedFunctions");
 
     // The additional functions we registered at runtime are recorded at:
-    // global.__additionalFunctions.id
+    // global.__optimizedFunctions.id
     let calls = [];
     for (let [funcValue, { funcId }] of recordedAdditionalFunctions) {
       // TODO #987: Make Additional Functions work with arguments
@@ -274,7 +241,7 @@ export class Functions {
         funcValue,
         t.callExpression(
           t.memberExpression(
-            t.memberExpression(t.identifier("global"), t.identifier("__additionalFunctions")),
+            t.memberExpression(t.identifier("global"), t.identifier("__optimizedFunctions")),
             t.identifier(funcId)
           ),
           []
@@ -320,11 +287,9 @@ export class Functions {
   }
 
   checkThatFunctionsAreIndependent() {
-    let inputFunctions = this._generateAdditionalFunctionCallsFromInput();
-    let recordedAdditionalFunctions = this.__generateAdditionalFunctionsMap("__additionalFunctions");
-    let additionalFunctions = inputFunctions.concat([...recordedAdditionalFunctions.keys()]);
+    let additionalFunctions = this.__generateAdditionalFunctionsMap("__optimizedFunctions");
 
-    for (let funcValue of additionalFunctions) {
+    for (let [funcValue] of additionalFunctions) {
       invariant(funcValue instanceof FunctionValue);
       let call = this._callOfFunction(funcValue);
       let effects = this.realm.evaluatePure(() =>
@@ -337,7 +302,7 @@ export class Functions {
 
     // check that functions are independent
     let conflicts: Map<BabelNodeSourceLocation, CompilerDiagnostic> = new Map();
-    for (let fun1 of additionalFunctions) {
+    for (let [fun1] of additionalFunctions) {
       invariant(fun1 instanceof FunctionValue);
       let fun1Name = this.functionExpressions.get(fun1) || fun1.intrinsicName || "(unknown function)";
       // Also do argument validation here
@@ -355,7 +320,7 @@ export class Functions {
         this.realm.handleError(error);
         throw new FatalError();
       }
-      for (let fun2 of additionalFunctions) {
+      for (let [fun2] of additionalFunctions) {
         if (fun1 === fun2) continue;
         invariant(fun2 instanceof FunctionValue);
         this.reportWriteConflicts(fun1Name, conflicts, e1[3], this._callOfFunction(fun2));

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -51,7 +51,7 @@ export class Serializer {
       !!serializerOptions.delayUnsupportedRequires,
       !!serializerOptions.accelerateUnsupportedRequires
     );
-    this.functions = new Functions(this.realm, serializerOptions.additionalFunctions, this.modules.moduleTracer);
+    this.functions = new Functions(this.realm, this.modules.moduleTracer);
     if (serializerOptions.trace) this.realm.tracers.push(new LoggingTracer(this.realm));
 
     this.options = serializerOptions;

--- a/test/error-handler/bad-functions.js
+++ b/test/error-handler/bad-functions.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":8,"column":26},"end":{"line":8,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function global.additional1 may terminate abruptly"}]
+// expected errors: [{"location":{"start":{"line":7,"column":26},"end":{"line":7,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function (unknown function) may terminate abruptly"}]
 var wildcard = global.__abstract ? global.__abstract("number", "123") : 123;
 global.a = "";
 
@@ -11,6 +10,11 @@ function additional1() {
 
 function additional2() {
   global.a = "foo";
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/bad-functions2.js
+++ b/test/error-handler/bad-functions2.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":13,"column":26},"end":{"line":13,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions2.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function global['additional2'] may terminate abruptly"}]
+// expected errors: [{"location":{"start":{"line":12,"column":26},"end":{"line":12,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions2.js"},"severity":"FatalError","errorCode":"PP1002","message":"Additional function (unknown function) may terminate abruptly"}]
 
 var wildcard = global.__abstract ? global.__abstract("number", "123") : 123;
 global.a = "";
@@ -11,6 +10,11 @@ function additional1() {
 
 function additional2() {
   if (wildcard) throw new Exception();
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/missing-functions.js
+++ b/test/error-handler/missing-functions.js
@@ -1,9 +1,0 @@
-// additional functions
-// recover-from-errors
-// expected errors: [{"location":null,"severity":"FatalError","errorCode":"PP1001","message":"Additional function global['additional2'] not defined in the global environment"}]
-
-function additional1() {}
-
-inspect = function() {
-  return "foo";
-}

--- a/test/error-handler/try-and-access-abstract-property.js
+++ b/test/error-handler/try-and-access-abstract-property.js
@@ -1,7 +1,6 @@
-// additional functions
 // abstract effects
 // recover-from-errors
-// expected errors: [{location: {"start":{"line":14,"column":11},"end":{"line":14,"column":15},"identifierName":"obj1","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"},{location: {"start":{"line":22,"column":11},"end":{"line":22,"column":15},"identifierName":"obj2","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
+// expected errors: [{location: {"start":{"line":13,"column":11},"end":{"line":13,"column":15},"identifierName":"obj1","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"},{location: {"start":{"line":21,"column":11},"end":{"line":21,"column":15},"identifierName":"obj2","source":"test/error-handler/try-and-access-abstract-property.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
 
 let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
 let obj2 = global.__abstract ? __abstract('object', '({foo:{bar:"baz"}})') : {foo:{bar:"baz"}};
@@ -23,6 +22,11 @@ function additional2() {
   } finally {
     return 2;
   }
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/try-and-call-abstract-function.js
+++ b/test/error-handler/try-and-call-abstract-function.js
@@ -1,6 +1,5 @@
-// additional functions
 // abstract effects
-// expected errors: [{location: {"start":{"line":27,"column":11},"end":{"line":27,"column":21},"identifierName":"abstractFn","source":"test/error-handler/try-and-call-abstract-function.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
+// expected errors: [{location: {"start":{"line":26,"column":11},"end":{"line":26,"column":21},"identifierName":"abstractFn","source":"test/error-handler/try-and-call-abstract-function.js"}, errorCode: "PP0021", severity: "RecoverableError", message: "Possible throw inside try/catch is not yet supported"}]
 // recover-from-errors
 
 let abstractFn = global.__abstract ? __abstract('function', '(function() { return true; })') : function() { return true; };
@@ -28,6 +27,11 @@ function additional2() {
   } catch (x) {
     return false;
   }
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-forin-conflict.js
+++ b/test/error-handler/write-forin-conflict.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":10,"column":16},"end":{"line":10,"column":22},"identifierName":"global","source":"test/error-handler/write-forin-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":9,"column":16},"end":{"line":9,"column":22},"identifierName":"global","source":"test/error-handler/write-forin-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 function additional1() {
   global.a = { f: "foo" };
@@ -10,6 +9,11 @@ function additional2() {
   for (let p in global.a) {
 
   }
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-in-conflict.js
+++ b/test/error-handler/write-in-conflict.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":10,"column":20},"end":{"line":10,"column":26},"identifierName":"global","source":"test/error-handler/write-in-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":9,"column":20},"end":{"line":9,"column":26},"identifierName":"global","source":"test/error-handler/write-in-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 function additional1() {
   global.a = "foo";
@@ -8,6 +7,11 @@ function additional1() {
 
 function additional2() {
   global.b = "a" in global;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-reflect-conflict.js
+++ b/test/error-handler/write-reflect-conflict.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":12,"column":29},"end":{"line":12,"column":30},"identifierName":"a","source":"test/error-handler/write-reflect-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":11,"column":29},"end":{"line":11,"column":30},"identifierName":"a","source":"test/error-handler/write-reflect-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 a = {};
 
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   global.b = Reflect.ownKeys(a);
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-write-conflict.js
+++ b/test/error-handler/write-write-conflict.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":12,"column":13},"end":{"line":12,"column":18},"source":"test/error-handler/write-write-conflict.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":8,"column":13},"end":{"line":8,"column":18},"source":"test/error-handler/write-write-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":11,"column":13},"end":{"line":11,"column":18},"source":"test/error-handler/write-write-conflict.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":7,"column":13},"end":{"line":7,"column":18},"source":"test/error-handler/write-write-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 global.a = "";
 
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   global.a = "bar";
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-write-conflict2.js
+++ b/test/error-handler/write-write-conflict2.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":12,"column":13},"end":{"line":12,"column":18},"source":"test/error-handler/write-write-conflict2.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":8,"column":9},"end":{"line":8,"column":15},"identifierName":"global","source":"test/error-handler/write-write-conflict2.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":11,"column":13},"end":{"line":11,"column":18},"source":"test/error-handler/write-write-conflict2.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":7,"column":9},"end":{"line":7,"column":15},"identifierName":"global","source":"test/error-handler/write-write-conflict2.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 global.a = "";
 
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   global.a = "bar";
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-write-conflict3.js
+++ b/test/error-handler/write-write-conflict3.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":12,"column":9},"end":{"line":12,"column":15},"identifierName":"global","source":"test/error-handler/write-write-conflict3.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":8,"column":13},"end":{"line":8,"column":18},"source":"test/error-handler/write-write-conflict3.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":11,"column":9},"end":{"line":11,"column":15},"identifierName":"global","source":"test/error-handler/write-write-conflict3.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":7,"column":13},"end":{"line":7,"column":18},"source":"test/error-handler/write-write-conflict3.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 global.a = "";
 
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   delete global.a;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-write-conflict4.js
+++ b/test/error-handler/write-write-conflict4.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":12,"column":13},"end":{"line":12,"column":18},"source":"test/error-handler/write-write-conflict4.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":8,"column":13},"end":{"line":8,"column":18},"source":"test/error-handler/write-write-conflict4.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":11,"column":13},"end":{"line":11,"column":18},"source":"test/error-handler/write-write-conflict4.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":7,"column":13},"end":{"line":7,"column":18},"source":"test/error-handler/write-write-conflict4.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 global.a = "";
 
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   global.a = "foo";
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/error-handler/write-write-unknown-prop-conflict.js
+++ b/test/error-handler/write-write-unknown-prop-conflict.js
@@ -1,6 +1,5 @@
-// additional functions
 // recover-from-errors
-// expected errors: [{"location":{"start":{"line":13,"column":16},"end":{"line":13,"column":21},"source":"test/error-handler/write-write-unknown-prop-conflict.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":9,"column":16},"end":{"line":9,"column":21},"source":"test/error-handler/write-write-unknown-prop-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
+// expected errors: [{"location":{"start":{"line":12,"column":16},"end":{"line":12,"column":21},"source":"test/error-handler/write-write-unknown-prop-conflict.js"},"severity":"FatalError","errorCode":"PP1003"},{"location":{"start":{"line":8,"column":16},"end":{"line":8,"column":21},"source":"test/error-handler/write-write-unknown-prop-conflict.js"},"severity":"FatalError","errorCode":"PP1003"}]
 
 let i = global.__abstract ? __abstract("string", "x") : "x";
 global.a = { x: "" }
@@ -11,6 +10,11 @@ function additional1() {
 
 function additional2() {
   global.a[i] = "bar";
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/abstract/AbstractPropertyDelete.js
+++ b/test/serializer/abstract/AbstractPropertyDelete.js
@@ -1,4 +1,3 @@
-// additional functions
 // add at runtime:global.obj1 = { a: 1 }; global.obj2 = { a: 2 };
 
 let obj1 = global.__abstract ? __abstract({}, 'obj1') : { a: 1 };
@@ -23,6 +22,11 @@ function additional2() {
   obj2.c = 5;
   delete obj2.b;
   return obj2;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/abstract/AbstractPropertyDelete2.js
+++ b/test/serializer/abstract/AbstractPropertyDelete2.js
@@ -1,4 +1,3 @@
-// additional functions
 // add at runtime:global.obj1 = { a: Math.random(), b: 10 }; global.obj2 = { a: Math.random(), b: 10 };
 
 let obj1 = global.__abstract ? __abstract({}, 'obj1') : { a: Math.random(), b: 10 };
@@ -23,6 +22,11 @@ function additional2() {
   obj2.c = 5;
   delete obj2.a;
   return obj2;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/abstract/AbstractPropertyDelete3.js
+++ b/test/serializer/abstract/AbstractPropertyDelete3.js
@@ -1,4 +1,3 @@
-// additional functions
 // add at runtime:global.obj1 = { "extends": Math.random(), b: 10 }; global.obj2 = { "while": Math.random(), b: 10 };
 
 let obj1 = global.__abstract ? __abstract({}, 'obj1') : { "extends": Math.random(), b: 10 };
@@ -23,6 +22,11 @@ function additional2() {
   obj2.c = 5;
   delete obj2['while'];
   return obj2;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/AdditionalFunCapturedScope.js
+++ b/test/serializer/additional-functions/AdditionalFunCapturedScope.js
@@ -7,8 +7,8 @@ var f = function(x) {
     i += 1;
     return i;
   }
-  if (global.__registerAdditionalFunctionToPrepack)
-    __registerAdditionalFunctionToPrepack(fun);
+  if (global.__optimize)
+    __optimize(fun);
   addit_funs.push(fun);
   return fun;
 }

--- a/test/serializer/additional-functions/Example1.js
+++ b/test/serializer/additional-functions/Example1.js
@@ -1,4 +1,3 @@
-// additional functions
 
 AGlobalObject = {};
 AGlobalValue = 5;
@@ -31,6 +30,11 @@ function additional2() {
   let tmp = hello() + world();
   let bigfib = fib(10);
   BGlobalValue = tmp + bigfib;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/ReadThenDelete.js
+++ b/test/serializer/additional-functions/ReadThenDelete.js
@@ -1,4 +1,3 @@
-// additional functions
 
 AGlobalObject = {};
 AGlobalValue = 5;
@@ -15,6 +14,11 @@ function additional1() {
 function additional2() {
   let x = BGlobalObject.bar;
   BGlobalObject.baz = BGlobalValue % x;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/TargetsWithGenerators.js
+++ b/test/serializer/additional-functions/TargetsWithGenerators.js
@@ -19,6 +19,6 @@
             }
         }
     }
-    if (global.__registerAdditionalFunctionToPrepack) __registerAdditionalFunctionToPrepack(f);
+    if (global.__optimize) __optimize(f);
     inspect = f;
 })();

--- a/test/serializer/additional-functions/abstract-property-modification.js
+++ b/test/serializer/additional-functions/abstract-property-modification.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 // add at runtime: global.a = {}; global.b = {};
@@ -20,6 +19,11 @@ function additional1() {
 function additional2() {
   global.b.bar = z + "bar";
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/arguments.js
+++ b/test/serializer/additional-functions/arguments.js
@@ -5,8 +5,8 @@ function additional1(argument) {
   var x = 5;
   return z;
 }
-if (global.__registerAdditionalFunctionToPrepack)
-  __registerAdditionalFunctionToPrepack(additional1);
+if (global.__optimize)
+  __optimize(additional1);
 
 inspect = function inspect() {
   let z = additional1(7);

--- a/test/serializer/additional-functions/arguments2.js
+++ b/test/serializer/additional-functions/arguments2.js
@@ -12,9 +12,9 @@ function additional2(argument) {
   return z;
 }
 
-if (global.__registerAdditionalFunctionToPrepack) {
-  __registerAdditionalFunctionToPrepack(additional1);
-  __registerAdditionalFunctionToPrepack(additional2);
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function inspect() {

--- a/test/serializer/additional-functions/arguments3.js
+++ b/test/serializer/additional-functions/arguments3.js
@@ -5,8 +5,8 @@ function additional1(argument, argument) {
   var x = 5;
   return z;
 }
-if (global.__registerAdditionalFunctionToPrepack)
-  __registerAdditionalFunctionToPrepack(additional1);
+if (global.__optimize)
+  __optimize(additional1);
 
 inspect = function inspect() {
   let z = additional1(7, 10);

--- a/test/serializer/additional-functions/arguments4.js
+++ b/test/serializer/additional-functions/arguments4.js
@@ -6,8 +6,8 @@ function additional1(argument1, argument2) {
   var x = 5;
   return [w, z];
 }
-if (global.__registerAdditionalFunctionToPrepack)
-  __registerAdditionalFunctionToPrepack(additional1);
+if (global.__optimize)
+  __optimize(additional1);
 
 inspect = function inspect() {
   let z = additional1(12, 3);

--- a/test/serializer/additional-functions/capture-local.js
+++ b/test/serializer/additional-functions/capture-local.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -11,6 +10,11 @@ function additional1() {
 function additional2() {
   global.y = function nested2() { return 6; };
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function inspect() {

--- a/test/serializer/additional-functions/create-local.js
+++ b/test/serializer/additional-functions/create-local.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -12,6 +11,11 @@ function additional2() {
   var z = { bar: 6 };
   global.y = z;
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/createdobject-modifications.js
+++ b/test/serializer/additional-functions/createdobject-modifications.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -21,6 +20,11 @@ function additional2() {
   delete local.y;
   var y = 10;
   global.foo.y = local;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/createdobject.js
+++ b/test/serializer/additional-functions/createdobject.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 let toCapture1 = {};
@@ -14,6 +13,11 @@ function additional2() {
   var y = 10;
   y = 5;
   global.y = y;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function inspect() {

--- a/test/serializer/additional-functions/func-nesting.js
+++ b/test/serializer/additional-functions/func-nesting.js
@@ -1,4 +1,3 @@
-// additional functions
 inspect = undefined;
 (function(){
   var Super =
@@ -27,6 +26,11 @@ inspect = undefined;
   }
 
   function additional2() {
+  }
+
+  if (global.__optimize) {
+    __optimize(additional1);
+    __optimize(additional2);
   }
 
   global.additional1 = additional1;

--- a/test/serializer/additional-functions/modified-global-let-simple.js
+++ b/test/serializer/additional-functions/modified-global-let-simple.js
@@ -1,4 +1,4 @@
-// additional functions
+
 let x = undefined;
 global.additional1 = function() {
   x = {};
@@ -7,6 +7,11 @@ global.additional1 = function() {
 
 global.additional2 = function() {
   return 20;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/modifiedobjects.js
+++ b/test/serializer/additional-functions/modifiedobjects.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 let toCapture1 = {};
@@ -22,6 +21,11 @@ function additional2() {
   y = 5;
   toCapture3 = y;
   global.y = y;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function inspect() {

--- a/test/serializer/additional-functions/named-function.js
+++ b/test/serializer/additional-functions/named-function.js
@@ -4,8 +4,8 @@ function additional1() {
   }};
 }
 
-if (this.__registerAdditionalFunctionToPrepack) {
-  __registerAdditionalFunctionToPrepack(additional1);
+if (this.__optimize) {
+  __optimize(additional1);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/nested_function.js
+++ b/test/serializer/additional-functions/nested_function.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:var y = 5;
 // does not contain:var y = 10;
 
@@ -16,6 +15,11 @@ function additional2() {
   "use strict";
   let x1 = produceObject();
   global.bar = function() { return x1; }
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/nested_function2.js
+++ b/test/serializer/additional-functions/nested_function2.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:= 7;
 // does not contain:= 10;
 
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   let x = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/nested_function3.js
+++ b/test/serializer/additional-functions/nested_function3.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:= 7;
 // does not contain:= 10;
 let x1 = { bar: 500 };
@@ -11,6 +10,11 @@ function additional1() {
 
 function additional2() {
   let x = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/nested_function4.js
+++ b/test/serializer/additional-functions/nested_function4.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:= 7;
 // does not contain:= 10;
 let addit_capture = { baz: 99 };
@@ -12,6 +11,11 @@ function additional1() {
 
 function additional2() {
   let x = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/nested_modifybinding.js
+++ b/test/serializer/additional-functions/nested_modifybinding.js
@@ -13,8 +13,8 @@
         return ++top;
     };
     global.f = af1;
-    if (global.__registerAdditionalFunctionToPrepack)
-      global.__registerAdditionalFunctionToPrepack(af1);
+    if (global.__optimize)
+      global.__optimize(af1);
     inspect = function() {
         return f()() + residual();
     }

--- a/test/serializer/additional-functions/noconflict-captures.js
+++ b/test/serializer/additional-functions/noconflict-captures.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -14,6 +13,11 @@ function additional1() {
 function additional2() {
   global.b = z + "bar";
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/noconflict-captures2.js
+++ b/test/serializer/additional-functions/noconflict-captures2.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -14,6 +13,11 @@ function additional1() {
 function additional2() {
   global.b = z + "bar";
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/noconflict-existantobject.js
+++ b/test/serializer/additional-functions/noconflict-existantobject.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -12,6 +11,11 @@ function additional1() {
 function additional2() {
   global.c.bar = 2;
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/noopfunc.js
+++ b/test/serializer/additional-functions/noopfunc.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -13,6 +12,11 @@ function additional1() {
 function additional2() {
   global.b = z + "bar";
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/precise_captures.js
+++ b/test/serializer/additional-functions/precise_captures.js
@@ -7,7 +7,7 @@ function Foo() {
   return Bar();
 }
 
-if (global.__registerAdditionalFunctionToPrepack) __registerAdditionalFunctionToPrepack(Foo);
+if (global.__optimize) __optimize(Foo);
 
 global.Foo = Foo;
 

--- a/test/serializer/additional-functions/prelude-ordering.js
+++ b/test/serializer/additional-functions/prelude-ordering.js
@@ -1,8 +1,13 @@
-// additional functions
 // simple closures
 function additional1() {
-    var obj = {x: 42};
-    return function() { let ret = obj; obj = {}; return ret; }
+  var obj = {x: 42};
+  return function() { let ret = obj; obj = {}; return ret; }
 }
 function additional2() {}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
+}
+
 inspect = function() { return additional1()().x; }

--- a/test/serializer/additional-functions/property-deletion.js
+++ b/test/serializer/additional-functions/property-deletion.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -15,6 +14,11 @@ function additional2() {
   global.foo.bar = z + global.foo.y;
   delete global.foo.y
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/property-modification.js
+++ b/test/serializer/additional-functions/property-modification.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -14,6 +13,11 @@ function additional1() {
 function additional2() {
   global.b.bar = z + "bar";
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/referentialization.js
+++ b/test/serializer/additional-functions/referentialization.js
@@ -8,8 +8,8 @@
     };
     return obj;
   }
-  if (global.__registerAdditionalFunctionToPrepack) {
-    global.__registerAdditionalFunctionToPrepack(additional);
+  if (global.__optimize) {
+    global.__optimize(additional);
   }
   inspect = function() {
     additional();

--- a/test/serializer/additional-functions/referentialization2.js
+++ b/test/serializer/additional-functions/referentialization2.js
@@ -8,8 +8,8 @@
     };
     return obj;
   }
-  if (global.__registerAdditionalFunctionToPrepack) {
-    global.__registerAdditionalFunctionToPrepack(additional);
+  if (global.__optimize) {
+    global.__optimize(additional);
   }
   inspect = function() {
     additional();

--- a/test/serializer/additional-functions/register_fail_test.js
+++ b/test/serializer/additional-functions/register_fail_test.js
@@ -13,9 +13,9 @@ function func2() {
   return global.y;
 }
 
-if (global.__registerAdditionalFunctionToPrepack && abstract_bool) {
-  __registerAdditionalFunctionToPrepack(func1);
-  __registerAdditionalFunctionToPrepack(func2);
+if (global.__optimize && abstract_bool) {
+  __optimize(func1);
+  __optimize(func2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/register_test.js
+++ b/test/serializer/additional-functions/register_test.js
@@ -12,9 +12,9 @@ function func2() {
   return global.y;
 }
 
-if (global.__registerAdditionalFunctionToPrepack) {
-  __registerAdditionalFunctionToPrepack(func1);
-  __registerAdditionalFunctionToPrepack(func2);
+if (global.__optimize) {
+  __optimize(func1);
+  __optimize(func2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/require_opt.js
+++ b/test/serializer/additional-functions/require_opt.js
@@ -1,5 +1,4 @@
 // es6
-// additional functions
 // does not contain:var y = 5;
 // does not contain:var y = 10;
 var modules = Object.create(null);
@@ -123,6 +122,11 @@ function additional1() {
 function additional2() {
   //global.bar = function() { return require(0).baz + "bar"; }
   global.bar = function() { return 5; }
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/return-value-simple.js
+++ b/test/serializer/additional-functions/return-value-simple.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -13,6 +12,11 @@ function additional1() {
 function additional2() {
   var y = 10;
   return z + "bar";
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/self_referential.js
+++ b/test/serializer/additional-functions/self_referential.js
@@ -6,8 +6,8 @@ function func1() {
   return z;
 }
 
-if (global.__registerAdditionalFunctionToPrepack) {
-  __registerAdditionalFunctionToPrepack(func1);
+if (global.__optimize) {
+  __optimize(func1);
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/write-in-conflict.js
+++ b/test/serializer/additional-functions/write-in-conflict.js
@@ -1,4 +1,3 @@
-// additional functions
 // throws introspection error
 
 function additional1() {
@@ -7,6 +6,11 @@ function additional1() {
 
 function additional2() {
   return "a" in global;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 global.__residual ? __residual("void", additional1) : additional1();

--- a/test/serializer/additional-functions/write-write-noconflict.js
+++ b/test/serializer/additional-functions/write-write-noconflict.js
@@ -1,4 +1,3 @@
-// additional functions
 // does not contain:x = 5;
 // does not contain:y = 10;
 
@@ -13,6 +12,11 @@ function additional1() {
 function additional2() {
   global.b = "bar";
   var y = 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/AbstractCall.js
+++ b/test/serializer/pure-functions/AbstractCall.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let forEach = global.__abstract ? __abstract('function', '(function(callback) { callback("a", 0); callback("b", 1); })') : function(callback) { callback("a", 0); callback("b", 1); };
@@ -17,6 +16,11 @@ function additional2() {
   set(obj, 'x', 2);
   set(obj, 'y', obj.x);
   bar = function() { return obj; }
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/AbstractCallUnknownType.js
+++ b/test/serializer/pure-functions/AbstractCallUnknownType.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj = global.__abstract ? __abstract('object', '({foo: function() { return 1; }})') : {foo: function() { return 1; }};
@@ -17,6 +16,11 @@ function additional2() {
   }
   let fnOrString = condition ? fn : 'string';
   return fnOrString();
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/AbstractCallUnknownType2.js
+++ b/test/serializer/pure-functions/AbstractCallUnknownType2.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj = {};
@@ -20,6 +19,11 @@ function additional2() {
   }
   let fnOrString = condition ? fn : 'string';
   return fnOrString();
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/AbstractPropertyRead.js
+++ b/test/serializer/pure-functions/AbstractPropertyRead.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
@@ -13,6 +12,11 @@ function additional1() {
 
 function additional2() {
   return obj2.foo.bar;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/AbstractProperyRead2.js
+++ b/test/serializer/pure-functions/AbstractProperyRead2.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
@@ -13,6 +12,11 @@ function additional1() {
 
 function additional2() {
   return obj2.foo["extends"];
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/BinaryExpressions.js
+++ b/test/serializer/pure-functions/BinaryExpressions.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj1 = global.__abstract ? __abstract('object', '({foo: {valueOf() { return 42; }}})') : {foo: {valueOf() { return 42; }}};
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   return obj2.foo.bar + 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/BinaryExpressions2.js
+++ b/test/serializer/pure-functions/BinaryExpressions2.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj1 = global.__abstract ? __abstract('object', '({foo: {valueOf() { return 42; }}})') : {foo: {valueOf() { return 42; }}};
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   return obj2.foo.bar > 42;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/BinaryExpressions3.js
+++ b/test/serializer/pure-functions/BinaryExpressions3.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj1 = global.__abstract ? __abstract('object', '({valueOf() { this.x = 10; return 42; }})') : {valueOf() { this.x = 10; return 42; }};
@@ -19,6 +18,11 @@ function additional2() {
     foo: 0
   };
   return x + '' + x.foo;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/CastStringOnUnknown.js
+++ b/test/serializer/pure-functions/CastStringOnUnknown.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj1 = global.__abstract ? __abstract('object', '({get foo() { return "bar"; }})') : {get foo() { return "bar"; }};
@@ -13,6 +12,11 @@ function additional1() {
 
 function additional2() {
   return String(obj2.foo.bar);
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/ObjectAssign.js
+++ b/test/serializer/pure-functions/ObjectAssign.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
@@ -9,6 +8,11 @@ function additional1() {
 
 function additional2() {
   return Object.assign(obj, {bar:1});
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/UnaryExpressions.js
+++ b/test/serializer/pure-functions/UnaryExpressions.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 let obj1 = global.__abstract ? __abstract('object', '({foo: {valueOf() { return 42; }}})') : {foo: {valueOf() { return 42; }}};
@@ -10,6 +9,11 @@ function additional1() {
 
 function additional2() {
   return ~obj2.foo.bar + 10;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/hasOwnProperty.js
+++ b/test/serializer/pure-functions/hasOwnProperty.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
@@ -17,6 +16,11 @@ function additional2() {
     return 'This should not be abstract.';
   }
   return dontHavocThis.bar;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {

--- a/test/serializer/pure-functions/hasOwnProperty2.js
+++ b/test/serializer/pure-functions/hasOwnProperty2.js
@@ -1,4 +1,3 @@
-// additional functions
 // abstract effects
 
 var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : {foo:1};
@@ -34,6 +33,11 @@ function additional2() {
     return 'This should not be abstract.';
   }
   return x;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
 }
 
 inspect = function() {


### PR DESCRIPTION
Release notes: `__registerAdditionalFunction` is now `__optimize`

This PR renames `__registerAdditionalFunction` to `__optimize` and removes all tests that use the `// additional functions` logic in favor of declaratively using `__optimize`. Also the serializer option for `additionalFunctions` is removed too.