### PR TITLE
Join JoinedAbruptCompletions when optimizing functions.

### DIFF
--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -125,7 +125,6 @@ export class Functions {
     return recordedAdditionalFunctions;
   }
 
-  // This will also handle postprocessing for PossiblyNormalCompletion
   _createAdditionalEffects(
     effects: Effects,
     fatalOnAbrupt: boolean,
@@ -133,41 +132,31 @@ export class Functions {
     environmentRecordIdAfterGlobalCode: number,
     parentAdditionalFunction: FunctionValue | void = undefined
   ): AdditionalFunctionEffects | null {
+    let realm = this.realm;
     let [pncResult] = effects;
-    if (pncResult instanceof PossiblyNormalCompletion) {
-      // This is a join point for all the forked paths in pncResult
-      effects = Join.joinEffectsAndPromoteNestedReturnCompletions(
-        this.realm,
-        pncResult,
-        construct_empty_effects(this.realm)
+    if (pncResult instanceof PossiblyNormalCompletion || pncResult instanceof JoinedAbruptCompletions) {
+      // The completion is not the end of function execution, but a fork point for separate threads of control.
+      // The effects of all of these threads need to get joined up and rolled into the top level effects,
+      // so that applying the effects before serializing the body will fully initialize all variables and objects.
+      effects = realm.evaluateForEffects(
+        () => {
+          realm.applyEffects(effects, "_createAdditionalEffects/1", false);
+          if (pncResult instanceof PossiblyNormalCompletion) {
+            [pncResult] = Join.joinPossiblyNormalCompletionWithAbruptCompletion(
+              realm,
+              pncResult,
+              new ReturnCompletion(pncResult.value),
+              construct_empty_effects(realm)
+            );
+          }
+          invariant(pncResult instanceof JoinedAbruptCompletions);
+          let completionEffects = Join.joinNestedEffects(realm, pncResult);
+          realm.applyEffects(completionEffects, "_createAdditionalEffects/2", false);
+          return pncResult;
+        },
+        undefined,
+        "_createAdditionalEffects"
       );
-      let [result] = effects;
-      if (result instanceof JoinedAbruptCompletions) {
-        if (result.alternate instanceof ReturnCompletion) {
-          result.alternateEffects[0] = pncResult.value;
-          result = new PossiblyNormalCompletion(
-            pncResult.value,
-            result.joinCondition,
-            result.consequent,
-            result.consequentEffects,
-            pncResult.value,
-            result.alternateEffects,
-            []
-          );
-        } else if (result.consequent instanceof ReturnCompletion) {
-          result.consequentEffects[0] = pncResult.value;
-          result = new PossiblyNormalCompletion(
-            pncResult.value,
-            result.joinCondition,
-            pncResult.value,
-            result.consequentEffects,
-            result.alternate,
-            result.alternateEffects,
-            []
-          );
-        }
-        effects[0] = result;
-      }
     }
     let retValue: AdditionalFunctionEffects = {
       parentAdditionalFunction,

--- a/src/types.js
+++ b/src/types.js
@@ -744,6 +744,8 @@ export type JoinType = {
 
   joinEffects(realm: Realm, joinCondition: AbstractValue, e1: Effects, e2: Effects): Effects,
 
+  joinNestedEffects(realm: Realm, c: Completion, precedingEffects?: Effects): Effects,
+
   joinResults(
     realm: Realm,
     joinCondition: AbstractValue,

--- a/test/serializer/additional-functions/return-or-many-throw.js
+++ b/test/serializer/additional-functions/return-or-many-throw.js
@@ -43,5 +43,5 @@ inspect = function() {
   } catch (e) {
     error = e.message;
   }
-  return 'err: ' + error + ' ret ' + ret + ' normal ret ' + normalRet + ' foo ' + foo;
+  return 'err: ' + error + ' ret ' + ret + ' normal ret ' + normalRet + ' foo ' + obj.foo;
 }

--- a/test/serializer/additional-functions/return-or-throw-simple.js
+++ b/test/serializer/additional-functions/return-or-throw-simple.js
@@ -7,7 +7,11 @@ else x = 3;
 function func1() {
   let z = 5;
   if (x > 10) {
+    x = 15;
     throw new Error("X greater than 10 " + x);
+  } else if (x > 20) {
+    x = 25;
+    throw new Error("X greater than 20 " + x);
   }
   return x;
 }


### PR DESCRIPTION
Release note: none

The effects constructed for an optimized function must join all paths that may leave the function in order to provide a full accounting of what the function might do to the global environment. Without this, the global environment can get polluted by side effects in the abrupt branches, because these effects are applied to the environment when constructing the generator from the overall effects, but are not reversed when backing out the overall effects.

This can break things in many different ways, one of which is illustrated in the modification of return-or-throw-simple.js, where the last return x is serialized as undefined rather than the abstract value, because x got polluted during the construction of the effects for func1.