### PR TITLE
Unknown properties that potentially mask props from prototype

### DIFF
--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -17,15 +17,7 @@ import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { ForInOfHeadEvaluation, ForInOfBodyEvaluation } from "./ForOfStatement.js";
 import { EnumerableOwnProperties, UpdateEmpty } from "../methods/index.js";
 import { Environment } from "../singletons.js";
-import {
-  AbstractValue,
-  AbstractObjectValue,
-  ArrayValue,
-  ObjectValue,
-  StringValue,
-  UndefinedValue,
-  Value,
-} from "../values/index.js";
+import { AbstractValue, AbstractObjectValue, ArrayValue, ObjectValue, StringValue, Value } from "../values/index.js";
 import type {
   BabelNodeExpression,
   BabelNodeForInStatement,
@@ -160,7 +152,8 @@ function emitResidualLoopIfSafe(
             let cond = sourceValue.args[0];
             // and because the write always creates a value of this shape
             invariant(cond instanceof AbstractValue && cond.kind === "template for property name condition");
-            if (sourceValue.args[2] instanceof UndefinedValue) {
+            let falseVal = sourceValue.args[2];
+            if (falseVal instanceof AbstractValue && falseVal.kind === "template for prototype member expression") {
               // check that the value that was assigned itself came from
               // an expression of the form sourceObject[absStr].
               let mem = sourceValue.args[1];

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -349,6 +349,7 @@ export class ResidualHeapSerializer {
 
   _getNestedAbstractValues(absVal: AbstractValue, values: Array<Value>): Array<Value> {
     if (absVal.kind === "widened property") return values;
+    if (absVal.kind === "template for prototype member expression") return values;
     invariant(absVal.args.length === 3);
     let cond = absVal.args[0];
     invariant(cond instanceof AbstractValue);
@@ -375,6 +376,7 @@ export class ResidualHeapSerializer {
 
   _emitPropertiesWithComputedNames(obj: ObjectValue, absVal: AbstractValue) {
     if (absVal.kind === "widened property") return;
+    if (absVal.kind === "template for prototype member expression") return;
     invariant(absVal.args.length === 3);
     let cond = absVal.args[0];
     invariant(cond instanceof AbstractValue);

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -320,6 +320,7 @@ export class ResidualHeapVisitor {
 
   visitObjectPropertiesWithComputedNames(absVal: AbstractValue): void {
     if (absVal.kind === "widened property") return;
+    if (absVal.kind === "template for prototype member expression") return;
     invariant(absVal.args.length === 3);
     let cond = absVal.args[0];
     invariant(cond instanceof AbstractValue);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -63,6 +63,7 @@ export type AbstractValueKind =
   | "check for known property"
   | "sentinel member expression"
   | "template for property name condition"
+  | "template for prototype member expression"
   | "this"
   | "this.refs"
   | "module"

--- a/test/serializer/abstract/GetValue10.js
+++ b/test/serializer/abstract/GetValue10.js
@@ -1,0 +1,20 @@
+var absx = global.__abstract ? __abstract('string', '("x")') : "x";
+var absy = global.__abstract ? __abstract('string', '("y")') : "y";
+var absz = global.__abstract ? __abstract('string', '("z")') : "z";
+
+function Foo() { }
+Foo.prototype.x = 111;
+var obj = new Foo();
+r0 = obj[absx];
+obj[absy] = 123;
+obj[absz] = 456;
+r1 = obj.x;
+r2 = obj.y;
+r3 = obj.z;
+r4 = obj[absx];
+r5 = obj[absy];
+r6 = obj[absz];
+//obj[absx] = 777;
+r7 = obj.x;
+
+inspect = function() { return JSON.stringify([r0, r1, r2, r3, r4, r5, r6, r7]) + JSON.stringify(obj); }

--- a/test/serializer/abstract/GetValue7.js
+++ b/test/serializer/abstract/GetValue7.js
@@ -12,7 +12,7 @@ b = {};
 if (global.__makeSimple) global.__makeSimple(b);
 z2 = b[m];
 
-b[m] = 789;
+//b[m] = 789;
 z3 = b[m];
 
 inspect = function() { return "" + a.x + a.y + a[n] + z + z1 + z2 + z3; }


### PR DESCRIPTION
Release note: Better support for o[p] where p is unknown and the runtime value denotes a property on the prototype.

Partially fixes issue: #1575

When a known object, say ob = { x: 1, y: 2},  is accessed with an abstract property name (p), we currently emit a cascade of conditions of the form "p === 'x' ? 1 : (p === 'y' ? 2 : undefined)". If there was previously a write the object with an abstract property name (q), say ob[q] = 3, the undefined case is  replaced with "p === q ? 3 : undefined" and the 1 is replaced with "q === 'x' ? 3 : 1" and so on.

If this seems very painful and inefficient to you, I can only agree, but note that it handles intermediate object states because the expression is a-temporal and is derived from the state of the object at a particular point in time. This is kind of important.

Nevertheless, this is not exactly correct either, hence issue 1575. The problem is basically that the undefined case at the end is wrong if the object has a prototype and the prototype has a property with name: (runtime value of p) and the object itself has not.

Fixing this is proving to be tricky and I think it is best get there in baby steps.

The first such step is to replace the undefined value in the expression above with the temporal expression ob[p]. This will run up the prototype chain rather than just return undefined.

Note, however, that this is just less wrong and not an actual solution. The problem is that by the time ob[p] is evaluated, ob may have a different value for p than it had at the temporal point where the expression was encountered. (The reason being that the final version of ob is the only one that actually gets serialized.)

I have some solutions in mind (Sebastian talks about some of them in the issue) but they are sufficiently complicated that I do not want to include them in this pull request, so please bear with me for while longer.