### PR TITLE
Reduce serialization noise by using length value internally

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -432,7 +432,7 @@ export function normalizeFunctionalComponentParamaters(func: ECMAScriptSourceFun
   lengthProperty.enumerable = false;
   lengthProperty.configurable = true;
   // ensure the length value is set to the new value
-  let lengthValue = Get(func.$Realm, func, "length");
+  let lengthValue = lengthProperty.value;
   invariant(lengthValue instanceof NumberValue);
   lengthValue.value = 2;
 


### PR DESCRIPTION
Release notes: none

As we are doing a `Get` this results in a generator entry with the property get in the render bodies, which is just noise. If we access the internal value directly, we don't emit a generator entry, meaning less noise.