### PR TITLE
Slightly nicer code generation for captured scopes

### DIFF
--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -12,7 +12,7 @@
 import { DeclarativeEnvironmentRecord } from "../environment.js";
 import type { SerializerOptions } from "../options.js";
 import * as t from "babel-types";
-import type { BabelNodeStatement, BabelNodeIdentifier } from "babel-types";
+import type { BabelNodeStatement, BabelNodeExpression, BabelNodeIdentifier } from "babel-types";
 import { NameGenerator } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import type { ResidualFunctionBinding, ScopeBinding, FunctionInstance } from "./types.js";
@@ -149,13 +149,15 @@ export class Referentializer {
     return scope;
   }
 
-  getReferentializedScopeInitialization(scope: ScopeBinding): Array<BabelNodeStatement> {
+  getReferentializedScopeInitialization(
+    scope: ScopeBinding,
+    scopeName: BabelNodeExpression
+  ): Array<BabelNodeStatement> {
     const capturedScope = scope.capturedScope;
     invariant(capturedScope);
     const state = this._getReferentializationState(scope.referentializationScope);
     const funcName = state.capturedScopeAccessFunctionId;
     const scopeArray = state.capturedScopesArray;
-    const scopeName = t.identifier(scope.name);
     // First get scope array entry and check if it's already initialized.
     // Only if not yet, then call the initialization function.
     const init = t.logicalExpression(

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -278,11 +278,7 @@ export class ResidualFunctions {
         // binding has been referentialized, so setup the scope to be able to
         // access bindings from other __captured_scopes initializers
         if (scope.referentializationScope !== funcValue) {
-          let decl = t.variableDeclaration("var", [
-            t.variableDeclarator(t.identifier(scope.name), t.numericLiteral(scope.id)),
-          ]);
-          let init = this.referentializer.getReferentializedScopeInitialization(scope);
-          bodySegment.push(decl);
+          let init = this.referentializer.getReferentializedScopeInitialization(scope, t.numericLiteral(scope.id));
           // flow forces me to do this
           Array.prototype.push.apply(bodySegment, init);
         }
@@ -457,14 +453,9 @@ export class ResidualFunctions {
               ((t.cloneDeep(funcBody): any): BabelNodeBlockStatement)
             );
             let scopeInitialization = [];
-            for (let [scopeName, scope] of scopeInstances) {
-              scopeInitialization.push(
-                t.variableDeclaration("var", [
-                  t.variableDeclarator(t.identifier(scopeName), t.numericLiteral(scope.id)),
-                ])
-              );
+            for (let scope of scopeInstances.values()) {
               scopeInitialization = scopeInitialization.concat(
-                this.referentializer.getReferentializedScopeInitialization(scope)
+                this.referentializer.getReferentializedScopeInitialization(scope, t.numericLiteral(scope.id))
               );
             }
             funcOrClassNode.body.body = scopeInitialization.concat(funcOrClassNode.body.body);
@@ -547,9 +538,10 @@ export class ResidualFunctions {
 
         let scopeInitialization = [];
         for (let [scopeName, scope] of normalInstances[0].scopeInstances) {
-          factoryParams.push(t.identifier(scopeName));
+          let scopeNameId = t.identifier(scopeName);
+          factoryParams.push(scopeNameId);
           scopeInitialization = scopeInitialization.concat(
-            this.referentializer.getReferentializedScopeInitialization(scope)
+            this.referentializer.getReferentializedScopeInitialization(scope, scopeNameId)
           );
         }
 


### PR DESCRIPTION
Release notes: None

This change avoids the declaration of an auxiliary variable that holds the numeric index of a captured closures.