### PR TITLE
Adds k limiting counter to simplification logic

### DIFF
--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -48,7 +48,7 @@ let prepackOptions = {
   omitInvariants: true,
   abstractEffectsInAdditionalFunctions: true,
   simpleClosures: true,
-  kLimit: 10000,
+  abstractValueImpliesMax: 1000,
 };
 let inputPath = path.resolve("fb-www/input.js");
 let outputPath = path.resolve("fb-www/output.js");

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -48,6 +48,7 @@ let prepackOptions = {
   omitInvariants: true,
   abstractEffectsInAdditionalFunctions: true,
   simpleClosures: true,
+  kLimit: 10000,
 };
 let inputPath = path.resolve("fb-www/input.js");
 let outputPath = path.resolve("fb-www/output.js");

--- a/src/options.js
+++ b/src/options.js
@@ -51,6 +51,7 @@ export type RealmOptions = {
   reactVerbose?: boolean,
   stripFlow?: boolean,
   abstractEffectsInAdditionalFunctions?: boolean,
+  kLimit?: number,
 };
 
 export type SerializerOptions = {

--- a/src/options.js
+++ b/src/options.js
@@ -51,7 +51,7 @@ export type RealmOptions = {
   reactVerbose?: boolean,
   stripFlow?: boolean,
   abstractEffectsInAdditionalFunctions?: boolean,
-  kLimit?: number,
+  abstractValueImpliesMax?: number,
 };
 
 export type SerializerOptions = {

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -55,7 +55,7 @@ export type PrepackOptions = {|
   maxStackDepth?: number,
   debugInFilePath?: string,
   debugOutFilePath?: string,
-  kLimit?: number,
+  abstractValueImpliesMax?: number,
 |};
 
 export function getRealmOptions({
@@ -77,7 +77,7 @@ export function getRealmOptions({
   stripFlow,
   timeout,
   maxStackDepth,
-  kLimit,
+  abstractValueImpliesMax,
 }: PrepackOptions): RealmOptions {
   return {
     abstractEffectsInAdditionalFunctions,
@@ -98,7 +98,7 @@ export function getRealmOptions({
     stripFlow,
     timeout,
     maxStackDepth,
-    kLimit,
+    abstractValueImpliesMax,
   };
 }
 

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -55,6 +55,7 @@ export type PrepackOptions = {|
   maxStackDepth?: number,
   debugInFilePath?: string,
   debugOutFilePath?: string,
+  kLimit?: number,
 |};
 
 export function getRealmOptions({
@@ -76,6 +77,7 @@ export function getRealmOptions({
   stripFlow,
   timeout,
   maxStackDepth,
+  kLimit,
 }: PrepackOptions): RealmOptions {
   return {
     abstractEffectsInAdditionalFunctions,
@@ -96,6 +98,7 @@ export function getRealmOptions({
     stripFlow,
     timeout,
     maxStackDepth,
+    kLimit,
   };
 }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -160,6 +160,8 @@ export class Realm {
     }
     this.strictlyMonotonicDateNow = !!opts.strictlyMonotonicDateNow;
 
+    // 0 = disabled
+    this.kLimitingCounterMax = opts.kLimit || 0;
     this.timeout = opts.timeout;
     if (this.timeout) {
       // We'll call Date.now for every this.timeoutCounterThreshold'th AST node.
@@ -228,6 +230,7 @@ export class Realm {
   trackLeaks: boolean;
   debugNames: void | boolean;
   isInPureTryStatement: boolean; // TODO(1264): Remove this once we implement proper exception handling in abstract calls.
+  kLimitingCounterMax: number;
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;

--- a/src/realm.js
+++ b/src/realm.js
@@ -230,7 +230,7 @@ export class Realm {
   trackLeaks: boolean;
   debugNames: void | boolean;
   isInPureTryStatement: boolean; // TODO(1264): Remove this once we implement proper exception handling in abstract calls.
-  abstractValueImpliesCounter: number;
+  abstractValueImpliesMax: number;
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;

--- a/src/realm.js
+++ b/src/realm.js
@@ -161,7 +161,7 @@ export class Realm {
     this.strictlyMonotonicDateNow = !!opts.strictlyMonotonicDateNow;
 
     // 0 = disabled
-    this.kLimitingCounterMax = opts.kLimit || 0;
+    this.abstractValueImpliesMax = opts.abstractValueImpliesMax || 0;
     this.timeout = opts.timeout;
     if (this.timeout) {
       // We'll call Date.now for every this.timeoutCounterThreshold'th AST node.
@@ -230,7 +230,7 @@ export class Realm {
   trackLeaks: boolean;
   debugNames: void | boolean;
   isInPureTryStatement: boolean; // TODO(1264): Remove this once we implement proper exception handling in abstract calls.
-  kLimitingCounterMax: number;
+  abstractValueImpliesCounter: number;
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -31,6 +31,9 @@ export default function simplifyAndRefineAbstractValue(
     };
     return simplify(realm, value, isCondition);
   } catch (e) {
+    if (e instanceof FatalError) {
+      throw e;
+    }
     return value;
   } finally {
     realm.errorHandler = savedHandler;


### PR DESCRIPTION
Release notes: adds an abstract value limiting counter

Following some discussion I had the other night with @hermanventer in regards to having a counter for Prepack abstract logic computation, so rather than hang the compilation process, we could throw and recover using the pure logic. 

This PR adds a "k-limiting" counter to `AbstractValue`'s as a method `_checkAbstractValueImpliesCounter `. When we try and resolve abstract conditions on a single AbstractValue and we reach the limit, a `CompilerDiagnostic` along with a `FatalError` gets thrown. Locally this works well for the React compiler input.

I only call `_checkAbstractValueImpliesCounter ` from `implies` right now and that might not be the best place, maybe it should be checked in other places too, but `implies` seemed the good place as it was in all stackframes when debugging.

This also adds a new option called `abstractValueImpliesCounter ` which is based as an option to Realm. By default this feature is not turned on when the option `abstractValueImpliesCounter ` value is `0` (which it has been set to). Maybe we should enable this by default and set it to a sensible level?

**Note:**

I tried using the `timeout` feature, but it didn't work and wasn't too reliable in general because it would always fire in places where I didn't care for "time taken" but rather the depth on a certain feature of computation – in this case, abstract logic simplification. 

Enabling the timeout causes many other parts of compilation to break unless I explicitly set the timeout to `0` through all the React reconciliation work, which kind of defeats the purpose of it (the React reconciler work can take minutes to deal with on very large, expensive trees, and this is totally expected). 

Furthermore, we should avoid using non-deterministic features like `feature` in such cases as they can skew test results.