### PR TITLE
Adds more fb-www mocks

### DIFF
--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -234,3 +234,108 @@ export function createFbMocks(realm: Realm, global: ObjectValue | AbstractObject
     createMagicGlobalObject(realm, global, objectName);
   }
 }
+
+export function createMockTimeSlice(realm: Realm, timeSliceRequireName: string): ObjectValue {
+  let timeSlice = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, `require("${timeSliceRequireName}")`, true);
+  timeSlice.makePartial();
+  timeSlice.makeSimple();
+
+  let registerExecutionContextObserverValue = new NativeFunctionValue(
+    realm,
+    undefined,
+    `registerExecutionContextObserver`,
+    1,
+    (context, [obj]) => {
+      AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        FunctionValue,
+        [registerExecutionContextObserverValue, obj],
+        ([methodNode, objNode]) => {
+          return t.callExpression(methodNode, [objNode]);
+        }
+      );
+      return realm.intrinsics.undefined;
+    }
+  );
+  timeSlice.$DefineOwnProperty("registerExecutionContextObserver", {
+    value: registerExecutionContextObserverValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  registerExecutionContextObserverValue.intrinsicName = `require("${timeSliceRequireName}").registerExecutionContextObserver`;
+
+  let catchUpOnDemandExecutionContextObserversValue = new NativeFunctionValue(
+    realm,
+    undefined,
+    `catchUpOnDemandExecutionContextObservers`,
+    1,
+    (context, [obj]) => {
+      AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        FunctionValue,
+        [catchUpOnDemandExecutionContextObserversValue, obj],
+        ([methodNode, objNode]) => {
+          return t.callExpression(methodNode, [objNode]);
+        }
+      );
+      return realm.intrinsics.undefined;
+    }
+  );
+  timeSlice.$DefineOwnProperty("catchUpOnDemandExecutionContextObservers", {
+    value: catchUpOnDemandExecutionContextObserversValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  catchUpOnDemandExecutionContextObserversValue.intrinsicName = `require("${timeSliceRequireName}").catchUpOnDemandExecutionContextObservers`;
+
+  let propagationTypeValue = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
+  propagationTypeValue.makePartial();
+  propagationTypeValue.makeSimple();
+  propagationTypeValue.makeFinal();
+  timeSlice.$DefineOwnProperty("PropagationType", {
+    value: propagationTypeValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  propagationTypeValue.intrinsicName = `require("${timeSliceRequireName}").PropagationType`;
+
+  timeSlice.refuseSerialization = false;
+  return timeSlice;
+}
+
+export function createVisibility(realm: Realm, visibilityName: string): ObjectValue {
+  let visibility = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, `require("${visibilityName}")`, true);
+  visibility.makePartial();
+  visibility.makeSimple();
+
+  let addListenerValue = new NativeFunctionValue(
+    realm,
+    undefined,
+    `addListener`,
+    2,
+    (context, [obj, obj2]) => {
+      AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        FunctionValue,
+        [addListenerValue, obj, obj2],
+        ([methodNode, objNode, objNode2]) => {
+          return t.callExpression(methodNode, [objNode, objNode2]);
+        }
+      );
+      return realm.intrinsics.undefined;
+    }
+  );
+  visibility.$DefineOwnProperty("addListener", {
+    value: addListenerValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  addListenerValue.intrinsicName = `require("${visibilityName}").addListener`;
+
+  visibility.refuseSerialization = false;
+  return visibility;
+}

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -14,7 +14,7 @@ import { AbstractValue, NativeFunctionValue, StringValue, ObjectValue } from "..
 import { createMockReact } from "./react-mocks.js";
 import { createMockReactRelay } from "./relay-mocks.js";
 import { createAbstract } from "../prepack/utils.js";
-import { createFbMocks } from "./fb-mocks.js";
+import { createFbMocks, createMockTimeSlice, createVisibility } from "./fb-mocks.js";
 import { FatalError } from "../../errors";
 import { Get } from "../../methods/index.js";
 import invariant from "../../invariant";
@@ -68,6 +68,20 @@ export default function(realm: Realm): void {
         let propTypes = Get(realm, realm.fbLibraries.react, "PropTypes");
         invariant(propTypes instanceof ObjectValue);
         return propTypes;
+      } else if (requireNameValValue === "TimeSlice") {
+        if (realm.fbLibraries.timeSlice === undefined) {
+          let timeSlice = createMockTimeSlice(realm, requireNameValValue);
+          realm.fbLibraries.timeSlice = timeSlice;
+          return timeSlice;
+        }
+        return realm.fbLibraries.timeSlice;
+      } else if (requireNameValValue === "Visibility") {
+        if (realm.fbLibraries.visibility === undefined) {
+          let visibility = createVisibility(realm, requireNameValValue);
+          realm.fbLibraries.visibility = visibility;
+          return visibility;
+        }
+        return realm.fbLibraries.visibility;
       } else {
         let requireVal;
 

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -589,15 +589,6 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
   });
   reactContextValue.intrinsicName = `require("${reactRequireName}").createContext`;
 
-  let reactIsValidElementValue = Get(realm, reactValue, "isValidElement");
-  reactIsValidElementValue.intrinsicName = `require("${reactRequireName}").isValidElement`;
-
-  let reactChildrenValue = Get(realm, reactValue, "Children");
-  reactChildrenValue.intrinsicName = `require("${reactRequireName}").Children`;
-
-  let reactPropTypesValue = Get(realm, reactValue, "PropTypes");
-  reactPropTypesValue.intrinsicName = `require("${reactRequireName}").PropTypes`;
-
   let createClassValue = new NativeFunctionValue(
     realm,
     undefined,
@@ -614,7 +605,16 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
     enumerable: false,
     configurable: true,
   });
-  reactContextValue.intrinsicName = `require("${reactRequireName}").createClass`;
+  createClassValue.intrinsicName = `require("${reactRequireName}").createClass`;
+
+  let reactIsValidElementValue = Get(realm, reactValue, "isValidElement");
+  reactIsValidElementValue.intrinsicName = `require("${reactRequireName}").isValidElement`;
+
+  let reactChildrenValue = Get(realm, reactValue, "Children");
+  reactChildrenValue.intrinsicName = `require("${reactRequireName}").Children`;
+
+  let reactPropTypesValue = Get(realm, reactValue, "PropTypes");
+  reactPropTypesValue.intrinsicName = `require("${reactRequireName}").PropTypes`;
 
   reactValue.refuseSerialization = false;
   return reactValue;

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -598,6 +598,24 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
   let reactPropTypesValue = Get(realm, reactValue, "PropTypes");
   reactPropTypesValue.intrinsicName = `require("${reactRequireName}").PropTypes`;
 
+  let createClassValue = new NativeFunctionValue(
+    realm,
+    undefined,
+    `createClass`,
+    0,
+    () => {
+      invariant(0, "React.createClass is not supported by the compiled, please upgrade to ES2015 classes!");
+      return realm.intrinsics.undefined;
+    }
+  );
+  reactValue.$DefineOwnProperty("createClass", {
+    value: createClassValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  reactContextValue.intrinsicName = `require("${reactRequireName}").createClass`;
+
   reactValue.refuseSerialization = false;
   return reactValue;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -216,6 +216,8 @@ export class Realm {
       other: new Map(),
       react: undefined,
       reactRelay: undefined,
+      timeSlice: undefined,
+      visibility: undefined,
     };
 
     this.errorHandler = opts.errorHandler;
@@ -288,6 +290,8 @@ export class Realm {
     other: Map<string, AbstractValue>,
     react: void | ObjectValue,
     reactRelay: void | ObjectValue,
+    timeSlice: void | ObjectValue,
+    visibility: void | ObjectValue,
   };
 
   $GlobalObject: ObjectValue | AbstractObjectValue;


### PR DESCRIPTION
Release notes: none

Adds more unsupported fb-www mocks and throws an invariant for `React.createClass` – as we do not support its use and to use it (I spent half a day trying) causes far too many havocing issues. If we want to support UFI, we'll have to manually upgrade them all to ES2015 classes.