### PR TITLE
Havoc the constructor for NewExpression recovery

### DIFF
--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -89,7 +89,8 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
     // otherwise we rethrow the error as we don't handle it at this
     // point in time
     if (error instanceof FatalError && constructor instanceof AbstractValue) {
-      // we need to havoc all the arguments
+      // we need to havoc all the arguments and the constructor
+      Havoc.value(realm, constructor);
       for (let arg of argsList) {
         Havoc.value(realm, arg);
       }


### PR DESCRIPTION
Release notes: none

Follow up to https://github.com/facebook/prepack/pull/1590. This havocs the constructor as per feedback.