### PR TITLE
Make __optimize calls in optimized functions work

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -280,6 +280,13 @@ export class Emitter {
 
     let val = ((dependencies: any): Value);
     if (this._activeValues.has(val)) {
+
+      // If a value is active and it's a function, then we still shouldn't wait on it.
+      if (val instanceof FunctionValue && !(val instanceof BoundFunctionValue)) {
+        // We ran into a function value.
+        result = callbacks.onFunction ? callbacks.onFunction(val) : undefined;
+        return result;
+      }
       // We ran into a cyclic dependency, where the value we are dependending on is still in the process of being emitted.
       result = callbacks.onActive ? callbacks.onActive(val) : undefined;
       if (result !== undefined) return result;

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -117,7 +117,6 @@ export class Emitter {
       this._activeGeneratorStack.push(targetBody);
     }
     if (isChild) {
-      invariant(targetBody.type === "Generator" || targetBody.type === "ConditionalAssignmentBranch");
       targetBody.parentBody = this._body;
       targetBody.nestingLevel = (this._body.nestingLevel || 0) + 1;
     }

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -280,7 +280,6 @@ export class Emitter {
 
     let val = ((dependencies: any): Value);
     if (this._activeValues.has(val)) {
-
       // If a value is active and it's a function, then we still shouldn't wait on it.
       if (val instanceof FunctionValue && !(val instanceof BoundFunctionValue)) {
         // We ran into a function value.

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1853,7 +1853,7 @@ export class ResidualHeapSerializer {
           return null;
         }, additionalEffects.effects);
       },
-      inAdditionalFunction
+      !!inAdditionalFunction
     );
   }
 

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -92,8 +92,17 @@ export class Functions {
       return null;
     }
 
+    let location = value.expressionLocation
+      ? `${value.expressionLocation.start.line}:${value.expressionLocation.start.column} ` +
+        `${value.expressionLocation.end.line}:${value.expressionLocation.end.line}`
+      : "location unknown";
     realm.handleError(
-      new CompilerDiagnostic(`Additional Function Value ${0} is an invalid value`, undefined, "PP0001", "FatalError")
+      new CompilerDiagnostic(
+        `Additional Function Value ${location} is an invalid value`,
+        undefined,
+        "PP0001",
+        "FatalError"
+      )
     );
     throw new FatalError("invalid Additional Function value");
   }

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -403,6 +403,8 @@ export class Functions {
           if (newEntry) {
             additionalFunctions.add(newEntry.value);
             additionalFunctionsToProcess.push(newEntry);
+            // TODO: process nested additional functions correctly by applying funcValue's effects
+            // and processing them right here
           }
         }
       }

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -65,12 +65,7 @@ export class Functions {
   moduleTracer: ModuleTracer;
   writeEffects: Map<FunctionValue, AdditionalFunctionEffects>;
 
-  __optimizedFunctionEntryOfValue(
-    value: Value
-  ): {
-    value: ECMAScriptSourceFunctionValue | AbstractValue,
-    config?: ReactComponentTreeConfig,
-  } | void {
+  __optimizedFunctionEntryOfValue(value: Value): AdditionalFunctionEntry | void {
     let realm = this.realm;
     if (value instanceof ECMAScriptSourceFunctionValue) {
       // additional function logic
@@ -98,13 +93,13 @@ export class Functions {
       : "location unknown";
     realm.handleError(
       new CompilerDiagnostic(
-        `Additional Function Value ${location} is an invalid value`,
+        `Optimized Function Value ${location} is an not a function or react element`,
         undefined,
-        "PP0001",
+        "PP0033",
         "FatalError"
       )
     );
-    throw new FatalError("invalid Additional Function value");
+    throw new FatalError("Optimized Function Values must be functions or react elements");
   }
 
   __generateInitialAdditionalFunctions(globalKey: string) {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -39,6 +39,9 @@ export type SerializedBody = {
 };
 
 export type AdditionalFunctionEffects = {
+  // All of these effects must be applied for this additional function
+  // to be properly setup
+  parentAdditionalFunction: FunctionValue | void,
   effects: Effects,
   generator: Generator,
   transforms: Array<Function>,

--- a/test/serializer/additional-functions/NestedOptimizedFunction1.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction1.js
@@ -1,0 +1,13 @@
+// does not contain:1 + 2
+// (It fails because 1 + 2 not (yet) getting optimized, as nested calls to __optimize seem to just get ignored?)
+(function () {
+    function g() {
+        return 1 + 2;
+    }
+    function f() {
+        if (global.__optimize) __optimize(g); // This call seems to be just getting ignored?
+        return g;
+    }
+    if (global.__optimize) __optimize(f);
+    global.inspect = function() { return f()(); }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction10.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction10.js
@@ -1,0 +1,17 @@
+(function () {
+    function f() {
+        var shared = {};
+        function g() {
+            return shared;
+        }
+        return g;
+    }
+    var g = f();
+    if (global.__optimize) {
+        __optimize(f);
+        __optimize(g);
+    }
+    global.inspect = function() { 
+        return f()() !== g();
+    }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction11.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction11.js
@@ -1,0 +1,21 @@
+(function () {
+    function f() {
+        var shared = {};
+        function g0() {
+            return shared;
+        }
+        function g1() {
+            return shared;
+        }
+        if (global.__optimize) {
+            __optimize(g0);
+            __optimize(g1);
+        }
+        return [g0, g1];
+    }
+    if (global.__optimize) __optimize(f);
+    global.inspect = function() {
+        var a = f();
+        return a[0]() === a[1]();
+    }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction12.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction12.js
@@ -1,0 +1,20 @@
+(function () {
+    function f() {
+        var shared = {huge: {huge: {huge: {huge: {huge: {huge: {huge: 42}}}}}}};
+        function g0() {
+            return shared;
+        }
+        function g1() {
+            return shared;
+        }
+        if (global.__optimize) {
+            __optimize(g0);
+            __optimize(g1);
+        }
+        return [g0, g1];
+    }
+    var a = f();
+    global.inspect = function() {
+        return a[0]() === a[1]();
+    }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction13.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction13.js
@@ -1,0 +1,23 @@
+(function () {
+    function f() {
+        let shared = Date.now();
+        function g0() {
+            return [shared, Date.now()];
+        }
+        function g1() {
+            return [shared, Date.now()];
+        }
+        if (global.__optimize) {
+            __optimize(g0);
+            __optimize(g1);
+        }
+        return [g0, g1];
+    }
+    if (global.__optimize) __optimize(f);
+    global.inspect = function() {
+        var a = f();
+        var a0 = a[0]();
+        var a1 = a[1]();
+        return a0[0] === a1[0] && a0[1] <= a1[1];
+    }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction14.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction14.js
@@ -1,0 +1,15 @@
+(function () {
+    function f(x, y, z) {
+        var g;
+        if (x) g = function() { return y; }
+        else g = function() { return z; }
+        if (global.__optimize) __optimize(g);
+        return g;
+    }
+    if (global.__optimize) __optimize(f);
+    global.inspect = function() {
+        let y = f(true, 42, 23)();
+        let z = f(false, 42, 23)();
+        return y + "|" + z;
+    }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction2.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction2.js
@@ -1,9 +1,9 @@
 // does not contain:1 + 2
 (function () {
-    function g() {
-        return 1 + 2;
-    }
     function f() {
+        function g() {
+            return 1 + 2;
+        }
         if (global.__optimize) __optimize(g);
         return g;
     }

--- a/test/serializer/additional-functions/NestedOptimizedFunction3.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction3.js
@@ -1,0 +1,11 @@
+(function () {
+    function f() {
+        function g() {
+            return {}; // Must maintain distinct identity of object
+        }
+        if (global.__optimize) __optimize(g);
+        return [g, g];
+    }
+    if (global.__optimize) __optimize(f);
+    global.inspect = function() { var a = f(); return a[0]() !== a[1](); }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction4.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction4.js
@@ -1,0 +1,12 @@
+(function () {
+    function f() {
+        var shared = {};
+        function g() {
+            return shared;
+        }
+        if (global.__optimize) __optimize(g);
+        return [g, g, shared];
+    }
+    if (global.__optimize) __optimize(f);
+    global.inspect = function() { var a = f(); return a[2] == a[0]() && a[2] == a[1](); }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction6.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction6.js
@@ -1,0 +1,21 @@
+(function () {
+    function f() {
+        var shared = {};
+        function g() {
+            var unique = {};
+            return [shared, unique];
+        }
+        if (global.__optimize) __optimize(g);
+        return [g, g, shared];
+    }
+    if (global.__optimize) __optimize(f);
+    global.inspect = function() { 
+        var a = f(); 
+        let a0 = a[0]();
+        let a1 = a[1]();
+        let shared = a[2];
+      return a0[0] === shared && a1[0] === shared && 
+        a0[1] !== shared && a1[1] !== shared &&
+        a0[1] !== a1[1];
+    }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction7.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction7.js
@@ -1,0 +1,21 @@
+// (It fails because of an output mismatch.)
+
+(function () {
+    function f() {
+        var shared = {};
+        function g() {
+            return shared;
+        }
+        return [g, g];
+    }
+    var a = f();
+    var g0 = a[0];
+    var g1 = a[1];
+    if (global.__optimize) {
+        __optimize(g0);
+        __optimize(g1);
+    }
+    global.inspect = function() { 
+        return g0() === g1();
+    }
+})();

--- a/test/serializer/additional-functions/NestedOptimizedFunction8.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction8.js
@@ -13,7 +13,7 @@
         __optimize(g0);
         __optimize(g1);
     }
-    global.inspect = function() { 
+    global.inspect = function() {
         return g0() === g1();
     }
 })();

--- a/test/serializer/additional-functions/NestedOptimizedFunction8.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction8.js
@@ -1,0 +1,19 @@
+// Copies of 42:1
+(function () {
+    function f(x) {
+        function g() {
+            return x;
+        }
+        return g;
+    }
+    var shared = {x: 42};
+    var g0 = f(shared);
+    var g1 = f(shared);
+    if (global.__optimize) {
+        __optimize(g0);
+        __optimize(g1);
+    }
+    global.inspect = function() { 
+        return g0() === g1();
+    }
+})();

--- a/test/serializer/additional-functions/self_referential_simple.js
+++ b/test/serializer/additional-functions/self_referential_simple.js
@@ -1,0 +1,15 @@
+// does not contain:x = 5;
+
+function func1() {
+  let x = 5;
+  let z = func1;
+  return z;
+}
+
+if (global.__optimize) {
+  __optimize(func1);
+}
+
+inspect = function() {
+  return func1()[0] === func1()[0];
+}


### PR DESCRIPTION
Steals test case from #1626.

`__optimize` calls now search for newly registered functions. This should allow more test cases, which are all included with the diff.

This also changes the serializer to serialize additional functions when they're first encountered in the serializer instead of at the end.