### PR TITLE
Push path conditions when simplifying conditional expressions.

### DIFF
--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import type { BabelNodeSourceLocation } from "babel-types";
-import { FatalError } from "../errors.js";
+import { FatalError, InfeasiblePathError } from "../errors.js";
 import { ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
 import { Realm } from "../realm.js";
@@ -76,8 +76,7 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
         let xx = simplify(realm, x00, true);
         if (isCondition || xx.getType() === BooleanValue) return xx;
       }
-      let x = simplify(realm, x0, true);
-      return negate(realm, x, loc, x0.equals(x) ? value : undefined);
+      return negate(realm, x0, loc, value, isCondition);
     }
     case "||":
     case "&&": {
@@ -108,7 +107,7 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       )
         return y;
       if (x.equals(x0) && y.equals(y0)) return value;
-      return AbstractValue.createFromLogicalOp(realm, (value.kind: any), x, y, loc, isCondition);
+      return AbstractValue.createFromLogicalOp(realm, (value.kind: any), x, y, loc, isCondition, true);
     }
     case "==":
     case "!=":
@@ -118,14 +117,34 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
     case "conditional": {
       let [c0, x0, y0] = value.args;
       let c = simplify(realm, c0, true);
-      let cs = simplify(realm, c0, isCondition);
-      let x = simplify(realm, x0, isCondition);
-      let y = simplify(realm, y0, isCondition);
+      let x, y;
+      if (c0 instanceof AbstractValue && c.mightBeFalse() && c.mightBeTrue()) {
+        try {
+          x = Path.withCondition(c0, () => simplify(realm, x0, isCondition));
+        } catch (e) {
+          if (e instanceof InfeasiblePathError) {
+            // We now know that c0 cannot be be true on this path
+            return simplify(realm, y0, isCondition);
+          }
+          throw e;
+        }
+        try {
+          y = Path.withInverseCondition(c0, () => simplify(realm, y0, isCondition));
+        } catch (e) {
+          if (e instanceof InfeasiblePathError) {
+            // We now know that c0 cannot be be false on this path
+            return x;
+          }
+          throw e;
+        }
+      }
+      if (x === undefined) x = simplify(realm, x0, isCondition);
+      if (y === undefined) y = simplify(realm, y0, isCondition);
       if (!c.mightNotBeTrue()) return x;
       if (!c.mightNotBeFalse()) return y;
       invariant(c instanceof AbstractValue);
       if (Path.implies(c)) return x;
-      let notc = AbstractValue.createFromUnaryOp(realm, "!", c, true, loc, isCondition);
+      let notc = AbstractValue.createFromUnaryOp(realm, "!", c, true, loc, isCondition, true);
       if (!notc.mightNotBeTrue()) return y;
       if (!notc.mightNotBeFalse()) return x;
       invariant(notc instanceof AbstractValue);
@@ -137,30 +156,31 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       // c ? x : x <=> x
       if (x.equals(y)) return x;
       // x ? x : y <=> x || y
-      if (cs.equals(x)) return AbstractValue.createFromLogicalOp(realm, "||", x, y, loc, isCondition);
+      let cs = isCondition ? c : simplify(realm, c0);
+      if (cs.equals(x)) return AbstractValue.createFromLogicalOp(realm, "||", x, y, loc, isCondition, true);
       // y ? x : y <=> y && x
-      if (cs.equals(y)) return AbstractValue.createFromLogicalOp(realm, "&&", y, x, loc, isCondition);
+      if (cs.equals(y)) return AbstractValue.createFromLogicalOp(realm, "&&", y, x, loc, isCondition, true);
       // c ? (c ? xx : xy) : y <=> c ? xx : y
       if (x instanceof AbstractValue && x.kind === "conditional") {
         let [xc, xx] = x.args;
         if (c.equals(xc))
-          return AbstractValue.createFromConditionalOp(realm, c, xx, y, value.expressionLocation, isCondition);
+          return AbstractValue.createFromConditionalOp(realm, c, xx, y, value.expressionLocation, isCondition, true);
       }
       // c ? x : (c ? y : z) : z <=> c ? x : z
       if (y instanceof AbstractValue && y.kind === "conditional") {
         let [yc, , z] = y.args;
         if (c.equals(yc))
-          return AbstractValue.createFromConditionalOp(realm, c, x, z, value.expressionLocation, isCondition);
+          return AbstractValue.createFromConditionalOp(realm, c, x, z, value.expressionLocation, isCondition, true);
       }
-      if (x.getType() === BooleanValue && y.getType() === BooleanValue) {
+      if (isCondition || (x.getType() === BooleanValue && y.getType() === BooleanValue)) {
         // c ? true : false <=> c
         if (!x.mightNotBeTrue() && !y.mightNotBeFalse()) return c;
         // c ? false : true <=> !c
         if (!x.mightNotBeFalse() && !y.mightNotBeTrue())
-          return AbstractValue.createFromUnaryOp(realm, "!", c, true, loc);
+          return AbstractValue.createFromUnaryOp(realm, "!", c, true, loc, true);
       }
       if (c.equals(c0) && x.equals(x0) && y.equals(y0)) return value;
-      return AbstractValue.createFromConditionalOp(realm, c, x, y, value.expressionLocation, isCondition);
+      return AbstractValue.createFromConditionalOp(realm, c, x, y, value.expressionLocation, isCondition, true);
     }
     case "abstractConcreteUnion": {
       // The union of an abstract value with one or more concrete values.
@@ -231,18 +251,21 @@ function negate(
   realm: Realm,
   value: Value,
   loc: ?BabelNodeSourceLocation = undefined,
-  unsimplifiedNegation: void | Value = undefined
+  unsimplifiedNegation: void | Value = undefined,
+  isCondition?: boolean
 ): Value {
   if (value instanceof ConcreteValue) return ValuesDomain.computeUnary(realm, "!", value);
   invariant(value instanceof AbstractValue);
+  value = simplify(realm, value, true);
+  if (!value.mightNotBeTrue()) return realm.intrinsics.false;
+  if (!value.mightNotBeFalse()) return realm.intrinsics.true;
+  invariant(value instanceof AbstractValue);
   if (value.kind === "!") {
     let [x] = value.args;
-    if (x.getType() === BooleanValue) return simplify(realm, x, true);
+    if (isCondition || x.getType() === BooleanValue) return simplify(realm, x, true);
     if (unsimplifiedNegation !== undefined) return unsimplifiedNegation;
     return makeBoolean(realm, x, loc);
   }
-  if (!value.mightNotBeTrue()) return realm.intrinsics.false;
-  if (!value.mightNotBeFalse()) return realm.intrinsics.true;
   // If NaN is not an issue, invert binary ops
   if (value.args.length === 2 && !value.args[0].mightBeNumber() && !value.args[1].mightBeNumber()) {
     let invertedComparison;
@@ -293,9 +316,16 @@ function negate(
     if (invertedLogicalOp !== undefined) {
       let left = negate(realm, value.args[0]);
       let right = negate(realm, value.args[1]);
-      return AbstractValue.createFromLogicalOp(realm, invertedLogicalOp, left, right, loc || value.expressionLocation);
+      return AbstractValue.createFromLogicalOp(
+        realm,
+        invertedLogicalOp,
+        left,
+        right,
+        loc || value.expressionLocation,
+        true
+      );
     }
   }
   if (unsimplifiedNegation !== undefined) return unsimplifiedNegation;
-  return AbstractValue.createFromUnaryOp(realm, "!", value, true, loc || value.expressionLocation);
+  return AbstractValue.createFromUnaryOp(realm, "!", value, true, loc || value.expressionLocation, true);
 }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -563,7 +563,8 @@ export default class AbstractValue extends Value {
     left: Value,
     right: Value,
     loc?: ?BabelNodeSourceLocation,
-    isCondition?: boolean
+    isCondition?: boolean,
+    doNotSimplify?: boolean
   ): Value {
     let leftTypes, leftValues;
     if (left instanceof AbstractValue) {
@@ -596,6 +597,7 @@ export default class AbstractValue extends Value {
     );
     result.kind = op;
     result.expressionLocation = loc;
+    if (doNotSimplify) return result;
     return isCondition
       ? realm.simplifyAndRefineAbstractCondition(result)
       : realm.simplifyAndRefineAbstractValue(result);
@@ -607,7 +609,8 @@ export default class AbstractValue extends Value {
     left: void | Value,
     right: void | Value,
     loc?: ?BabelNodeSourceLocation,
-    isCondition?: boolean
+    isCondition?: boolean,
+    doNotSimplify?: boolean
   ): Value {
     let types = TypesDomain.joinValues(left, right);
     if (types.getType() === NullValue) return realm.intrinsics.null;
@@ -621,7 +624,7 @@ export default class AbstractValue extends Value {
     result.expressionLocation = loc;
     if (left) result.mightBeEmpty = left.mightHaveBeenDeleted();
     if (right && !result.mightBeEmpty) result.mightBeEmpty = right.mightHaveBeenDeleted();
-    if (result.mightBeEmpty) return result;
+    if (doNotSimplify || result.mightBeEmpty) return result;
     return isCondition
       ? realm.simplifyAndRefineAbstractCondition(result)
       : realm.simplifyAndRefineAbstractValue(result);
@@ -633,7 +636,8 @@ export default class AbstractValue extends Value {
     operand: AbstractValue,
     prefix?: boolean,
     loc?: ?BabelNodeSourceLocation,
-    isCondition?: boolean
+    isCondition?: boolean,
+    doNotSimplify?: boolean
   ): Value {
     invariant(op !== "delete" && op !== "++" && op !== "--"); // The operation must be pure
     let resultTypes = TypesDomain.unaryOp(op, new TypesDomain(operand.getType()));
@@ -643,6 +647,7 @@ export default class AbstractValue extends Value {
     );
     result.kind = op;
     result.expressionLocation = loc;
+    if (doNotSimplify) return result;
     return isCondition
       ? realm.simplifyAndRefineAbstractCondition(result)
       : realm.simplifyAndRefineAbstractValue(result);

--- a/test/serializer/optimizations/simplify8a.js
+++ b/test/serializer/optimizations/simplify8a.js
@@ -1,0 +1,8 @@
+// does not contain: bar
+let a = global.__abstractOrNull ? __abstractOrNull("object", "({ foo: 0 })") : {};
+let b = a == null;
+let c = !b;
+let ob = b ? null : { bar: 1 };
+let obstr = ob ? "ob" : "str";
+
+inspect = function() { return obstr; }

--- a/test/serializer/optimizations/simplify8b.js
+++ b/test/serializer/optimizations/simplify8b.js
@@ -1,0 +1,6 @@
+// does not contain: bar
+let a = global.__abstract ? __abstract("boolean", "(true)") : true;
+let ob = a ? null : { bar: 1 };
+let nob = !ob && "not an object";
+
+inspect = function() { return nob; }

--- a/test/serializer/optimizations/simplify8c.js
+++ b/test/serializer/optimizations/simplify8c.js
@@ -1,0 +1,38 @@
+// does not contain: bar
+let _$G_derived = global.__abstractOrNull ? __abstractOrNull("object", "({ foo: 0 })") : {};
+let _$H_derived = global.__abstractOrNull ? __abstractOrNull("object", "({ foo: 1 })") : {};
+let _$I_derived = global.__abstractOrNull ? __abstractOrNull("object", "({ foo: 2 })") : {};
+let _$J_derived = global.__abstractOrNull ? __abstractOrNull("object", "({ foo: 3 })") : {};
+let _$K_derived = global.__abstractOrNull ? __abstractOrNull("object", "({ foo: 4 })") : {};
+
+let _1Ex_ = _$G_derived != null;
+
+let _1F0_ = _$H_derived != null;
+
+let _1F3_ = _$I_derived != null;
+
+let _1F6_ = _$J_derived != null;
+
+let _1FD_ = _1F6_ ? _$K_derived : _$J_derived;
+
+let _1FC_ = _1F3_ ? _1FD_ : _$I_derived;
+
+let _1FB_ = _1F0_ ? _1FC_ : _$H_derived;
+
+let _1FA_item = _1Ex_ ? _1FB_ : _$G_derived;
+
+let _1F9_ = !_1FA_item;
+
+let _1FW_ = {
+  bar: 1
+};
+
+let _1FV_rendered = _1F9_ ? null : _1FW_;
+
+let _1FU_ = !_1FV_rendered;
+
+if (!_1FU_) {
+  var x = 123;
+}
+
+inspect = function() { return x; }


### PR DESCRIPTION
Release note: none

The basic change here is to use path conditions when simplifying conditional expressions. Doing so led to an explosion of work in the simplifier, so I had to introduce more flags to reign in the simplifier and preventing it from trying to simplify things that have already been simplified.