### PR TITLE
Only set the length if the function component has arguments

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -434,7 +434,9 @@ export function normalizeFunctionalComponentParamaters(func: ECMAScriptSourceFun
   // ensure the length value is set to the new value
   let lengthValue = lengthProperty.value;
   invariant(lengthValue instanceof NumberValue);
-  lengthValue.value = 2;
+  if (func.$FormalParameters.length !== 0) {
+    lengthValue.value = 2;
+  }
 
   func.$FormalParameters = func.$FormalParameters.map((param, i) => {
     if (i === 0) {


### PR DESCRIPTION
Release notes: none

We should only override the length of functional components (where we add in `context` when its missing) if there's actually arguments to begin with. This doesn't fix anything, it's just something I noticed when scanning through the logic.