### PR TITLE
Add source locations to AST

### DIFF
--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -59,7 +59,7 @@ let uniqueEvaluatedComponents = 0;
 function compileSource(source) {
   let serialized;
   try {
-    serialized = prepackSources([{ filePath: "", fileContents: source, sourceMapContents: "" }], prepackOptions);
+    serialized = prepackSources([{ filePath: inputPath, fileContents: source, sourceMapContents: "" }], prepackOptions);
   } catch (e) {
     errorsCaptured.forEach(error => {
       console.error(error);


### PR DESCRIPTION
Release note: none

Debugging is more painful with debug-fb-ww than it needs to be, because the AST that goes into the abstract interpreter does not have source locations.

This little change fixes that. Please be so kind as to bless it.