### PR TITLE
Make Generator._deconstruct complete

### DIFF
--- a/test/serializer/abstract/Throw6a.js
+++ b/test/serializer/abstract/Throw6a.js
@@ -1,0 +1,12 @@
+let a = global.__abstract ? __abstract("boolean", "false") : false;
+let b = global.__abstract ? __abstract("boolean", "(false)") : false;
+
+function foo() {
+  if (a) throw new Error("one");
+  if (b) throw new Error("true");
+  return "!a && !b";
+}
+
+z = foo();
+
+inspect = function() { return z; }


### PR DESCRIPTION
Release note: none

Generator._deconstruct did not handle PossiblyNormalCompletion and was asymmetrical for ReturnCompletion. Fixed this and added a test case.

Also deleted a dead method. 