### PR TITLE
[WIP] React Reconciler - add nested optimized function support

### DIFF
--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -85,6 +85,7 @@ let reactCode = `
       this.props = props;
       this.context = context;
       this.refs = {};
+      this.setState = () => {}; // NO-OP
     }
     
     Component.prototype.isReactComponent = {};
@@ -93,6 +94,7 @@ let reactCode = `
       this.props = props;
       this.context = context;
       this.refs = {};
+      this.setState = () => {}; // NO-OP
     }
 
     PureComponent.prototype.isReactComponent = {};

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -20,7 +20,12 @@ import {
 } from "../values/index.js";
 import * as t from "babel-types";
 import type { BabelNodeIdentifier } from "babel-types";
-import { valueIsClassComponent, deleteRefAndKeyFromProps, getProperty } from "./utils";
+import {
+  valueIsClassComponent,
+  deleteRefAndKeyFromProps,
+  getProperty,
+  evaluateAndCaptureNewFunctionsForEvaluation,
+} from "./utils";
 import { ExpectedBailOut, SimpleClassBailOut } from "./errors.js";
 import { Get, Construct } from "../methods/index.js";
 import { Properties } from "../singletons.js";
@@ -160,7 +165,9 @@ export function createClassInstanceForFirstRenderOnly(
   props: ObjectValue | AbstractValue,
   context: ObjectValue | AbstractValue
 ): ObjectValue {
-  let instance = Construct(realm, componentType, [props, context]);
+  let instance = evaluateAndCaptureNewFunctionsForEvaluation(realm, componentType, () =>
+    Construct(realm, componentType, [props, context])
+  );
   invariant(instance instanceof ObjectValue);
   instance.intrinsicName = "this";
   instance.refuseSerialization = true;

--- a/src/realm.js
+++ b/src/realm.js
@@ -56,6 +56,7 @@ import { Generator, PreludeGenerator } from "./utils/generator.js";
 import { emptyExpression, voidExpression } from "./utils/internalizer.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
+import type { Reconciler } from "./react/reconcilation.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
 import * as t from "babel-types";
 
@@ -198,6 +199,7 @@ export class Realm {
       abstractHints: new WeakMap(),
       classComponentMetadata: new Map(),
       currentOwner: undefined,
+      currentReconciler: null,
       enabled: opts.reactEnabled || false,
       output: opts.reactOutput || "create-element",
       hoistableFunctions: new WeakMap(),
@@ -268,6 +270,7 @@ export class Realm {
     abstractHints: WeakMap<AbstractValue | ObjectValue, ReactHint>,
     classComponentMetadata: Map<ECMAScriptSourceFunctionValue, ClassComponentMetadata>,
     currentOwner?: ObjectValue,
+    currentReconciler: null | Reconciler,
     enabled: boolean,
     hoistableFunctions: WeakMap<FunctionValue, boolean>,
     hoistableReactElements: WeakMap<ObjectValue, boolean>,

--- a/src/values/FunctionValue.js
+++ b/src/values/FunctionValue.js
@@ -19,6 +19,11 @@ import invariant from "../invariant.js";
 export default class FunctionValue extends ObjectValue {
   constructor(realm: Realm, intrinsicName?: string) {
     super(realm, realm.intrinsics.FunctionPrototype, intrinsicName);
+    let currentReconciler = realm.react.currentReconciler;
+
+    if (realm.react.enabled && currentReconciler !== null && currentReconciler.functionsToEvalaute !== null) {
+      currentReconciler.functionsToEvalaute.add(this);
+    }
   }
 
   $Environment: LexicalEnvironment;

--- a/test/react/mocks/fb1.js
+++ b/test/react/mocks/fb1.js
@@ -20,7 +20,7 @@ module.exports = this.__evaluatePureFunction(() => {
           ${query}
         `}
         variables={someVariables}
-        render={({error, props}) => {
+        render={data => {
           return <span>Hello world</span>
         }}
       />

--- a/test/react/render-props/relay-query-renderer.js
+++ b/test/react/render-props/relay-query-renderer.js
@@ -8,7 +8,7 @@ this['QueryRenderer'] = QueryRenderer;
 function App(props) {
   return (
     <QueryRenderer
-      render={({error, props}) => {
+      render={data => {
         return <span>Hello world</span>;
       }}
     />

--- a/test/react/render-props/relay-query-renderer2.js
+++ b/test/react/render-props/relay-query-renderer2.js
@@ -8,7 +8,7 @@ this['QueryRenderer'] = QueryRenderer;
 function App(props) {
   return (
     <QueryRenderer
-      render={({error, _props}) => {
+      render={data => {
         return <span>Hello world {props.foo}</span>;
       }}
     />

--- a/test/react/render-props/relay-query-renderer3.js
+++ b/test/react/render-props/relay-query-renderer3.js
@@ -20,7 +20,7 @@ class SomeClassThatShouldNotMakeRootAClass extends React.Component {
 function App(props) {
   return (
     <QueryRenderer
-      render={({error, _props}) => {
+      render={data => {
         return <SomeClassThatShouldNotMakeRootAClass />;
       }}
     />


### PR DESCRIPTION
Release notes: none

This is a pretty big refactor of how nested optimized functions get handled by the React reconciler. Previous, we special cased how the various "render prop" functions were handled but it wasn't scalable. This time, when we enter the React reconciler phase we mark **every** function value encounter during that evaluation effects of a React component render phase. Once we've done that we then go back through all the functions we found and try and optimize them all and if needed, put through through the reconciliation phase independently.

Lots of code was removed as this new implementation doesn't need much of it. Furthermore, this won't be able to land until a bug with optimized functions is fixed (variables defined in a nested additonal function get appended to the mainBody – I looked, and `_getTarget` doesn't work with them yet, maybe @NTillmann can help me here?).

I still need to refine the behaviour somewhat to get better inlining but this is a major step forward. 