### PR TITLE
Make AbstractValue.describe more linear and avoid calling it

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -157,7 +157,9 @@ function tryToEvaluateCallOrLeaveAsAbstract(
   tailCall: boolean
 ): Value {
   let effects;
+  let savedSuppressDiagnostics = realm.suppressDiagnostics;
   try {
+    realm.suppressDiagnostics = true;
     effects = realm.evaluateForEffects(
       () => EvaluateDirectCall(realm, strictCode, env, ref, func, thisValue, ast.arguments, tailCall),
       undefined,
@@ -165,6 +167,7 @@ function tryToEvaluateCallOrLeaveAsAbstract(
     );
   } catch (error) {
     if (error instanceof FatalError) {
+      realm.suppressDiagnostics = savedSuppressDiagnostics;
       return realm.evaluateWithPossibleThrowCompletion(
         () => generateRuntimeCall(ref, func, ast, strictCode, env, realm),
         TypesDomain.topVal,
@@ -173,6 +176,8 @@ function tryToEvaluateCallOrLeaveAsAbstract(
     } else {
       throw error;
     }
+  } finally {
+    realm.suppressDiagnostics = savedSuppressDiagnostics;
   }
   let completion = effects[0];
   if (completion instanceof PossiblyNormalCompletion) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -330,6 +330,7 @@ export class Realm {
   MOBILE_JSC_VERSION = "jsc-600-1-4-17";
 
   errorHandler: ?ErrorHandler;
+  suppressDiagnostics = false;
   objectCount = 0;
   symbolCount = 867501803871088;
   // Unique tag for identifying function body ast node. It is neeeded


### PR DESCRIPTION
Release note: none

AbstractValue.describe can get very expensive when the same (expensive to describe) condition shows up many times inside a large conditional value. This can be avoided with a suitable occurs check.

Of course, if the description is going to be ignored, there is not much point in generating it in the first place, so there is now a flag to prevent that.