### PR TITLE
Join all normal paths together for optimized functions

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -823,6 +823,7 @@ export class ResidualHeapVisitor {
   }
 
   visitValue(val: Value): void {
+    invariant(val !== undefined);
     invariant(!(val instanceof ObjectValue && val.refuseSerialization));
     if (val instanceof AbstractValue) {
       if (this.preProcessValue(val)) this.visitAbstractValue(val);

--- a/test/error-handler/bad-functions.js
+++ b/test/error-handler/bad-functions.js
@@ -1,5 +1,5 @@
 // recover-from-errors
-// expected errors: [{location: {"start":{"line":7,"column":26},"end":{"line":7,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions.js"}}, {location: {"start":{"line":8,"column":13},"end":{"line":8,"column":18},"source":"test/error-handler/bad-functions.js"}}]
+// expected errors: [{location: {"start":{"line":7,"column":26},"end":{"line":7,"column":35},"identifierName":"Exception","source":"test/error-handler/bad-functions.js"}},{"location":{"start":{"line":12,"column":13},"end":{"line":12,"column":18},"source":"test/error-handler/bad-functions.js"},"severity":"FatalError","errorCode":"PP1003"}, {location: {"start":{"line":8,"column":13},"end":{"line":8,"column":18},"source":"test/error-handler/bad-functions.js"}}]
 var wildcard = global.__abstract ? global.__abstract("number", "123") : 123;
 global.a = "";
 


### PR DESCRIPTION
Release note: none

The effects that get applied when serializing an optimized function should include the join of all the normal paths through the function, not just the common prefix.