### PR TITLE
Some missing additions to havocing/makeFinal

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -67,7 +67,8 @@ function deriveGetBinding(realm: Realm, binding: Binding) {
 
 export function havocBinding(binding: Binding) {
   let realm = binding.environment.realm;
-  if (!binding.hasLeaked) {
+  let value = binding.value;
+  if (!binding.hasLeaked && (value instanceof ObjectValue && !value.isFinalObject())) {
     realm.recordModifiedBinding(binding).hasLeaked = true;
   }
 }

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -599,5 +599,6 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
   reactPropTypesValue.intrinsicName = `require("${reactRequireName}").PropTypes`;
 
   reactValue.refuseSerialization = false;
+  reactValue.makeFinal();
   return reactValue;
 }

--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -73,5 +73,6 @@ export function createMockReactRelay(realm: Realm, relayRequireName: string): Ob
 
   // we set refuseSerialization back to false
   reactRelay.refuseSerialization = false;
+  reactRelay.makeFinal();
   return reactRelay;
 }


### PR DESCRIPTION
Release notes: none

Missing from changes to unblock UFI work, these changes are around makeFinal and havocing in relation to the React/Relay bindings.