### PR TITLE
Get rid of PossiblyNormalCompletion.pathConditions

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -106,7 +106,6 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     consequentEffects: Effects,
     alternate: Completion | Value,
     alternateEffects: Effects,
-    pathConditions: Array<AbstractValue>,
     savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
@@ -140,7 +139,6 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     this.alternate = alternate;
     this.alternateEffects = alternateEffects;
     this.savedEffects = savedEffects;
-    this.pathConditions = pathConditions;
     this.savedPathConditions = savedPathConditions;
   }
 
@@ -150,7 +148,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   alternate: Completion | Value;
   alternateEffects: Effects;
   savedEffects: void | Effects;
-  pathConditions: Array<AbstractValue>;
+  // The path conditions that applied at the time of the oldest fork that caused this completion to arise.
   savedPathConditions: Array<AbstractValue>;
 
   containsBreakOrContinue(): boolean {

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1123,7 +1123,10 @@ export class FunctionImplementation {
     let savedCompletion = realm.savedCompletion;
     if (savedCompletion !== undefined) {
       if (savedCompletion.savedPathConditions) {
+        // Since we are joining several control flow paths, we need the curent path conditions to reflect
+        // only the refinements that applied at the corresponding fork point.
         realm.pathConditions = savedCompletion.savedPathConditions;
+        savedCompletion.savedPathConditions = [];
       }
       realm.savedCompletion = undefined;
       if (c === undefined) return savedCompletion;

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -160,9 +160,6 @@ export class JoinImplementation {
     c: PossiblyNormalCompletion
   ): PossiblyNormalCompletion {
     invariant(c.savedEffects === undefined); // the caller should ensure this
-    //merge the two pathConditions
-    let composedPath = [];
-    composedPath = pnc.pathConditions.concat(c.pathConditions);
     let savedPathConditions = pnc.savedPathConditions;
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
@@ -175,7 +172,6 @@ export class JoinImplementation {
           pnc.consequentEffects,
           c,
           newAlternateEffects,
-          composedPath,
           savedPathConditions,
           pnc.savedEffects
         );
@@ -191,7 +187,6 @@ export class JoinImplementation {
         pnc.consequentEffects,
         new_alternate,
         newAlternateEffects,
-        composedPath,
         savedPathConditions,
         pnc.savedEffects
       );
@@ -207,7 +202,6 @@ export class JoinImplementation {
           newConsequentEffects,
           pnc.alternate,
           pnc.alternateEffects,
-          composedPath,
           savedPathConditions,
           pnc.savedEffects
         );
@@ -223,7 +217,6 @@ export class JoinImplementation {
         newConsequentEffects,
         pnc.alternate,
         pnc.alternateEffects,
-        composedPath,
         savedPathConditions,
         pnc.savedEffects
       );
@@ -420,7 +413,7 @@ export class JoinImplementation {
     invariant(ra instanceof Value || ra instanceof Completion);
     let rv = ra instanceof PossiblyNormalCompletion ? ra.value : ra;
     invariant(rv instanceof Value);
-    return new PossiblyNormalCompletion(rv, rJoinCondition, rc, rce, ra, rae, [], []);
+    return new PossiblyNormalCompletion(rv, rJoinCondition, rc, rce, ra, rae, []);
   }
 
   joinEffectsAndPromoteNestedReturnCompletions(
@@ -514,21 +507,7 @@ export class JoinImplementation {
     let empty_effects = construct_empty_effects(realm);
     let v = realm.intrinsics.empty;
     if (c.consequent instanceof ReturnCompletion) {
-      let negation = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition);
-      // Simply negating the (known to be abstract) join condition should
-      // not become a concrete value
-      invariant(negation instanceof AbstractValue);
-      let pathConditions = [negation];
-      let pnc = new PossiblyNormalCompletion(
-        v,
-        c.joinCondition,
-        v,
-        empty_effects,
-        c.alternate,
-        c.alternateEffects,
-        pathConditions,
-        []
-      );
+      let pnc = new PossiblyNormalCompletion(v, c.joinCondition, v, empty_effects, c.alternate, c.alternateEffects, []);
       return [c.consequentEffects, pnc];
     } else if (c.alternate instanceof ReturnCompletion) {
       let pnc = new PossiblyNormalCompletion(
@@ -538,7 +517,6 @@ export class JoinImplementation {
         c.consequentEffects,
         v,
         empty_effects,
-        [c.joinCondition],
         []
       );
       return [c.alternateEffects, pnc];
@@ -659,15 +637,11 @@ export class JoinImplementation {
     if (result1 instanceof AbruptCompletion) {
       let value = result2;
       let savedEffects;
-      let pathConditions;
       let savedPathConditions = [];
       if (result2 instanceof PossiblyNormalCompletion) {
         value = result2.value;
         savedEffects = result2.savedEffects;
-        pathConditions = [joinCondition].concat(result2.pathConditions);
         savedPathConditions = result2.savedPathConditions;
-      } else {
-        pathConditions = [joinCondition];
       }
       invariant(value instanceof Value);
       return new PossiblyNormalCompletion(
@@ -677,7 +651,6 @@ export class JoinImplementation {
         e1,
         result2,
         e2,
-        pathConditions,
         savedPathConditions,
         savedEffects
       );
@@ -685,15 +658,11 @@ export class JoinImplementation {
     if (result2 instanceof AbruptCompletion) {
       let value = result1;
       let savedEffects;
-      let pathConditions;
       let savedPathConditions = [];
       if (result1 instanceof PossiblyNormalCompletion) {
         value = result1.value;
         savedEffects = result1.savedEffects;
-        pathConditions = [joinCondition].concat(result1.pathConditions);
         savedPathConditions = result1.savedPathConditions;
-      } else {
-        pathConditions = [joinCondition];
       }
       invariant(value instanceof Value);
       return new PossiblyNormalCompletion(
@@ -703,7 +672,6 @@ export class JoinImplementation {
         e1,
         result2,
         e2,
-        pathConditions,
         savedPathConditions,
         savedEffects
       );

--- a/src/realm.js
+++ b/src/realm.js
@@ -954,22 +954,23 @@ export class Realm {
     if (this.savedCompletion === undefined) {
       this.savedCompletion = completion;
       this.savedCompletion.savedPathConditions = this.pathConditions;
+      this.pathConditions = [].concat(this.pathConditions);
       this.captureEffects(completion);
     } else {
       this.savedCompletion = Join.composePossiblyNormalCompletions(this, this.savedCompletion, completion);
     }
-    if (completion.consequent instanceof AbruptCompletion) {
-      Path.pushInverseAndRefine(completion.joinCondition);
-      if (completion.alternate instanceof PossiblyNormalCompletion) {
-        completion.alternate.pathConditions.forEach(Path.pushAndRefine);
-      }
-    } else if (completion.alternate instanceof AbruptCompletion) {
-      Path.pushAndRefine(completion.joinCondition);
-      if (completion.consequent instanceof PossiblyNormalCompletion) {
-        completion.consequent.pathConditions.forEach(Path.pushAndRefine);
+    pushPathConditionsLeadingToNormalCompletion(completion);
+    return completion.value;
+
+    function pushPathConditionsLeadingToNormalCompletion(c: PossiblyNormalCompletion) {
+      if (c.consequent instanceof AbruptCompletion) {
+        Path.pushInverseAndRefine(c.joinCondition);
+        if (c.alternate instanceof PossiblyNormalCompletion) pushPathConditionsLeadingToNormalCompletion(c.alternate);
+      } else if (c.alternate instanceof AbruptCompletion) {
+        Path.pushAndRefine(c.joinCondition);
+        if (c.consequent instanceof PossiblyNormalCompletion) pushPathConditionsLeadingToNormalCompletion(c.consequent);
       }
     }
-    return completion.value;
   }
 
   incorporatePriorSavedCompletion(priorCompletion: void | PossiblyNormalCompletion) {


### PR DESCRIPTION
Release note: none

I was debugging in this area and found my exploding because things did not quite make sense. Looking into it some more, it seems that PossiblyNormalCompletion.pathConditions is not actually used for anything. Deleting it all together breaks no tests.

Since this code is implicated in a "push false" invariant failure, I'd like to delete it until it becomes clearly needed.

Also added comments and made sure savedPathConditions doesn't get clobbered.