### PR TITLE
Simplify truthy conditionals in condition context

### DIFF
--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -124,7 +124,7 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
         let [yc, , z] = y.args;
         if (c.equals(yc)) return AbstractValue.createFromConditionalOp(realm, c, x, z);
       }
-      if (x.getType() === BooleanValue && y.getType() === BooleanValue) {
+      if (isCondition || (x.getType() === BooleanValue && y.getType() === BooleanValue)) {
         // c ? true : false <=> c
         if (!x.mightNotBeTrue() && !y.mightNotBeFalse()) return c;
         // c ? false : true <=> !c

--- a/test/serializer/optimizations/simplify6.js
+++ b/test/serializer/optimizations/simplify6.js
@@ -1,0 +1,7 @@
+// does not contain: {}
+let x = global.abstract ? __abstract(undefined, "5") : 5;
+let xIsNull = x == null;
+let y = xIsNull ? null : {};
+if (y) global.result = true;
+
+inspect = function() { return result; }


### PR DESCRIPTION
Release note: Simplify conditions like c ? {} : null to just c if used in a condition context

Resolves: #1582

The simplifier already simplifies c ? true : false to just c. It can also do this for truthy values that are known to convert to true and false, if the result of the conditional is used as a condition.