### PR TITLE
Collecting more fine-grained timing statistics

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -417,7 +417,7 @@ fi
     if (statsFileName) {
       if (
         serialized.statistics === undefined ||
-        serialized.timingStats === undefined ||
+        serialized.timingStatistics === undefined ||
         serialized.realmStatistics === undefined
       ) {
         return;
@@ -425,7 +425,7 @@ fi
       let stats = {
         RealmStatistics: serialized.realmStatistics,
         SerializerStatistics: serialized.statistics,
-        TimingStatistics: serialized.timingStats,
+        TimingStatistics: serialized.timingStatistics,
         MemoryStatistics: v8.getHeapStatistics(),
       };
       fs.writeFileSync(statsFileName, JSON.stringify(stats));

--- a/src/realm.js
+++ b/src/realm.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import type {
+  RealmTimingStatistics,
   Intrinsics,
   PropertyBinding,
   Descriptor,
@@ -229,6 +230,7 @@ export class Realm {
   }
 
   statistics: RealmStatistics;
+  timingStatistics: void | RealmTimingStatistics;
   start: number;
   isReadOnly: boolean;
   isStrict: boolean;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -55,7 +55,7 @@ import type {
   AdditionalFunctionEffects,
 } from "./types.js";
 import type { SerializerOptions } from "../options.js";
-import { TimingStatistics, SerializerStatistics, BodyReference } from "./types.js";
+import { SerializerStatistics, BodyReference } from "./types.js";
 import { Logger } from "../utils/logger.js";
 import { Modules } from "../utils/modules.js";
 import { ResidualHeapInspector } from "./ResidualHeapInspector.js";
@@ -203,7 +203,6 @@ export class ResidualHeapSerializer {
   residualHeapValueIdentifiers: ResidualHeapValueIdentifiers;
   requireReturns: Map<number | string, BabelNodeExpression>;
   statistics: SerializerStatistics;
-  timingStats: TimingStatistics;
   residualHeapInspector: ResidualHeapInspector;
   residualValues: Map<Value, Set<Scope>>;
   residualFunctionInstances: Map<FunctionValue, FunctionInstance>;

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -17,7 +17,7 @@ import { SameValue } from "../methods/abstract.js";
 import { Realm, type Effects } from "../realm.js";
 import invariant from "../invariant.js";
 import type { Generator } from "../utils/generator.js";
-import type { RealmStatistics } from "../types.js";
+import { type RealmStatistics, RealmTimingStatistics } from "../types.js";
 
 export type TryQuery<T> = (f: () => T, defaultValue: T) => T;
 
@@ -149,21 +149,42 @@ export class BodyReference {
   index: number;
 }
 
-export class TimingStatistics {
+export class TimingStatistics extends RealmTimingStatistics {
   constructor() {
+    super();
     this.totalTime = 0;
-    this.globalCodeTime = 0;
+    this.resolveInitializedModulesTime = 0;
     this.initializeMoreModulesTime = 0;
+    this.optimizeReactComponentTreeRootsTime = 0;
+    this.checkThatFunctionsAreIndependentTime = 0;
     this.deepTraversalTime = 0;
     this.referenceCountsTime = 0;
     this.serializePassTime = 0;
+    this.babelGenerateTime = 0;
   }
   totalTime: number;
-  globalCodeTime: number;
+  resolveInitializedModulesTime: number;
   initializeMoreModulesTime: number;
+  optimizeReactComponentTreeRootsTime: number;
+  checkThatFunctionsAreIndependentTime: number;
   deepTraversalTime: number;
   referenceCountsTime: number;
   serializePassTime: number;
+  babelGenerateTime: number;
+
+  log() {
+    super.log(this.totalTime);
+    console.log(
+      `${this.resolveInitializedModulesTime}ms resolving initialized modules, ${this
+        .initializeMoreModulesTime}ms initializing more modules, ${this
+        .optimizeReactComponentTreeRootsTime}ms optimizing react component tree roots, ${this
+        .checkThatFunctionsAreIndependentTime}ms evaluating functions to optimize`
+    );
+    console.log(
+      `${this.deepTraversalTime}ms visiting residual heap, ${this.referenceCountsTime}ms reference counting, ${this
+        .serializePassTime}ms generating AST, ${this.babelGenerateTime}ms generating source code`
+    );
+  }
 }
 
 export type ReactEvaluatedNode = {
@@ -277,6 +298,6 @@ export type SerializedResult = {
   realmStatistics?: RealmStatistics,
   reactStatistics?: ReactStatistics,
   statistics?: SerializerStatistics,
-  timingStats?: TimingStatistics,
+  timingStatistics?: TimingStatistics,
   heapGraph?: string,
 };

--- a/src/types.js
+++ b/src/types.js
@@ -1033,3 +1033,24 @@ export class RealmStatistics {
     console.log(`${this.simplifications} abstract values simplified after ${this.simplificationAttempts} attempts.`);
   }
 }
+
+export class RealmTimingStatistics {
+  constructor() {
+    this.parsingTime = 0;
+    this.fixupSourceLocationsTime = 0;
+    this.fixupFilenamesTime = 0;
+    this.evaluationTime = 0;
+  }
+  parsingTime: number;
+  fixupSourceLocationsTime: number;
+  fixupFilenamesTime: number;
+  evaluationTime: number;
+
+  log(totalTime: number): void {
+    console.log(`=== timing statistics: ${totalTime}ms total time`);
+    console.log(
+      `${this.parsingTime}ms parsing, ${this.fixupSourceLocationsTime}ms fixing source locations, ${this
+        .fixupSourceLocationsTime}ms fixing source locations, ${this.evaluationTime}ms evaluating global code`
+    );
+  }
+}


### PR DESCRIPTION
Release notes: None

The existing timing statistics had rotted a bit. This breaks up
"global code time" into more fine grained metrics (parsing, source maps fix up, evaluation),
and also looks more closely at the time spent during serialization.