### PR TITLE
Generate better code in nested residual functions

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -408,6 +408,7 @@ export class ResidualHeapVisitor {
 
     if (!functionInfo) {
       functionInfo = {
+        depth: 0,
         unbound: new Set(),
         modified: new Set(),
         usesArguments: false,

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -74,6 +74,7 @@ export type FunctionInstance = {
 };
 
 export type FunctionInfo = {
+  depth: number,
   unbound: Set<string>,
   modified: Set<string>,
   usesArguments: boolean,

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -251,7 +251,8 @@ export let ClosureRefVisitor = {
     if (ignorePath(path)) return;
 
     let innerName = path.node.name;
-    if (innerName === "arguments" && state.functionInfo.depth === 1) {
+    // TODO #1621: doesn't check that `arguments` is in top function.
+    if (innerName === "arguments") {
       state.functionInfo.usesArguments = true;
       return;
     }

--- a/test/serializer/basic/ClosureRefVisitor2.js
+++ b/test/serializer/basic/ClosureRefVisitor2.js
@@ -1,0 +1,12 @@
+// does not contain:call
+(function() {
+    var f = function() {
+        return function() {
+            return (function() { return this.x; }).bind({x: 42});
+        }
+    }
+    var g1 = f();
+    var g2 = f();
+    var g3 = f();
+    inspect = function() { return g1() + g2() + g3(); }
+})();

--- a/test/serializer/basic/Values.js
+++ b/test/serializer/basic/Values.js
@@ -1,7 +1,7 @@
 function g(i) {
   function f() {
     /* This comment is here so that the function gets too big to be considered for inlining by our serialiser. */
-    return i + arguments[0]; 
+    return i + arguments[0];
   }
   return f;
 }


### PR DESCRIPTION
Solve #886 
`ClosureRefVisitor` tracks the depth of the traversing, and sets the `usesArguments`/`useThis` flags only if they were used in the top level function (depth = 1). 
