### PR TITLE
Add --frozen-lockfile to CI and package JSON

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 9.7.1
+    version: 8.9.4
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
 
@@ -11,7 +11,7 @@ compile:
 
 dependencies:
   override:
-    - yarn
+    - yarn install --frozen-lockfile # make sure that lockfile is up-to-date
   cache_directories:
     - ~/.cache/yarn
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "precheck": "yarn prepack-cli --check",
     "prepack-cli": "node --stack_size=10000 --stack_trace_limit=200 --max_old_space_size=16384 lib/prepack-cli.js --accelerateUnsupportedRequires --compatibility jsc-600-1-4-17 --delayUnsupportedRequires --mathRandomSeed 0",
     "prepack-prepack": "node --stack_size=10000 --max_old_space_size=8096 ./bin/prepack.js ./lib/prepack-cli.js --out ./lib/prepack-cli.prepacked.js --compatibility node-cli --mathRandomSeed rnd",
-    "validate": "yarn build && yarn build-scripts && yarn lint && yarn depcheck && yarn flow && yarn test",
+    "validate": "yarn install --frozen-lockfile && yarn build && yarn build-scripts && yarn lint && yarn depcheck && yarn flow && yarn test",
     "prepublish": "yarn build",
     "depcheck": "babel-node scripts/detect_bad_deps.js",
     "prettier": "node ./scripts/prettier.js write-changed",


### PR DESCRIPTION
There was nothing that verified that our yarn.lock was up-to-date in our CI. Added the `--frozen-lockfile` option to CircleCI and `package.json` to make sure that we update the `yarn.lock` when we put up a commit.

Also downgraded the node version on CI according to #1738 