### PR TITLE
Disable "factory functions" in the presence of optimized functions

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -158,6 +158,12 @@ export class ResidualFunctions {
     for (const [functionBody, instances] of this.functions) {
       invariant(instances.length > 0);
 
+      // Factory functions are later used by the ClosureRefReplacer to rewrite residual functions
+      // that references factory functions. However, this doesn't play nice with the value scoped
+      // computation done by the ResidualHeapVisitor and ResidualHeapSerializer.
+      // TODO: Revisit factory functions and scopes.
+      if (!instances.every(instance => instance.containingAdditionalFunction === undefined)) continue;
+
       let factoryId;
       const suffix = instances[0].functionValue.__originalName || this.realm.debugNames ? "factoryFunction" : "";
       if (this._shouldUseFactoryFunction(functionBody, instances)) {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -948,11 +948,12 @@ export class Generator {
   }
 }
 
-// some characters are invalid within a JavaScript identifier,
-// such as: . , : ( ) ' " ` [ ] -
-// so we replace these character instances with an underscore
-function replaceInvalidCharactersWithUnderscore(string: string) {
-  return string.replace(/[.,:\(\)\"\'\`\[\]\-]/g, "_");
+function escapeInvalidIdentifierCharacters(s: string) {
+  let res = "";
+  for (let c of s)
+    if ((c >= "0" && c <= "9") || (c >= "a" && c <= "z") || (c >= "A" && c <= "Z")) res += c;
+    else res += "_" + c.charCodeAt(0);
+  return res;
 }
 
 const base62characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -987,7 +988,7 @@ export class NameGenerator {
       id = this.prefix + base62encode(this.uidCounter++);
       if (this.uniqueSuffix.length > 0) id += this.uniqueSuffix;
       if (this.debugNames) {
-        if (debugSuffix) id += "_" + replaceInvalidCharactersWithUnderscore(debugSuffix);
+        if (debugSuffix) id += "_" + escapeInvalidIdentifierCharacters(debugSuffix);
         else id += "_";
       }
     } while (this.forbiddenNames.has(id));


### PR DESCRIPTION
Release notes: None

The purpose of these factory functions is to maximize code sharing
when residual functions reference anonymous functions
that end up with multiple references in the generated code.

Currently, this factory function optimization happens very late
and doesn't properly participate in the scope computation logic.
It causes issues when such factory functions get embedded in
optimized functions, so this change disables the optimization in such
scenarios for now.

Also, make debugNames feature more robust by properly escaping
possibly offending characters.