### PR TITLE
[fb-www] Treat fbt as a global object

### DIFF
--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -144,6 +144,7 @@ function lintCompiledSource(source) {
       ifRequired: true,
       ix: true,
       fbglyph: true,
+      fbt: true,
       requireWeak: true,
       xuiglyph: true,
       // ES 6

--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -46,7 +46,7 @@ const fbMagicGlobalFunctions = [
   "xuiglyph",
 ];
 
-const fbMagicGlobalObjects = ["JSResource", "Bootloader"];
+const fbMagicGlobalObjects = ["JSResource", "Bootloader", "fbt"];
 
 function createBabelHelpers(realm: Realm, global: ObjectValue | AbstractObjectValue) {
   let babelHelpersValue = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, `babelHelpers`, true);


### PR DESCRIPTION
It seems like it's unsafe to rename on www (it breaks Haste) so we should add it to the whitelist of globals.

It's both a function *and* it has properties that are functions, but for now I'll model it as an object since we never use it directly. In fact it seems like www transforms direct calls on it to `fbt._` calls or something like that so maybe keeping it as an object is right. We don't have a single direct call to `fbt()` as a function in our bundle.

This fix unblocks testing the bundle initialization in Jest www environment.