### PR TITLE
[fb-www] Internal bootloader changes

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2920,6 +2920,16 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -5897,6 +5907,16 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -8839,6 +8859,16 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -11778,6 +11808,16 @@ ReactStatistics {
   "inlinedComponents": 9,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -646,6 +646,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb11.js");
       });
 
+      it("fb-www 13", async () => {
+        await runTest(directory, "fb13.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -256,6 +256,5 @@ export function createFbMocks(realm: Realm, global: ObjectValue | AbstractObject
   for (let objectName of fbMagicGlobalObjects) {
     createMagicGlobalObject(realm, global, objectName);
   }
-
   createBootloader(realm, global);
 }

--- a/test/react/mocks/fb13.js
+++ b/test/react/mocks/fb13.js
@@ -1,25 +1,18 @@
 
-if (!this.__evaluatePureFunction) {
-  this.__evaluatePureFunction = function(f) {
-    return f();
-  };
-}
-
-if (typeof Bootloader === "undefined") {
-  var Bootloader = {
-    loadModules() {}
-  }
-}
-
-__evaluatePureFunction(() => {
-  var x = window.__abstract ? __abstract("boolean", "(true)") : true;
-  var y;
-
+function func(x) {
   if (x) {
     Bootloader.loadModules(['Foo'], function() {}, "Bar");
   }
-  
-  window.foo = [x, y];
-})
+}
 
+if (window.__optimize) {
+  __optimize(func);
+}
 
+if (!window.__abstract) {
+  if (!func.toString().includes(`Bootloader.loadModules(['Foo'], function () {}, "Bar");`)) {
+    throw new Error("Test failed!");
+  }
+}
+
+window.result = func;

--- a/test/react/mocks/fb13.js
+++ b/test/react/mocks/fb13.js
@@ -8,14 +8,8 @@ if (window.__optimize) {
   __optimize(func);
 }
 
-// when running this test through the JS evaluator
-// rather than Prepack, window.__abstract will be
-// undefined, allowing the evaluation to run this
-// assertion
-if (!window.__abstract) {
-  if (!func.toString().includes(`Bootloader.loadModules(['Foo'], function () {}, "Bar");`)) {
-    throw new Error("Test failed!");
-  }
-}
+func.getTrials = function() {
+  return func.toString().includes(`Bootloader.loadModules(['Foo'], function () {}, "Bar");`);
+};
 
-window.result = func;
+module.exports = func;

--- a/test/react/mocks/fb13.js
+++ b/test/react/mocks/fb13.js
@@ -8,8 +8,10 @@ if (window.__optimize) {
   __optimize(func);
 }
 
-func.getTrials = function() {
-  return func.toString().includes(`Bootloader.loadModules(['Foo'], function () {}, "Bar");`);
+func.getTrials = function(_, fn) {
+  if (!fn.toString().includes('Bootloader.loadModules(')) {
+    throw new Error('Expected to find Bootloader.loadModules() call.');
+  }
 };
 
 module.exports = func;

--- a/test/react/mocks/fb13.js
+++ b/test/react/mocks/fb13.js
@@ -12,6 +12,7 @@ func.getTrials = function(_, fn) {
   if (!fn.toString().includes('Bootloader.loadModules(')) {
     throw new Error('Expected to find Bootloader.loadModules() call.');
   }
+  return [];
 };
 
 module.exports = func;

--- a/test/react/mocks/fb13.js
+++ b/test/react/mocks/fb13.js
@@ -1,0 +1,25 @@
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+if (typeof Bootloader === "undefined") {
+  var Bootloader = {
+    loadModules() {}
+  }
+}
+
+__evaluatePureFunction(() => {
+  var x = window.__abstract ? __abstract("boolean", "(true)") : true;
+  var y;
+
+  if (x) {
+    Bootloader.loadModules(['Foo'], function() {}, "Bar");
+  }
+  
+  window.foo = [x, y];
+})
+
+

--- a/test/react/mocks/fb13.js
+++ b/test/react/mocks/fb13.js
@@ -1,4 +1,3 @@
-
 function func(x) {
   if (x) {
     Bootloader.loadModules(['Foo'], function() {}, "Bar");

--- a/test/react/mocks/fb13.js
+++ b/test/react/mocks/fb13.js
@@ -9,6 +9,10 @@ if (window.__optimize) {
   __optimize(func);
 }
 
+// when running this test through the JS evaluator
+// rather than Prepack, window.__abstract will be
+// undefined, allowing the evaluation to run this
+// assertion
 if (!window.__abstract) {
   if (!func.toString().includes(`Bootloader.loadModules(['Foo'], function () {}, "Bar");`)) {
     throw new Error("Test failed!");


### PR DESCRIPTION
Release notes: none

Some internal changes to ensure `Bootloader.loadModules()` global stays as is and doesn't get destructured. Also changed the incorrect usage of `context.$Realm.generator.derive` in the mocks.