### PR TITLE
Speeding up isSimpleObject

### DIFF
--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -186,7 +186,7 @@ export function IsArray(realm: Realm, argument: Value): boolean {
   }
 
   // 4. Return false.
-  if (!argument.isSimpleObject()) argument.throwIfNotConcrete();
+  if (argument instanceof AbstractValue && !argument.isSimpleObject()) argument.throwIfNotConcrete();
   return false;
 }
 


### PR DESCRIPTION
Release notes: None

isSimpleObject is surprisingly expensive, as it iterates over all properties.
The serializer used to indirectly call it in a way that made things quadratic over the number of properties.
This fixes it for more cases.