### PR TITLE
Write conflicts possibly normal completions

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -277,6 +277,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-10.js");
       });
 
+      it("Simple 11", async () => {
+        await runTest(directory, "simple-11.js");
+      });
+
       it("Simple fragments", async () => {
         await runTest(directory, "simple-fragments.js");
       });


### PR DESCRIPTION
Release notes: none

When digging deeper into detecting write conflicts with React component trees, I found that PossiblyNormalCompletions were not handled properly, so this PR ensures that the effects tree is recursively traversed so all modified bindings are collected, even from PossiblyNormalCompletions.

In doing this, I stumbled across a larger issue that seems to be a long existing issue before that we didn't have a small repro case for. Specifically, it's an invariant that has been affecting us a lot with the internal FB work:

![screen shot 2018-04-13 at 11 16 08](https://user-images.githubusercontent.com/1519870/38729820-2629a7b0-3f0c-11e8-9b2f-ad1c053a35fc.png)

You can see in this PR, that I've added a test that repros this issue. `simple-11.js`.