### PR TITLE
! operator should only care about truthiness

### DIFF
--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -224,7 +224,7 @@ function evaluateOperation(
     expr;
 
     // 2. Let oldValue be ToBoolean(? GetValue(expr)).
-    let value = Environment.GetValue(realm, expr);
+    let value = Environment.GetConditionValue(realm, expr);
     if (value instanceof AbstractValue) return AbstractValue.createFromUnaryOp(realm, "!", value);
     invariant(value instanceof ConcreteValue);
     let oldValue = To.ToBoolean(realm, value);

--- a/test/serializer/optimizations/simplify8c.js
+++ b/test/serializer/optimizations/simplify8c.js
@@ -34,5 +34,9 @@ let _1FU_ = !_1FV_rendered;
 if (!_1FU_) {
   var x = 123;
 }
+if (_1FU_) {
+  var x = 456;
+}
+
 
 inspect = function() { return x; }


### PR DESCRIPTION
Release note: More aggressive simplification of !e expressions

Since only the truthiness of e matters, it can be simplified more aggressively than e can by itself. To do this, one uses Environment.GetConditionValue rather than Environment.GetValue.