### PR TITLE
Leverage generator's path conditions to reduce conditionals

### DIFF
--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -74,7 +74,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     statistics: SerializerStatistics,
     react: ReactSerializerState,
     referentializer: Referentializer,
-    generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">
+    generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">,
+    conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>
   ) {
     super(
       realm,
@@ -94,7 +95,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       statistics,
       react,
       referentializer,
-      generatorParents
+      generatorParents,
+      conditionalFeasibility
     );
     this._lazyObjectIdSeed = 1;
     this._valueLazyIds = new Map();

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -163,7 +163,7 @@ export class ResidualHeapSerializer {
       this.additionalFunctionValueNestedFunctions,
       referentializer
     );
-    this.emitter = new Emitter(this.residualFunctions, referencedDeclaredValues);
+    this.emitter = new Emitter(this.residualFunctions, referencedDeclaredValues, conditionalFeasibility);
     this.mainBody = this.emitter.getBody();
     this.residualHeapInspector = residualHeapInspector;
     this.residualValues = residualValues;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -106,7 +106,8 @@ export class ResidualHeapSerializer {
     statistics: SerializerStatistics,
     react: ReactSerializerState,
     referentializer: Referentializer,
-    generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">
+    generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">,
+    conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>
   ) {
     this.realm = realm;
     this.logger = logger;
@@ -177,6 +178,7 @@ export class ResidualHeapSerializer {
     this.rewrittenAdditionalFunctions = new Map();
     this.declarativeEnvironmentRecordsBindings = declarativeEnvironmentRecordsBindings;
     this.generatorParents = generatorParents;
+    this.conditionalFeasibility = conditionalFeasibility;
     this.additionalFunctionGenerators = new Map();
     this.declaredGlobalLets = new Map();
   }
@@ -228,6 +230,7 @@ export class ResidualHeapSerializer {
   additionalFunctionValueNestedFunctions: Set<FunctionValue>;
 
   generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">;
+  conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>;
 
   declaredGlobalLets: Map<string, Value>;
 
@@ -1678,6 +1681,14 @@ export class ResidualHeapSerializer {
 
   _serializeAbstractValue(val: AbstractValue): void | BabelNodeExpression {
     invariant(val.kind !== "sentinel member expression", "invariant established by visitor");
+    if (val.kind === "conditional") {
+      let cf = this.conditionalFeasibility.get(val);
+      invariant(cf !== undefined);
+      if (cf.t && !cf.f) return this.serializeValue(val.args[1]);
+      else if (!cf.t && cf.f) return this.serializeValue(val.args[2]);
+      else invariant(cf.t && cf.f);
+    }
+
     if (val.hasIdentifier()) {
       return this._serializeAbstractValueHelper(val);
     } else {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -422,7 +422,7 @@ export class ResidualHeapVisitor {
             this.visitValue(value);
           } else {
             progress = false;
-            this._withUnrelatedScope(this.scope, fixpoint_rerun);
+            this._enqueueWithUnrelatedScope(this.scope, fixpoint_rerun);
           }
           return progress;
         };
@@ -462,7 +462,7 @@ export class ResidualHeapVisitor {
             this.visitValue(entry);
           } else {
             progress = false;
-            this._withUnrelatedScope(this.scope, fixpoint_rerun);
+            this._enqueueWithUnrelatedScope(this.scope, fixpoint_rerun);
           }
           return progress;
         };
@@ -606,7 +606,7 @@ export class ResidualHeapVisitor {
     // If the binding is new for this bindingState, have all functions capturing bindings from that scope visit it
     if (!bindingState.capturedBindings.has(residualFunctionBinding)) {
       for (let functionValue of bindingState.capturingFunctions) {
-        this._withUnrelatedScope(functionValue, () => this._visitBindingHelper(residualFunctionBinding));
+        this._enqueueWithUnrelatedScope(functionValue, () => this._visitBindingHelper(residualFunctionBinding));
       }
       bindingState.capturedBindings.add(residualFunctionBinding);
     }
@@ -656,7 +656,7 @@ export class ResidualHeapVisitor {
           potentialReferentializationScopes: new Set(),
         };
         // Queue up visiting of global binding exactly once in the globalGenerator scope.
-        this._withUnrelatedScope(this.globalGenerator, () => {
+        this._enqueueWithUnrelatedScope(this.globalGenerator, () => {
           let value = this.realm.getGlobalLetBinding(name);
           if (value !== undefined) residualFunctionBinding.value = this.visitEquivalentValue(value);
         });
@@ -1152,7 +1152,7 @@ export class ResidualHeapVisitor {
           this._visitReactLibrary(this.someReactElement);
           progress = true;
         } else {
-          this._withUnrelatedScope(this.globalGenerator, fixpoint_rerun);
+          this._enqueueWithUnrelatedScope(this.globalGenerator, fixpoint_rerun);
           progress = false;
         }
         return progress;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -228,7 +228,8 @@ export class Serializer {
         this.statistics,
         this.react,
         referentializer,
-        residualHeapVisitor.generatorParents
+        residualHeapVisitor.generatorParents,
+        residualHeapVisitor.conditionalFeasibility
       ).serialize();
       if (timingStatistics !== undefined)
         timingStatistics.referenceCountsTime = Date.now() - timingStatistics.referenceCountsTime;
@@ -258,7 +259,8 @@ export class Serializer {
       this.statistics,
       this.react,
       referentializer,
-      residualHeapVisitor.generatorParents
+      residualHeapVisitor.generatorParents,
+      residualHeapVisitor.conditionalFeasibility
     );
 
     let ast = residualHeapSerializer.serialize();

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -383,6 +383,7 @@ export class Generator {
     this.id = realm.nextGeneratorId++;
     this._name = name;
     this.effectsToApply = effects;
+    this.pathConditions = [].concat(realm.pathConditions);
   }
 
   realm: Realm;
@@ -391,6 +392,7 @@ export class Generator {
   effectsToApply: void | Effects;
   id: number;
   _name: string;
+  pathConditions: Array<AbstractValue>;
 
   static _generatorOfEffects(realm: Realm, name: string, environmentRecordIdAfterGlobalCode: number, effects: Effects) {
     let [result, generator, modifiedBindings, modifiedProperties, createdObjects] = effects;

--- a/test/serializer/abstract/Property3.js
+++ b/test/serializer/abstract/Property3.js
@@ -1,0 +1,14 @@
+// does not contain: 456
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+let ob = { };
+if (x) {
+    ob.x = 123;
+} else {
+    ob.x = 456;
+}
+if (x) {
+    y = ob;
+}
+
+inspect = function() { return y; }

--- a/test/serializer/abstract/Property4.js
+++ b/test/serializer/abstract/Property4.js
@@ -1,0 +1,14 @@
+// does not contain: now
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+let ob = { };
+if (x) {
+    ob.x = 123;
+} else {
+    ob.x = Date.now();
+}
+if (x) {
+    y = ob;
+}
+
+inspect = function() { return y; }

--- a/test/serializer/abstract/Property4.js
+++ b/test/serializer/abstract/Property4.js
@@ -1,4 +1,5 @@
 // does not contain:Date
+// omit invariants
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 let ob = { };

--- a/test/serializer/abstract/Property4.js
+++ b/test/serializer/abstract/Property4.js
@@ -1,4 +1,4 @@
-// does not contain: now
+// does not contain:now
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 let ob = { };

--- a/test/serializer/abstract/Property4.js
+++ b/test/serializer/abstract/Property4.js
@@ -1,4 +1,4 @@
-// does not contain:now
+// does not contain:Date
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 let ob = { };

--- a/test/serializer/abstract/Property5.js
+++ b/test/serializer/abstract/Property5.js
@@ -1,11 +1,12 @@
-// does not contain:456
+// does not contain:dead
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 
 let ob = { };
 if (x) {
     ob.x = 123;
 } else {
-    ob.x = 456;
+    let nested = { p: "dead" };
+    ob.x = { left: nested, right: nested };
 }
 if (x) {
     y = ob;


### PR DESCRIPTION
Release notes: Improved code generation in the presence of branching

This is fully implemented now:
- The visitor keeps track of whether the consequent or alternate of conditional values are feasible. If something is known to be infeasible, it is never visited.
- This in turn allows the serializer to skip serializing infeasible branches of conditional values.
- The emitter also knows that those infeasible branches are no dependencies.
- Added a test case for the basic functionality, one that shows that complex objects get eliminated, and one that tests the dependency code.