### PR TITLE
Turn TODO into invariants

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1078,6 +1078,33 @@ export class ResidualHeapVisitor {
     return callbacks;
   }
 
+  _validateCreatedObjectsAddition(createdObject: ObjectValue, generator: Generator) {
+    let creatingGenerator = this.createdObjects.get(createdObject);
+    // If there is already an entry in createdObjects, it must be for a generator that is a parent of this generator
+    // This is because createdObjects of nested effects of optimized functions are strict subsets of the
+    // optimized function's createdObjects set.
+    if (creatingGenerator && creatingGenerator !== generator) {
+      let currentScope = generator;
+      // Walk up generator parent chain to make sure that creatingGenerator is a parent of generator.
+      while (currentScope !== creatingGenerator) {
+        if (currentScope instanceof Generator) {
+          currentScope = this.generatorParents.get(currentScope);
+        } else if (currentScope instanceof FunctionValue) {
+          // We're trying to walk up generatorParents and should only be falling into this case if we hit an
+          // optimized function value as a generator parent. Optimized function values must always have generator
+          // or "GLOBAL" parents
+          invariant(this.additionalFunctionValuesAndEffects.has(currentScope));
+          currentScope = this.createdObjects.get(currentScope) || "GLOBAL";
+        }
+        invariant(currentScope !== undefined, "Should have already encountered all parents of this generator.");
+        invariant(
+          currentScope !== "GLOBAL",
+          "If an object is in two generators' effects' createdObjects, the second must be a child of the first."
+        );
+      }
+    }
+  }
+
   visitGenerator(
     generator: Generator,
     parent: Generator | FunctionValue | "GLOBAL",
@@ -1091,30 +1118,7 @@ export class ResidualHeapVisitor {
     this.generatorParents.set(generator, parent);
     if (generator.effectsToApply)
       for (const createdObject of generator.effectsToApply[4]) {
-        let creatingGenerator = this.createdObjects.get(createdObject);
-        // If there is already an entry in createdObjects, it must be for a generator that is a parent of this generator
-        // This is because createdObjects of nested effects of optimized functions are strict subsets of the
-        // optimized function's createdObjects set.
-        if (creatingGenerator && creatingGenerator !== generator) {
-          let currentScope = generator;
-          // Walk up generator parent chain to make sure that creatingGenerator is a parent of generator.
-          while (currentScope !== creatingGenerator) {
-            if (currentScope instanceof Generator) {
-              currentScope = this.generatorParents.get(currentScope);
-            } else if (currentScope instanceof FunctionValue) {
-              // We're trying to walk up generatorParents and should only be falling into this case if we hit an
-              // optimized function value as a generator parent. Optimized function values must always have generator
-              // or "GLOBAL" parents
-              invariant(this.additionalFunctionValuesAndEffects.has(currentScope));
-              currentScope = this.createdObjects.get(currentScope) || "GLOBAL";
-            }
-            invariant(currentScope !== undefined, "Should have already encountered all parents of this generator.");
-            invariant(
-              currentScope !== "GLOBAL",
-              "If an object is in two generators' effects' createdObjects, the second must be a child of the first."
-            );
-          }
-        }
+        this._validateCreatedObjectsAddition(createdObject, generator);
         if (!this.createdObjects.has(createdObject)) this.createdObjects.set(createdObject, generator);
       }
 


### PR DESCRIPTION
Release Notes: None

Adds invariant to visitGenerator enforcing that if createdObjects has an entry for one of the createdObjects, it is due to a child generator. This should be true because optimized functions' nested effects' createdObjects are a strict subset of the overall optimized function effects. 