### PR TITLE
Fold Relay components via createFragmentContainer for firstRenderOnly

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3273,6 +3273,37 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child",
+              "status": "INLINED",
+            },
+          ],
+          "message": "RelayContainer",
+          "name": "WrappedApp",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -6603,6 +6634,37 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child",
+              "status": "INLINED",
+            },
+          ],
+          "message": "RelayContainer",
+          "name": "WrappedApp",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -9898,6 +9960,37 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child",
+              "status": "INLINED",
+            },
+          ],
+          "message": "RelayContainer",
+          "name": "WrappedApp",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -13190,6 +13283,37 @@ ReactStatistics {
   "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 0,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child",
+              "status": "INLINED",
+            },
+          ],
+          "message": "RelayContainer",
+          "name": "WrappedApp",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -695,6 +695,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb13.js");
       });
 
+      it("fb-www 14", async () => {
+        await runTest(directory, "fb14.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -620,7 +620,7 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
         return t.callExpression(t.memberExpression(reactValueNode, t.identifier("forwardRef")), [funcNode]);
       });
       invariant(forwardedRef instanceof AbstractObjectValue);
-      realm.react.abstractHints.set(forwardedRef, createReactHintObject(reactValue, "forwardRef", [func]));
+      realm.react.abstractHints.set(forwardedRef, createReactHintObject(reactValue, "forwardRef", [func], realm.intrinsics.undefined));
       return forwardedRef;
     }
   );

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -448,8 +448,14 @@ export function normalizeFunctionalComponentParamaters(func: ECMAScriptSourceFun
   lengthValue.value = func.$FormalParameters.length;
 }
 
-export function createReactHintObject(object: ObjectValue, propertyName: string, args: Array<Value>): ReactHint {
+export function createReactHintObject(
+  object: ObjectValue,
+  propertyName: string,
+  args: Array<Value>,
+  firstRenderValue: Value
+): ReactHint {
   return {
+    firstRenderValue,
     object,
     propertyName,
     args,
@@ -653,8 +659,7 @@ export function getProperty(
 ): Value {
   if (object instanceof AbstractObjectValue) {
     if (object.values.isTop()) {
-      // fallback to the original Get implementation
-      return Get(realm, object, property);
+      return realm.intrinsics.undefined;
     }
     let elements = object.values.getElements();
     if (elements && elements.size > 0) {
@@ -669,7 +674,6 @@ export function getProperty(
     binding = object.symbols.get(property);
   }
   if (!binding) {
-    invariant(!object.isPartialObject(), "getProperty used on a partial object with no binding");
     return realm.intrinsics.undefined;
   }
   let descriptor = binding.descriptor;

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -30,7 +30,7 @@ import {
 import { Generator } from "../utils/generator.js";
 import { Get } from "../methods/index.js";
 import { ModuleTracer } from "../utils/modules.js";
-import { Join } from "../singletons.js";
+import { Join, Properties } from "../singletons.js";
 import { ReactStatistics } from "./types";
 import type { ReactSerializerState, AdditionalFunctionEffects, ReactEvaluatedNode } from "./types";
 import { Reconciler, type ComponentTreeState } from "../react/reconcilation.js";
@@ -47,7 +47,6 @@ import {
 } from "../react/utils.js";
 import * as t from "babel-types";
 import { createAbstractArgument } from "../intrinsics/prepack/utils.js";
-import { Properties } from "../../lib/singletons.js";
 
 type AdditionalFunctionEntry = {
   value: ECMAScriptSourceFunctionValue | AbstractValue,

--- a/src/types.js
+++ b/src/types.js
@@ -324,7 +324,7 @@ export type ClassComponentMetadata = {
   instanceSymbols: Set<SymbolValue>,
 };
 
-export type ReactHint = {| object: ObjectValue, propertyName: string, args: Array<Value> |};
+export type ReactHint = {| firstRenderValue: Value, object: ObjectValue, propertyName: string, args: Array<Value> |};
 
 export type ReactComponentTreeConfig = {
   firstRenderOnly: boolean,

--- a/test/react/mocks/fb14.js
+++ b/test/react/mocks/fb14.js
@@ -1,0 +1,102 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+var {createFragmentContainer} = require('RelayModern');
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = this.__evaluatePureFunction(() => {
+
+  function Child(props) {
+    return <div className={props.className}>uid: {props.id}</div>;
+  }
+
+  var Node = {
+    kind: "Fragment",
+    name: "Test_foo",
+    type: "Foo",
+    metadata: null,
+    argumentDefinitions: [],
+    selections: [
+      {
+        kind: "ScalarField",
+        alias: null,
+        name: "id",
+        args: null,
+        storageKey: null,
+      },
+    ],
+  };
+
+  var WrappedApp = createFragmentContainer(Child, {
+    foo: function foo() {
+      return Node;
+    },
+  })
+
+  function App(props, context) {
+    return <WrappedApp {...props} />;
+  }
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App, {
+      firstRenderOnly: true,
+    });
+  }
+
+  // this is a mocked out relay mock for this test
+  class RelayMock extends React.Component {
+    getChildContext() {
+      return {
+        relay: {
+          environment: {
+            ['@@RelayModernEnvironment']: true,
+            check() {},
+            lookup() {},
+            retain() {},
+            sendQuery() {},
+            execute() {},
+            subscribe() {},
+            unstable_internal: {
+              getFragment() {
+                
+              },
+              createFragmentSpecResolver() {
+                return {
+                  resolve() {
+                    return {
+                      className: "fb-class",
+                      title: "Hello world",
+                    };
+                  },
+                  isLoading() {
+                    return false;
+                  },
+                };
+              }
+            },
+          },
+          variables: {},
+        },
+      };
+    }
+    render() {
+      return <App />;
+    }
+  }
+
+  RelayMock.childContextTypes = {
+    relay: () => {},
+  };
+
+  RelayMock.getTrials = function(renderer, Root) {
+    renderer.update(<Root />);
+    return [['fb14 mocks', renderer.toJSON()]];
+  };
+
+  return RelayMock;
+});

--- a/test/react/mocks/fb3.js
+++ b/test/react/mocks/fb3.js
@@ -7,6 +7,7 @@ if (!window.__evaluatePureFunction) {
 (function() {
   function App() {}
   require('React');
+
   var ReactRelay = require('RelayModern');
 
   window.__evaluatePureFunction(() => {

--- a/test/react/mocks/fb3.js
+++ b/test/react/mocks/fb3.js
@@ -6,6 +6,7 @@ if (!window.__evaluatePureFunction) {
 
 (function() {
   function App() {}
+  require('React');
   var ReactRelay = require('RelayModern');
 
   window.__evaluatePureFunction(() => {

--- a/test/react/mocks/fb4.js
+++ b/test/react/mocks/fb4.js
@@ -12,6 +12,7 @@ App.otherArray = [];
 App.otherArray.length = 10;
 
 this.WrappedApp = this.__evaluatePureFunction(() => {
+  require('React');
 	return require("RelayModern").createFragmentContainer(App);
 });
 

--- a/test/react/mocks/fb4.js
+++ b/test/react/mocks/fb4.js
@@ -13,6 +13,6 @@ App.otherArray.length = 10;
 
 this.WrappedApp = this.__evaluatePureFunction(() => {
   require('React');
-	return require("RelayModern").createFragmentContainer(App);
+  return require("RelayModern").createFragmentContainer(App);
 });
 


### PR DESCRIPTION
Release notes: none

This adds the functionality to fold/inline ReactRelay components via `createFragmentContainer`. This is for first-render only for now.