### PR TITLE
Explicitly allow AbstractObjectValue on the prototype chain

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -585,7 +585,7 @@ export class FunctionEnvironmentRecord extends DeclarativeEnvironmentRecord {
   }
 
   // ECMA262 8.1.1.3.5
-  GetSuperBase(): ObjectValue | NullValue | UndefinedValue {
+  GetSuperBase(): ObjectValue | AbstractObjectValue | NullValue | UndefinedValue {
     // 1. Let envRec be the function Environment Record for which the method was invoked.
     let envRec = this;
 

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -304,7 +304,7 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.1.2.10
   func.defineNativeMethod("getPrototypeOf", 1, (context, [O]) => {
     // 1. Let obj be ? ToObject(O).
-    let obj = To.ToObject(realm, O.throwIfNotConcrete());
+    let obj = To.ToObjectPartial(realm, O);
 
     // 2. Return ? obj.[[GetPrototypeOf]]().
     return obj.$GetPrototypeOf();

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -512,7 +512,7 @@ export function OrdinaryHasInstance(realm: Realm, C: Value, O: Value): boolean {
     if (O instanceof NullValue) return false;
 
     // c. If SameValue(P, O) is true, return true.
-    if (SameValue(realm, P, O) === true) return true;
+    if (SameValuePartial(realm, P, O) === true) return true;
   }
 
   return false;

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -41,7 +41,7 @@ import type { BabelNodeIdentifier, BabelNodeLVal, BabelNodeFunctionDeclaration }
 
 export class CreateImplementation {
   // ECMA262 9.4.3.3
-  StringCreate(realm: Realm, value: StringValue, prototype: ObjectValue): ObjectValue {
+  StringCreate(realm: Realm, value: StringValue, prototype: ObjectValue | AbstractObjectValue): ObjectValue {
     // 1. Assert: Type(value) is String.
     invariant(value instanceof StringValue, "expected string value");
 
@@ -277,7 +277,7 @@ export class CreateImplementation {
   }
 
   // ECMA262 9.4.2.2
-  ArrayCreate(realm: Realm, length: number, proto?: ObjectValue): ArrayValue {
+  ArrayCreate(realm: Realm, length: number, proto?: ObjectValue | AbstractObjectValue): ArrayValue {
     // 1. Assert: length is an integer Number ≥ 0.
     invariant(length >= 0);
 
@@ -600,7 +600,11 @@ export class CreateImplementation {
   }
 
   // ECMA262 9.1.12
-  ObjectCreate(realm: Realm, proto: ObjectValue | NullValue, internalSlotsList?: { [key: string]: void }): ObjectValue {
+  ObjectCreate(
+    realm: Realm,
+    proto: ObjectValue | AbstractObjectValue | NullValue,
+    internalSlotsList?: { [key: string]: void }
+  ): ObjectValue {
     // 1. If internalSlotsList was not provided, let internalSlotsList be an empty List.
     internalSlotsList = internalSlotsList || {};
 

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -19,6 +19,7 @@ import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord } from "../environment.js";
 import {
   AbstractValue,
+  AbstractObjectValue,
   BoundFunctionValue,
   ECMAScriptSourceFunctionValue,
   EmptyValue,
@@ -863,7 +864,7 @@ export class FunctionImplementation {
   // ECMA262 9.2.3
   FunctionAllocate(
     realm: Realm,
-    functionPrototype: ObjectValue,
+    functionPrototype: ObjectValue | AbstractObjectValue,
     strict: boolean,
     functionKind: "normal" | "non-constructor" | "generator"
   ): ECMAScriptSourceFunctionValue {

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -163,7 +163,7 @@ export function OrdinaryGet(
       // c. Return ? parent.[[Get]](P, Receiver).
       if (descValue.mightHaveBeenDeleted() && descValue instanceof AbstractValue) {
         // We don't know for sure that O.P does not exist.
-        let parentVal = OrdinaryGet(realm, parent, P, descValue, true);
+        let parentVal = OrdinaryGet(realm, parent.throwIfNotConcreteObject(), P, descValue, true);
         if (parentVal instanceof UndefinedValue)
           // even O.P returns undefined it is still the right value.
           return descValue;
@@ -325,7 +325,7 @@ export function GetPrototypeFromConstructor(
   realm: Realm,
   constructor: ObjectValue,
   intrinsicDefaultProto: string
-): ObjectValue {
+): ObjectValue | AbstractObjectValue {
   // 1. Assert: intrinsicDefaultProto is a String value that is this specification's name of an intrinsic
   //   object. The corresponding object must be an intrinsic that is intended to be used as the [[Prototype]]
   //   value of an object.
@@ -338,7 +338,7 @@ export function GetPrototypeFromConstructor(
   let proto = Get(realm, constructor, new StringValue(realm, "prototype"));
 
   // 4. If Type(proto) is not Object, then
-  if (!(proto instanceof ObjectValue)) {
+  if (!(proto instanceof ObjectValue) && !(proto instanceof AbstractObjectValue)) {
     // a. Let realm be ? GetFunctionRealm(constructor).
     realm = GetFunctionRealm(realm, constructor);
 

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -14,6 +14,7 @@ import type { TypedArrayKind } from "../types.js";
 import { FatalError } from "../errors.js";
 import {
   AbstractValue,
+  AbstractObjectValue,
   IntegerIndexedExotic,
   ObjectValue,
   Value,
@@ -55,7 +56,7 @@ export const ArrayElementType = {
 // ECMA262 9.4.5.7
 export function IntegerIndexedObjectCreate(
   realm: Realm,
-  prototype: ObjectValue,
+  prototype: ObjectValue | AbstractObjectValue,
   internalSlotsList: { [key: string]: void }
 ): ObjectValue {
   // 1. Assert: internalSlotsList contains the names [[ViewedArrayBuffer]], [[ArrayLength]], [[ByteOffset]], and [[TypedArrayName]].

--- a/src/types.js
+++ b/src/types.js
@@ -476,7 +476,7 @@ export type FunctionType = {
   // ECMA262 9.2.3
   FunctionAllocate(
     realm: Realm,
-    functionPrototype: ObjectValue,
+    functionPrototype: ObjectValue | AbstractObjectValue,
     strict: boolean,
     functionKind: "normal" | "non-constructor" | "generator"
   ): ECMAScriptSourceFunctionValue,
@@ -798,7 +798,7 @@ export type JoinType = {
 
 export type CreateType = {
   // ECMA262 9.4.3.3
-  StringCreate(realm: Realm, value: StringValue, prototype: ObjectValue): ObjectValue,
+  StringCreate(realm: Realm, value: StringValue, prototype: ObjectValue | AbstractObjectValue): ObjectValue,
 
   // B.2.3.2.1
   CreateHTML(realm: Realm, string: Value, tag: string, attribute: string, value: string | Value): StringValue,
@@ -822,7 +822,7 @@ export type CreateType = {
   CreateArrayIterator(realm: Realm, array: ObjectValue, kind: IterationKind): ObjectValue,
 
   // ECMA262 9.4.2.2
-  ArrayCreate(realm: Realm, length: number, proto?: ObjectValue): ArrayValue,
+  ArrayCreate(realm: Realm, length: number, proto?: ObjectValue | AbstractObjectValue): ArrayValue,
 
   // ECMA262 7.3.16
   CreateArrayFromList(realm: Realm, elems: Array<Value>): ArrayValue,
@@ -849,7 +849,11 @@ export type CreateType = {
   CreateDataPropertyOrThrow(realm: Realm, O: Value, P: PropertyKeyValue, V: Value): boolean,
 
   // ECMA262 9.1.12
-  ObjectCreate(realm: Realm, proto: ObjectValue | NullValue, internalSlotsList?: { [key: string]: void }): ObjectValue,
+  ObjectCreate(
+    realm: Realm,
+    proto: ObjectValue | AbstractObjectValue | NullValue,
+    internalSlotsList?: { [key: string]: void }
+  ): ObjectValue,
 
   // ECMA262 9.1.13
   OrdinaryCreateFromConstructor(

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -12,7 +12,7 @@
 import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
-import { AbstractValue, ArrayValue, ObjectValue, StringValue, Value, NumberValue } from "./index.js";
+import { AbstractValue, ArrayValue, ObjectValue, StringValue, Value, NumberValue, NullValue } from "./index.js";
 import type { AbstractValueBuildNodeFunction } from "./AbstractValue.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { IsDataDescriptor, cloneDescriptor, equalDescriptors } from "../methods/index.js";
@@ -202,6 +202,58 @@ export default class AbstractObjectValue extends AbstractValue {
 
   throwIfNotObject(): AbstractObjectValue {
     return this;
+  }
+
+  // ECMA262 9.1.1
+  $GetPrototypeOf(): ObjectValue | AbstractObjectValue | NullValue {
+    if (this.values.isTop()) {
+      AbstractValue.reportIntrospectionError(this);
+      throw new FatalError();
+    }
+    let elements = this.values.getElements();
+    if (elements.size === 1) {
+      for (let cv of elements) {
+        invariant(cv instanceof ObjectValue);
+        return cv.$GetPrototypeOf();
+      }
+      invariant(false);
+    } else if (this.kind === "conditional") {
+      // this is the join of two concrete objects
+      // use this join condition for the join of the two property values
+      let [cond, ob1, ob2] = this.args;
+      invariant(cond instanceof AbstractValue);
+      invariant(ob1 instanceof ObjectValue);
+      invariant(ob2 instanceof ObjectValue);
+      let p1 = ob1.$GetPrototypeOf();
+      let p2 = ob2.$GetPrototypeOf();
+      let joinedObject = Join.joinValuesAsConditional(this.$Realm, cond, p1, p2);
+      invariant(joinedObject instanceof AbstractObjectValue);
+      return joinedObject;
+    } else if (this.kind === "widened") {
+      // This abstract object was created by repeated assignments of freshly allocated objects to the same binding inside a loop
+      let [ob1, ob2] = this.args; // ob1: summary of iterations 1...n, ob2: summary of iteration n+1
+      invariant(ob1 instanceof ObjectValue);
+      invariant(ob2 instanceof ObjectValue);
+      let p1 = ob1.$GetPrototypeOf();
+      let p2 = ob2.$GetPrototypeOf();
+      let widenedObject = Widen.widenValues(this.$Realm, p1, p2);
+      invariant(widenedObject instanceof AbstractObjectValue);
+      return widenedObject;
+    } else {
+      let joinedObject;
+      for (let cv of elements) {
+        invariant(cv instanceof ObjectValue);
+        let p = cv.$GetPrototypeOf();
+        if (joinedObject === undefined) {
+          joinedObject = p;
+        } else {
+          let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
+          joinedObject = Join.joinValuesAsConditional(this.$Realm, cond, p, joinedObject);
+        }
+      }
+      invariant(joinedObject instanceof AbstractObjectValue);
+      return joinedObject;
+    }
   }
 
   // ECMA262 9.1.3

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -210,6 +210,7 @@ export default class AbstractObjectValue extends AbstractValue {
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();
     }
+    invariant(this.kind !== "widened", "widening currently always leads to top values");
     let elements = this.values.getElements();
     if (elements.size === 1) {
       for (let cv of elements) {
@@ -229,16 +230,6 @@ export default class AbstractObjectValue extends AbstractValue {
       let joinedObject = Join.joinValuesAsConditional(this.$Realm, cond, p1, p2);
       invariant(joinedObject instanceof AbstractObjectValue);
       return joinedObject;
-    } else if (this.kind === "widened") {
-      // This abstract object was created by repeated assignments of freshly allocated objects to the same binding inside a loop
-      let [ob1, ob2] = this.args; // ob1: summary of iterations 1...n, ob2: summary of iteration n+1
-      invariant(ob1 instanceof ObjectValue);
-      invariant(ob2 instanceof ObjectValue);
-      let p1 = ob1.$GetPrototypeOf();
-      let p2 = ob2.$GetPrototypeOf();
-      let widenedObject = Widen.widenValues(this.$Realm, p1, p2);
-      invariant(widenedObject instanceof AbstractObjectValue);
-      return widenedObject;
     } else {
       let joinedObject;
       for (let cv of elements) {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -145,7 +145,7 @@ export default class ObjectValue extends ConcreteValue {
     }
   }
 
-  $Prototype: ObjectValue | NullValue;
+  $Prototype: ObjectValue | AbstractObjectValue | NullValue;
   $Extensible: BooleanValue | AbstractValue;
 
   $ParameterMap: void | ObjectValue; // undefined when the property is "missing"
@@ -571,7 +571,7 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   // ECMA262 9.1.1
-  $GetPrototypeOf(): ObjectValue | NullValue {
+  $GetPrototypeOf(): ObjectValue | AbstractObjectValue | NullValue {
     return this.$Prototype;
   }
 

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -10,10 +10,18 @@
 /* @flow */
 
 import { Realm } from "../realm.js";
-import { Value, SymbolValue, NullValue, ObjectValue, UndefinedValue, StringValue } from "./index.js";
+import {
+  Value,
+  AbstractObjectValue,
+  SymbolValue,
+  NullValue,
+  ObjectValue,
+  UndefinedValue,
+  StringValue,
+} from "./index.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
 import invariant from "../invariant.js";
-import { SameValue, SameValuePartial, SamePropertyKey } from "../methods/abstract.js";
+import { SameValuePartial, SamePropertyKey } from "../methods/abstract.js";
 import { GetMethod } from "../methods/get.js";
 import { IsExtensible, IsPropertyKey, IsDataDescriptor, IsAccessorDescriptor } from "../methods/is.js";
 import { Create, Properties, To } from "../singletons.js";
@@ -47,7 +55,7 @@ export default class ProxyValue extends ObjectValue {
   }
 
   // ECMA262 9.5.1
-  $GetPrototypeOf(): NullValue | ObjectValue {
+  $GetPrototypeOf(): NullValue | AbstractObjectValue | ObjectValue {
     let realm = this.$Realm;
 
     // 1. Let handler be the value of the [[ProxyHandler]] internal slot of O.
@@ -92,7 +100,7 @@ export default class ProxyValue extends ObjectValue {
     let targetProto = target.$GetPrototypeOf();
 
     // 12. If SameValue(handlerProto, targetProto) is false, throw a TypeError exception.
-    if (!SameValue(realm, handlerProto, targetProto)) {
+    if (!SameValuePartial(realm, handlerProto, targetProto)) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
     }
 
@@ -147,7 +155,7 @@ export default class ProxyValue extends ObjectValue {
     let targetProto = target.$GetPrototypeOf();
 
     // 13. If SameValue(V, targetProto) is false, throw a TypeError exception.
-    if (!SameValue(realm, V, targetProto)) {
+    if (!SameValuePartial(realm, V, targetProto)) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
     }
 

--- a/test/serializer/abstract/AbstractPrototype.js
+++ b/test/serializer/abstract/AbstractPrototype.js
@@ -1,0 +1,8 @@
+let obj = global.__abstract ? __abstract("object", "({})") : {};
+
+function Constructor() {}
+Constructor.prototype = obj;
+
+let obj2 = new Constructor();
+
+inspect = function() { return Object.getPrototypeOf(obj2) === obj; }

--- a/test/serializer/abstract/GetPrototypeOf.js
+++ b/test/serializer/abstract/GetPrototypeOf.js
@@ -1,0 +1,11 @@
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+let p1 = {p:1};
+let p2 = {p:2};
+let o1 = Object.create(p1);
+let o2 = Object.create(p2);
+let o = x ? o1 : o2;
+
+z = Object.getPrototypeOf(o);
+
+inspect = function() { return z.p; }

--- a/test/serializer/abstract/GetPrototypeOf2.js
+++ b/test/serializer/abstract/GetPrototypeOf2.js
@@ -1,0 +1,5 @@
+let o = global.__abstract ? __abstract({}, "{}") : {};
+
+p = Object.getPrototypeOf(o);
+
+inspect = function() { return p === Object.prototype; }


### PR DESCRIPTION
Fixes #1598

This is actually already allowed to be abstract since all the internal objectvalue properties can be abstract and there are tests for it. This PR just makes it a bit more explicitly handled and properly typed.

I also need this so I can write more tests around abstract prototype chains so I don't break the code paths that already are designed to support them.

I also did a pass to search for other instanceof ObjectValue checks but I didn't find any obviously similar issues.