### PR TITLE
Adds failing test and enables possible normal completion logic for React reconciler

### DIFF
--- a/test/react/mocks/fb12.js
+++ b/test/react/mocks/fb12.js
@@ -1,0 +1,55 @@
+var React = require('React');
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = this.__evaluatePureFunction(() => {
+  function nullthrows(x) {
+    var message = arguments.length <= 1 || arguments[1] === undefined ? 'Got unexpected null or undefined' : arguments[1];
+    if (x != null) {
+      return x;
+    }
+    var error = new Error(message);
+
+    error.framesToPop = 1;
+    throw error;
+  };
+
+  function A(props) {
+    return (
+      <div className={props.className}>
+        <div>Hello {props.x} {props.y}</div>
+        <B />
+        <C />
+      </div>
+    );
+  }
+
+  function B() {
+    return <div>World</div>;
+  }
+
+  function C() {
+    return "!";
+  }
+
+  function App(props) {
+    nullthrows(props.className);
+    return <A className={props.className} />;
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root className="Rooty McRootface" />);
+    return [['simple render', renderer.toJSON()]];
+  };
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App);
+  }
+
+  return App;
+});


### PR DESCRIPTION
Release notes: none

This enables the React reconciler to use the work done by @cblappert and PossiblyNormalCompletions. Closes https://github.com/facebook/prepack/pull/1455