### PR TITLE
Undefined check in serializer utils

### DIFF
--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -119,7 +119,7 @@ export function getObjectPrototypeMetadata(realm: Realm, obj: ObjectValue) {
   if (obj.$IsClassPrototype) {
     skipPrototype = true;
   }
-  if (proto.$IsClassPrototype) {
+  if (proto && proto.$IsClassPrototype) {
     invariant(proto instanceof ObjectValue);
     // we now need to check if the prototpe has a constructor
     if (proto.properties.has("constructor")) {


### PR DESCRIPTION
Release notes: none

`proto` should be checked before being accessed, not sure why Flow didn't pick up on this one either. This bug occurred only during UFI code, but it unblocks the work there.