### PR TITLE
Update how modified bindings are serialized

### DIFF
--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -10,7 +10,6 @@
 /* @flow */
 
 import { DeclarativeEnvironmentRecord } from "../environment.js";
-import { FatalError, CompilerDiagnostic } from "../errors.js";
 import { FunctionValue } from "../values/index.js";
 import type { SerializerOptions } from "../options.js";
 import * as t from "babel-types";
@@ -219,10 +218,7 @@ export class Referentializer {
     }
   }
 
-  referentialize(
-    unbound: Set<string>,
-    instances: Array<FunctionInstance>,
-  ): void {
+  referentialize(unbound: Set<string>, instances: Array<FunctionInstance>): void {
     for (let instance of instances) {
       let residualBindings = instance.residualFunctionBindings;
 

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -222,30 +222,17 @@ export class Referentializer {
   referentialize(
     unbound: Set<string>,
     instances: Array<FunctionInstance>,
-    shouldReferentializeInstanceFn: FunctionInstance => boolean
   ): void {
     for (let instance of instances) {
       let residualBindings = instance.residualFunctionBindings;
 
       for (let name of unbound) {
         let residualBinding = residualBindings.get(name);
-        invariant(residualBinding !== undefined);
+        if (residualBinding === undefined) continue;
         if (residualBinding.modified) {
           // Initialize captured scope at function call instead of globally
           if (!residualBinding.declarativeEnvironmentRecord) residualBinding.referentialized = true;
           if (!residualBinding.referentialized) {
-            if (!shouldReferentializeInstanceFn(instance)) {
-              // TODO #989: Fix additional functions and referentialization
-              this.realm.handleError(
-                new CompilerDiagnostic(
-                  "Referentialization for prepacked functions unimplemented",
-                  instance.functionValue.loc,
-                  "PP1005",
-                  "FatalError"
-                )
-              );
-              throw new FatalError("TODO: implement referentialization for prepacked functions");
-            }
             if (!this._options.simpleClosures) this._getSerializedBindingScopeInstance(residualBinding);
             residualBinding.referentialized = true;
           }

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -662,10 +662,7 @@ export class ResidualFunctions {
         invariant(insertionPoint instanceof BodyReference);
         // v8 seems to do something clever with array splicing, so this potentially
         // expensive operations seems to be actually cheap.
-        Array.prototype.splice.apply(
-          insertionPoint.body.entries,
-          ([insertionPoint.index, 0]: Array<any>).concat((functionBody: Array<any>))
-        );
+        insertionPoint.body.entries.splice(insertionPoint.index, 0, ...functionBody);
       }
     }
 
@@ -680,10 +677,7 @@ export class ResidualFunctions {
       let insertionPoint = additionalFunctionInfo.instance.insertionPoint;
       invariant(insertionPoint);
       // TODO: I think this inserts things in the wrong place
-      Array.prototype.splice.apply(
-        insertionPoint.body.entries,
-        ([insertionPoint.index, 0]: Array<any>).concat((initializationStatements: Array<any>))
-      );
+      insertionPoint.body.entries.splice(insertionPoint.index, 0, ...initializationStatements);
       if (bodySegment) body.unshift(...bodySegment);
       if (prelude) body.unshift(...prelude);
     }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1037,12 +1037,9 @@ export class ResidualHeapVisitor {
     if (referentializer !== undefined) {
       let bodyToInstances = new Map();
       for (let instance of this.functionInstances.values()) {
-        // TODO: do something for additional functions
-        if (!this.additionalFunctionValuesAndEffects.has(instance.functionValue)) {
-          let code = instance.functionValue.$ECMAScriptCode;
-          invariant(code !== undefined);
-          getOrDefault(bodyToInstances, code, () => []).push(instance);
-        }
+        let code = instance.functionValue.$ECMAScriptCode;
+        invariant(code !== undefined);
+        getOrDefault(bodyToInstances, code, () => []).push(instance);
       }
 
       for (let [funcBody, instances] of bodyToInstances) {
@@ -1051,7 +1048,6 @@ export class ResidualHeapVisitor {
         referentializer.referentialize(
           functionInfo.unbound,
           instances,
-          instance => !this.additionalFunctionValuesAndEffects.has(instance.functionValue)
         );
       }
     }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1045,10 +1045,7 @@ export class ResidualHeapVisitor {
       for (let [funcBody, instances] of bodyToInstances) {
         let functionInfo = this.functionInfos.get(funcBody);
         invariant(functionInfo !== undefined);
-        referentializer.referentialize(
-          functionInfo.unbound,
-          instances,
-        );
+        referentializer.referentialize(functionInfo.unbound, instances);
       }
     }
   }

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -107,7 +107,6 @@ export type ResidualFunctionBinding = {
   // new values
   // TODO #1087: make this a map and support arbitrary binding modifications
   additionalFunctionOverridesValue?: true,
-  additionalValueSerialized?: BabelNodeExpression,
 };
 
 export type ScopeBinding = {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -42,9 +42,6 @@ export type AdditionalFunctionEffects = {
   effects: Effects,
   generator: Generator,
   transforms: Array<Function>,
-  joinedEffects?: Effects,
-  returnArguments?: Array<Value>,
-  returnBuildNode?: (Array<BabelNodeExpression>) => BabelNodeStatement,
 };
 
 export type AdditionalFunctionInfo = {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -206,18 +206,16 @@ class ModifiedBindingEntry extends GeneratorEntry {
       return;
     }
     invariant(this.modifiedBinding.value === this.newValue);
-    invariant(residualFunctionBinding.serializedValue, "ResidualFunctionBinding must be referentialized before serializing a mutation to it.")
+    invariant(
+      residualFunctionBinding.serializedValue,
+      "ResidualFunctionBinding must be referentialized before serializing a mutation to it."
+    );
     let newValue = this.newValue;
     if (newValue) {
       let bindingReference = ((residualFunctionBinding.serializedValue: any): BabelNodeLVal);
-      invariant(t.isLVal(bindingReference), "Referentialized values must be LVals")
+      invariant(t.isLVal(bindingReference), "Referentialized values must be LVals");
       let serializedNewValue = context.serializeValue(newValue);
-      context.emit(
-        t.expressionStatement(
-          t.assignmentExpression(
-            "=",
-            bindingReference,
-            serializedNewValue)));
+      context.emit(t.expressionStatement(t.assignmentExpression("=", bindingReference, serializedNewValue)));
     }
   }
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -49,6 +49,7 @@ import type {
   BabelNodeMemberExpression,
   BabelNodeVariableDeclaration,
   BabelNodeBlockStatement,
+  BabelNodeLVal,
 } from "babel-types";
 import { nullExpression } from "./internalizer.js";
 import { Utils, concretize } from "../singletons.js";
@@ -205,7 +206,19 @@ class ModifiedBindingEntry extends GeneratorEntry {
       return;
     }
     invariant(this.modifiedBinding.value === this.newValue);
-    if (this.newValue) residualFunctionBinding.additionalValueSerialized = context.serializeValue(this.newValue);
+    invariant(residualFunctionBinding.serializedValue, "ResidualFunctionBinding must be referentialized before serializing a mutation to it.")
+    let newValue = this.newValue;
+    if (newValue) {
+      let bindingReference = ((residualFunctionBinding.serializedValue: any): BabelNodeLVal);
+      invariant(t.isLVal(bindingReference), "Referentialized values must be LVals")
+      let serializedNewValue = context.serializeValue(newValue);
+      context.emit(
+        t.expressionStatement(
+          t.assignmentExpression(
+            "=",
+            bindingReference,
+            serializedNewValue)));
+    }
   }
 
   visit(context: VisitEntryCallbacks, containingGenerator: Generator) {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -213,7 +213,10 @@ class ModifiedBindingEntry extends GeneratorEntry {
     let newValue = this.newValue;
     if (newValue) {
       let bindingReference = ((residualFunctionBinding.serializedValue: any): BabelNodeLVal);
-      invariant(t.isLVal(bindingReference), "Referentialized values must be LVals");
+      invariant(
+        t.isLVal(bindingReference),
+        "Referentialized values must be LVals even though serializedValues may be any Expression"
+      );
       let serializedNewValue = context.serializeValue(newValue);
       context.emit(t.expressionStatement(t.assignmentExpression("=", bindingReference, serializedNewValue)));
     }

--- a/test/serializer/additional-functions/possible_throw_object_assign.js
+++ b/test/serializer/additional-functions/possible_throw_object_assign.js
@@ -1,0 +1,18 @@
+// abstract effects
+
+global.f = function(x, y) {
+    if (y) Object.assign({}, x); else throw new Error();
+};
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() {
+  let normalRet = f({foo: "bar"}, true);
+  let errorRet, error;
+  try {
+    errorRet = f({baz: "qux"}, false);
+  } catch (e) {
+    error = e;
+  }
+  return JSON.stringify(normalRet) + " " + errorRet + " " + JSON.stringify(error);
+}

--- a/test/serializer/additional-functions/return-or-many-throw.js
+++ b/test/serializer/additional-functions/return-or-many-throw.js
@@ -1,0 +1,47 @@
+// does not contain:z = 5;
+// add at runtime: x = 3;
+
+var x;
+if (global.__abstract) x = __abstract("number", "(4)");
+else x = 4;
+var obj = { foo: null };
+
+function func1(doNotThrow) {
+  let z = 5;
+  obj.foo = 10;
+  if (x > 10) {
+    obj.foo = 15;
+    if (doNotThrow) {
+      obj.foo = 18;
+      return 15;
+    } else {
+      throw new Error("X greater than 10 " + x);
+    }
+  } else if (x > 5) {
+    if (doNotThrow) {
+      return 100;
+    } else {
+      obj.foo = 17;
+      throw new Error("X greater than 5 " + x);
+    }
+  }
+  obj.foo = 20;
+  throw new Error("Returning " + x);
+  //return x;
+}
+
+if (global.__optimize)
+  __optimize(func1);
+
+inspect = function() {
+  let error;
+  let normalRet;
+  let ret;
+  try {
+    normalRet = func1(true);
+    ret = func1(false);
+  } catch (e) {
+    error = e.message;
+  }
+  return 'err: ' + error + ' ret ' + ret + ' normal ret ' + normalRet + ' foo ' + foo;
+}

--- a/test/serializer/additional-functions/return-or-multiple-throw.js
+++ b/test/serializer/additional-functions/return-or-multiple-throw.js
@@ -1,6 +1,5 @@
 // does not contain:z = 5;
 // add at runtime: x = 3;
-// skip this test for now
 
 var x;
 if (global.__abstract) x = __abstract("number", "(11)");

--- a/test/serializer/additional-functions/return-or-throw-modifybindings2.js
+++ b/test/serializer/additional-functions/return-or-throw-modifybindings2.js
@@ -1,6 +1,5 @@
 // does not contain:z = 5;
 // add at runtime: x = 3;
-// skip this test for now
 var x;
 if (global.__abstract) x = __abstract("number", "(11)");
 else x = 11;

--- a/test/serializer/additional-functions/return-or-throw-modifybindings3.js
+++ b/test/serializer/additional-functions/return-or-throw-modifybindings3.js
@@ -1,6 +1,5 @@
 // does not contain:z = 5;
 // add at runtime: x = 3;
-// skip this test for now
 var x;
 if (global.__abstract) x = __abstract("number", "(3)");
 else x = 3;


### PR DESCRIPTION
The additional functions refactor temporarily broke updating modified bindings more than once. This is a more principled solution to that problem that involves emitting the update to the modified binding as the generator entry is encountered instead of after-the-fact in the ResidualFunctions file. This is now possible because of a previous refactor pulling the referentialization logic to happen earlier in serialization.

Makes progress towards #1087 with being able to serialize multiple modifications to the same variable now for that, we just need to automatically make captured variables abstract or intrinsic so that their updates are serialized out correctly (without assuming their concrete value).

Seems to also fix serializing PossiblyNormalCompletions with nested JoinedAbruptCompletions.