### PR TITLE
Use node 8.9.4 and change prepublish to prepublishOnly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 9.7.1
+    version: 8.9.4
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "prepack-cli": "node --stack_size=10000 --stack_trace_limit=200 --max_old_space_size=16384 lib/prepack-cli.js --accelerateUnsupportedRequires --compatibility jsc-600-1-4-17 --delayUnsupportedRequires --mathRandomSeed 0",
     "prepack-prepack": "node --stack_size=10000 --max_old_space_size=8096 ./bin/prepack.js ./lib/prepack-cli.js --out ./lib/prepack-cli.prepacked.js --compatibility node-cli --mathRandomSeed rnd",
     "validate": "yarn build && yarn build-scripts && yarn lint && yarn depcheck && yarn flow && yarn test",
-    "prepublish": "yarn build",
+    "prepublishOnly": "yarn build",
     "depcheck": "babel-node scripts/detect_bad_deps.js",
     "prettier": "node ./scripts/prettier.js write-changed",
     "prettier-all": "node ./scripts/prettier.js write",


### PR DESCRIPTION
Release notes: CI uses Node 8.9.4 for better performance and prepublishOnly for NPM publishing

I found in local testing that Node 8.9.4 offers *much* better performance with Prepack, around 3-4x faster on large files. I also noticed we were using `prepublish` when causes `yarn` to call `yarn build`, which isn't really what we want from running `yarn`. Furthermore, `prepublish` has been deprecated in favor of `prepublishOnly` – meaning we save around 30 seconds on the CI build just from that.