### PR TITLE
Support inlining dynamic ReactElement "type" fields

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -1121,6 +1121,42 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Dynamic ReactElement type #2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Dynamic ReactElement type 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -4000,6 +4036,42 @@ ReactStatistics {
           "children": Array [],
           "message": "",
           "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Dynamic ReactElement type #2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
           "status": "INLINED",
         },
       ],
@@ -6907,6 +6979,42 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Dynamic ReactElement type #2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Dynamic ReactElement type 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -9751,6 +9859,42 @@ ReactStatistics {
           "children": Array [],
           "message": "",
           "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Dynamic ReactElement type #2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
           "status": "INLINED",
         },
       ],

--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -1121,6 +1121,36 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Dynamic ReactElement type 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -3979,6 +4009,36 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Dynamic ReactElement type 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -6847,6 +6907,36 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Dynamic ReactElement type 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Dynamic context 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -9670,6 +9760,36 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Dynamic ReactElement type 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bar",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -435,6 +435,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
       it("Additional functions closure scope capturing", async () => {
         await runTest(directory, "additional-function-regression.js");
       });
+
+      it("Dynamic ReactElement type", async () => {
+        await runTest(directory, "dynamic-type.js");
+      });
     });
 
     describe("Class component folding", () => {

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -439,6 +439,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
       it("Dynamic ReactElement type", async () => {
         await runTest(directory, "dynamic-type.js");
       });
+
+      it("Dynamic ReactElement type #2", async () => {
+        await runTest(directory, "dynamic-type2.js");
+      });
     });
 
     describe("Class component folding", () => {

--- a/src/react/branching.js
+++ b/src/react/branching.js
@@ -75,7 +75,7 @@ export class BranchState {
     }
   }
 
-  applyBranchedLogic(realm: Realm, reactSerializerState: ReactSerializerState): void {
+  applyBranchedLogic(realm: Realm, reactSerializerState: ReactSerializerState): boolean {
     let reactElementType;
     let applyBranchedLogic = false;
 
@@ -93,7 +93,20 @@ export class BranchState {
       for (let i = 0; i < this._branchesToValidate.length; i++) {
         this._applyBranchedLogicValue(realm, reactSerializerState, this._branchesToValidate[i].value);
       }
+      return true;
     }
+    return false;
+  }
+
+  mergeBranchedLogic(siblingBranchState: BranchState): void {
+    this._branchesToValidate.push(...siblingBranchState.getBranchesToValidate());
+  }
+
+  getBranchesToValidate(): Array<{
+    type: Value,
+    value: Value,
+  }> {
+    return this._branchesToValidate;
   }
 
   captureBranchedValue(type: Value, value: Value): Value {

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -147,3 +147,21 @@ export function createReactElement(
   obj.makeFinal();
   return obj;
 }
+
+export function createInternalReactElement(
+  realm: Realm,
+  type: Value,
+  key: Value,
+  ref: Value,
+  props: ObjectValue | AbstractValue
+) {
+  let obj = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
+  Create.CreateDataPropertyOrThrow(realm, obj, "$$typeof", getReactSymbol("react.element", realm));
+  Create.CreateDataPropertyOrThrow(realm, obj, "type", type);
+  Create.CreateDataPropertyOrThrow(realm, obj, "key", key);
+  Create.CreateDataPropertyOrThrow(realm, obj, "ref", ref);
+  Create.CreateDataPropertyOrThrow(realm, obj, "props", props);
+  Create.CreateDataPropertyOrThrow(realm, obj, "_owner", realm.intrinsics.null);
+  obj.makeFinal();
+  return obj;
+}

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -136,16 +136,7 @@ export function createReactElement(
   children: Value
 ) {
   let { key, props, ref } = createPropsObject(realm, type, config, children);
-
-  let obj = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
-  Create.CreateDataPropertyOrThrow(realm, obj, "$$typeof", getReactSymbol("react.element", realm));
-  Create.CreateDataPropertyOrThrow(realm, obj, "type", type);
-  Create.CreateDataPropertyOrThrow(realm, obj, "key", key);
-  Create.CreateDataPropertyOrThrow(realm, obj, "ref", ref);
-  Create.CreateDataPropertyOrThrow(realm, obj, "props", props);
-  Create.CreateDataPropertyOrThrow(realm, obj, "_owner", realm.intrinsics.null);
-  obj.makeFinal();
-  return obj;
+  return createInternalReactElement(realm, type, key, ref, props);
 }
 
 export function createInternalReactElement(

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -61,6 +61,7 @@ import { AbruptCompletion, Completion } from "../completions.js";
 import { Logger } from "../utils/logger.js";
 import type { ClassComponentMetadata, ReactComponentTreeConfig } from "../types.js";
 import { createAbstractArgument } from "../intrinsics/prepack/utils.js";
+import { createInternalReactElement } from "./elements.js";
 
 type ComponentResolutionStrategy =
   | "NORMAL"
@@ -321,7 +322,6 @@ export class Reconciler {
   _queueNewComponentTree(
     rootValue: Value,
     evaluatedNode: ReactEvaluatedNode,
-    nested?: boolean = false,
     props?: ObjectValue | AbstractObjectValue | null = null,
     context?: ObjectValue | AbstractObjectValue | null = null
   ) {
@@ -812,6 +812,53 @@ export class Reconciler {
     return value;
   }
 
+  _resolveBranchedComponentType(
+    componentType: Value,
+    reactElement: ObjectValue,
+    context: ObjectValue | AbstractObjectValue,
+    branchStatus: BranchStatusEnum,
+    branchState: BranchState | null,
+    evaluatedNode: ReactEvaluatedNode
+  ) {
+    let typeValue = getProperty(this.realm, reactElement, "type");
+    let propsValue = getProperty(this.realm, reactElement, "props");
+    let keyValue = getProperty(this.realm, reactElement, "key");
+    let refValue = getProperty(this.realm, reactElement, "ref");
+
+    const resolveBranch = (abstract: AbstractValue): AbstractValue => {
+      let condition = abstract.args[0];
+      invariant(condition instanceof AbstractValue);
+      let left = abstract.args[1];
+      let right = abstract.args[2];
+
+      if (left instanceof AbstractValue && left.kind === "conditional") {
+        left = resolveBranch(left);
+      } else {
+        invariant(propsValue instanceof ObjectValue || propsValue instanceof AbstractValue);
+        left = createInternalReactElement(this.realm, left, keyValue, refValue, propsValue);
+      }
+      if (right instanceof AbstractValue && right.kind === "conditional") {
+        right = resolveBranch(right);
+      } else {
+        invariant(propsValue instanceof ObjectValue || propsValue instanceof AbstractValue);
+        right = createInternalReactElement(this.realm, right, keyValue, refValue, propsValue);
+      }
+      let val = AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
+      invariant(val instanceof AbstractValue);
+      return val;
+    };
+    invariant(typeValue instanceof AbstractValue);
+
+    return this._resolveAbstractValue(
+      componentType,
+      resolveBranch(typeValue),
+      context,
+      branchStatus,
+      branchState,
+      evaluatedNode
+    );
+  }
+
   _resolveUnknownComponentType(reactElement: ObjectValue, evaluatedNode: ReactEvaluatedNode) {
     let typeValue = getProperty(this.realm, reactElement, "type");
     let propsValue = getProperty(this.realm, reactElement, "props");
@@ -987,6 +1034,16 @@ export class Reconciler {
 
       switch (componentResolutionStrategy) {
         case "NORMAL": {
+          if (typeValue instanceof AbstractValue && typeValue.kind === "conditional") {
+            return this._resolveBranchedComponentType(
+              componentType,
+              reactElement,
+              context,
+              branchStatus,
+              branchState,
+              evaluatedNode
+            );
+          }
           if (
             !(typeValue instanceof ECMAScriptSourceFunctionValue || valueIsKnownReactAbstraction(this.realm, typeValue))
           ) {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -244,17 +244,6 @@ export function convertSimpleClassComponentToFunctionalComponent(
   prototype.descriptor.configurable = true;
   Properties.DeletePropertyOrThrow(realm, complexComponentType, "prototype");
 
-  // fix the length as we've changed the arguments
-  let lengthProperty = GetDescriptorForProperty(complexComponentType, "length");
-  invariant(lengthProperty);
-  lengthProperty.writable = false;
-  lengthProperty.enumerable = false;
-  lengthProperty.configurable = true;
-  // ensure the length value is set to the new value
-  let lengthValue = Get(realm, complexComponentType, "length");
-  invariant(lengthValue instanceof NumberValue);
-  lengthValue.value = 2;
-
   // change the function kind
   complexComponentType.$FunctionKind = "normal";
   // set the prototype back to an object
@@ -436,6 +425,17 @@ export function convertFunctionalComponentToComplexClassComponent(
 }
 
 export function normalizeFunctionalComponentParamaters(func: ECMAScriptSourceFunctionValue): void {
+  // fix the length as we may change the arguments
+  let lengthProperty = GetDescriptorForProperty(func, "length");
+  invariant(lengthProperty);
+  lengthProperty.writable = false;
+  lengthProperty.enumerable = false;
+  lengthProperty.configurable = true;
+  // ensure the length value is set to the new value
+  let lengthValue = Get(func.$Realm, func, "length");
+  invariant(lengthValue instanceof NumberValue);
+  lengthValue.value = 2;
+
   func.$FormalParameters = func.$FormalParameters.map((param, i) => {
     if (i === 0) {
       return t.isIdentifier(param) ? param : t.identifier("props");

--- a/test/react/functional-components/dynamic-type.js
+++ b/test/react/functional-components/dynamic-type.js
@@ -1,0 +1,28 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Foo(props) {
+  return <span>{props.name}</span>;
+}
+
+function Bar(props) {
+  return <div>{props.name}</div>;
+}
+
+function App(props) {
+  let Type = props.switch ? Foo : Bar;
+
+  return <Type name={"Dominic"} />
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['render with dynamic prop access', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/dynamic-type2.js
+++ b/test/react/functional-components/dynamic-type2.js
@@ -11,9 +11,9 @@ function Bar(props) {
 }
 
 function App(props) {
-  let Type = props.switch ? Foo : Bar;
+  let Type = props.switch ? (props.switch ? Foo : Bar) : Bar;
 
-  return <Type name={"Dominic"} />
+  return <Type name={"Dan"} />
 }
 
 App.getTrials = function(renderer, Root) {


### PR DESCRIPTION
Release notes: none

This adds a really cool feature – dynamic ReactElement type. As per a conversation in Messenger yesterday by @gaearon, it got me thinking about how we might "simplify" recursively on a conditional in complex cases and I decided it was probably worth adding to inline components. This PR makes it possible to inline component trees without having to break out when the type is an abstract conditional.