### PR TITLE
Small createdObjects change to visitor

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -905,7 +905,7 @@ export class ResidualHeapVisitor {
     };
   }
 
-  _getObjectsCreatedByIncludingAdditionalFunction(generator: Generator) {
+  _getObjectsCreatedByIncludingAdditionalFunction(generator: Generator): Set<ObjectValue> {
     const s = new Set();
     for (let g = generator; g !== undefined; g = this.generatorParents.get(g))
       if (g.effectsToApply !== undefined) for (const createdObject of g.effectsToApply[4]) s.add(createdObject);


### PR DESCRIPTION
Release notes: None

Deleting redundant code to set up createObjects.
Changing definition of set of createdObjects: Let it be all objects created in additional function that includes the current generator
(instead of being some growing set that depends on the visiting order).