### PR TITLE
Allow NewExpression constructor to recover in pure wrapper

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -1975,6 +1975,22 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple with new expression 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Simple with unary expressions 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -4709,6 +4725,22 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output Functional component folding Simple with new expression 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output Functional component folding Simple with unary expressions 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -7408,6 +7440,22 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Simple with new expression 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Simple with unary expressions 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -10092,6 +10140,22 @@ ReactStatistics {
 `;
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with new expression 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
   "evaluatedRootNodes": Array [

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -47,6 +47,19 @@ function getDataFile(directory, name) {
   return data;
 }
 
+function MockURI(url) {
+  this.url = url;
+}
+
+MockURI.prototype.addQueryData = function() {
+  this.url += "&queryData";
+  return this;
+};
+
+MockURI.prototype.makeString = function() {
+  return this.url;
+};
+
 function runTestSuite(outputJsx, shouldTranspileSource) {
   let errorsCaptured = [];
   let reactTestRoot = path.join(__dirname, "../test/react/");
@@ -118,6 +131,8 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
           return cxShim;
         case "FBEnvironment":
           return {};
+        case "URI":
+          return MockURI;
         default:
           throw new Error(`Unrecognized import: "${name}".`);
       }
@@ -252,6 +267,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
 
       it("Simple children", async () => {
         await runTest(directory, "simple-children.js");
+      });
+
+      it("Simple with new expression", async () => {
+        await runTest(directory, "simple-with-new-expression.js");
       });
 
       it("Simple refs", async () => {

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -11,20 +11,23 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { ObjectValue } from "../values/index.js";
+import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
+import { TypesDomain, ValuesDomain } from "../domains/index.js";
+import { ObjectValue, Value, AbstractObjectValue, AbstractValue } from "../values/index.js";
 import { Environment } from "../singletons.js";
-import { IsConstructor } from "../methods/index.js";
-import { ArgumentListEvaluation } from "../methods/index.js";
+import { IsConstructor, ArgumentListEvaluation } from "../methods/index.js";
 import { Construct } from "../methods/index.js";
 import invariant from "../invariant.js";
-import type { BabelNodeNewExpression } from "babel-types";
+import { FatalError } from "../errors.js";
+import * as t from "babel-types";
+import { BabelNodeNewExpression, type BabelNodeExpression } from "babel-types";
 
 export default function(
   ast: BabelNodeNewExpression,
   strictCode: boolean,
   env: LexicalEnvironment,
   realm: Realm
-): ObjectValue {
+): ObjectValue | AbstractObjectValue {
   realm.setNextExecutionContextLocation(ast.loc);
 
   // ECMA262 12.3.3.1 We just implement this method inline since it's only called here.
@@ -59,6 +62,70 @@ export default function(
     // b. ReturnIfAbrupt(argList).
   }
 
+  // If we are in pure scope, attempt to recover from creating the construct if
+  // it fails by creating a temporal abstract
+  if (realm.isInPureScope()) {
+    return tryToEvaluateConstructOrLeaveAsAbstract(constructor, argsList, strictCode, realm);
+  } else {
+    return createConstruct(constructor, argsList, realm);
+  }
+}
+
+function tryToEvaluateConstructOrLeaveAsAbstract(
+  constructor: Value,
+  argsList: Array<Value>,
+  strictCode: boolean,
+  realm: Realm
+): ObjectValue | AbstractObjectValue {
+  let effects;
+  try {
+    effects = realm.evaluateForEffects(
+      () => createConstruct(constructor, argsList, realm),
+      undefined,
+      "tryToEvaluateConstructOrLeaveAsAbstract"
+    );
+  } catch (error) {
+    // if the constructor is abstract, then create a unary op for it,
+    // otherwise we rethrow the error as we don't handle it at this
+    // point in time
+    if (error instanceof FatalError && constructor instanceof AbstractValue) {
+      let abstractValue = realm.evaluateWithPossibleThrowCompletion(
+        () =>
+          AbstractValue.createTemporalFromBuildFunction(
+            realm,
+            ObjectValue,
+            [constructor, ...argsList],
+            ([constructorNode, ...argListNodes]: Array<BabelNodeExpression>) =>
+              t.newExpression(constructorNode, argListNodes)
+          ),
+        TypesDomain.topVal,
+        ValuesDomain.topVal
+      );
+      invariant(abstractValue instanceof AbstractObjectValue);
+      return abstractValue;
+    } else {
+      throw error;
+    }
+  }
+  let completion = effects[0];
+  if (completion instanceof PossiblyNormalCompletion) {
+    // in this case one of the branches may complete abruptly, which means that
+    // not all control flow branches join into one flow at this point.
+    // Consequently we have to continue tracking changes until the point where
+    // all the branches come together into one.
+    completion = realm.composeWithSavedCompletion(completion);
+  }
+
+  // Note that the effects of (non joining) abrupt branches are not included
+  // in joinedEffects, but are tracked separately inside completion.
+  realm.applyEffects(effects);
+  // return or throw completion
+  if (completion instanceof AbruptCompletion) throw completion;
+  invariant(completion instanceof ObjectValue || completion instanceof AbstractObjectValue);
+  return completion;
+}
+
+function createConstruct(constructor: Value, argsList: Array<Value>, realm: Realm): ObjectValue {
   // 7. If IsConstructor(constructor) is false, throw a TypeError exception.
   if (IsConstructor(realm, constructor) === false) {
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -14,7 +14,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { ObjectValue, Value, AbstractObjectValue, AbstractValue } from "../values/index.js";
-import { Environment } from "../singletons.js";
+import { Environment, Havoc } from "../singletons.js";
 import { IsConstructor, ArgumentListEvaluation } from "../methods/index.js";
 import { Construct } from "../methods/index.js";
 import invariant from "../invariant.js";
@@ -89,6 +89,10 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
     // otherwise we rethrow the error as we don't handle it at this
     // point in time
     if (error instanceof FatalError && constructor instanceof AbstractValue) {
+      // we need to havoc all the arguments
+      for (let arg of argsList) {
+        Havoc.value(realm, arg);
+      }
       let abstractValue = realm.evaluateWithPossibleThrowCompletion(
         () =>
           AbstractValue.createTemporalFromBuildFunction(

--- a/test/react/functional-components/simple-with-new-expression.js
+++ b/test/react/functional-components/simple-with-new-expression.js
@@ -1,0 +1,45 @@
+const React = require("react");
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = __evaluatePureFunction(() => {
+  var URI = require("URI");
+
+  function App(props) {
+    var _ref, _ref2;
+    var _props = props;
+    var className = _props.className;
+    var text = _props.text;
+    var feedback = _props.feedback;
+    var trackingInfo = _props.trackingInfo;
+
+    var url = (_ref2 = feedback) != null ? _ref2.url : _ref2;
+
+    var href = new URI(url)
+      .addQueryData({ comment_tracking: trackingInfo })
+      .makeString();
+
+    return <a href={href} className={className}>{text}</a>
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root 
+      className="link-class"
+      title="Click me!"
+      feedback={{url: "http://fb.com"}}
+      trackingInfo={null}
+    />);
+    return [['simple render with new expression', renderer.toJSON()]];
+  };
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App);
+  }
+
+  return App;
+});

--- a/test/serializer/pure-functions/NewExpression.js
+++ b/test/serializer/pure-functions/NewExpression.js
@@ -1,0 +1,15 @@
+// abstract effects
+
+var Foo = global.__abstract ? __abstract(undefined, "(function () { this.x = 10 })") : function () { this.x = 10 };
+
+function additional1() {
+  return new Foo();
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+}
+
+inspect = function() {
+  return JSON.stringify(additional1());
+}


### PR DESCRIPTION
Release notes: none

It's common for a `new Something()` call to exist in pure wrappers where `Something` is an abstract value. Currently, this fails with a FatalError with no recovery. This PR adds a recover for this when in a pure wrapper so we can continue evaluating.