### PR TITLE
Don't generate redundant calls to query captured scopes

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -262,14 +262,13 @@ export class ResidualFunctions {
 
     // Emit code for ModifiedBindings for additional functions
     for (let [funcValue, funcInfo] of this.additionalFunctionValueInfos) {
+      let scopes = new Set();
       for (let [, residualBinding] of funcInfo.modifiedBindings) {
         let scope = residualBinding.scope;
-        if (scope === undefined) continue;
+        if (scope === undefined || scopes.has(scope)) continue;
+        scopes.add(scope);
 
-        // TODO #989: This should probably be an invariant once captures work properly
-        // Currently we don't referentialize bindings in additional functions (but we
-        // do for bindings nested in additional functions)
-        if (!residualBinding.referentialized) continue;
+        invariant(residualBinding.referentialized);
 
         // Find the proper prelude to emit to (global vs additional function's prelude)
         let bodySegment = getModifiedBindingsSegment(funcValue);

--- a/test/serializer/additional-functions/ModifiedBindingsCapturedScopesCalls.js
+++ b/test/serializer/additional-functions/ModifiedBindingsCapturedScopesCalls.js
@@ -1,0 +1,16 @@
+// add at runtime:var a = 17;
+// Copies of \|\|:2
+(function () {
+    let a, b, c, d;
+    global.f = function() {
+        a = 1;
+        b = 2;
+        c = 3;
+        d = 4;
+    }
+    if (global.__optimize) __optimize(f);
+    inspect = function() {
+        global.f();
+        return a + b + c + d;
+    }
+})();


### PR DESCRIPTION
Release notes: None

Don't generate redundant calls of the form
`var __captured__scope_2 = __scope_0[0] || __scope_1(0);`

Adding regression test.

This addresses one of the observations of #1732.
Also deleted unneeded left-over code and comment that used to refer #989.