### PR TITLE
Fixing lifetime of objects referenced by optimized functions

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -455,7 +455,7 @@ export class ResidualHeapVisitor {
         invariant(functionInfo);
         for (let innerName of functionInfo.unbound) {
           let environment = this.resolveBinding(val, innerName);
-          let residualBinding = this.visitBinding(val, environment, innerName);
+          let residualBinding = this.visitBinding(val, environment, innerName, /* createBinding */ true);
           invariant(residualBinding !== undefined);
           residualFunctionBindings.set(innerName, residualBinding);
           if (functionInfo.modified.has(innerName)) {
@@ -543,8 +543,7 @@ export class ResidualHeapVisitor {
     val: FunctionValue,
     environment: EnvironmentRecord,
     name: string,
-    createBinding?: boolean = true,
-    skipBindingUpdate?: boolean = false
+    createBinding: boolean
   ): ResidualFunctionBinding | void {
     if (environment === this.globalEnvironmentRecord.$DeclarativeRecord) environment = this.globalEnvironmentRecord;
 
@@ -594,7 +593,7 @@ export class ResidualHeapVisitor {
     }
     if (residualFunctionBinding && residualFunctionBinding.value) {
       let equivalentValue = this.visitEquivalentValue(residualFunctionBinding.value);
-      if (!skipBindingUpdate || createdBinding) residualFunctionBinding.value = equivalentValue;
+      residualFunctionBinding.value = equivalentValue;
     }
     return residualFunctionBinding;
   }
@@ -878,8 +877,7 @@ export class ResidualHeapVisitor {
             functionValue,
             modifiedBinding.environment,
             modifiedBinding.name,
-            true,
-            false
+            /* createBinding */ true
           );
           invariant(residualBinding !== undefined);
           // named functions inside an additional function that have a global binding
@@ -1010,7 +1008,7 @@ export class ResidualHeapVisitor {
         }
         for (let innerName of functionInfo.unbound) {
           let environment = this.resolveBinding(functionValue, innerName);
-          let residualBinding = this.visitBinding(functionValue, environment, innerName, false);
+          let residualBinding = this.visitBinding(functionValue, environment, innerName, /* createBinding */ false);
           if (residualBinding) {
             funcInstance.residualFunctionBindings.set(innerName, residualBinding);
             delete residualBinding.referencedOnlyFromAdditionalFunctions;

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1008,7 +1008,7 @@ export class ResidualHeapVisitor {
         }
         for (let innerName of functionInfo.unbound) {
           let environment = this.resolveBinding(functionValue, innerName);
-          let residualBinding = this.visitBinding(functionValue, environment, innerName, /* createBinding */ false);
+          let residualBinding = this.visitBinding(functionValue, environment, innerName, /* createBinding */ true);
           if (residualBinding) {
             funcInstance.residualFunctionBindings.set(innerName, residualBinding);
             delete residualBinding.referencedOnlyFromAdditionalFunctions;

--- a/test/serializer/additional-functions/ObjectLifetime1.js
+++ b/test/serializer/additional-functions/ObjectLifetime1.js
@@ -1,0 +1,8 @@
+(function () {
+    let a = [1,2,3];
+    let f = function() {
+        return a;
+    }
+    if (global.__optimize) __optimize(f);
+    inspect = function() { return f() === f(); } 
+})();

--- a/test/serializer/additional-functions/ObjectLifetime2.js
+++ b/test/serializer/additional-functions/ObjectLifetime2.js
@@ -1,0 +1,14 @@
+(function () {
+    let a = [1,2,3];
+    let f = function() {
+        let b = a;
+        a = undefined;
+        return b;
+    }
+    if (global.__optimize) __optimize(f);
+    inspect = function() { 
+        var a1 = a;
+        var a2 = f();
+        return a1 === a2 && a === undefined; 
+    }
+})();


### PR DESCRIPTION
Release notes: Fixes to optimized function object lifetimes, #1542 and #1543.

Achieved by simplifying `visitBindings`.