### PR TITLE
Be more selective in what directories to include in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "files": [
     "LICENSE",
     "PATENTS",
-    "bin/",
-    "lib/"
+    "/bin/",
+    "/lib/"
   ],
   "bin": {
     "prepack": "bin/prepack.js",


### PR DESCRIPTION
Release notes: None

I noticed that `yarn pack` might include some bogus artefacts
that matched "lib" and "bin". This changes make sure that it
only includes the top-level directories.