### PR TITLE
Make additional functions correctly emit initializers

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -680,8 +680,11 @@ export class ResidualFunctions {
 
     for (let [additionalFunction, body] of rewrittenAdditionalFunctions.entries()) {
       let bodySegment = additionalFunctionModifiedBindingsSegment.get(additionalFunction);
-      let prelude = additionalFunctionPreludes.get(additionalFunction);
-      if (prelude) body.unshift(...prelude);
+      let prelude = additionalFunctionPreludes.get(additionalFunction) || [];
+      let additionalFunctionInfo = this.additionalFunctionValueInfos.get(additionalFunction);
+      invariant(additionalFunctionInfo);
+      prelude.unshift(...getFunctionBody(additionalFunctionInfo.instance));
+      body.unshift(...prelude);
       if (bodySegment) {
         if (body.length > 0 && t.isReturnStatement(body[body.length - 1])) {
           let returnStatement = body.pop();


### PR DESCRIPTION
Release notes: none

Fixes #1571. Essentially, when we evaluatePure for an additional function, any bindings that get used by nested functions will cause a emitBindingModification generator entry that will add an initializer to the additional function's instance in the Referentializer. These initializationStatements for additional functions were not correctly being appended to the function, now they are.