### PR TITLE
Ensure addSourceNamesTo does not get stuck

### DIFF
--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -87,7 +87,7 @@ export default class AbstractValue extends Value {
     }
   }
 
-  addSourceNamesTo(names: Array<string>, alreadyAdded: Set<Array<Value>>): void {
+  addSourceNamesTo(names: Array<string>, alreadyAddedArgs: Set<Array<Value>>): void {
     let gen = this.$Realm.preludeGenerator;
     function add_intrinsic(name: string) {
       if (name.startsWith("_$")) {
@@ -99,11 +99,13 @@ export default class AbstractValue extends Value {
     }
     function add_args(args: void | Array<Value>) {
       if (args === undefined) return;
+      if (alreadyAddedArgs.has(args)) return;
+      alreadyAddedArgs.add(args);
       for (let val of args) {
         if (val.intrinsicName) {
           add_intrinsic(val.intrinsicName);
         } else if (val instanceof AbstractValue) {
-          val.addSourceNamesTo(names, alreadyAdded);
+          val.addSourceNamesTo(names, alreadyAddedArgs);
         } else if (val instanceof StringValue) {
           if (val.value.startsWith("__")) {
             names.push(val.value.slice(2));
@@ -114,10 +116,6 @@ export default class AbstractValue extends Value {
     if (this.intrinsicName) {
       add_intrinsic(this.intrinsicName);
     }
-    if (alreadyAdded.has(this.args)) {
-      return;
-    }
-    alreadyAdded.add(this.arg);
     add_args(this.args);
   }
 
@@ -787,10 +785,10 @@ export default class AbstractValue extends Value {
 
   static generateErrorInformationForAbstractVal(val: AbstractValue): string {
     let names = [];
-    let alreadyAdded = new Set();
-    val.addSourceNamesTo(names, alreadyAdded);
+    let alreadyAddedArgs = new Set();
+    val.addSourceNamesTo(names, alreadyAddedArgs);
     if (names.length === 0) {
-      val.addSourceNamesTo(names, alreadyAdded);
+      val.addSourceNamesTo(names, alreadyAddedArgs);
     }
     return `abstract value${names.length > 1 ? "s" : ""} ${names.join(" and ")}`;
   }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -87,7 +87,7 @@ export default class AbstractValue extends Value {
     }
   }
 
-  addSourceNamesTo(names: Array<string>) {
+  addSourceNamesTo(names: Array<string>, alreadyAdded: Set<Array<Value>>): void {
     let gen = this.$Realm.preludeGenerator;
     function add_intrinsic(name: string) {
       if (name.startsWith("_$")) {
@@ -103,7 +103,7 @@ export default class AbstractValue extends Value {
         if (val.intrinsicName) {
           add_intrinsic(val.intrinsicName);
         } else if (val instanceof AbstractValue) {
-          val.addSourceNamesTo(names);
+          val.addSourceNamesTo(names, alreadyAdded);
         } else if (val instanceof StringValue) {
           if (val.value.startsWith("__")) {
             names.push(val.value.slice(2));
@@ -114,6 +114,10 @@ export default class AbstractValue extends Value {
     if (this.intrinsicName) {
       add_intrinsic(this.intrinsicName);
     }
+    if (alreadyAdded.has(this.args)) {
+      return;
+    }
+    alreadyAdded.add(this.arg);
     add_args(this.args);
   }
 
@@ -783,9 +787,10 @@ export default class AbstractValue extends Value {
 
   static generateErrorInformationForAbstractVal(val: AbstractValue): string {
     let names = [];
-    val.addSourceNamesTo(names);
+    let alreadyAdded = new Set();
+    val.addSourceNamesTo(names, alreadyAdded);
     if (names.length === 0) {
-      val.addSourceNamesTo(names);
+      val.addSourceNamesTo(names, alreadyAdded);
     }
     return `abstract value${names.length > 1 ? "s" : ""} ${names.join(" and ")}`;
   }


### PR DESCRIPTION
Release notes: none

I noticed when running the UFI, that `addSourceNamesTo` can get stuck for a long time on the same values. This stops that from happening.