### PR TITLE
No longer fail hard on a React root component tree failing

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2315,7 +2315,7 @@ ReactStatistics {
         },
         Object {
           "children": Array [],
-          "message": "evaluation failed on new component tree branch",
+          "message": "completely unknown component render currently supported on first render",
           "name": "Middle",
           "status": "BAIL-OUT",
         },
@@ -5065,7 +5065,7 @@ ReactStatistics {
         },
         Object {
           "children": Array [],
-          "message": "evaluation failed on new component tree branch",
+          "message": "completely unknown component render currently supported on first render",
           "name": "Middle",
           "status": "BAIL-OUT",
         },
@@ -7780,7 +7780,7 @@ ReactStatistics {
         },
         Object {
           "children": Array [],
-          "message": "evaluation failed on new component tree branch",
+          "message": "completely unknown component render currently supported on first render",
           "name": "Middle",
           "status": "BAIL-OUT",
         },
@@ -10495,7 +10495,7 @@ ReactStatistics {
         },
         Object {
           "children": Array [],
-          "message": "evaluation failed on new component tree branch",
+          "message": "completely unknown component render currently supported on first render",
           "name": "Middle",
           "status": "BAIL-OUT",
         },

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -24,6 +24,31 @@ let { Linter } = require("eslint");
 
 let errorsCaptured = [];
 
+function printError(error) {
+  let msg = `${error.errorCode}: ${error.message}`;
+  if (error.location) {
+    let loc_start = error.location.start;
+    let loc_end = error.location.end;
+    msg += ` at ${loc_start.line}:${loc_start.column} to ${loc_end.line}:${loc_end.column}`;
+  }
+  switch (error.severity) {
+    case "Information":
+      console.log(`Info: ${msg}`);
+      return "Recover";
+    case "Warning":
+      console.warn(`Warn: ${msg}`);
+      return "Recover";
+    case "RecoverableError":
+      console.error(`Error: ${msg}`);
+      return "Fail";
+    case "FatalError":
+      console.error(`Fatal Error: ${msg}`);
+      return "Fail";
+    default:
+      console.log(msg);
+  }
+}
+
 let prepackOptions = {
   errorHandler: diag => {
     errorsCaptured.push(diag);
@@ -62,9 +87,8 @@ function compileSource(source) {
   try {
     serialized = prepackSources([{ filePath: inputPath, fileContents: source, sourceMapContents: "" }], prepackOptions);
   } catch (e) {
-    errorsCaptured.forEach(error => {
-      console.error(error);
-    });
+    console.log(`\n${chalk.inverse(`=== Diagnostics Log ===`)}\n`);
+    errorsCaptured.forEach(error => printError(error));
     throw e;
   }
   return {
@@ -214,6 +238,7 @@ readComponentsList()
     console.log(`${chalk.gray(`Compile time`)}: ${timeTaken}s\n`);
   })
   .catch(e => {
+    console.log(`\n${chalk.inverse(`=== Compilation Failed ===`)}\n`);
     console.error(e.nativeStack || e.stack);
     process.exit(1);
   });

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -51,11 +51,11 @@ function printError(error) {
 
 let prepackOptions = {
   errorHandler: diag => {
-    errorsCaptured.push(diag);
     if (diag.severity === "Information") {
       console.log(diag.message);
       return "Recover";
     }
+    errorsCaptured.push(diag);
     if (diag.severity !== "Warning") {
       return "Fail";
     }

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -197,12 +197,20 @@ export class Functions {
         continue;
       }
       let evaluatedRootNode = createReactEvaluatedNode("ROOT", getComponentName(this.realm, componentType));
-      logger.logInformation(`- ${evaluatedRootNode.name} (root)...`);
+      if (this.realm.react.verbose) {
+        logger.logInformation(`- ${evaluatedRootNode.name} (root)...`);
+      }
       statistics.evaluatedRootNodes.push(evaluatedRootNode);
       if (reconciler.hasEvaluatedRootNode(componentType, evaluatedRootNode)) {
         continue;
       }
       let effects = reconciler.render(componentType, null, null, evaluatedRootNode);
+      if (effects[0] === this.realm.intrinsics.undefined) {
+        if (this.realm.react.verbose) {
+          logger.logInformation(`- ${evaluatedRootNode.name} failed (root)`);
+        }
+        continue;
+      }
       let componentTreeState = reconciler.componentTreeState;
       this._generateWriteEffectsForReactComponentTree(componentType, effects, componentTreeState, evaluatedRootNode);
 
@@ -220,8 +228,16 @@ export class Functions {
             return;
           }
           reconciler.clearComponentTreeState();
-          logger.logInformation(`  - ${evaluatedNode.name} (branch)...`);
+          if (this.realm.react.verbose) {
+            logger.logInformation(`  - ${evaluatedNode.name} (branch)...`);
+          }
           let branchEffects = reconciler.render(branchComponentType, null, null, evaluatedNode);
+          if (effects[0] === this.realm.intrinsics.undefined) {
+            if (this.realm.react.verbose) {
+              logger.logInformation(`- ${evaluatedNode.name} failed (branch)`);
+            }
+            return;
+          }
           let branchComponentTreeState = reconciler.componentTreeState;
           this._generateWriteEffectsForReactComponentTree(
             branchComponentType,

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -202,7 +202,7 @@ export class Functions {
       if (reconciler.hasEvaluatedRootNode(componentType, evaluatedRootNode)) {
         continue;
       }
-      let effects = reconciler.render(componentType, null, null, true, evaluatedRootNode);
+      let effects = reconciler.render(componentType, null, null, evaluatedRootNode);
       let componentTreeState = reconciler.componentTreeState;
       this._generateWriteEffectsForReactComponentTree(componentType, effects, componentTreeState, evaluatedRootNode);
 
@@ -221,7 +221,7 @@ export class Functions {
           }
           reconciler.clearComponentTreeState();
           logger.logInformation(`  - ${evaluatedNode.name} (branch)...`);
-          let branchEffects = reconciler.render(branchComponentType, null, null, false, evaluatedNode);
+          let branchEffects = reconciler.render(branchComponentType, null, null, evaluatedNode);
           let branchComponentTreeState = reconciler.componentTreeState;
           this._generateWriteEffectsForReactComponentTree(
             branchComponentType,

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -189,7 +189,6 @@ export default class AbstractValue extends Value {
         "FatalError"
       );
       realm.handleError(diagnostic);
-      if (realm.handleError(diagnostic) === "Fail") throw new FatalError();
     }
   }
 


### PR DESCRIPTION
Release notes: none

When working with lots of component roots, having the build fatal hard on a root bail-out out is just added noise and stops the workflow. This PR changes this logic so they don't hard fail and instead just bail out like branch trees do already. The information for the bail-out still gets logged.