### PR TITLE
Handle cases where gDSFP is given an abstract state

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -822,6 +822,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output First render only getDerivedStateFromProps 2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "React.Fragment",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -3810,6 +3848,44 @@ ReactStatistics {
 `;
 
 exports[`Test React with JSX input, create-element output First render only getDerivedStateFromProps 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "React.Fragment",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only getDerivedStateFromProps 2 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,
   "evaluatedRootNodes": Array [
@@ -6872,6 +6948,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output First render only getDerivedStateFromProps 2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "React.Fragment",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Additional functions closure scope capturing 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -9825,6 +9939,44 @@ ReactStatistics {
 `;
 
 exports[`Test React with create-element input, create-element output First render only getDerivedStateFromProps 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "React.Fragment",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child1",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only getDerivedStateFromProps 2 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,
   "evaluatedRootNodes": Array [

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -564,6 +564,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "get-derived-state-from-props.js", true);
       });
 
+      it("getDerivedStateFromProps 2", async () => {
+        await runTest(directory, "get-derived-state-from-props2.js", true);
+      });
+
       it("React Context", async () => {
         await runTest(directory, "react-context.js");
       });

--- a/test/react/first-render-only/get-derived-state-from-props2.js
+++ b/test/react/first-render-only/get-derived-state-from-props2.js
@@ -1,0 +1,85 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Child3(props) {
+  return <span>{props.data.text}</span>;
+}
+
+class Child2 extends React.Component {
+  constructor() {
+    super();
+    this.randomVar = {
+      text: "Hello world",
+    };
+  }
+  render() {
+    return (
+      <React.Fragment>
+        {Array.from(this.props.items).map(item =>
+          <Child3 data={item} key={item.id} />
+        )}
+        <span>{this.randomVar.text}</span>
+      </React.Fragment>
+    );
+  }
+  componentWillMount() {
+    this.randomVar.text = "It worked!";
+  }
+}
+
+class Child1 extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      counter: 0,
+    };
+    this.handleClick = () => {
+      this.setState({ counter: this.state.counter + 1 });
+    };
+  }
+  render() {
+    return (
+      <div onClick={this.handleClick}>
+        <Child2  items={this.props.items} />
+        <span>Counter is at: {this.state.counter}</span>
+        <span>{this.state.title}</span>
+      </div>
+    );
+  }
+  static getDerivedStateFromProps(nextProps, prevState) {
+    if (nextProps.a !== nextProps.b) {
+      return Object.assign({}, 
+        prevState,
+        { title: "Hello world" }, 
+      );
+    }
+    return null;
+  }
+}
+
+function App(props) {
+  return <Child1 {...props} />
+}
+
+App.getTrials = function(renderer, Root) {
+  var items = [
+    {id: 0, text: "Item 1"},
+    {id: 1, text: "Item 2"},
+    {id: 2, text: "Item 3"},
+  ];
+  let results = [];
+  renderer.update(<Root items={items} a={true} b={true} />);
+  results.push(['render simple first render only tree (true true)', renderer.toJSON()]);
+  renderer.update(<Root items={items} a={true} b={false} />);
+  results.push(['render simple first render only tree (true false)', renderer.toJSON()]);
+  return results;
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

When working on internal projects, I found cases where the `getDerivedStateFromProps` would throw a FatalError because the partial state wasn't an abstract object value or object value. In this case, we need to ensure we emit a temporal Object.assign and go through a slightly different codepath. We can make far better assumptions here as we control the Object.assign and the target and one source.