### PR TITLE
Don't visit a "widened property" value on a path

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -204,7 +204,7 @@ export class ResidualHeapVisitor {
       ) {
         continue;
       }
-      if (propertyBindingKey.pathNode !== undefined) continue; // property is written to inside a loop
+      if (propertyBindingValue.pathNode !== undefined) continue; // property is written to inside a loop
       invariant(propertyBindingValue);
       this.visitObjectProperty(propertyBindingValue);
     }

--- a/test/serializer/abstract/DoWhile10.js
+++ b/test/serializer/abstract/DoWhile10.js
@@ -1,0 +1,9 @@
+let n = global.__abstract ? __abstract("number", "(3)") : 3;
+let i = 0;
+let o = {x:0};
+do {
+  o.x = i;
+  i++;
+} while (i < n);
+
+inspect = function() { return JSON.stringify(o); }


### PR DESCRIPTION
This accidentally checked the pathNode on the key instead of the value.

This is ignored by the serializer and the visitor needs to line up:

https://github.com/facebook/prepack/blob/21fcfb2a0996abd2b90b61fb3ebd80bd3c9b8928/src/serializer/ResidualHeapSerializer.js#L261

Fixes #1551