### PR TITLE
Various Fixes to GetPartial

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1384,14 +1384,8 @@ export class Reference {
     this.referencedName = refName;
     invariant(
       !(refName instanceof AbstractValue) ||
-        !(
-          refName.mightNotBeString() &&
-          refName.mightNotBeNumber() &&
-          !refName.isSimpleObject() &&
-          // if the base is a simple abstract object but
-          // the refName is not simple, this is also okay
-          (base instanceof AbstractValue && !base.isSimpleObject())
-        )
+        !(refName.mightNotBeString() && refName.mightNotBeNumber() && !refName.isSimpleObject()) ||
+        refName.$Realm.isInPureScope()
     );
     this.strict = strict;
     this.thisValue = thisValue;

--- a/src/types.js
+++ b/src/types.js
@@ -996,6 +996,8 @@ export type ToType = {
 
   ToStringValue(realm: Realm, val: Value): Value,
 
+  ToStringAbstract(realm: Realm, val: AbstractValue): AbstractValue,
+
   // ECMA262 7.1.2
   ToBoolean(realm: Realm, val: ConcreteValue): boolean,
 

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -525,7 +525,6 @@ export default class AbstractObjectValue extends AbstractValue {
 
   $GetPartial(P: AbstractValue | PropertyKeyValue, Receiver: Value): Value {
     if (!(P instanceof AbstractValue)) return this.$Get(P, Receiver);
-    invariant(this === Receiver, "TODO #1021");
     if (this.values.isTop()) {
       if (this.isSimpleObject() && this.isIntrinsic()) {
         return AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [this, P], ([o, p]) =>
@@ -539,13 +538,13 @@ export default class AbstractObjectValue extends AbstractValue {
     let elements = this.values.getElements();
     if (elements.size === 1) {
       for (let cv of elements) {
-        return cv.$GetPartial(P, cv);
+        return cv.$GetPartial(P, Receiver === this ? cv : Receiver);
       }
       invariant(false);
     } else {
       let result;
       for (let cv of elements) {
-        let cvVal = cv.$GetPartial(P, cv);
+        let cvVal = cv.$GetPartial(P, Receiver === this ? cv : Receiver);
         if (result === undefined) result = cvVal;
         else {
           let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -531,13 +531,19 @@ export default class AbstractObjectValue extends AbstractValue {
           t.memberExpression(o, p, true)
         );
       }
-      if (this.$Realm.isInPureScope() && Receiver === this) {
+      if (this.$Realm.isInPureScope()) {
         // If we're in a pure scope, we can havoc the key and the instance,
-        // and leave a residual property access in place.
-        Havoc.value(this.$Realm, this);
+        // and leave the residual property access in place.
+        // We assume that if the receiver is different than this object,
+        // then we only got here because there can be no other keys with
+        // this name on earlier parts of the prototype chain.
+        // We have to havoc since the property may be a getter or setter,
+        // which can run unknown code that has access to Receiver and
+        // (even in pure mode) can modify it in unknown ways.
+        Havoc.value(this.$Realm, Receiver);
         // Coercion can only have effects on anything reachable from the key.
         Havoc.value(this.$Realm, P);
-        return AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [this, P], ([o, p]) =>
+        return AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [Receiver, P], ([o, p]) =>
           t.memberExpression(o, p, true)
         );
       }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -210,7 +210,7 @@ export default class AbstractObjectValue extends AbstractValue {
       let error = new CompilerDiagnostic(
         "prototype access on unknown object",
         this.$Realm.currentLocation,
-        "PP0031",
+        "PP0032",
         "FatalError"
       );
       this.$Realm.handleError(error);

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -531,6 +531,16 @@ export default class AbstractObjectValue extends AbstractValue {
           t.memberExpression(o, p, true)
         );
       }
+      if (this.$Realm.isInPureScope() && Receiver === this) {
+        // If we're in a pure scope, we can havoc the key and the instance,
+        // and leave a residual property access in place.
+        Havoc.value(this.$Realm, this);
+        // Coercion can only have effects on anything reachable from the key.
+        Havoc.value(this.$Realm, P);
+        return AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [this, P], ([o, p]) =>
+          t.memberExpression(o, p, true)
+        );
+      }
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();
     }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
 import { AbstractValue, ArrayValue, ObjectValue, StringValue, Value, NumberValue, NullValue } from "./index.js";
@@ -207,7 +207,13 @@ export default class AbstractObjectValue extends AbstractValue {
   // ECMA262 9.1.1
   $GetPrototypeOf(): ObjectValue | AbstractObjectValue | NullValue {
     if (this.values.isTop()) {
-      AbstractValue.reportIntrospectionError(this);
+      let error = new CompilerDiagnostic(
+        "prototype access on unknown object",
+        this.$Realm.currentLocation,
+        "PP0031",
+        "FatalError"
+      );
+      this.$Realm.handleError(error);
       throw new FatalError();
     }
     invariant(this.kind !== "widened", "widening currently always leads to top values");
@@ -257,7 +263,13 @@ export default class AbstractObjectValue extends AbstractValue {
     if (P instanceof StringValue) P = P.value;
 
     if (this.values.isTop()) {
-      AbstractValue.reportIntrospectionError(this, P);
+      let error = new CompilerDiagnostic(
+        "property access on unknown object",
+        this.$Realm.currentLocation,
+        "PP0031",
+        "FatalError"
+      );
+      this.$Realm.handleError(error);
       throw new FatalError();
     }
 
@@ -408,7 +420,13 @@ export default class AbstractObjectValue extends AbstractValue {
   $HasProperty(P: PropertyKeyValue): boolean {
     if (P instanceof StringValue) P = P.value;
     if (this.values.isTop()) {
-      AbstractValue.reportIntrospectionError(this, P);
+      let error = new CompilerDiagnostic(
+        "property access on unknown object",
+        this.$Realm.currentLocation,
+        "PP0031",
+        "FatalError"
+      );
+      this.$Realm.handleError(error);
       throw new FatalError();
     }
 
@@ -470,7 +488,13 @@ export default class AbstractObjectValue extends AbstractValue {
           ValuesDomain.topVal
         );
       }
-      AbstractValue.reportIntrospectionError(this, P);
+      let error = new CompilerDiagnostic(
+        "property access on unknown object",
+        this.$Realm.currentLocation,
+        "PP0031",
+        "FatalError"
+      );
+      this.$Realm.handleError(error);
       throw new FatalError();
     }
 
@@ -547,7 +571,13 @@ export default class AbstractObjectValue extends AbstractValue {
           t.memberExpression(o, p, true)
         );
       }
-      AbstractValue.reportIntrospectionError(this);
+      let error = new CompilerDiagnostic(
+        "property access on unknown object",
+        this.$Realm.currentLocation,
+        "PP0031",
+        "FatalError"
+      );
+      this.$Realm.handleError(error);
       throw new FatalError();
     }
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -661,9 +661,11 @@ export default class ObjectValue extends ConcreteValue {
       }
     }
     // If all else fails, use this expression
+    // TODO #1675: Check the prototype chain for known properties too.
     let result;
     if (this.isPartialObject()) {
       if (isWidenedValue(P)) {
+        // TODO #1678: Use a snapshot or havoc this object.
         return AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [this, P], ([o, p]) =>
           t.memberExpression(o, p, true)
         );

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { Realm, ExecutionContext } from "../realm.js";
-import { ValuesDomain } from "../domains/index.js";
+import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type {
   DataBlock,
@@ -59,6 +59,32 @@ function isWidenedValue(v: void | Value) {
     if (isWidenedValue(a)) return true;
   }
   return false;
+}
+
+function ToStringPartial(realm: Realm, value: AbstractValue): AbstractValue {
+  if (value.mightNotBeString()) {
+    // If the property is not a string we need to coerce it.
+    let coerceToString = ([p]) => t.binaryExpression("+", t.stringLiteral(""), p);
+    let result;
+    if (value.mightNotBeNumber() && !value.isSimpleObject()) {
+      // If this might be a non-simple object, we need to coerce this at a
+      // temporal point since it can have side-effects.
+      // We can't rely on comparison to do it later, even if
+      // it is non-strict comparison since we'll do multiple
+      // comparisons. So we have to be explicit about when this
+      // happens.
+      result = realm.evaluateWithPossibleThrowCompletion(
+        () => AbstractValue.createTemporalFromBuildFunction(realm, StringValue, [value], coerceToString),
+        TypesDomain.topVal,
+        ValuesDomain.topVal
+      );
+    } else {
+      result = AbstractValue.createFromBuildFunction(realm, StringValue, [value], coerceToString);
+    }
+    invariant(result instanceof AbstractValue);
+    return result;
+  }
+  return value;
 }
 
 const lengthTemplateSrc = "(A).length";
@@ -693,6 +719,8 @@ export default class ObjectValue extends ConcreteValue {
       }
     }
 
+    P = ToStringPartial(this.$Realm, P);
+
     // If all else fails, use this expression
     // TODO #1675: Check the prototype chain for known properties too.
     let result;
@@ -801,6 +829,8 @@ export default class ObjectValue extends ConcreteValue {
       AbstractValue.reportIntrospectionError(P, "TODO #1021");
       throw new FatalError();
     }
+
+    P = ToStringPartial(this.$Realm, P);
 
     let prop;
     if (this.unknownProperty === undefined) {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -651,14 +651,8 @@ export default class ObjectValue extends ConcreteValue {
       !this.isSimpleObject() ||
       (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject())
     ) {
-      // if P is an abstract value that we don't know about, but we're in pure scope
-      // then if the object is simple, then we can safely continue without throwing
-      // the introspection error below, since converting P to a string is assumed to
-      // be well behaved in a pure scope
-      if (!(this.$Realm.isInPureScope() && this.isSimpleObject() && this === Receiver)) {
-        AbstractValue.reportIntrospectionError(P, "TODO: #1021");
-        throw new FatalError();
-      }
+      AbstractValue.reportIntrospectionError(P, "TODO: #1021");
+      throw new FatalError();
     }
     // If all else fails, use this expression
     // TODO #1675: Check the prototype chain for known properties too.

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -11,7 +11,7 @@
 
 import type { Realm, ExecutionContext } from "../realm.js";
 import { ValuesDomain } from "../domains/index.js";
-import { FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type {
   DataBlock,
   Descriptor,
@@ -655,8 +655,15 @@ export default class ObjectValue extends ConcreteValue {
         // Coercion can only have effects on anything reachable from the key.
         Havoc.value(this.$Realm, P);
       } else {
-        AbstractValue.reportIntrospectionError(P, "property key might not have a well behaved toString");
-        throw new FatalError();
+        let error = new CompilerDiagnostic(
+          "property key might not have a well behaved toString or be a symbol",
+          this.$Realm.currentLocation,
+          "PP0002",
+          "RecoverableError"
+        );
+        if (this.$Realm.handleError(error) !== "Recover") {
+          throw new FatalError();
+        }
       }
     }
 
@@ -674,8 +681,15 @@ export default class ObjectValue extends ConcreteValue {
           t.memberExpression(o, p, true)
         );
       } else {
-        AbstractValue.reportIntrospectionError(P, "unknown property access might need to invoke a getter");
-        throw new FatalError();
+        let error = new CompilerDiagnostic(
+          "unknown property access might need to invoke a getter",
+          this.$Realm.currentLocation,
+          "PP0030",
+          "RecoverableError"
+        );
+        if (this.$Realm.handleError(error) !== "Recover") {
+          throw new FatalError();
+        }
       }
     }
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -647,7 +647,6 @@ export default class ObjectValue extends ConcreteValue {
     if (!(P instanceof AbstractValue)) return this.$Get(P, Receiver);
     // We assume that simple objects have no getter/setter properties.
     if (
-      this !== Receiver ||
       !this.isSimpleObject() ||
       (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject())
     ) {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -662,11 +662,15 @@ export default class ObjectValue extends ConcreteValue {
 
     // We assume that simple objects have no getter/setter properties.
     if (!this.isSimpleObject()) {
-      if (this.$Realm.isInPureScope() && Receiver === this) {
+      if (this.$Realm.isInPureScope()) {
         // If we're in pure scope, we can havoc the object. Coercion
         // can only have effects on anything reachable from this object.
-        Havoc.value(this.$Realm, this);
-        return AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [this, P], ([o, p]) =>
+        // We assume that if the receiver is different than this object,
+        // then we only got here because there were no other keys with
+        // this name on other parts of the prototype chain.
+        // TODO #1675: A fix to 1675 needs to take this into account.
+        Havoc.value(this.$Realm, Receiver);
+        return AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [Receiver, P], ([o, p]) =>
           t.memberExpression(o, p, true)
         );
       } else {

--- a/test/serializer/abstract/UnknownNumericKey.js
+++ b/test/serializer/abstract/UnknownNumericKey.js
@@ -1,0 +1,5 @@
+var n = global.__abstract ? __abstract('number', '(0)') : 0;
+result = {0:'a'}[n];
+inspect = function() {
+  return result;
+}

--- a/test/serializer/abstract/UnknownObjectKey.js
+++ b/test/serializer/abstract/UnknownObjectKey.js
@@ -1,0 +1,7 @@
+var o = global.__abstract ? __abstract('object', '({toString() { return "x"; }})') : {toString() { return "x"; }};
+if (global.__makeSimple) __makeSimple(o);
+if (global.__makePartial) __makePartial(o);
+result = {'x':'a'}[o];
+inspect = function() {
+  return result;
+}

--- a/test/serializer/pure-functions/AbstractComputedProperty.js
+++ b/test/serializer/pure-functions/AbstractComputedProperty.js
@@ -1,0 +1,15 @@
+if (!global.__evaluatePureFunction) {
+  global.__evaluatePureFunction = f => f();
+}
+
+__evaluatePureFunction(() => {
+  var x = (global.__abstract ? __abstract(undefined, "({foo: 123})"): {foo: 123}) ||
+    (global.__abstract ? __abstract(undefind, "(false)") : false);
+  var y = global.__abstract ? __abstract(undefined, "('foo')") : "foo";
+
+  global.x = x[y];
+});
+
+inspect = function() {
+  return global.x;
+}

--- a/test/serializer/pure-functions/AbstractPropertyObjectKey.js
+++ b/test/serializer/pure-functions/AbstractPropertyObjectKey.js
@@ -1,0 +1,21 @@
+if (!global.__evaluatePureFunction) {
+  global.__evaluatePureFunction = f => f();
+}
+
+inspect = __evaluatePureFunction(() => {
+  let c = global.__abstract ? __abstract("boolean", '(true)') : true;
+  let objAsKey = {
+    y: 1,
+    get toString() {
+      this.y = 2;
+      return function() {
+        return 'x';
+      };
+    }
+  };
+  let abstractKey = c ? objAsKey : 'y';
+  let obj = {x:3};
+  let x = obj[abstractKey];
+  let y = objAsKey.y;
+  return function() { return JSON.stringify({x,y}); }
+});

--- a/test/serializer/pure-functions/UnknownGetter.js
+++ b/test/serializer/pure-functions/UnknownGetter.js
@@ -1,0 +1,31 @@
+if (!global.__evaluatePureFunction) {
+  global.__evaluatePureFunction = f => f();
+}
+
+__evaluatePureFunction(() => {
+  let c = global.__abstract ? __abstract("boolean", '(true)') : true;
+  let unknown = global.__abstract ? __abstract("string", '("x")') : "x";
+  let objWithGetter = {
+    y: 1,
+    get x() {
+      this.y = 2;
+      return 3;
+    }
+  };
+  let objWithoutGetter = {
+    y: 4,
+    x: 5,
+    get z() {
+    }
+  };
+  let abstractObj = c ? objWithGetter : objWithoutGetter;
+  function Foo() {
+  }
+  Foo.prototype = abstractObj;
+  let objWithProto = new Foo();
+  x = objWithProto[unknown];
+  y1 = abstractObj.y;
+  y2 = objWithProto.y;
+
+  inspect = function() { return JSON.stringify({x,y1,y2}); }
+});


### PR DESCRIPTION
This adds havocing in the right places that was not done properly in the previous solution.

This also allows non-self Receivers. For simple objects, this is allowed because they can't possibly have any meaningful impact if the object is truly simple since only getters expose the receiver concept.

More than that we can also make an assumption for non-simple objects, in pure mode. I assume that if the receiver is not self then the only reason we got here is because we concluded that anything else on the prototype chain cannot have had this property key on it. For example, that happens with a ToObject coercion. The original values doesn't have any properties on it.

A fix to #1675 might need to account for this scenario because currently we never propagate up the prototype chain so this can never happen.

However, even if there might be something else shadowing this on the prototype chain, this property access will still be ok since the residual is serialized as a property access on the receiver - which is havoced.

Fixes #1676