### PR TITLE
Make cpuprofile dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "queue-fifo": "^0.2.3",
     "seedrandom": "^2.4.2",
     "source-map": "^0.5.6",
-    "v8-profiler": "^5.7.0",
     "vscode-debugadapter": "^1.24.0",
     "vscode-debugprotocol": "^1.24.0"
   },
@@ -113,6 +112,9 @@
     "test262-integrator": "^1.2.0",
     "webpack": "^4.1.0",
     "webpack-cli": "^2.0.10"
+  },
+  "optionalDependencies": {
+    "v8-profiler": "^5.7.0"
   },
   "engines": {
     "node": ">=6.1.0"

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -404,8 +404,9 @@ fi
     if (cpuprofilePath !== undefined) {
       try {
         profiler = require("v8-profiler");
-      } catch (e) { // Profiler optional dependency failed
-        console.error("v8-profiler doesn't work correctly on windows, see issue #1695");
+      } catch (e) {
+        // Profiler optional dependency failed
+        console.error("v8-profiler doesn't work correctly on Windows, see issue #1695");
         throw e;
       }
       profiler.setSamplingInterval(100); // default is 1000us

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -402,7 +402,12 @@ fi
   let profiler;
   try {
     if (cpuprofilePath !== undefined) {
-      profiler = require("v8-profiler");
+      try {
+        profiler = require("v8-profiler");
+      } catch (e) { // Profiler optional dependency failed
+        console.error("v8-profiler doesn't work correctly on windows, see issue #1695");
+        throw e;
+      }
       profiler.setSamplingInterval(100); // default is 1000us
       profiler.startProfiling("");
     }


### PR DESCRIPTION
Release Notes: Works on windows now?

Solves #1695.

Since v8-profiler doesn't work properly on some platforms, make it a conditional dependency. If it fails to install, it won't stop the installation of Prepack entirely now. If the dependency is nonexistant, using the `--cpuprofile` option will throw an error. 