### PR TITLE
Emit explicit conversion to object

### DIFF
--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -153,7 +153,7 @@ export function ForInOfHeadEvaluation(
     }
 
     // b. Let obj be ToObject(exprValue).
-    let obj = To.ToObjectPartial(realm, exprValue);
+    let obj = To.ToObject(realm, exprValue);
 
     // c. Return ? EnumerateObjectProperties(obj).
     if (obj.isPartialObject() || obj instanceof AbstractObjectValue) {

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -69,7 +69,7 @@ function evaluateDeleteOperation(expr: Value | Reference, realm: Realm) {
     let base = Environment.GetBase(realm, ref);
     // Constructing the reference checks that base is coercible to an object hence
     invariant(base instanceof ConcreteValue || base instanceof AbstractObjectValue);
-    let baseObj = base instanceof ConcreteValue ? To.ToObject(realm, base) : base;
+    let baseObj = To.ToObject(realm, base);
 
     // c. Let deleteStatus be ? baseObj.[[Delete]](GetReferencedName(ref)).
     let deleteStatus = baseObj.$Delete(Environment.GetReferencedName(realm, ref));

--- a/src/evaluators/WithStatement.js
+++ b/src/evaluators/WithStatement.js
@@ -36,7 +36,7 @@ export default function(
     let error = new CompilerDiagnostic("with object must be a known value", loc, "PP0007", "RecoverableError");
     if (realm.handleError(error) === "Fail") throw new FatalError();
   }
-  let obj = To.ToObjectPartial(realm, val);
+  let obj = To.ToObject(realm, val);
 
   // 3. Let oldEnv be the running execution context's LexicalEnvironment.
   let oldEnv = env;

--- a/src/intrinsics/ecma262/ArrayProto_toString.js
+++ b/src/intrinsics/ecma262/ArrayProto_toString.js
@@ -25,7 +25,7 @@ export default function(realm: Realm): NativeFunctionValue {
     0,
     context => {
       // 1. Let array be ? ToObject(this value).
-      let array = To.ToObjectPartial(realm, context);
+      let array = To.ToObject(realm, context);
 
       // 2. Let func be ? Get(array, "join").
       let func = Get(realm, array, "join");

--- a/src/intrinsics/ecma262/ArrayProto_values.js
+++ b/src/intrinsics/ecma262/ArrayProto_values.js
@@ -17,9 +17,9 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 22.1.3.30
   return new NativeFunctionValue(realm, "Array.prototype.values", "values", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Return CreateArrayIterator(O, "value").
-    return Create.CreateArrayIterator(realm, O, "value");
+    return Create.CreateArrayIterator(realm, O.throwIfNotConcreteObject(), "value");
   });
 }

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -37,10 +37,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.1
   obj.defineNativeMethod("concat", 1, (context, args, argCount) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let A be ? ArraySpeciesCreate(O, 0).
-    let A = Create.ArraySpeciesCreate(realm, O, 0);
+    let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), 0);
 
     // 3. Let n be 0.
     let n = 0;
@@ -121,7 +121,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
     obj.defineNativeMethod("copyWithin", 2, (context, [target, start, end]) => {
       // 1. Let O be ? ToObject(this value).
-      let O = To.ToObject(realm, context.throwIfNotConcrete());
+      let O = To.ToObject(realm, context);
 
       // 2. Let len be ? ToLength(? Get(O, "length")).
       let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -184,7 +184,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         } else {
           // e. Else fromPresent is false,
           // i. Perform ? DeletePropertyOrThrow(O, toKey).
-          Properties.DeletePropertyOrThrow(realm, O, toKey);
+          Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), toKey);
         }
 
         // f. Let from be from + direction.
@@ -204,16 +204,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.4
   obj.defineNativeMethod("entries", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Return CreateArrayIterator(O, "key+value").
-    return Create.CreateArrayIterator(realm, O, "key+value");
+    return Create.CreateArrayIterator(realm, O.throwIfNotConcreteObject(), "key+value");
   });
 
   // ECMA262 22.1.3.5
   obj.defineNativeMethod("every", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -260,7 +260,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.6
   obj.defineNativeMethod("fill", 1, (context, [value, start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -296,7 +296,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.7
   obj.defineNativeMethod("filter", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -310,7 +310,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let T = thisArg || realm.intrinsics.undefined;
 
     // 5. Let A be ? ArraySpeciesCreate(O, 0).
-    let A = Create.ArraySpeciesCreate(realm, O, 0);
+    let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), 0);
 
     // 6. Let k be 0.
     let k = 0;
@@ -355,7 +355,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.8
   obj.defineNativeMethod("find", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -396,7 +396,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.9
   obj.defineNativeMethod("findIndex", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -437,7 +437,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.10
   obj.defineNativeMethod("forEach", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -482,7 +482,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
     obj.defineNativeMethod("includes", 1, (context, [searchElement, fromIndex]) => {
       // 1. Let O be ? ToObject(this value).
-      let O = To.ToObject(realm, context.throwIfNotConcrete());
+      let O = To.ToObject(realm, context);
 
       // 2. Let len be ? ToLength(? Get(O, "length")).
       let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -525,7 +525,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.12
   obj.defineNativeMethod("indexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -581,7 +581,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.13
   obj.defineNativeMethod("join", 1, (context, [separator]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -639,16 +639,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.14
   obj.defineNativeMethod("keys", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Return CreateArrayIterator(O, "key").
-    return Create.CreateArrayIterator(realm, O, "key");
+    return Create.CreateArrayIterator(realm, O.throwIfNotConcreteObject(), "key");
   });
 
   // ECMA262 22.1.3.15
   obj.defineNativeMethod("lastIndexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -698,7 +698,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.16
   obj.defineNativeMethod("map", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -712,7 +712,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let T = thisArg || realm.intrinsics.undefined;
 
     // 5. Let A be ? ArraySpeciesCreate(O, len).
-    let A = Create.ArraySpeciesCreate(realm, O, len);
+    let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), len);
 
     // 6. Let k be 0.
     let k = 0;
@@ -748,7 +748,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.17
   obj.defineNativeMethod("pop", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -772,7 +772,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let element = Get(realm, O, indx);
 
       // d. Perform ? DeletePropertyOrThrow(O, indx).
-      Properties.DeletePropertyOrThrow(realm, O, indx);
+      Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), indx);
 
       // e. Perform ? Set(O, "length", newLen, true).
       Properties.Set(realm, O, "length", new NumberValue(realm, newLen), true);
@@ -785,7 +785,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.18
   obj.defineNativeMethod("push", 1, (context, args, argCount) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, new StringValue(realm, "length")));
@@ -823,7 +823,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.19
   obj.defineNativeMethod("reduce", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -910,7 +910,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.20
   obj.defineNativeMethod("reduceRight", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -995,7 +995,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.21
   obj.defineNativeMethod("reverse", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -1055,13 +1055,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
         Properties.Set(realm, O, lowerP, upperValue, true);
 
         // ii. Perform ? DeletePropertyOrThrow(O, upperP).
-        Properties.DeletePropertyOrThrow(realm, O, upperP);
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), upperP);
       } else if (lowerExists && !upperExists) {
         // j. Else if lowerExists is true and upperExists is false, then
         invariant(lowerValue, "expected lower value to exist");
 
         // i. Perform ? DeletePropertyOrThrow(O, lowerP).
-        Properties.DeletePropertyOrThrow(realm, O, lowerP);
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), lowerP);
 
         // ii. Perform ? Set(O, upperP, lowerValue, true).
         Properties.Set(realm, O, upperP, lowerValue, true);
@@ -1081,7 +1081,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.22
   obj.defineNativeMethod("shift", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -1122,7 +1122,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       } else {
         // d. Else fromPresent is false,
         // i. Perform ? DeletePropertyOrThrow(O, to).
-        Properties.DeletePropertyOrThrow(realm, O, to);
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), to);
       }
 
       // e. Increase k by 1.
@@ -1130,7 +1130,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 7. Perform ? DeletePropertyOrThrow(O, ! ToString(len-1)).
-    Properties.DeletePropertyOrThrow(realm, O, new StringValue(realm, len - 1 + ""));
+    Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), new StringValue(realm, len - 1 + ""));
 
     // 8. Perform ? Set(O, "length", len-1, true).
     Properties.Set(realm, O, "length", new NumberValue(realm, len - 1), true);
@@ -1142,7 +1142,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.23
   obj.defineNativeMethod("slice", 2, (context, [start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -1163,7 +1163,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let count = Math.max(final - k, 0);
 
     // 8. Let A be ? ArraySpeciesCreate(O, count).
-    let A = Create.ArraySpeciesCreate(realm, O, count);
+    let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), count);
 
     // 9. Let n be 0.
     let n = 0;
@@ -1202,7 +1202,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.24
   obj.defineNativeMethod("some", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -1252,7 +1252,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.25
   obj.defineNativeMethod("sort", 1, (context, [comparefn]) => {
     // 1. Let obj be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(obj, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -1406,7 +1406,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       } else {
         // If obj is not sparse then DeletePropertyOrThrow must not be called.
         invariant(sparse);
-        Properties.DeletePropertyOrThrow(realm, O, j.toString());
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), j.toString());
       }
     }
     // If an abrupt completion is returned from any of these operations, it is immediately returned as the value of this function.
@@ -1418,7 +1418,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.26
   obj.defineNativeMethod("splice", 2, (context, [start, deleteCount, ...items], argLength) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -1464,7 +1464,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 9. Let A be ? ArraySpeciesCreate(O, actualDeleteCount).
-    let A = Create.ArraySpeciesCreate(realm, O, actualDeleteCount);
+    let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), actualDeleteCount);
 
     // 10. Let k be 0.
     let k = 0;
@@ -1526,7 +1526,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         } else {
           // v. Else fromPresent is false,
           // 1. Perform ? DeletePropertyOrThrow(O, to).
-          Properties.DeletePropertyOrThrow(realm, O, to);
+          Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), to);
         }
 
         // vi. Increase k by 1.
@@ -1539,7 +1539,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       // d. Repeat, while k > (len - actualDeleteCount + itemCount)
       while (k > len - actualDeleteCount + itemCount) {
         // i. Perform ? DeletePropertyOrThrow(O, ! ToString(k-1)).
-        Properties.DeletePropertyOrThrow(realm, O, new StringValue(realm, k - 1 + ""));
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), new StringValue(realm, k - 1 + ""));
 
         // ii. Decrease k by 1.
         k--;
@@ -1570,7 +1570,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         } else {
           // v. Else fromPresent is false,
           // 1. Perform ? DeletePropertyOrThrow(O, to).
-          Properties.DeletePropertyOrThrow(realm, O, to);
+          Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), to);
         }
 
         // vi. Decrease k by 1.
@@ -1603,7 +1603,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.27
   obj.defineNativeMethod("toLocaleString", 0, context => {
     // 1. Let array be ? ToObject(this value).
-    let array = To.ToObject(realm, context.throwIfNotConcrete());
+    let array = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(array, "length")).
     let len = To.ToLength(realm, Get(realm, array, "length"));
@@ -1667,7 +1667,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.29
   obj.defineNativeMethod("unshift", 1, (context, items, argCount) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
@@ -1706,7 +1706,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         } else {
           // vi. Else fromPresent is false,
           // 1. Perform ? DeletePropertyOrThrow(O, to).
-          Properties.DeletePropertyOrThrow(realm, O, to);
+          Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), to);
         }
 
         // vii. Decrease k by 1.

--- a/src/intrinsics/ecma262/DatePrototype.js
+++ b/src/intrinsics/ecma262/DatePrototype.js
@@ -690,10 +690,10 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 20.3.4.37
   obj.defineNativeMethod("toJSON", 1, (context, [key]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let tv be ? ToPrimitive(O, hint Number).
-    let tv = To.ToPrimitive(realm, O, "number");
+    let tv = To.ToPrimitive(realm, O.throwIfNotConcreteObject(), "number");
 
     // 3. If Type(tv) is Number and tv is not finite, return null.
     if (tv instanceof NumberValue && !isFinite(tv.value)) {

--- a/src/intrinsics/ecma262/ObjectProto_toString.js
+++ b/src/intrinsics/ecma262/ObjectProto_toString.js
@@ -30,7 +30,7 @@ export default function(realm: Realm): NativeFunctionValue {
       if (context instanceof NullValue) return new StringValue(realm, "[object Null]");
 
       // 3. Let O be ToObject(this value).
-      let O = To.ToObjectPartial(realm, context);
+      let O = To.ToObject(realm, context);
 
       let builtinTag;
 

--- a/src/intrinsics/ecma262/ObjectPrototype.js
+++ b/src/intrinsics/ecma262/ObjectPrototype.js
@@ -37,7 +37,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // The pure parts are wrapped with a recovery mode.
     try {
       // 2. Let O be ? ToObject(this value).
-      let O = To.ToObjectPartial(realm, context);
+      let O = To.ToObject(realm, context);
 
       // 3. Return ? HasOwnProperty(O, P).
       return new BooleanValue(realm, HasOwnProperty(realm, O, P));
@@ -73,7 +73,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     V = V.throwIfNotConcreteObject();
 
     // 2. Let O be ? ToObject(this value).
-    let O = To.ToObjectPartial(realm, context);
+    let O = To.ToObject(realm, context);
 
     // 3. Repeat
     while (true) {
@@ -96,7 +96,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let P = To.ToPropertyKey(realm, V.throwIfNotConcrete());
 
     // 2. Let O be ? ToObject(this value).
-    let O = To.ToObjectPartial(realm, context);
+    let O = To.ToObject(realm, context);
 
     // 3. Let desc be ? O.[[GetOwnProperty]](P).
     let desc = O.$GetOwnProperty(P);
@@ -124,14 +124,14 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 19.1.3.7
   obj.defineNativeMethod("valueOf", 0, context => {
     // 1. Return ? ToObject(this value).
-    return To.ToObjectPartial(realm, context);
+    return To.ToObject(realm, context);
   });
 
   obj.$DefineOwnProperty("__proto__", {
     // B.2.2.1.1
     get: new NativeFunctionValue(realm, undefined, "get __proto__", 0, context => {
       // 1. Let O be ? ToObject(this value).
-      let O = To.ToObject(realm, context.throwIfNotConcrete());
+      let O = To.ToObject(realm, context);
 
       // 2. Return ? O.[[GetPrototypeOf]]().
       return O.$GetPrototypeOf();

--- a/src/intrinsics/ecma262/String.js
+++ b/src/intrinsics/ecma262/String.js
@@ -135,10 +135,10 @@ export default function(realm: Realm): NativeFunctionValue {
       let numberOfSubstitutions = substitutions.length;
 
       // 3. Let cooked be ? ToObject(template).
-      let cooked = To.ToObjectPartial(realm, template);
+      let cooked = To.ToObject(realm, template);
 
       // 4. Let raw be ? ToObject(? Get(cooked, "raw")).
-      let raw = To.ToObjectPartial(realm, Get(realm, cooked, "raw"));
+      let raw = To.ToObject(realm, Get(realm, cooked, "raw"));
 
       // 5. Let literalSegments be ? ToLength(? Get(raw, "length")).
       let literalSegments = To.ToLength(realm, Get(realm, raw, "length"));

--- a/src/intrinsics/ecma262/TypedArray.js
+++ b/src/intrinsics/ecma262/TypedArray.js
@@ -122,7 +122,7 @@ export default function(realm: Realm): NativeFunctionValue {
     // 8. NOTE: source is not an Iterable so assume it is already an array-like object.
 
     // 9. Let arrayLike be ! ToObject(source).
-    let arrayLike = To.ToObjectPartial(realm, source);
+    let arrayLike = To.ToObject(realm, source);
 
     // 10. Let len be ? ToLength(? Get(arrayLike, "length")).
     let len = To.ToLength(realm, Get(realm, arrayLike, "length"));

--- a/src/intrinsics/ecma262/TypedArrayProto_values.js
+++ b/src/intrinsics/ecma262/TypedArrayProto_values.js
@@ -18,12 +18,12 @@ export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 22.1.3.30
   return new NativeFunctionValue(realm, "Array.prototype.values", "values", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Return CreateArrayIterator(O, "value").
-    return Create.CreateArrayIterator(realm, O, "value");
+    return Create.CreateArrayIterator(realm, O.throwIfNotConcreteObject(), "value");
   });
 }

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -134,13 +134,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.5
   obj.defineNativeMethod("copyWithin", 2, (context, [target, start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. Let relativeTarget be ? ToInteger(target).
@@ -201,7 +201,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       } else {
         // e. Else fromPresent is false,
         // i. Perform ? DeletePropertyOrThrow(O, toKey).
-        Properties.DeletePropertyOrThrow(realm, O, toKey);
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), toKey);
       }
 
       // f. Let from be from + direction.
@@ -234,13 +234,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.7
   obj.defineNativeMethod("every", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -285,13 +285,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.8
   obj.defineNativeMethod("fill", 1, (context, [value, start, end]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. Let relativeStart be ? ToInteger(start).
@@ -398,13 +398,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.10
   obj.defineNativeMethod("find", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If IsCallable(predicate) is false, throw a TypeError exception.
@@ -443,13 +443,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.11
   obj.defineNativeMethod("findIndex", 1, (context, [predicate, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If IsCallable(predicate) is false, throw a TypeError exception.
@@ -488,13 +488,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.12
   obj.defineNativeMethod("forEach", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -536,13 +536,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.14
   obj.defineNativeMethod("includes", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If len is 0, return false.
@@ -583,13 +583,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.14
   obj.defineNativeMethod("indexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If len is 0, return -1.
@@ -643,13 +643,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.15
   obj.defineNativeMethod("join", 1, (context, [separator]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If separator is undefined, let separator be the single-element String ",".
@@ -718,13 +718,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.17
   obj.defineNativeMethod("lastIndexOf", 1, (context, [searchElement, fromIndex]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If len is 0, return -1.
@@ -857,13 +857,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.20
   obj.defineNativeMethod("reduce", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -948,13 +948,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.21
   obj.defineNativeMethod("reduceRight", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -1037,13 +1037,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.21
   obj.defineNativeMethod("reverse", 0, context => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. Let middle be floor(len/2).
@@ -1101,13 +1101,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
         Properties.Set(realm, O, lowerP, upperValue, true);
 
         // ii. Perform ? DeletePropertyOrThrow(O, upperP).
-        Properties.DeletePropertyOrThrow(realm, O, upperP);
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), upperP);
       } else if (lowerExists && !upperExists) {
         // j. Else if lowerExists is true and upperExists is false, then
         invariant(lowerValue, "expected lower value to exist");
 
         // i. Perform ? DeletePropertyOrThrow(O, lowerP).
-        Properties.DeletePropertyOrThrow(realm, O, lowerP);
+        Properties.DeletePropertyOrThrow(realm, O.throwIfNotConcreteObject(), lowerP);
 
         // ii. Perform ? Set(O, upperP, lowerValue, true).
         Properties.Set(realm, O, upperP, lowerValue, true);
@@ -1187,7 +1187,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       invariant(typeof targetByteOffset === "number");
 
       // 15. Let src be ? ToObject(array).
-      let src = To.ToObjectPartial(realm, array);
+      let src = To.ToObject(realm, array);
 
       // 16. Let srcLength be ? ToLength(? Get(src, "length")).
       let srcLength = To.ToLength(realm, Get(realm, src, "length"));
@@ -1509,13 +1509,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.25
   obj.defineNativeMethod("some", 1, (context, [callbackfn, thisArg]) => {
     // 1. Let O be ? ToObject(this value).
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(O).
     ValidateTypedArray(realm, O);
 
     // 3. Let len be O.[[ArrayLength]].
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -1563,13 +1563,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.26
   obj.defineNativeMethod("sort", 1, (context, [comparefn]) => {
     // 1. Let obj be the this value.
-    let O = To.ToObject(realm, context.throwIfNotConcrete());
+    let O = To.ToObject(realm, context);
 
     // 2. Let buffer be ? ValidateTypedArray(obj).
     let buffer = ValidateTypedArray(realm, O);
 
     // 3. Let len be the value of obj's [[ArrayLength]] internal slot.
-    let len = O.$ArrayLength;
+    let len = O.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 22.2.3.26 Runtime Semantics: SortCompare( x, y )#
@@ -1639,7 +1639,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
     let arr = [];
     for (let j = 0; j < len; j++) {
-      let val = IntegerIndexedElementGet(realm, O, j);
+      let val = IntegerIndexedElementGet(realm, O.throwIfNotConcreteObject(), j);
       arr[j] = val;
     }
 
@@ -1647,7 +1647,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
 
     //Apply the permutation back to the original array.
     for (let j = 0; j < len; j++) {
-      IntegerIndexedElementSet(realm, O, j, arr[j]);
+      IntegerIndexedElementSet(realm, O.throwIfNotConcreteObject(), j, arr[j]);
     }
 
     // 2. Return obj;
@@ -1722,13 +1722,13 @@ export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.2.3.28
   obj.defineNativeMethod("toLocaleString", 0, context => {
     // 1. Let array be ? ToObject(this value).
-    let array = To.ToObject(realm, context.throwIfNotConcrete());
+    let array = To.ToObject(realm, context);
 
     // 2. Perform ? ValidateTypedArray(array).
     ValidateTypedArray(realm, array);
 
     // 3. Let len be array.[[ArrayLength]].
-    let len = array.$ArrayLength;
+    let len = array.throwIfNotConcreteObject().$ArrayLength;
     invariant(typeof len === "number");
 
     // 4. Let separator be the String value for the list-separator String appropriate for the host environment's current locale (this is derived in an implementation-defined way).

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -271,7 +271,7 @@ export function OrdinaryCallBindThis(
     } else {
       //  b. Else,
       // i. Let thisValue be ! ToObject(thisArgument).
-      thisValue = To.ToObjectPartial(calleeRealm, thisArgument);
+      thisValue = To.ToObject(calleeRealm, thisArgument);
 
       // ii. NOTE ToObject produces wrapper objects using calleeRealm.
     }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -137,7 +137,7 @@ export class EnvironmentImplementation {
       if (base instanceof AbstractValue) {
         // Ensure that abstract values are coerced to objects. This might yield
         // an operation that might throw.
-        base = To.ToObjectPartial(realm, base);
+        base = To.ToObject(realm, base);
       }
       // a. If HasPrimitiveBase(V) is true, then
       if (this.HasPrimitiveBase(realm, V)) {
@@ -145,7 +145,7 @@ export class EnvironmentImplementation {
         invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
 
         // ii. Let base be To.ToObject(base).
-        base = To.ToObjectPartial(realm, base);
+        base = To.ToObject(realm, base);
       }
       invariant(base instanceof ObjectValue || base instanceof AbstractObjectValue);
 

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -397,7 +397,7 @@ export function GetV(realm: Realm, V: Value, P: PropertyKeyValue): Value {
   invariant(IsPropertyKey(realm, P), "Not a valid property key");
 
   // 2. Let O be ? ToObject(V).
-  let O = To.ToObjectPartial(realm, V);
+  let O = To.ToObject(realm, V);
 
   // 3. Return ? O.[[Get]](P, V).
   return O.$Get(P, V);

--- a/src/methods/own.js
+++ b/src/methods/own.js
@@ -20,7 +20,7 @@ import invariant from "../invariant.js";
 // ECMA262 19.1.2.8.1
 export function GetOwnPropertyKeys(realm: Realm, O: Value, Type: Function): ArrayValue {
   // 1. Let obj be ? ToObject(O).
-  let obj = To.ToObject(realm, O.throwIfNotConcrete());
+  let obj = To.ToObject(realm, O);
 
   // 2. Let keys be ? obj.[[OwnPropertyKeys]]().
   let keys = obj.$OwnPropertyKeys();

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -873,7 +873,7 @@ export class PropertiesImplementation {
     invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue);
 
     // 2. Let props be ? ToObject(Properties).
-    let props = To.ToObject(realm, Properties.throwIfNotConcrete());
+    let props = To.ToObject(realm, Properties);
 
     // 3. Let keys be ? props.[[OwnPropertyKeys]]().
     let keys = props.$OwnPropertyKeys();
@@ -1001,7 +1001,7 @@ export class PropertiesImplementation {
         invariant(base instanceof Value && !HasSomeCompatibleType(base, UndefinedValue, NullValue));
 
         // ii. Set base to ToObject(base).
-        base = To.ToObjectPartial(realm, base);
+        base = To.ToObject(realm, base);
       }
       if (!(base instanceof AbstractObjectValue) && base instanceof AbstractValue) {
         let diagnostic = new CompilerDiagnostic(

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -409,7 +409,7 @@ export class ToImplementation {
 
   _WrapAbstractInObject(realm: Realm, arg: AbstractValue): ObjectValue | AbstractObjectValue {
     let obj;
-    switch (arg.types.getType()) {
+    switch (arg.getType()) {
       case IntegralValue:
       case NumberValue:
         obj = new ObjectValue(realm, realm.intrinsics.NumberPrototype);
@@ -437,7 +437,8 @@ export class ToImplementation {
 
       default:
         if (realm.isInPureScope()) {
-          // will be serialized as Object(serialized_arg)
+          invariant(arg.getType() === Value); // Can't be primitive or object for sure, which leaves just Value.
+          // will be serialized as Object.assign(serialized_arg)
           obj = AbstractValue.createFromType(realm, ObjectValue, "explicit conversion to object");
           invariant(obj instanceof AbstractObjectValue);
           obj.args = [arg];

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1653,7 +1653,7 @@ export class ResidualHeapSerializer {
     if (val.kind === "explicit conversion to object") {
       let ob = serializedArgs[0];
       invariant(ob !== undefined);
-      return t.callExpression(this.preludeGenerator.memoizeReference("Object"), [ob]);
+      return t.callExpression(this.preludeGenerator.memoizeReference("Object.assign"), [ob]);
     }
     let serializedValue = val.buildNode(serializedArgs);
     if (serializedValue.type === "Identifier") {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1650,10 +1650,10 @@ export class ResidualHeapSerializer {
       invariant(abstractIndex >= 0 && abstractIndex < val.args.length);
       return serializedArgs[abstractIndex];
     }
-    if (val.kind === "implicit conversion to object") {
+    if (val.kind === "explicit conversion to object") {
       let ob = serializedArgs[0];
       invariant(ob !== undefined);
-      return ob;
+      return t.callExpression(this.preludeGenerator.memoizeReference("Object"), [ob]);
     }
     let serializedValue = val.buildNode(serializedArgs);
     if (serializedValue.type === "Identifier") {

--- a/src/types.js
+++ b/src/types.js
@@ -944,9 +944,7 @@ export type ToType = {
   ToPropertyDescriptor(realm: Realm, Obj: Value): Descriptor,
 
   // ECMA262 7.1.13
-  ToObject(realm: Realm, arg: ConcreteValue): ObjectValue,
-
-  ToObjectPartial(realm: Realm, arg: Value): ObjectValue | AbstractObjectValue,
+  ToObject(realm: Realm, arg: Value): ObjectValue | AbstractObjectValue,
 
   // ECMA262 7.1.15
   ToLength(realm: Realm, argument: numberOrValue): number,

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -59,7 +59,7 @@ export type AbstractValueKind =
   | "conditional"
   | "resolved"
   | "dummy parameter"
-  | "implicit conversion to object"
+  | "explicit conversion to object"
   | "check for known property"
   | "sentinel member expression"
   | "template for property name condition"

--- a/test/serializer/pure-functions/ToObject.js
+++ b/test/serializer/pure-functions/ToObject.js
@@ -1,0 +1,38 @@
+// abstract effects
+
+var obj = global.__abstract && global.__makePartial && global.__makeSimple ? __makePartial(__makeSimple(__abstract({}, "({foo:1})"))) : {foo:1};
+var num = global.__abstract ? __abstract("number", "(1)") : 1;
+var val = global.__abstract ? __abstract(undefined, "(true)") : true;
+var str = global.__abstract ? __abstract("string", "('123')") : '123';
+
+function f1() {
+  return Object.assign(obj.foo);
+}
+
+function f2() {
+  return Object.prototype.valueOf.call(obj.foo);
+}
+
+function f3() {
+  return Object.getPrototypeOf(num);
+}
+
+function f4() {
+  return Object.getPrototypeOf(val);
+}
+
+function f5() {
+  return str.valueOf;
+}
+
+if (global.__optimize) {
+  __optimize(f1);
+  __optimize(f2);
+  __optimize(f3);
+  __optimize(f4);
+  __optimize(f5);
+}
+
+inspect = function() {
+  return JSON.stringify({ f1: f1().name, f2: f2().name, f3: f3().name, f4: f4().name, f5: f5().name });
+}

--- a/test/serializer/pure-functions/ToObject.js
+++ b/test/serializer/pure-functions/ToObject.js
@@ -1,5 +1,3 @@
-// abstract effects
-
 var obj = global.__abstract && global.__makePartial && global.__makeSimple ? __makePartial(__makeSimple(__abstract({}, "({foo:1})"))) : {foo:1};
 var num = global.__abstract ? __abstract("number", "(1)") : 1;
 var val = global.__abstract ? __abstract(undefined, "(true)") : true;


### PR DESCRIPTION
Release note: Fix problem where the results of To.ToObject were lost during serialization

Fixes issue: #1595

The serializer will now serialize the abstract result of calling To.ToObjectPartial on an abstract value as "Object.assign(abstract_value)". In the one case where the serialized code is known to implicitly convert the abstract value to an object anyway, the caller of To.ToObjectPartial strips away the wrapper in order to avoid the redundant explicit conversion.

Since I ended up looking at every call of To.ToObjectPartial, I used this an opportunity to merge it into To.ToObject.

I also made AbstractObjectValue.$GetPrototypeOf aware of the wrapper and made it return concrete values if the type of the wrapped primitive is known. 