### PR TITLE
Upgrading to Flow .69, starting @flow strict annotations

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -19,3 +19,12 @@ suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 module.name_mapper='/lib/' -> '/src/'
+
+[strict]
+nonstrict-import
+unclear-type
+unsafe-getters-setters
+untyped-import
+untyped-type-import
+sketchy-null
+

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "eslint-plugin-flowtype": "^2.20.0",
     "eslint-plugin-header": "^1.0.0",
     "eslint-plugin-prettier": "^2.1.2",
-    "flow-bin": "^0.68.0",
+    "flow-bin": "^0.69.0",
     "flow-typed": "^2.3.0",
     "graceful-fs": "^4.1.11",
     "invariant": "^2.2.0",

--- a/src/errors.js
+++ b/src/errors.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict */
 
 import type { BabelNodeSourceLocation } from "babel-types";
 
@@ -37,7 +37,7 @@ export class CompilerDiagnostic extends Error {
 // built-in super classes.
 export class FatalError extends Error {
   constructor(message?: string) {
-    super(message || "A fatal error occurred while prepacking.");
+    super(message === undefined ? "A fatal error occurred while prepacking." : message);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,9 +3653,9 @@ flow-bin@^0.28.0:
     bin-wrapper "^3.0.2"
     logalot "^2.0.0"
 
-flow-bin@^0.68.0:
-  version "0.68.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
+flow-bin@^0.69.0:
+  version "0.69.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.69.0.tgz#053159a684a6051fcbf0b71a2eb19a9679082da6"
 
 flow-parser@^0.*:
   version "0.66.0"


### PR DESCRIPTION
Release notes: None

Upgraded to Flow .69
Added [strict] section to .flowconfig
Started going strict with a simple file

The Flow team suggests to do this on a file-by-file basis,
instead of doing it on a rule-by-rule basis.