### PR TITLE
Execute Do/While loop condition in the proper place

### DIFF
--- a/test/serializer/abstract/DoWhile12.js
+++ b/test/serializer/abstract/DoWhile12.js
@@ -1,0 +1,7 @@
+var n = global.__abstract ? __abstract('number', '(2)') : 2;
+let i = 0;
+do {
+  console.log(i++);
+} while (i++ < n);
+
+inspect = function() { return i; }


### PR DESCRIPTION
Release note: Execute Do/While loop condition in the proper place

Fixes issue: #1677

The fixpoint computation computed the while condition of the first iteration as part of the second, and so on.

Refactored the code to make the fixed point computation independent of where the loop condition is executed. This simplifies things and will come in handy when doing while/do.