### PR TITLE
Diagnostic for variable write conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "depcheck": "babel-node scripts/detect_bad_deps.js",
     "prettier": "node ./scripts/prettier.js write-changed",
     "prettier-all": "node ./scripts/prettier.js write",
-    "debug-fb-www": "node --stack_trace_limit=200 --stack_size=10000 ./scripts/debug-fb-www.js"
+    "debug-fb-www": "node --stack_trace_limit=200 --stack_size=10000 --max_old_space_size=16384 ./scripts/debug-fb-www.js"
   },
   "dependencies": {
     "babel-core": "^6.26.0",

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord, EnvironmentRecord } from "../environment.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { Realm } from "../realm.js";
 import type { Descriptor, PropertyBinding, ObjectKind } from "../types.js";
 import type { Binding } from "../environment.js";
@@ -25,6 +26,7 @@ import {
   NativeFunctionValue,
   ObjectValue,
   ProxyValue,
+  StringValue,
   SymbolValue,
   UndefinedValue,
   Value,
@@ -925,12 +927,20 @@ export class ResidualHeapVisitor {
         invariant(newValue);
         this.visitValue(newValue);
         residualBinding.modified = true;
-        // This should be enforced by checkThatFunctionsAreIndependent
-        invariant(
-          !residualBinding.additionalFunctionOverridesValue ||
-            residualBinding.additionalFunctionOverridesValue === functionValue,
-          "We should only have one additional function value modifying any given residual binding"
-        );
+        let otherFunc = residualBinding.additionalFunctionOverridesValue;
+        if (otherFunc !== undefined && otherFunc !== functionValue) {
+          let otherNameVal = otherFunc.$Get("name", otherFunc);
+          let otherNameStr = otherNameVal instanceof StringValue ? otherNameVal.value : "unknown function";
+          let funcNameVal = functionValue.$Get("name", functionValue);
+          let funNameStr = funcNameVal instanceof StringValue ? funcNameVal.value : "unknown function";
+          let error = new CompilerDiagnostic(
+            `Variable ${modifiedBinding.name} written to in optimized function ${funNameStr} conflicts with write in another optimized function ${otherNameStr}`,
+            funcNameVal.expressionLocation,
+            "PP1001",
+            "RecoverableError"
+          );
+          if (functionValue.$Realm.handleError(error) === "Fail") throw new FatalError();
+        }
         if (previousValue) residualBinding.additionalFunctionOverridesValue = functionValue;
         additionalFunctionInfo.modifiedBindings.set(modifiedBinding, residualBinding);
         return residualBinding;

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -537,7 +537,7 @@ export class Functions {
   ) {
     let reportConflict = (location: BabelNodeSourceLocation) => {
       let error = new CompilerDiagnostic(
-        `Property access conflicts with write in additional function ${fname}`,
+        `Property access conflicts with write in optimized function ${fname}`,
         location,
         "PP1003",
         "FatalError"


### PR DESCRIPTION
Release note: Diagnostic PP1001 for variable write conflict among optimized functions

Remove an erroneous invariant that asserts that a fatal error has been issued earlier for a variable write conflict among optimized functions.

Replaced with a recoverable error.