### PR TITLE
Preserve order of joined throw completions at function end

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -497,7 +497,7 @@ export class JoinImplementation {
     let [r3] = e3;
     if (r3 instanceof JoinedAbruptCompletions) {
       let [joinedEffects, possiblyNormalCompletion] = this.unbundleReturnCompletion(realm, r3);
-      realm.composeWithSavedCompletion(possiblyNormalCompletion);
+      realm.wrapSavedCompletion(possiblyNormalCompletion);
       return joinedEffects;
     }
     return e3;

--- a/src/realm.js
+++ b/src/realm.js
@@ -1027,6 +1027,20 @@ export class Realm {
     }
   }
 
+  wrapSavedCompletion(completion: PossiblyNormalCompletion) {
+    if (this.savedCompletion !== undefined) {
+      if (completion.consequent instanceof AbruptCompletion) {
+        completion.alternate = this.savedCompletion;
+      } else {
+        completion.consequent = this.savedCompletion;
+      }
+      completion.savedEffects = this.savedCompletion.savedEffects;
+    } else {
+      this.captureEffects(completion);
+    }
+    this.savedCompletion = completion;
+  }
+
   composeWithSavedCompletion(completion: PossiblyNormalCompletion): Value {
     if (this.savedCompletion === undefined) {
       this.savedCompletion = completion;

--- a/test/serializer/additional-functions/return-or-throw-simple1.js
+++ b/test/serializer/additional-functions/return-or-throw-simple1.js
@@ -1,0 +1,27 @@
+var x = global.__abstract ? x = __abstract("number", "(23)") : 23;
+
+function func1() {
+  let z = 5;
+  if (x > 20) {
+    x = 15;
+    throw new Error("X greater than 10 " + x);
+  } else if (x > 10) {
+    x = 25;
+    throw new Error("X greater than 20 " + x);
+  }
+  return x;
+}
+
+if (global.__optimize)
+  __optimize(func1);
+
+inspect = function() {
+  let error;
+  let ret;
+  try {
+    ret = func1();
+  } catch (e) {
+    error = e.message;
+  }
+  return 'err: ' + error + ' ret ' + ret;
+}


### PR DESCRIPTION
Release note: none

The code for disentangling return completions from throw completions uses a recursive algorithm that caused the throw completions to get reversed. Fix this to prepend rather than append so that the order comes out right.

This is also an opportunity to not mess with the path conditions.