### PR TITLE
Do not mutate abstract value args in React reconciliation

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -793,7 +793,7 @@ export class Reconciler {
   ): AbstractValue {
     let length = value.args.length;
     // TODO investigate what other kinds than "conditional" might be safe to deeply resolve
-    if (length > 0 && value.kind === "conditional") {
+    if (length === 3 && value.kind === "conditional") {
       let newBranchState = new BranchState();
       let args = [];
       let shouldCreateNewAbstract = false;


### PR DESCRIPTION
Release notes: none

Ensure we do not mutate the args of an abstract value during React reconciliation, instead opt to create a new abstract value with the new args when we resolve an arg to be a new value.