### PR TITLE
Replace "sentinel Object" with "implicit conversion to object"

### DIFF
--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -434,7 +434,7 @@ export class ToImplementation {
           // Create a placeholder value to represent the ObjectValue that we would've
           // received, but this object should never leak so as an optimization we will
           // let operations on top of this object force the ToObject operations instead.
-          obj = AbstractValue.createFromType(realm, ObjectValue, "sentinel ToObject");
+          obj = AbstractValue.createFromType(realm, ObjectValue, "implicit conversion to object");
           invariant(obj instanceof AbstractObjectValue);
           obj.args = [arg];
         } else {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1619,6 +1619,11 @@ export class ResidualHeapSerializer {
       invariant(abstractIndex >= 0 && abstractIndex < val.args.length);
       return serializedArgs[abstractIndex];
     }
+    if (val.kind === "implicit conversion to object") {
+      let ob = serializedArgs[0];
+      invariant(ob !== undefined);
+      return ob;
+    }
     let serializedValue = val.buildNode(serializedArgs);
     if (serializedValue.type === "Identifier") {
       let id = ((serializedValue: any): BabelNodeIdentifier);
@@ -1633,10 +1638,7 @@ export class ResidualHeapSerializer {
   }
 
   _serializeAbstractValue(val: AbstractValue): void | BabelNodeExpression {
-    invariant(
-      val.kind !== "sentinel member expression" && val.kind !== "sentinel ToObject",
-      "invariant established by visitor"
-    );
+    invariant(val.kind !== "sentinel member expression", "invariant established by visitor");
     if (val.hasIdentifier()) {
       return this._serializeAbstractValueHelper(val);
     } else {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -745,7 +745,6 @@ export class ResidualHeapVisitor {
   visitAbstractValue(val: AbstractValue): void {
     if (val.kind === "sentinel member expression")
       this.logger.logError(val, "expressions of type o[p] are not yet supported for partially known o and unknown p");
-    if (val.kind === "sentinel ToObject") this.logger.logError(val, "Unknown object cannot be coerced to Object");
     for (let i = 0, n = val.args.length; i < n; i++) {
       val.args[i] = this.visitEquivalentValue(val.args[i]);
     }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -360,11 +360,10 @@ export default class AbstractObjectValue extends AbstractValue {
       let generateAbstractGet = () => {
         let type = Value;
         if (P === "length" && Value.isTypeCompatibleWith(this.getType(), ArrayValue)) type = NumberValue;
-        let object = this.kind === "sentinel ToObject" ? this.args[0] : this;
         return AbstractValue.createTemporalFromBuildFunction(
           this.$Realm,
           type,
-          [object],
+          [this],
           ([o]) => {
             invariant(typeof P === "string");
             return t.isValidIdentifier(P)


### PR DESCRIPTION
Release note: Fix delayed conversions of abstract values to objects in pure mode

The "sentinel Object" wrapper name is a bit misleading, so I've renamed it to "implicit conversion to object".

The bug itself arises from the fact that the abstract value (wrapper) was stripped before it arrived at the serializer. This broke the dependency tracking logic of the serializer. The proper way to do this is to let the serializer do the stripping.

Unfortunately I do not have a small regression test case that gets fixed by this. I'm still looking, but meanwhile the bug fix will unblock Nikolai and perhaps others too.