### PR TITLE
Check all assumed result for all property accesses on partial objects

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -325,11 +325,7 @@ function InternalJSONClone(realm: Realm, val: Value): Value {
     // TODO #1010: NaN and Infinity must be mapped to null.
     return val;
   }
-  if (
-    (val instanceof NumberValue && !isFinite(val.value)) ||
-    val instanceof UndefinedValue ||
-    val instanceof NullValue
-  ) {
+  if (val instanceof NumberValue && !isFinite(val.value)) {
     return realm.intrinsics.null;
   }
   if (val instanceof PrimitiveValue) {

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1252,40 +1252,44 @@ export class PropertiesImplementation {
     // 5. If X is a data property, then
     if (IsDataDescriptor(realm, X)) {
       let value = X.value;
-      if (O.isPartialObject() && value instanceof AbstractValue && value.kind !== "resolved") {
-        let savedUnion;
-        let savedIndex;
-        if (value.kind === "abstractConcreteUnion") {
-          savedUnion = value;
-          savedIndex = savedUnion.args.findIndex(e => e instanceof AbstractValue);
-          invariant(savedIndex >= 0);
-          value = savedUnion.args[savedIndex];
-          invariant(value instanceof AbstractValue);
+      if (O.isIntrinsic() && O.isPartialObject()) {
+        if (value instanceof AbstractValue) {
+          let savedUnion;
+          let savedIndex;
+          if (value.kind === "abstractConcreteUnion") {
+            savedUnion = value;
+            savedIndex = savedUnion.args.findIndex(e => e instanceof AbstractValue);
+            invariant(savedIndex >= 0);
+            value = savedUnion.args[savedIndex];
+            invariant(value instanceof AbstractValue);
+          }
+          if (value.kind !== "resolved") {
+            let realmGenerator = realm.generator;
+            invariant(realmGenerator);
+            value = realmGenerator.derive(value.types, value.values, value.args, value.getBuildNode(), {
+              kind: "resolved",
+              // We can't emit the invariant here otherwise it'll assume the AbstractValue's type not the union type
+              skipInvariant: true,
+            });
+            if (savedUnion !== undefined) {
+              invariant(savedIndex !== undefined);
+              let args = savedUnion.args.slice(0);
+              args[savedIndex] = value;
+              value = AbstractValue.createAbstractConcreteUnion(realm, ...args);
+            }
+            if (typeof P === "string") realmGenerator.emitFullInvariant(O, P, value);
+            InternalSetProperty(realm, O, P, {
+              value: value,
+              writable: "writable" in X ? X.writable : false,
+              enumerable: "enumerable" in X ? X.enumerable : false,
+              configurable: "configurable" in X ? X.configurable : false,
+            });
+          }
+        } else if (value instanceof Value && !(value instanceof AbstractValue)) {
+          let realmGenerator = realm.generator;
+          invariant(realmGenerator);
+          if (typeof P === "string") realmGenerator.emitFullInvariant(O, P, value);
         }
-        let realmGenerator = realm.generator;
-        invariant(realmGenerator);
-        value = realmGenerator.derive(value.types, value.values, value.args, value.getBuildNode(), {
-          kind: "resolved",
-          // We can't emit the invariant here otherwise it'll assume the AbstractValue's type not the union type
-          skipInvariant: true,
-        });
-        if (savedUnion !== undefined) {
-          invariant(savedIndex !== undefined);
-          let args = savedUnion.args.slice(0);
-          args[savedIndex] = value;
-          value = AbstractValue.createAbstractConcreteUnion(realm, ...args);
-        }
-        if (typeof P === "string") realmGenerator.emitFullInvariant(O, P, value);
-        InternalSetProperty(realm, O, P, {
-          value: value,
-          writable: "writable" in X ? X.writable : false,
-          enumerable: "enumerable" in X ? X.enumerable : false,
-          configurable: "configurable" in X ? X.configurable : false,
-        });
-      } else if (O.isPartialObject() && value instanceof Value && !(value instanceof AbstractValue)) {
-        let realmGenerator = realm.generator;
-        invariant(realmGenerator);
-        if (typeof P === "string") realmGenerator.emitFullInvariant(O, P, value);
       }
 
       // a. Set D.[[Value]] to the value of X's [[Value]] attribute.

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1282,6 +1282,10 @@ export class PropertiesImplementation {
           enumerable: "enumerable" in X ? X.enumerable : false,
           configurable: "configurable" in X ? X.configurable : false,
         });
+      } else if (O.isPartialObject() && value instanceof Value && !(value instanceof AbstractValue)) {
+        let realmGenerator = realm.generator;
+        invariant(realmGenerator);
+        if (typeof P === "string") realmGenerator.emitFullInvariant(O, P, value);
       }
 
       // a. Set D.[[Value]] to the value of X's [[Value]] attribute.

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -695,7 +695,12 @@ export class Generator {
   // e.g: (obj.property !== undefined && typeof obj.property !== "object")
   // NB: if the type of the AbstractValue is top, skips the invariant
   emitFullInvariant(object: ObjectValue | AbstractObjectValue, key: string, value: Value) {
-    if (this.realm.omitInvariants || object.refuseSerialization || value.refuseSerialization) return;
+    if (
+      this.realm.omitInvariants ||
+      object.refuseSerialization ||
+      (value instanceof ObjectValue && value.refuseSerialization)
+    )
+      return;
     let propertyIdentifier = this.getAsPropertyNameExpression(key);
     let computed = !t.isIdentifier(propertyIdentifier);
     let accessedPropertyOf = objectNode => t.memberExpression(objectNode, propertyIdentifier, computed);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -695,7 +695,7 @@ export class Generator {
   // e.g: (obj.property !== undefined && typeof obj.property !== "object")
   // NB: if the type of the AbstractValue is top, skips the invariant
   emitFullInvariant(object: ObjectValue | AbstractObjectValue, key: string, value: Value) {
-    if (this.realm.omitInvariants) return;
+    if (this.realm.omitInvariants || object.refuseSerialization || value.refuseSerialization) return;
     let propertyIdentifier = this.getAsPropertyNameExpression(key);
     let computed = !t.isIdentifier(propertyIdentifier);
     let accessedPropertyOf = objectNode => t.memberExpression(objectNode, propertyIdentifier, computed);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -748,6 +748,17 @@ export class Generator {
         };
         this.emitInvariant([value, value], condition, valueNode => valueNode);
       }
+    } else if (value instanceof FunctionValue) {
+      // We do a special case for functions,
+      // as we like to use concrete functions in the model to model abstract behaviors.
+      // These concrete functions do not have the right identity.
+      condition = ([objectNode]) =>
+        t.binaryExpression(
+          "!==",
+          t.unaryExpression("typeof", accessedPropertyOf(objectNode), true),
+          t.stringLiteral("function")
+        );
+      this.emitInvariant([object, value, object], condition, objnode => accessedPropertyOf(objnode));
     } else {
       condition = ([objectNode, valueNode]) => t.binaryExpression("!==", accessedPropertyOf(objectNode), valueNode);
       this.emitInvariant([object, value, object], condition, objnode => accessedPropertyOf(objnode));

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -695,6 +695,7 @@ export class Generator {
   // e.g: (obj.property !== undefined && typeof obj.property !== "object")
   // NB: if the type of the AbstractValue is top, skips the invariant
   emitFullInvariant(object: ObjectValue | AbstractObjectValue, key: string, value: Value) {
+    if (this.realm.omitInvariants) return;
     let propertyIdentifier = this.getAsPropertyNameExpression(key);
     let computed = !t.isIdentifier(propertyIdentifier);
     let accessedPropertyOf = objectNode => t.memberExpression(objectNode, propertyIdentifier, computed);

--- a/test/serializer/abstract/ForInStatement12.js
+++ b/test/serializer/abstract/ForInStatement12.js
@@ -1,6 +1,5 @@
-let tmp = { w: undefined, nest: { x: 1 } };
-let str = "({ w: undefined, nest: { x: 1 } })";
-let ob = global.__abstract ? __abstract(tmp, str) : tmp;
+// add at runtime:let tmp = { w: undefined, nest: { x: 1 } };
+let ob = global.__abstract ? __abstract({ w: undefined, nest: __abstract({ x: 1 }) }, "tmp") : tmp;
 
 let tgt = {};
 

--- a/test/serializer/abstract/InvariantsForNonAbstractProperties.js
+++ b/test/serializer/abstract/InvariantsForNonAbstractProperties.js
@@ -1,0 +1,13 @@
+// add at runtime:global.a = {p: 42, q: global, r: function() {}};
+// Count of Prepack model invariant violation:5
+(function () {
+    if (global.__assumeDataProperty) __assumeDataProperty(global, "a",
+        __abstract({
+            p: 42, q: global, r: function() { }, s: undefined
+        }));
+    global.ap = a.p;
+    global.aq = a.q;
+    global.ar = a.r;
+    global.as = a.s;
+    inspect = function() { return global.ap; }
+})();


### PR DESCRIPTION
Release notes: None

In the past, invariant checks would only be emitted if properties
hold abstract values. In the past, we missed some model inconsistencies where
properties were modeled with concrete values (in particular, `undefined`).