### PR TITLE
Disable some simplifier special cases when isCondition is true.

### DIFF
--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -149,10 +149,12 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       if (!notc.mightNotBeFalse()) return x;
       invariant(notc instanceof AbstractValue);
       if (Path.implies(notc)) return y;
-      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, x))) return x;
-      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, x))) return y;
-      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, y))) return x;
-      if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, y))) return y;
+      if (!isCondition) {
+        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, x))) return x;
+        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, x))) return y;
+        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, y))) return x;
+        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, y))) return y;
+      }
       // c ? x : x <=> x
       if (x.equals(y)) return x;
       // x ? x : y <=> x || y

--- a/test/serializer/optimizations/simplify9.js
+++ b/test/serializer/optimizations/simplify9.js
@@ -1,0 +1,14 @@
+let ob = global.__abstract ? __makeSimple(__abstract("object", "({a: 1})")) : {a : 1};
+let a = ob.a;
+
+let _1aw_ = !a;
+
+let _1bx_ = _1aw_ ? null : ob;
+
+let _1bw_ = !_1bx_;
+
+if (!_1bw_) {
+  var y = _1bw_ ? 123 : 456;
+}
+
+inspect = function() { return y; }


### PR DESCRIPTION
Release note: none

If the x and y part of a c ? x : y are simplified under the assumption that they will only be used contexts where they are converted to Booleans, then it is not safe to use them in equality comparisons. Hence the simplification rules that do so must be disabled in this situation.