### PR TITLE
Dealing with mightHaveBeenDeleted values in module map

### DIFF
--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -417,7 +417,9 @@ export class Modules {
       let property = globalInitializedModulesMap.properties.get(moduleId);
       invariant(property);
       let moduleValue = property.descriptor && property.descriptor.value;
-      if (moduleValue instanceof Value) this.initializedModules.set(moduleId, moduleValue);
+      if (moduleValue instanceof Value && !moduleValue.mightHaveBeenDeleted()) {
+        this.initializedModules.set(moduleId, moduleValue);
+      }
     }
     this.statistics.initializedModules = this.initializedModules.size;
     this.statistics.totalModules = this.moduleIds.size;

--- a/test/serializer/optimizations/require_mightHaveBeenDeleted.js
+++ b/test/serializer/optimizations/require_mightHaveBeenDeleted.js
@@ -1,0 +1,110 @@
+// add at runtime:let flag=false;
+// es6
+
+var modules = Object.create(null);
+
+__d = define;
+function require(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+}
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = module.exports = {};
+  var _module = module,
+      factory = _module.factory,
+      dependencyMap = _module.dependencyMap;
+      try {
+
+   var _moduleObject = { exports: exports };
+
+   factory(global, require, _moduleObject, exports, dependencyMap);
+
+      module.factory = undefined;
+
+   return module.exports = _moduleObject.exports;
+ } catch (e) {
+   module.hasError = true;
+   module.isInitialized = false;
+   module.exports = undefined;
+   throw e;
+ }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+var target = {};
+
+define(function(global, require, module, exports) {
+  module.exports = target;
+}, 0, null);
+
+define(function(global, require, module, exports) {
+  module.exports = require(0);
+}, 1, null);
+
+let __flag = global.__abstract ? __abstract("boolean", "flag") : flag;
+if (__flag) require(0);
+
+inspect = function() { return require(1) === target; }


### PR DESCRIPTION
Release notes: None

We keep track of initialized modules via an internal `__initializedModules` object.
However, after state joins and conditional `require()` calls, some of the
initialized module values `mightHaveBeenDeleted()`, indicating that they
might or might not have been initialized.
In that case, we should treat them just as other uninitialized modules.

Added regression test.