### PR TITLE
Fixes mismatch between visitor and serializer.

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -983,7 +983,7 @@ export class ResidualHeapSerializer {
     let value = valueFn();
     let assignment = t.expressionStatement(t.assignmentExpression("=", location, value));
     if (mightHaveBeenDeleted) {
-      let condition = t.binaryExpression("!==", value, this.serializeValue(this.realm.intrinsics.empty));
+      let condition = t.binaryExpression("!==", value, this._serializeEmptyValue());
       let deletion = null;
       if (deleteIfMightHaveBeenDeleted) {
         invariant(location.type === "MemberExpression");
@@ -1702,14 +1702,18 @@ export class ResidualHeapSerializer {
     }
   }
 
+  _serializeEmptyValue(): BabelNodeExpression {
+    this.needsEmptyVar = true;
+    return emptyExpression;
+  }
+
   _serializeValue(val: Value): void | BabelNodeExpression {
     if (val instanceof AbstractValue) {
       return this._serializeAbstractValue(val);
     } else if (val.isIntrinsic()) {
       return this._serializeValueIntrinsic(val);
     } else if (val instanceof EmptyValue) {
-      this.needsEmptyVar = true;
-      return emptyExpression;
+      return this._serializeEmptyValue();
     } else if (val instanceof UndefinedValue) {
       return voidExpression;
     } else if (ResidualHeapInspector.isLeaf(val)) {

--- a/test/serializer/abstract/MightBeEmptyAssignment.js
+++ b/test/serializer/abstract/MightBeEmptyAssignment.js
@@ -1,0 +1,9 @@
+(function () {
+    var a = {};
+    var c = global.__abstract ? __abstract("boolean", "true") : "c";
+    if (c) { 
+        a.foo = 42; 
+        global.a = a; 
+    }
+    inspect = function() { return global.a.foo; }
+})();


### PR DESCRIPTION
Release notes: None

The serializer used simply invoke the serialization
machinery for the special empty value when it was
trying to generate code for a possibly-deleted property.
However, there was no matching visiting of the special empty value.

This fixes issue #1747.

Adding regression test case.