### PR TITLE
Tweak simplifier to avoid "push false" invariant

### DIFF
--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -50,14 +50,21 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
   switch (op) {
     case "!": {
       let [x0] = value.args;
+      invariant(x0 instanceof AbstractValue);
+      if (x0.kind === "!") {
+        invariant(x0 instanceof AbstractValue);
+        let [x00] = x0.args;
+        let xx = simplify(realm, x00, true);
+        if (xx.getType() === BooleanValue) return xx;
+      }
       let x = simplify(realm, x0, true);
       return negate(realm, x, loc, x0.equals(x) ? value : undefined);
     }
     case "||":
     case "&&": {
       let [x0, y0] = value.args;
-      let x = simplify(realm, x0);
-      let y = simplify(realm, y0);
+      let x = simplify(realm, x0, isCondition);
+      let y = simplify(realm, y0, isCondition);
       if (x instanceof AbstractValue && x.equals(y)) return x;
       // true && y <=> y
       // true || y <=> true
@@ -82,7 +89,7 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       )
         return y;
       if (x.equals(x0) && y.equals(y0)) return value;
-      return AbstractValue.createFromLogicalOp(realm, (value.kind: any), x, y, loc);
+      return AbstractValue.createFromLogicalOp(realm, (value.kind: any), x, y, loc, isCondition);
     }
     case "==":
     case "!=":
@@ -92,14 +99,14 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
     case "conditional": {
       let [c0, x0, y0] = value.args;
       let c = simplify(realm, c0, true);
-      let cs = simplify(realm, c0);
-      let x = simplify(realm, x0);
-      let y = simplify(realm, y0);
+      let cs = simplify(realm, c0, isCondition);
+      let x = simplify(realm, x0, isCondition);
+      let y = simplify(realm, y0, isCondition);
       if (!c.mightNotBeTrue()) return x;
       if (!c.mightNotBeFalse()) return y;
       invariant(c instanceof AbstractValue);
       if (Path.implies(c)) return x;
-      let notc = AbstractValue.createFromUnaryOp(realm, "!", c);
+      let notc = AbstractValue.createFromUnaryOp(realm, "!", c, true, loc, isCondition);
       if (!notc.mightNotBeTrue()) return y;
       if (!notc.mightNotBeFalse()) return x;
       invariant(notc instanceof AbstractValue);
@@ -111,20 +118,22 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       // c ? x : x <=> x
       if (x.equals(y)) return x;
       // x ? x : y <=> x || y
-      if (cs.equals(x)) return AbstractValue.createFromLogicalOp(realm, "||", x, y, loc);
+      if (cs.equals(x)) return AbstractValue.createFromLogicalOp(realm, "||", x, y, loc, isCondition);
       // y ? x : y <=> y && x
-      if (cs.equals(y)) return AbstractValue.createFromLogicalOp(realm, "&&", y, x, loc);
+      if (cs.equals(y)) return AbstractValue.createFromLogicalOp(realm, "&&", y, x, loc, isCondition);
       // c ? (c ? xx : xy) : y <=> c ? xx : y
       if (x instanceof AbstractValue && x.kind === "conditional") {
         let [xc, xx] = x.args;
-        if (c.equals(xc)) return AbstractValue.createFromConditionalOp(realm, c, xx, y);
+        if (c.equals(xc))
+          return AbstractValue.createFromConditionalOp(realm, c, xx, y, value.expressionLocation, isCondition);
       }
       // c ? x : (c ? y : z) : z <=> c ? x : z
       if (y instanceof AbstractValue && y.kind === "conditional") {
         let [yc, , z] = y.args;
-        if (c.equals(yc)) return AbstractValue.createFromConditionalOp(realm, c, x, z);
+        if (c.equals(yc))
+          return AbstractValue.createFromConditionalOp(realm, c, x, z, value.expressionLocation, isCondition);
       }
-      if (isCondition || (x.getType() === BooleanValue && y.getType() === BooleanValue)) {
+      if (x.getType() === BooleanValue && y.getType() === BooleanValue) {
         // c ? true : false <=> c
         if (!x.mightNotBeTrue() && !y.mightNotBeFalse()) return c;
         // c ? false : true <=> !c
@@ -132,7 +141,7 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
           return AbstractValue.createFromUnaryOp(realm, "!", c, true, loc);
       }
       if (c.equals(c0) && x.equals(x0) && y.equals(y0)) return value;
-      return AbstractValue.createFromConditionalOp(realm, c, x, y, value.expressionLocation);
+      return AbstractValue.createFromConditionalOp(realm, c, x, y, value.expressionLocation, isCondition);
     }
     case "abstractConcreteUnion": {
       // The union of an abstract value with one or more concrete values.

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -181,6 +181,12 @@ export default class AbstractValue extends Value {
     if (!val.mightNotBeTrue()) return true; // x => true regardless of the value of x
     if (val instanceof AbstractValue) {
       // Neither this (x) nor val (y) is a known value, so we need to do some reasoning based on the structure
+      // x => x || y
+      if (val.kind === "||") {
+        let [x, y] = val.args;
+        return this.implies(x) || this.implies(y);
+      }
+
       // x => !y if y => !x
       if (val.kind === "!") {
         let [y] = val.args;
@@ -203,6 +209,38 @@ export default class AbstractValue extends Value {
           return x.implies(val);
         }
       }
+      if (this.kind === "conditional") {
+        let [c, x, y] = this.args;
+        // (c ? x : y) => val if x is true and y is false and c = val
+        if (!x.mightNotBeTrue() && !y.mightNotBeFalse()) {
+          return c.equals(val);
+        }
+
+        // (c ? false : y) => y !== undefined && y !== null && y !== f
+        if (val.kind === "!==") {
+          let [vx, vy] = val.args;
+          if (!x.mightNotBeFalse()) {
+            if (y.implies(vx)) return vy instanceof NullValue || vy instanceof UndefinedValue;
+            if (y.implies(vy)) return vx instanceof NullValue || vx instanceof UndefinedValue;
+          } else if (!y.mightNotBeFalse()) {
+            if (x.implies(vx)) return vy instanceof NullValue || vy instanceof UndefinedValue;
+            if (x.implies(vy)) return vx instanceof NullValue || vx instanceof UndefinedValue;
+          }
+        }
+
+        // (c ? x : (c || false)) => c (if c were false this value could not be true)
+        if (y.kind === "||") {
+          invariant(y instanceof AbstractValue);
+          let [yx, yy] = y.args;
+          return c.equals(yx) && !yy.mightNotBeFalse() && c.equals(val);
+        }
+      }
+      // (0 !== x) => x since undefined, null, false, 0, NaN and "" are excluded by the !== and all other values are thruthy
+      if (this.kind === "!==") {
+        let [x, y] = this.args;
+        if (x instanceof NumberValue && x.value === 0) return y.equals(val);
+        if (y instanceof NumberValue && y.value === 0) return x.equals(val);
+      }
     }
     return false;
   }
@@ -216,6 +254,7 @@ export default class AbstractValue extends Value {
       // !x => !y if y => x
       if (this.kind === "!") {
         let [x] = this.args;
+        invariant(x instanceof AbstractValue);
         if (x.kind === "!") {
           // !!x => !y if y => !x
           invariant(x instanceof AbstractValue);
@@ -486,7 +525,8 @@ export default class AbstractValue extends Value {
     op: BabelNodeLogicalOperator,
     left: Value,
     right: Value,
-    loc?: ?BabelNodeSourceLocation
+    loc?: ?BabelNodeSourceLocation,
+    isCondition?: boolean
   ): Value {
     let leftTypes, leftValues;
     if (left instanceof AbstractValue) {
@@ -519,7 +559,9 @@ export default class AbstractValue extends Value {
     );
     result.kind = op;
     result.expressionLocation = loc;
-    return realm.simplifyAndRefineAbstractValue(result);
+    return isCondition
+      ? realm.simplifyAndRefineAbstractCondition(result)
+      : realm.simplifyAndRefineAbstractValue(result);
   }
 
   static createFromConditionalOp(
@@ -527,7 +569,8 @@ export default class AbstractValue extends Value {
     condition: AbstractValue,
     left: void | Value,
     right: void | Value,
-    loc?: ?BabelNodeSourceLocation
+    loc?: ?BabelNodeSourceLocation,
+    isCondition?: boolean
   ): Value {
     let types = TypesDomain.joinValues(left, right);
     if (types.getType() === NullValue) return realm.intrinsics.null;
@@ -542,7 +585,9 @@ export default class AbstractValue extends Value {
     if (left) result.mightBeEmpty = left.mightHaveBeenDeleted();
     if (right && !result.mightBeEmpty) result.mightBeEmpty = right.mightHaveBeenDeleted();
     if (result.mightBeEmpty) return result;
-    return realm.simplifyAndRefineAbstractValue(result);
+    return isCondition
+      ? realm.simplifyAndRefineAbstractCondition(result)
+      : realm.simplifyAndRefineAbstractValue(result);
   }
 
   static createFromUnaryOp(
@@ -550,7 +595,8 @@ export default class AbstractValue extends Value {
     op: BabelUnaryOperator,
     operand: AbstractValue,
     prefix?: boolean,
-    loc?: ?BabelNodeSourceLocation
+    loc?: ?BabelNodeSourceLocation,
+    isCondition?: boolean
   ): Value {
     invariant(op !== "delete" && op !== "++" && op !== "--"); // The operation must be pure
     let resultTypes = TypesDomain.unaryOp(op, new TypesDomain(operand.getType()));
@@ -560,7 +606,9 @@ export default class AbstractValue extends Value {
     );
     result.kind = op;
     result.expressionLocation = loc;
-    return realm.simplifyAndRefineAbstractValue(result);
+    return isCondition
+      ? realm.simplifyAndRefineAbstractCondition(result)
+      : realm.simplifyAndRefineAbstractValue(result);
   }
 
   /* Note that the template is parameterized by the names A, B, C and so on.

--- a/test/serializer/optimizations/simplify7.js
+++ b/test/serializer/optimizations/simplify7.js
@@ -1,0 +1,8 @@
+// does not contain: "no"
+let s = global.__abstract ? __abstract("string", "('s')") : 's';
+
+if (s ? "t" : "") {
+  y = s ? "yes" : "no";
+}
+
+inspect = function() { return y + " " + z; }


### PR DESCRIPTION
Release note: Added more logic to simplifier

The simplifier was ignoring the "isCondition" flag in some cases, which broke symmetry.

Also added this rule: (c ? x : (c || false)) => c

Test cases to come later.