### PR TITLE
Find more React component roots

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2377,7 +2377,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Render props Relay QueryRenderer 3 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -2402,7 +2402,7 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedNestedClosures": 1,
-  "optimizedTrees": 1,
+  "optimizedTrees": 2,
 }
 `;
 
@@ -5240,7 +5240,7 @@ ReactStatistics {
 
 exports[`Test React with JSX input, create-element output Render props Relay QueryRenderer 3 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -5265,7 +5265,7 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedNestedClosures": 1,
-  "optimizedTrees": 1,
+  "optimizedTrees": 2,
 }
 `;
 
@@ -8068,7 +8068,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Render props Relay QueryRenderer 3 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -8093,7 +8093,7 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedNestedClosures": 1,
-  "optimizedTrees": 1,
+  "optimizedTrees": 2,
 }
 `;
 
@@ -10896,7 +10896,7 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Render props Relay QueryRenderer 3 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -10921,7 +10921,7 @@ ReactStatistics {
   ],
   "inlinedComponents": 0,
   "optimizedNestedClosures": 1,
-  "optimizedTrees": 1,
+  "optimizedTrees": 2,
 }
 `;
 

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -86,7 +86,6 @@ export type BranchReactComponentTree = {
 };
 
 export type ComponentTreeState = {
-  branchedComponentTrees: Array<BranchReactComponentTree>,
   componentType: void | ECMAScriptSourceFunctionValue,
   deadEnds: number,
   status: "SIMPLE" | "COMPLEX",
@@ -110,6 +109,7 @@ export class Reconciler {
     this.alreadyEvaluatedNestedClosures = new Set();
     this.componentTreeConfig = componentTreeConfig;
     this.nestedOptimizedClosures = [];
+    this.branchedComponentTrees = [];
   }
 
   realm: Realm;
@@ -122,6 +122,7 @@ export class Reconciler {
   componentTreeConfig: ReactComponentTreeConfig;
   currentEffectsStack: Array<Effects>;
   nestedOptimizedClosures: Array<OptimizedClosure>;
+  branchedComponentTrees: Array<BranchReactComponentTree>;
 
   renderReactComponentTree(
     componentType: ECMAScriptSourceFunctionValue,
@@ -266,6 +267,7 @@ export class Reconciler {
             baseObject instanceof AbstractObjectValue ||
             baseObject instanceof UndefinedValue
         );
+        debugger;
         let value = getValueFromFunctionCall(this.realm, func, baseObject, args);
         invariant(componentType instanceof Value);
         invariant(context instanceof ObjectValue || context instanceof AbstractObjectValue);
@@ -308,6 +310,7 @@ export class Reconciler {
     context: ObjectValue | AbstractObjectValue | null,
     branchState: BranchState | null
   ): void {
+    debugger;
     this.nestedOptimizedClosures.push({
       evaluatedNode,
       func,
@@ -327,7 +330,7 @@ export class Reconciler {
   ) {
     invariant(rootValue instanceof ECMAScriptSourceFunctionValue || rootValue instanceof AbstractValue);
     this.componentTreeState.deadEnds++;
-    this.componentTreeState.branchedComponentTrees.push({
+    this.branchedComponentTrees.push({
       context,
       evaluatedNode,
       props,
@@ -751,7 +754,6 @@ export class Reconciler {
 
   _createComponentTreeState(): ComponentTreeState {
     return {
-      branchedComponentTrees: [],
       componentType: undefined,
       deadEnds: 0,
       status: "SIMPLE",

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -267,7 +267,6 @@ export class Reconciler {
             baseObject instanceof AbstractObjectValue ||
             baseObject instanceof UndefinedValue
         );
-        debugger;
         let value = getValueFromFunctionCall(this.realm, func, baseObject, args);
         invariant(componentType instanceof Value);
         invariant(context instanceof ObjectValue || context instanceof AbstractObjectValue);
@@ -310,7 +309,6 @@ export class Reconciler {
     context: ObjectValue | AbstractObjectValue | null,
     branchState: BranchState | null
   ): void {
-    debugger;
     this.nestedOptimizedClosures.push({
       evaluatedNode,
       func,

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -232,8 +232,13 @@ export class Functions {
         evaluatedRootNode,
         environmentRecordIdAfterGlobalCode
       );
-      this._optimizeReactComponentTreeBranches(reconciler, environmentRecordIdAfterGlobalCode);
-      this._optimizeReactNestedClosures(reconciler, environmentRecordIdAfterGlobalCode);
+
+      let startingComponentTreeBranches = 0;
+      do {
+        startingComponentTreeBranches = reconciler.branchedComponentTrees.length;
+        this._optimizeReactComponentTreeBranches(reconciler, environmentRecordIdAfterGlobalCode);
+        this._optimizeReactNestedClosures(reconciler, environmentRecordIdAfterGlobalCode);
+      } while (startingComponentTreeBranches !== reconciler.branchedComponentTrees.length);
     }
   }
 
@@ -290,11 +295,10 @@ export class Functions {
   }
 
   _optimizeReactComponentTreeBranches(reconciler: Reconciler, environmentRecordIdAfterGlobalCode: number): void {
-    let componentTreeState = reconciler.componentTreeState;
     let logger = this.moduleTracer.modules.logger;
     // for now we just use abstract props/context, in the future we'll create a new branch with a new component
     // that used the props/context. It will extend the original component and only have a render method
-    for (let { rootValue: branchRootValue, evaluatedNode } of componentTreeState.branchedComponentTrees) {
+    for (let { rootValue: branchRootValue, evaluatedNode } of reconciler.branchedComponentTrees) {
       let branchComponentType = getComponentTypeFromRootValue(this.realm, branchRootValue);
       if (branchComponentType === null) {
         evaluatedNode.status = "UNKNOWN_TYPE";


### PR DESCRIPTION
Release notes: none

The way we currently do it isn't right, there's a better way to ensure we reach all roots. We should now scan more trees with this change as reflected in the existing tests. This PR changes the logic so it loops over the component trees ensuring all new branches are evaluated (they made have been added from evaluating a previous branch).