### PR TITLE
[WIP] Handle React first render cases where a closure accesses "this"

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -593,6 +593,29 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output First render only Replace this in callbacks 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output First render only Simple #2 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -3340,6 +3363,29 @@ ReactStatistics {
   ],
   "inlinedComponents": 4,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only Replace this in callbacks 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
 }
 `;
 
@@ -6093,6 +6139,29 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output First render only Replace this in callbacks 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output First render only Simple #2 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -8805,6 +8874,29 @@ ReactStatistics {
   ],
   "inlinedComponents": 4,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only Replace this in callbacks 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -572,6 +572,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
       it("React Context 5", async () => {
         await runTest(directory, "react-context5.js");
       });
+
+      it.only("Replace this in callbacks", async () => {
+        await runTest(directory, "replace-this-in-callbacks.js");
+      });
     });
 
     describe("fb-www mocks", () => {

--- a/test/react/first-render-only/replace-this-in-callbacks.js
+++ b/test/react/first-render-only/replace-this-in-callbacks.js
@@ -1,0 +1,41 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+
+class Child1 extends React.Component {
+  constructor() {
+    super();
+    this.someMethod = () => {
+      return this.props.bar;
+    };
+  }
+  render() {
+    let DeOptComponent = this.props.DeOptComponent;
+    return (
+      <div>
+        <DeOptComponent someMethod={this.someMethod} />
+      </div>
+    );
+  }
+}
+
+function App(props) {
+  return <Child1 {...props} />
+}
+
+App.getTrials = function(renderer, Root) {
+  function DeOptComponent(props) {
+    return <span>{props.someMethod()}</span>;
+  }
+  renderer.update(<Root DeOptComponent={DeOptComponent} bar="123" />);
+  return [['render replace this in callbacks', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This is a WIP. I've added a failing test case that seems to be common in the UFI upon bail-outs. What do we do if we bail-out and reference a component with a prop that passes a reference to a closure that wraps over "this". This will get more complicated when we have a reference to something that isn't "this" and is of the closure.

First way is to attack them as optimized functions, but how do we know to flag them as such? It would be easy if the closure is referenced in the return value, but that might not be the case – what about `forEach` etc?

Another way is to do like we do already when converting class components to functional components, we could just use the same logic to replace AST of `this.props` references to `props`. We can still do that and that will fix the failing test. That will fail though on things in the closure that aren't `this.props`. We could traverse through each closure and add all the contents of the function, i.e. `this.props`, `this.class` etc. This will have to have happen in `ResdualFunctions.js`.

This is a hard problem but one we definitely need to fix for firstRender bail-out cases.

@sebmarkbage How do you think we can handle this? Do we simply somehow find it a bail-out?