### PR TITLE
Make Path.pushRefinedContions linear

### DIFF
--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -39,7 +39,7 @@ export class PathImplementation {
     realm.pathConditions = [];
     try {
       pushPathCondition(condition);
-      pushRefinedConditions(savedPath);
+      pushRefinedConditions(condition, savedPath);
       return evaluate();
     } finally {
       realm.pathConditions = savedPath;
@@ -52,7 +52,7 @@ export class PathImplementation {
     realm.pathConditions = [];
     try {
       pushInversePathCondition(condition);
-      pushRefinedConditions(savedPath);
+      pushRefinedConditions(condition, savedPath);
       return evaluate();
     } finally {
       realm.pathConditions = savedPath;
@@ -65,7 +65,7 @@ export class PathImplementation {
     realm.pathConditions = [];
 
     pushPathCondition(condition);
-    pushRefinedConditions(savedPath);
+    pushRefinedConditions(condition, savedPath);
   }
 
   pushInverseAndRefine(condition: AbstractValue) {
@@ -74,7 +74,7 @@ export class PathImplementation {
     realm.pathConditions = [];
 
     pushInversePathCondition(condition);
-    pushRefinedConditions(savedPath);
+    pushRefinedConditions(condition, savedPath);
   }
 }
 
@@ -149,8 +149,10 @@ function pushInversePathCondition(condition: Value) {
   }
 }
 
-function pushRefinedConditions(unrefinedConditions: Array<AbstractValue>) {
-  for (let unrefinedCond of unrefinedConditions) {
-    pushPathCondition(unrefinedCond.$Realm.simplifyAndRefineAbstractCondition(unrefinedCond));
-  }
+function pushRefinedConditions(condition: AbstractValue, unrefinedConditions: Array<AbstractValue>) {
+  let realm = condition.$Realm;
+  let refinedConditions = unrefinedConditions.map(c => realm.simplifyAndRefineAbstractCondition(c));
+  let pc = realm.pathConditions.pop();
+  for (let c of refinedConditions) pushPathCondition(c);
+  realm.pathConditions.push(pc);
 }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -249,8 +249,7 @@ export default class AbstractValue extends Value {
         }
 
         // (c ? x : (c || false)) => c (if c were false this value could not be true)
-        invariant(y instanceof AbstractValue);
-        if (y.kind === "||") {
+        if (y instanceof AbstractValue && y.kind === "||") {
           let [yx, yy] = y.args;
           return c.equals(yx) && !yy.mightNotBeFalse() && c.equals(val);
         }


### PR DESCRIPTION
Release note: Performance tweak

We now first simplify/refine all old path conditions before pushing them back onto the realm's list. This means that the length of the paths conditions used to refine the old conditions does not grow while doing the refinement, which removes a non linearity from this code path.

There should not be a significant reduction in precision, since each of the old conditions have already been simplified/refined in the light of all of the other old conditions before the latest condition gets pushed onto the condition list.

There is also a small bug fix for an invariant that should have been a conditional. This crept in during the update for Flow. Of course, a small regression test would have prevent this, but I have actually tried to construct such a test before and it proved to be harder than I have time for.