### PR TITLE
Tweak to NewExpression recovery

### DIFF
--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -85,10 +85,7 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
       "tryToEvaluateConstructOrLeaveAsAbstract"
     );
   } catch (error) {
-    // if the constructor is abstract, then create a unary op for it,
-    // otherwise we rethrow the error as we don't handle it at this
-    // point in time
-    if (error instanceof FatalError && constructor instanceof AbstractValue) {
+    if (error instanceof FatalError) {
       // we need to havoc all the arguments and the constructor
       Havoc.value(realm, constructor);
       for (let arg of argsList) {

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -85,6 +85,8 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
       "tryToEvaluateConstructOrLeaveAsAbstract"
     );
   } catch (error) {
+    // if a FatalError occurs when constructing the constructor
+    // then try and recover and create an abstract for this construct
     if (error instanceof FatalError) {
       // we need to havoc all the arguments and the constructor
       Havoc.value(realm, constructor);


### PR DESCRIPTION
Release notes: none

The constructor can be any `Value` for the recovery to occur, not just `Abstract`.