### PR TITLE
Introducing an AbstractValueKind to detect spelling errors

### DIFF
--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -14,6 +14,7 @@ import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import {
   ArrayValue,
   AbstractValue,
+  type AbstractValueKind,
   FunctionValue,
   AbstractObjectValue,
   NativeFunctionValue,

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -72,7 +72,7 @@ export function createAbstractArgument(realm: Realm, name: string, location: ?Ba
   let locString;
   if (location) locString = describeLocation(realm, undefined, undefined, location);
   let locVal = new StringValue(realm, locString || "(unknown location)");
-  let kind = "__abstract_" + realm.objectCount++; // need not be an object, but must be unique
+  let kind = AbstractValue.makeKind("abstractCounted", (realm.objectCount++).toString()); // need not be an object, but must be unique
   let result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(name), Value, [locVal], kind);
   result.intrinsicName = name;
 
@@ -107,10 +107,10 @@ export function createAbstract(
   }
   if (!name) {
     let locVal = new StringValue(realm, locString || "(unknown location)");
-    let kind = "__abstract_" + realm.objectCount++; // need not be an object, but must be unique
+    let kind = AbstractValue.makeKind("abstractCounted", (realm.objectCount++).toString()); // need not be an object, but must be unique
     result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
   } else {
-    let kind = "__abstract_" + name;
+    let kind = AbstractValue.makeKind("abstract", name);
     if (!realm.isNameStringUnique(name)) {
       let error = new CompilerDiagnostic("An abstract value with the same name exists", loc, "PP0019", "FatalError");
       realm.handleError(error);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1194,7 +1194,7 @@ export class PropertiesImplementation {
                   ([node]) => {
                     return t.memberExpression(node, pname, !t.isIdentifier(pname));
                   },
-                  { kind: P }
+                  { kind: AbstractValue.makeKind("property", P) }
                 );
               } else {
                 return AbstractValue.createTemporalFromBuildFunction(

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -16,6 +16,7 @@ import type { Binding } from "../environment.js";
 import {
   AbstractObjectValue,
   AbstractValue,
+  type AbstractValueKind,
   BooleanValue,
   ConcreteValue,
   FunctionValue,
@@ -783,9 +784,9 @@ export class Generator {
     values: ValuesDomain,
     createCallee: () => BabelNodeExpression,
     args: Array<Value>,
-    kind?: string
+    kind?: AbstractValueKind
   ): AbstractValue {
-    return this.derive(types, values, args, (nodes: any) => t.callExpression(createCallee(), nodes));
+    return this.derive(types, values, args, (nodes: any) => t.callExpression(createCallee(), nodes), { kind });
   }
 
   emitStatement(args: Array<Value>, buildNode_: (Array<BabelNodeExpression>) => BabelNodeStatement) {
@@ -846,7 +847,7 @@ export class Generator {
     values: ValuesDomain,
     args: Array<Value>,
     buildNode_: DerivedExpressionBuildNodeFunction | BabelNodeExpression,
-    optionalArgs?: {| kind?: string, isPure?: boolean, skipInvariant?: boolean |}
+    optionalArgs?: {| kind?: AbstractValueKind, isPure?: boolean, skipInvariant?: boolean |}
   ): AbstractValue {
     invariant(buildNode_ instanceof Function || args.length === 0);
     let id = t.identifier(this.preludeGenerator.nameGenerator.generate("derived"));

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -12,7 +12,16 @@
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { Descriptor, PropertyKeyValue } from "../types.js";
-import { AbstractValue, ArrayValue, ObjectValue, StringValue, Value, NumberValue, NullValue } from "./index.js";
+import {
+  AbstractValue,
+  type AbstractValueKind,
+  ArrayValue,
+  ObjectValue,
+  StringValue,
+  Value,
+  NumberValue,
+  NullValue,
+} from "./index.js";
 import type { AbstractValueBuildNodeFunction } from "./AbstractValue.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { IsDataDescriptor, cloneDescriptor, equalDescriptors } from "../methods/index.js";
@@ -29,7 +38,7 @@ export default class AbstractObjectValue extends AbstractValue {
     hashValue: number,
     args: Array<Value>,
     buildNode?: AbstractValueBuildNodeFunction | BabelNodeExpression,
-    optionalArgs?: {| kind?: string, intrinsicName?: string |}
+    optionalArgs?: {| kind?: AbstractValueKind, intrinsicName?: string |}
   ) {
     super(realm, types, values, hashValue, args, buildNode, optionalArgs);
     if (!values.isTop()) {

--- a/src/values/index.js
+++ b/src/values/index.js
@@ -38,4 +38,5 @@ export { default as StringValue } from "./StringValue.js";
 export { default as SymbolValue } from "./SymbolValue.js";
 
 export { default as AbstractValue, AbstractValueBuildNodeFunction } from "./AbstractValue.js";
+export type { AbstractValueKind } from "./AbstractValue.js";
 export { default as AbstractObjectValue } from "./AbstractObjectValue.js";


### PR DESCRIPTION
Release notes: None

Introducing an `AbstractValueKind` to detect spelling errors and other oddities in how the kind property of AbstractValue are used (it matters semantically as its a key for CSE).

I made the list complete enough to pass Flow, but I am pretty sure that the current type union isn't comprehensive. So more fun to come if we can get Flow to cover more. (For example, check out how `createFromBinaryOp` assigns to `kind` -- that can't possibly type check, but it does... Will follow up with Flow team --- @avikchaudhuri?)