### PR TITLE
Clean up Widen

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -883,8 +883,8 @@ export type WidenType = {
   // Returns an abstract value that includes both v1 and v2 as potential values.
   widenValues(
     realm: Realm,
-    v1: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
-    v2: void | Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
+    v1: Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
+    v2: Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>
   ): Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
 
   containsArraysOfValue(realm: Realm, a1: void | Array<Value>, a2: void | Array<Value>): boolean,

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -343,10 +343,11 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(desc !== undefined);
       if (IsDataDescriptor(this.$Realm, desc)) {
         // Values may be different, i.e. values may be loop variant, so the widened value summarizes the entire loop
+        // equalDescriptors guarantees that both have value props and if you have a value prop is value is defined.
         let d1Value = d1.value;
-        invariant(d1Value === undefined || d1Value instanceof Value);
+        invariant(d1Value instanceof Value);
         let d2Value = d2.value;
-        invariant(d2Value === undefined || d2Value instanceof Value);
+        invariant(d2Value instanceof Value);
         desc.value = Widen.widenValues(this.$Realm, d1Value, d2Value);
       } else {
         // In this case equalDescriptors guarantees exact equality betwee d1 and d2.


### PR DESCRIPTION
Release note: none

widenValues had some funny looking code for the case where one of its parameters are void. See issue #1554.

While the code seems wrong, it is also not clear how to write a test case that will fail because of it, so instead I've tightened up the type annotations to prevent a void argument to widenValues. That leaves the funky decision of what to do about undefined values to _widenArrayOfsMapEntries, where it is at least a bit more contextual. This is also untested because this method is more a place holder right now than a part of a tested scenario.