### PR TITLE
Cache describeLocation value to prevent stack overflows

### DIFF
--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -31,6 +31,13 @@ export function describeLocation(
   let displayName = "";
 
   if (callerFn) {
+    if (realm.alreadyDescribedLocations.has(callerFn)) {
+      return realm.alreadyDescribedLocations.get(callerFn);
+    }
+    realm.alreadyDescribedLocations.set(callerFn, undefined);
+  }
+
+  if (callerFn) {
     if (callerFn instanceof NativeFunctionValue) {
       locString = "native";
     }
@@ -52,11 +59,16 @@ export function describeLocation(
     }
   }
 
+  let location;
   if (displayName) {
-    return `at ${displayName} (${locString})`;
+    location = `at ${displayName} (${locString})`;
   } else {
-    return `at ${locString}`;
+    location = `at ${locString}`;
   }
+  if (callerFn) {
+    realm.alreadyDescribedLocations.set(callerFn, location);
+  }
+  return location;
 }
 
 function buildStack(realm: Realm, context: ObjectValue) {

--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -30,14 +30,16 @@ export function describeLocation(
   let locString = "";
   let displayName = "";
 
+  // check if we've already encountered the callFn and if so
+  // re-use that described location. plus we may get stuck trying
+  // to get the location by recursively checking the same fun
+  // so this also prevents a stack overflow
   if (callerFn) {
     if (realm.alreadyDescribedLocations.has(callerFn)) {
       return realm.alreadyDescribedLocations.get(callerFn);
     }
     realm.alreadyDescribedLocations.set(callerFn, undefined);
-  }
 
-  if (callerFn) {
     if (callerFn instanceof NativeFunctionValue) {
       locString = "native";
     }

--- a/src/realm.js
+++ b/src/realm.js
@@ -209,6 +209,7 @@ export class Realm {
       verbose: opts.reactVerbose || false,
     };
 
+    this.alreadyDescribedLocations = new WeakMap();
     this.stripFlow = opts.stripFlow || false;
 
     this.fbLibraries = {
@@ -280,6 +281,7 @@ export class Realm {
     symbols: Map<ReactSymbolTypes, SymbolValue>,
     verbose: boolean,
   };
+  alreadyDescribedLocations: WeakMap<FunctionValue, string | void>;
   stripFlow: boolean;
 
   fbLibraries: {


### PR DESCRIPTION
Release notes: none

This caches the values from describeLocation in the Realm to prevent stack overflows from occurring on the UFI.