### PR TITLE
Change invariant in paths.js to a FatalError

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "depcheck": "babel-node scripts/detect_bad_deps.js",
     "prettier": "node ./scripts/prettier.js write-changed",
     "prettier-all": "node ./scripts/prettier.js write",
-    "debug-fb-www": "node ./scripts/debug-fb-www.js"
+    "debug-fb-www": "node --stack_size=10000 --stack_trace_limit=200 --max_old_space_size=16384 ./scripts/debug-fb-www.js"
   },
   "dependencies": {
     "babel-core": "^6.26.0",

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -432,8 +432,6 @@ export function OrdinaryCallEvaluateBody(
             invariant(c instanceof Value || c instanceof AbruptCompletion);
             return c;
           }
-        } catch (e) {
-          throw e;
         } finally {
           realm.incorporatePriorSavedCompletion(priorSavedCompletion);
         }

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -432,6 +432,8 @@ export function OrdinaryCallEvaluateBody(
             invariant(c instanceof Value || c instanceof AbruptCompletion);
             return c;
           }
+        } catch (e) {
+          throw e;
         } finally {
           realm.incorporatePriorSavedCompletion(priorSavedCompletion);
         }


### PR DESCRIPTION
Release notes: none

I can't reproduce this invariant without using the UFI bundle, so unfortunately there are no tests attached. This unblocks the React reconciler work. Also, interestingly this causes memory to explode (I guess we're now evaluating far more than before since this invariant was blocking that from happening).