### PR TITLE
Protect against common firstRender issues

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -382,6 +382,35 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output First render only Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output First render only React Context 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,
@@ -2285,6 +2314,35 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
   "componentsEvaluated": 5,
@@ -3083,6 +3141,35 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
@@ -4990,6 +5077,35 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
   "componentsEvaluated": 5,
@@ -5788,6 +5904,35 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output First render only Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
@@ -7660,6 +7805,35 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks Hacker News app 1`] = `
 ReactStatistics {
   "componentsEvaluated": 5,
@@ -8458,6 +8632,35 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 2,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
@@ -10327,6 +10530,35 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks Function bind 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Middle",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed on new component tree branch",
+          "name": "Middle",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -382,35 +382,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with JSX input, JSX output First render only Function bind 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 3,
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Middle",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "evaluation failed on new component tree branch",
-          "name": "Middle",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "message": "",
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
-  "optimizedTrees": 1,
-}
-`;
-
 exports[`Test React with JSX input, JSX output First render only React Context 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,
@@ -3141,35 +3112,6 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 2,
-  "optimizedTrees": 1,
-}
-`;
-
-exports[`Test React with JSX input, create-element output First render only Function bind 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 3,
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Middle",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "evaluation failed on new component tree branch",
-          "name": "Middle",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "message": "",
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;
@@ -5908,35 +5850,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with create-element input, JSX output First render only Function bind 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 3,
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Middle",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "evaluation failed on new component tree branch",
-          "name": "Middle",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "message": "",
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
-  "optimizedTrees": 1,
-}
-`;
-
 exports[`Test React with create-element input, JSX output First render only React Context 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,
@@ -8632,35 +8545,6 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 2,
-  "optimizedTrees": 1,
-}
-`;
-
-exports[`Test React with create-element input, create-element output First render only Function bind 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 3,
-  "evaluatedRootNodes": Array [
-    Object {
-      "children": Array [
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Middle",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "evaluation failed on new component tree branch",
-          "name": "Middle",
-          "status": "BAIL-OUT",
-        },
-      ],
-      "message": "",
-      "name": "App",
-      "status": "ROOT",
-    },
-  ],
-  "inlinedComponents": 0,
   "optimizedTrees": 1,
 }
 `;

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -616,6 +616,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         let data = JSON.parse(getDataFile(directory, "hacker-news.json"));
         await runTest(directory, "hacker-news.js", false, data);
       });
+
+      it("Function bind", async () => {
+        await runTest(directory, "function-bind.js");
+      });
     });
   });
 }

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -244,7 +244,7 @@ export class Reconciler {
     let renderMethod = Get(this.realm, instance, "render");
     invariant(renderMethod instanceof ECMAScriptSourceFunctionValue);
     // the render method doesn't have any arguments, so we just assign the context of "this" to be the instance
-    return getValueFromRenderCall(this.realm, renderMethod, instance, []);
+    return getValueFromRenderCall(this.realm, renderMethod, instance, [], this.componentTreeConfig);
   }
 
   _renderSimpleClassComponent(
@@ -260,7 +260,7 @@ export class Reconciler {
     let renderMethod = Get(this.realm, instance, "render");
     invariant(renderMethod instanceof ECMAScriptSourceFunctionValue);
     // the render method doesn't have any arguments, so we just assign the context of "this" to be the instance
-    return getValueFromRenderCall(this.realm, renderMethod, instance, []);
+    return getValueFromRenderCall(this.realm, renderMethod, instance, [], this.componentTreeConfig);
   }
 
   _renderFunctionalComponent(
@@ -268,7 +268,13 @@ export class Reconciler {
     props: ObjectValue | AbstractValue | AbstractObjectValue,
     context: ObjectValue | AbstractObjectValue
   ) {
-    return getValueFromRenderCall(this.realm, componentType, this.realm.intrinsics.undefined, [props, context]);
+    return getValueFromRenderCall(
+      this.realm,
+      componentType,
+      this.realm.intrinsics.undefined,
+      [props, context],
+      this.componentTreeConfig
+    );
   }
 
   _getClassComponentMetadata(
@@ -404,7 +410,13 @@ export class Reconciler {
             // make sure this context is in our tree
             if (this._hasReferenceForContextNode(typeValue)) {
               let valueProp = Get(this.realm, typeValue, "currentValue");
-              let result = getValueFromRenderCall(this.realm, renderProp, this.realm.intrinsics.undefined, [valueProp]);
+              let result = getValueFromRenderCall(
+                this.realm,
+                renderProp,
+                this.realm.intrinsics.undefined,
+                [valueProp],
+                this.componentTreeConfig
+              );
               this.statistics.inlinedComponents++;
               this.statistics.componentsEvaluated++;
               evaluatedChildNode.status = "INLINED";
@@ -549,12 +561,7 @@ export class Reconciler {
       componentWillMount.$Call(instance, []);
     }
     invariant(renderMethod instanceof ECMAScriptSourceFunctionValue);
-    // the render method doesn't have any arguments, so we just assign the context of "this" to be the instance
-    let value = getValueFromRenderCall(this.realm, renderMethod, instance, []);
-    if (value instanceof AbstractValue && value.args.length === 0) {
-      throw new ExpectedBailOut("completely unknown component render currently supported on first render");
-    }
-    return value;
+    return getValueFromRenderCall(this.realm, renderMethod, instance, [], this.componentTreeConfig);
   }
 
   _renderComponent(

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -23,7 +23,7 @@ import {
   ArrayValue,
   ObjectValue,
   AbstractObjectValue,
-  BoundFunctionValue,
+  FunctionValue,
 } from "../values/index.js";
 import { ReactStatistics, type ReactSerializerState, type ReactEvaluatedNode } from "../serializer/types.js";
 import {
@@ -1052,11 +1052,11 @@ export class Reconciler {
   }
 
   _findReactComponentTrees(value: Value, evaluatedNode: ReactEvaluatedNode): void {
-    if (value instanceof BoundFunctionValue) {
+    if (value instanceof FunctionValue && !(value instanceof ECMAScriptSourceFunctionValue)) {
       // TODO treat as nested additional function
       // until then we don't support this so we need to bail out on first render
       if (this.componentTreeConfig.firstRenderOnly) {
-        throw new ExpectedBailOut("bound function is not currently supported on first render");
+        throw new ExpectedBailOut("non script function is not currently supported on first render");
       }
     } else if (value instanceof AbstractValue) {
       if (value.args.length > 0) {

--- a/test/react/mocks/function-bind.js
+++ b/test/react/mocks/function-bind.js
@@ -1,0 +1,55 @@
+var React = require('react');
+this['React'] = React;
+
+// FB www polyfill
+if (!this.babelHelpers) {
+  this.babelHelpers = {
+    inherits(subClass, superClass) {
+      Object.assign(subClass, superClass);
+      subClass.prototype = Object.create(superClass && superClass.prototype);
+      subClass.prototype.constructor = subClass;
+      subClass.__superConstructor__ = superClass;
+      return superClass;
+    },
+  };
+}
+
+var _React$Component = babelHelpers.inherits(
+  Middle,
+  React.Component
+);
+_superProto = _React$Component && _React$Component.prototype;
+
+function Middle(props) {
+  _superProto.constructor.call(this, props);
+  this.$Middle_renderItem = function() {
+    return this.props.item;
+  }.bind(this);
+}
+Middle.prototype.render = function() {
+  var children = this.props.children;
+  return children({
+    renderItem: this.$Middle_renderItem,
+  });
+};
+
+function App(props) {
+  return <Middle {...props} />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(
+    <Root item={<span>Hi</span>}>
+      {obj => <h1>{obj.renderItem()}</h1>}
+    </Root>
+  );
+  return [['render with bound child function', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true
+  });
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

firstRender can fail when `Function.prototype.bind` is passed around because the firstRender removes the class component entirely, along with any concept of state etc. To prevent outputting the incorrect value, we now check for bind and if we're given something that is completely abstract as a child from a render, we bail out in that case too.