### PR TITLE
Make AbstractValue.createFromType take arguments

### DIFF
--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -439,9 +439,8 @@ export class ToImplementation {
         if (realm.isInPureScope()) {
           invariant(arg.getType() === Value); // Can't be primitive or object for sure, which leaves just Value.
           // will be serialized as Object.assign(serialized_arg)
-          obj = AbstractValue.createFromType(realm, ObjectValue, "explicit conversion to object");
+          obj = AbstractValue.createFromType(realm, ObjectValue, "explicit conversion to object", [arg]);
           invariant(obj instanceof AbstractObjectValue);
-          obj.args = [arg];
         } else {
           obj = arg.throwIfNotConcreteObject();
         }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -36,7 +36,7 @@ import {
   UndefinedValue,
   Value,
 } from "./index.js";
-import { hashBinary, hashCall, hashString, hashTernary, hashUnary } from "../methods/index.js";
+import { hashBinary, hashCall, hashTernary, hashUnary } from "../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
 
@@ -103,7 +103,6 @@ export default class AbstractValue extends Value {
   ) {
     invariant(realm.useAbstractInterpretation);
     super(realm, optionalArgs ? optionalArgs.intrinsicName : undefined);
-    invariant(buildNode instanceof Function || args.length === 0);
     invariant(!Value.isTypeCompatibleWith(types.getType(), ObjectValue) || this instanceof AbstractObjectValue);
     invariant(types.getType() !== NullValue && types.getType() !== UndefinedValue);
     this.types = types;
@@ -734,11 +733,16 @@ export default class AbstractValue extends Value {
     return result;
   }
 
-  static createFromType(realm: Realm, resultType: typeof Value, kind?: AbstractValueKind): AbstractValue {
+  static createFromType(
+    realm: Realm,
+    resultType: typeof Value,
+    kind?: AbstractValueKind,
+    operands?: Array<Value>
+  ): AbstractValue {
     let types = new TypesDomain(resultType);
     let Constructor = Value.isTypeCompatibleWith(resultType, ObjectValue) ? AbstractObjectValue : AbstractValue;
-    let hash = hashString(resultType.name + (kind || ""));
-    let result = new Constructor(realm, types, ValuesDomain.topVal, hash, []);
+    let [hash, args] = hashCall(resultType.name + (kind || ""), ...(operands || []));
+    let result = new Constructor(realm, types, ValuesDomain.topVal, hash, args);
     if (kind) result.kind = kind;
     result.expressionLocation = realm.currentLocation;
     return result;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -705,8 +705,7 @@ export default class ObjectValue extends ConcreteValue {
           t.memberExpression(o, p, true)
         );
       }
-      result = AbstractValue.createFromType(this.$Realm, Value, "sentinel member expression");
-      result.args = [this, P];
+      result = AbstractValue.createFromType(this.$Realm, Value, "sentinel member expression", [this, P]);
     } else {
       result = AbstractValue.createTemporalFromBuildFunction(this.$Realm, Value, [this, P], ([o, p]) =>
         t.memberExpression(o, p, true)
@@ -836,8 +835,9 @@ export default class ObjectValue extends ConcreteValue {
       if (!(V instanceof UndefinedValue) && !isWidenedValue(P)) {
         // join V with sentinel, using a property name test as the condition
         let cond = createTemplate(this.$Realm, P);
-        let sentinel = AbstractValue.createFromType(this.$Realm, Value, "template for prototype member expression");
-        sentinel.args = [Receiver];
+        let sentinel = AbstractValue.createFromType(this.$Realm, Value, "template for prototype member expression", [
+          Receiver,
+        ]);
         newVal = Join.joinValuesAsConditional(this.$Realm, cond, V, sentinel);
       }
       prop.descriptor = {


### PR DESCRIPTION
Release note: none

AbstractValue.createFromType assumed that the values it produces will have no arguments, not least because of the expectation that arguments must be fed into the build function in all cases.

Since then it has become convenient to create some values that take no build function but have arguments. These have been constructed by using AbstractValue.createFromType and then adding arguments afterwards, which is an anti-pattern because of hashing concerns and general code hygiene.

Given current reality, the constructor of AbstractValue no longer sports an invariant that requires a build function to be present if arguments are supplied, and createFromType now has an extra parameter for arguments.