### PR TITLE
Disabling abstract recursion check.

### DIFF
--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -327,7 +327,11 @@ export function OrdinaryCallEvaluateBody(
       // 4. Return Completion{[[Type]]: return, [[Value]]: G, [[Target]]: empty}.
       return new ReturnCompletion(G, realm.currentLocation);
     } else {
-      if (!realm.useAbstractInterpretation || realm.pathConditions.length === 0) return normalCall();
+      // TODO #1586: abstractRecursionSummarization is disabled for now, as it is likely too limiting
+      // (as observed in large internal tests).
+      const abstractRecursionSummarization = false;
+      if (!realm.useAbstractInterpretation || realm.pathConditions.length === 0 || !abstractRecursionSummarization)
+        return normalCall();
       let savedIsSelfRecursive = F.isSelfRecursive;
       try {
         F.isSelfRecursive = false;

--- a/test/serializer/abstract/Fibonacci.js
+++ b/test/serializer/abstract/Fibonacci.js
@@ -1,3 +1,4 @@
+// skip this test for now
 // throws introspection error
 let n = global.__abstract ? global.__abstract("number", "4") : 4;
 


### PR DESCRIPTION
Release notes: None.

Unfortunately, the abstract recursion check seems to conservative, as it triggered on some large internal tests even though there was no issue.
Disabled test test/serializer/abstract/Fibonacci.js that now fails.
I created an issue to track this.