### PR TITLE
Add failing test to demonstrate ToObject yielding wrong output

### DIFF
--- a/test/serializer/pure-functions/ToObject.js
+++ b/test/serializer/pure-functions/ToObject.js
@@ -1,0 +1,22 @@
+// abstract effects
+
+var obj = global.__abstract && global.__makePartial && global.__makeSimple ? __makePartial(__makeSimple(__abstract({}, "({foo:1})"))) : {foo:1};
+
+function additional1() {
+  return Object.assign(obj.foo);
+}
+
+function additional2() {
+  return Object.prototype.valueOf.call(obj.foo);
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
+}
+
+inspect = function() {
+  var foo1 = typeof additional1();
+  var foo2 = typeof additional2();
+  return JSON.stringify({ foo1, foo2 });
+}


### PR DESCRIPTION
This used to fatal during serialization as "Unknown object cannot be coerced to Object" but after #1578 it generates incorrect code instead.

This is because if we ever get an implicit ToObject, we need to ensure that there is at least one operation serialized that at runtime implicitly turns it into an object. The placeholder value can trick us to optimize that away.