### PR TITLE
Inline trivial generators

### DIFF
--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -276,7 +276,7 @@ export class Functions {
       let additionalFunctionEffects = this._createAdditionalEffects(
         closureEffects,
         true,
-        "ReactAdditionalFunctionEffects",
+        "ReactNestedAdditionalFunctionEffects",
         environmentRecordIdAfterGlobalCode
       );
       invariant(additionalFunctionEffects);


### PR DESCRIPTION
Release notes: None

Trivial generators are now inlined, which improves the generated code quality for a few reasons:
- Fewer unnecessary curly braces!
- By having less structure, the serializer/emitter is "waiting" less for declared values to become available

However, this revealed a design flaw in the way the serializer/emitter deal with "waiting" and nested generators in general.
To fix this, there's now a `valuesToProcess` set being dragged around, and a new emitter function `processValues`,
which triggers the processing of waiting emitter entries at the right time.
For example, in the case of an `if`, we need to wait until both the consequent and the alternate have been emitted,
not just for one of them. So the processing is typically done at the end of such structured constructs.