### PR TITLE
Fixing issues around global let bindings and optimized functions

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1031,6 +1031,11 @@ export class ResidualHeapVisitor {
       this._visitReactLibrary(this.someReactElement);
     }
 
+    // Make sure to visit all global bindings in global scope
+    this._withScope(generator, () => {
+      for (let binding of this.globalBindings.values()) if (binding.value) this.visitValue(binding.value);
+    });
+
     // Do a fixpoint over all pure generator entries to make sure that we visit
     // arguments of only BodyEntries that are required by some other residual value
     let oldDelayedEntries = [];

--- a/test/serializer/additional-functions/GlobalLetBinding.js
+++ b/test/serializer/additional-functions/GlobalLetBinding.js
@@ -1,0 +1,12 @@
+let x = undefined;
+let y = undefined;
+global.f = function() {
+    x = {};
+};
+
+global.f1 = function() {
+    y = {};
+};
+  
+if (global.__optimize) __optimize(f);
+global.inspect = function() { f(); f1(); return x !== y; }


### PR DESCRIPTION
Release notes: None

This fix for #1250 ensures that Prepack properly emits global let bindings,
which was broken in particular in the presence of optimized functions.

(Looking at the code, the whole approach of rewriting residual bindings
while processing optimized values seems quite brittle, but changing that
is for a later pull request.)