### PR TITLE
Refactored visiting/serialization of bindings

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -312,6 +312,8 @@ export class ResidualHeapVisitor {
   }
 
   visitValueArray(val: ObjectValue): void {
+    this._registerAdditionalRoot(val);
+
     this.visitObjectProperties(val);
     const realm = this.realm;
     let lenProperty;
@@ -456,7 +458,8 @@ export class ResidualHeapVisitor {
         invariant(functionInfo);
         for (let innerName of functionInfo.unbound) {
           let environment = this.resolveBinding(val, innerName);
-          let residualBinding = this.visitBinding(val, environment, innerName);
+          let residualBinding = this.getBinding(val, environment, innerName);
+          this.visitBinding(val, residualBinding);
           invariant(residualBinding !== undefined);
           residualFunctionBindings.set(innerName, residualBinding);
           if (functionInfo.modified.has(innerName)) {
@@ -539,15 +542,12 @@ export class ResidualHeapVisitor {
   }
 
   // Visits a binding, returns a ResidualFunctionBinding
-  visitBinding(val: FunctionValue, environment: EnvironmentRecord, name: string): ResidualFunctionBinding {
+  getBinding(val: FunctionValue, environment: EnvironmentRecord, name: string): ResidualFunctionBinding {
     if (environment === this.globalEnvironmentRecord.$DeclarativeRecord) environment = this.globalEnvironmentRecord;
 
-    let residualFunctionBinding;
-    let createdBinding;
     if (environment === this.globalEnvironmentRecord) {
       // Global Binding
-      createdBinding = !this.globalBindings.has(name);
-      residualFunctionBinding = getOrDefault(
+      return getOrDefault(
         this.globalBindings,
         name,
         () =>
@@ -566,8 +566,7 @@ export class ResidualHeapVisitor {
         environment,
         () => new Map()
       );
-      createdBinding = !residualFunctionBindings.has(name);
-      residualFunctionBinding = getOrDefault(residualFunctionBindings, name, (): ResidualFunctionBinding => {
+      return getOrDefault(residualFunctionBindings, name, (): ResidualFunctionBinding => {
         invariant(environment instanceof DeclarativeEnvironmentRecord);
         let binding = environment.bindings[name];
         invariant(binding !== undefined);
@@ -579,8 +578,13 @@ export class ResidualHeapVisitor {
           potentialReferentializationScopes: new Set(),
         };
       });
-      if (createdBinding)
-        residualFunctionBinding.potentialReferentializationScopes.add(this.containingAdditionalFunction || "GLOBAL");
+    }
+  }
+
+  // Visits a binding, returns a ResidualFunctionBinding
+  visitBinding(val: FunctionValue, residualFunctionBinding: ResidualFunctionBinding): ResidualFunctionBinding {
+    if (residualFunctionBinding.declarativeEnvironmentRecord !== null) {
+      residualFunctionBinding.potentialReferentializationScopes.add(this.containingAdditionalFunction || "GLOBAL");
       this._recordBindingVisitedAndRevisit(val, residualFunctionBinding);
     }
     if (residualFunctionBinding.value) {
@@ -736,6 +740,8 @@ export class ResidualHeapVisitor {
   }
 
   visitValueProxy(val: ProxyValue): void {
+    this._registerAdditionalRoot(val);
+
     this.visitValue(val.$ProxyTarget);
     this.visitValue(val.$ProxyHandler);
   }
@@ -860,12 +866,10 @@ export class ResidualHeapVisitor {
         invariant(additionalFunctionInfo);
         let { functionValue } = additionalFunctionInfo;
         invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
-        let code = functionValue.$ECMAScriptCode;
-        let functionInfo = this.functionInfos.get(code);
         let residualBinding;
         this._withScope(functionValue, () => {
-          // Also visit the original value of the binding
-          residualBinding = this.visitBinding(functionValue, modifiedBinding.environment, modifiedBinding.name);
+          residualBinding = this.getBinding(functionValue, modifiedBinding.environment, modifiedBinding.name);
+          this.visitBinding(functionValue, residualBinding);
           invariant(residualBinding !== undefined);
           // named functions inside an additional function that have a global binding
           // can be skipped, as we don't want them to bind to the global
@@ -876,12 +880,6 @@ export class ResidualHeapVisitor {
             residualBinding = null;
             return;
           }
-          // Fixup the binding to have the correct value
-          // No previousValue means this is a binding for a nested function
-          if (previousValue && residualBinding.value === modifiedBinding.value)
-            residualBinding.value = this.visitEquivalentValue(previousValue);
-          invariant(functionInfo !== undefined);
-          if (functionInfo.modified.has(modifiedBinding.name)) residualBinding.modified;
         });
         if (residualBinding === null) return;
         invariant(residualBinding);
@@ -993,11 +991,15 @@ export class ResidualHeapVisitor {
           prevReVisit.set(value, additionalParentGenerators);
           this.visitValue(value);
         }
-        for (let innerName of functionInfo.unbound) {
-          let environment = this.resolveBinding(functionValue, innerName);
-          let residualBinding = this.visitBinding(functionValue, environment, innerName);
+        for (let { modifiedBinding, oldValue } of additionalEffects.generator.getModifiedBindings()) {
+          invariant(oldValue !== undefined);
+          let residualBinding = this.getBinding(functionValue, modifiedBinding.environment, modifiedBinding.name);
+          // Fixup the binding to have the correct value
+          // No previousValue means this is a binding for a nested function
+          residualBinding.value = this.visitEquivalentValue(oldValue);
+          this.visitBinding(functionValue, residualBinding);
           invariant(residualBinding !== undefined);
-          funcInstance.residualFunctionBindings.set(innerName, residualBinding);
+          funcInstance.residualFunctionBindings.set(modifiedBinding.name, residualBinding);
           // TODO nested optimized functions: revisit adding GLOBAL as outer optimized function
           residualBinding.potentialReferentializationScopes.add("GLOBAL");
         }
@@ -1016,11 +1018,6 @@ export class ResidualHeapVisitor {
       this._visitReactLibrary(this.someReactElement);
     }
 
-    // Make sure to visit all global bindings in global scope
-    this._withScope(generator, () => {
-      for (let binding of this.globalBindings.values()) if (binding.value) this.visitValue(binding.value);
-    });
-
     // Do a fixpoint over all pure generator entries to make sure that we visit
     // arguments of only BodyEntries that are required by some other residual value
     let oldDelayedEntries = [];
@@ -1035,21 +1032,14 @@ export class ResidualHeapVisitor {
       }
     }
 
-    let referentializer = this.referentializer;
-    if (referentializer !== undefined) {
-      let bodyToInstances = new Map();
-      for (let instance of this.functionInstances.values()) {
-        let code = instance.functionValue.$ECMAScriptCode;
-        invariant(code !== undefined);
-        getOrDefault(bodyToInstances, code, () => []).push(instance);
-      }
+    // Make sure to visit all global bindings in global scope
+    this._withScope(generator, () => {
+      for (let binding of this.globalBindings.values()) if (binding.value) this.visitValue(binding.value);
+    });
 
-      for (let [funcBody, instances] of bodyToInstances) {
-        let functionInfo = this.functionInfos.get(funcBody);
-        invariant(functionInfo !== undefined);
-        referentializer.referentialize(functionInfo.unbound, instances);
-      }
-    }
+    let referentializer = this.referentializer;
+    if (referentializer !== undefined)
+      for (let instance of this.functionInstances.values()) referentializer.referentialize(instance);
   }
 
   _visitReactLibrary(someReactElement: ObjectValue) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -991,7 +991,7 @@ export class ResidualHeapVisitor {
           prevReVisit.set(value, additionalParentGenerators);
           this.visitValue(value);
         }
-        for (let { modifiedBinding, oldValue } of additionalEffects.generator.getModifiedBindings()) {
+        for (let [modifiedBinding, oldValue] of additionalEffects.generator.getModifiedBindingOldValues()) {
           invariant(oldValue !== undefined);
           let residualBinding = this.getBinding(functionValue, modifiedBinding.environment, modifiedBinding.name);
           // Fixup the binding to have the correct value

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -221,6 +221,7 @@ class ModifiedBindingEntry extends GeneratorEntry {
       invariant(this.modifiedBinding.value instanceof FunctionValue);
       return;
     }
+    invariant(residualFunctionBinding.referentialized);
     invariant(this.modifiedBinding.value === this.newValue);
     invariant(
       residualFunctionBinding.serializedValue,
@@ -894,6 +895,20 @@ export class Generator {
     }
 
     return res;
+  }
+
+  getModifiedBindings(): Set<{ modifiedBinding: Binding, oldValue: void | Value }> {
+    let result = new Set();
+    let visit = generator => {
+      for (let entry of generator._entries) {
+        if (entry instanceof ModifiedBindingEntry)
+          result.add({ modifiedBinding: entry.modifiedBinding, oldValue: entry.oldValue });
+        if (entry instanceof TemporalBuildNodeEntry && entry.dependencies)
+          for (let dependency of entry.dependencies) visit(dependency);
+      }
+    };
+    visit(this);
+    return result;
   }
 
   visit(callbacks: VisitEntryCallbacks) {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -897,14 +897,27 @@ export class Generator {
     return res;
   }
 
-  getModifiedBindings(): Set<{ modifiedBinding: Binding, oldValue: void | Value }> {
-    let result = new Set();
+  // This function does a deep traversal of this and all dependent generators
+  // in order to find all ModifiedBindingEntry entries.
+  // Their modifiedBinding and oldValue properties are eventually returned.
+  // Note that the modifiedBindings set is different from effectsToApply[2],
+  // and the old values are meaningful without effectsToApply being applied.
+  getModifiedBindingOldValues(): Map<Binding, void | Value> {
+    let result = new Map();
     let visit = generator => {
       for (let entry of generator._entries) {
-        if (entry instanceof ModifiedBindingEntry)
-          result.add({ modifiedBinding: entry.modifiedBinding, oldValue: entry.oldValue });
-        if (entry instanceof TemporalBuildNodeEntry && entry.dependencies)
-          for (let dependency of entry.dependencies) visit(dependency);
+        if (entry instanceof ModifiedBindingEntry) {
+          if (!result.has(entry.modifiedBinding)) result.set(entry.modifiedBinding, entry.oldValue);
+        } else if (entry instanceof TemporalBuildNodeEntry) {
+          if (entry.dependencies) for (let dependency of entry.dependencies) visit(dependency);
+        } else if (entry instanceof PossiblyNormalReturnEntry) {
+          for (let dependency of [entry.consequentGenerator, entry.alternateGenerator]) visit(dependency);
+        } else {
+          invariant(
+            entry instanceof ReturnValueEntry || entry instanceof ModifiedPropertyEntry,
+            entry.constructor.name
+          );
+        }
       }
     };
     visit(this);


### PR DESCRIPTION
Release notes: None

- for additional functions, ignore the statically inferred "unbound" identifiers, instead go just by actually detected modified bindings
- deleted some referentialization code I didn't understand and which caused issues
- arrays and proxies need to be considered as additional roots
- fixed bug where an additional root got inlined