### PR TITLE
Make effects into a class in smallest possible change

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -109,8 +109,8 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
-    invariant(consequent === consequentEffects[0]);
-    invariant(alternate === alternateEffects[0]);
+    invariant(consequent === consequentEffects.data[0]);
+    invariant(alternate === alternateEffects.data[0]);
     invariant(
       consequent instanceof NormalCompletion ||
         consequent instanceof Value ||

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -217,7 +217,7 @@ export function computeBinary(
     }
 
     if (isPure && effects) {
-      let completion = effects[0];
+      let completion = effects.data[0];
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
         // not all control flow branches join into one flow at this point.

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -12,6 +12,7 @@
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
+import { Effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { EnvironmentRecord } from "../environment.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -69,21 +70,21 @@ function callBothFunctionsAndJoinTheirEffects(
     () => EvaluateCall(func1, func1, ast, strictCode, env, realm),
     undefined,
     "callBothFunctionsAndJoinTheirEffects/1"
-  );
+  ).data;
 
   let [compl2, gen2, bindings2, properties2, createdObj2] = realm.evaluateForEffects(
     () => EvaluateCall(func2, func2, ast, strictCode, env, realm),
     undefined,
     "callBothFunctionsAndJoinTheirEffects/2"
-  );
+  ).data;
 
   let joinedEffects = Join.joinEffects(
     realm,
     cond,
-    [compl1, gen1, bindings1, properties1, createdObj1],
-    [compl2, gen2, bindings2, properties2, createdObj2]
+    new Effects(compl1, gen1, bindings1, properties1, createdObj1),
+    new Effects(compl2, gen2, bindings2, properties2, createdObj2)
   );
-  let completion = joinedEffects[0];
+  let completion = joinedEffects.data[0];
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.
@@ -179,7 +180,7 @@ function tryToEvaluateCallOrLeaveAsAbstract(
   } finally {
     realm.suppressDiagnostics = savedSuppressDiagnostics;
   }
-  let completion = effects[0];
+  let completion = effects.data[0];
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/evaluators/DoWhileStatement.js
+++ b/src/evaluators/DoWhileStatement.js
@@ -79,8 +79,8 @@ export default function(
   let result = realm.evaluateForFixpointEffects(iteration);
   if (result !== undefined) {
     let [outsideEffects, insideEffects, cond] = result;
-    let [rval] = outsideEffects;
-    let [, bodyGenerator] = insideEffects;
+    let [rval] = outsideEffects.data;
+    let [, bodyGenerator] = insideEffects.data;
     realm.applyEffects(outsideEffects);
     let generator = realm.generator;
     invariant(generator !== undefined);

--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -137,7 +137,7 @@ function emitResidualLoopIfSafe(
       envRec.CreateMutableBinding(n, false);
       envRec.InitializeBinding(n, absStr);
     }
-    let [compl, gen, bindings, properties, createdObj] = realm.evaluateNodeForEffects(body, strictCode, blockEnv);
+    let [compl, gen, bindings, properties, createdObj] = realm.evaluateNodeForEffects(body, strictCode, blockEnv).data;
     if (compl instanceof Value && gen.empty() && bindings.size === 0 && properties.size === 1) {
       invariant(createdObj.size === 0); // or there will be more than one property
       let targetObject;

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -111,7 +111,7 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
       throw error;
     }
   }
-  let completion = effects[0];
+  let completion = effects.data[0];
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -173,7 +173,7 @@ function AbstractCaseBlockEvaluation(
       invariant(trueEffects !== undefined);
       invariant(falseEffects !== undefined);
       let joinedEffects = Join.joinEffects(realm, selectionResult, trueEffects, falseEffects);
-      let completion = joinedEffects[0];
+      let completion = joinedEffects.data[0];
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
         // not all control flow branches join into one flow at this point.

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -58,7 +58,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       }
       // All of the forked threads of control are now joined together and the global state reflects their joint effects
       let handlerEffects = composeNestedThrowEffectsWithHandler(blockRes);
-      handlerRes = handlerEffects[0];
+      handlerRes = handlerEffects.data[0];
       if (handlerRes instanceof Value) {
         // This can happen if all of the abrupt completions in blockRes were throw completions
         // and if the handler does not introduce any abrupt completions of its own.
@@ -81,7 +81,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       // The current global state is a the point of the fork that led to blockRes
       // All subsequent effects are kept inside the branches of blockRes.
       let finalizerEffects = composeNestedEffectsWithFinalizer(blockRes);
-      finalizerRes = finalizerEffects[0];
+      finalizerRes = finalizerEffects.data[0];
       // The result may become abrupt because of the finalizer, but it cannot become normal.
       invariant(!(finalizerRes instanceof Value));
     } else {
@@ -165,7 +165,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         undefined,
         "composeNestedEffectsWithFinalizer/1"
       );
-      if (!(consequentEffects[0] instanceof AbruptCompletion)) consequentEffects[0] = consequent;
+      if (!(consequentEffects.data[0] instanceof AbruptCompletion)) consequentEffects.data[0] = consequent;
     }
     priorEffects.pop();
     let alternate = c.alternate;
@@ -183,7 +183,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         undefined,
         "composeNestedThrowEffectsWithHandler"
       );
-      if (!(alternateEffects[0] instanceof AbruptCompletion)) alternateEffects[0] = alternate;
+      if (!(alternateEffects.data[0] instanceof AbruptCompletion)) alternateEffects.data[0] = alternate;
     }
     priorEffects.pop();
     return Join.joinEffects(realm, c.joinCondition, consequentEffects, alternateEffects);

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -129,7 +129,7 @@ function tryToEvaluateOperationOrLeaveAsAbstract(
       throw error;
     }
   }
-  let completion = effects[0];
+  let completion = effects.data[0];
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -342,7 +342,7 @@ export function OrdinaryCallEvaluateBody(
           //todo: need to emit a specialized function that temporally captures the heap state at this point
         } else {
           realm.applyEffects(effects);
-          let c = effects[0];
+          let c = effects.data[0];
           return processResult(() => {
             invariant(c instanceof Value || c instanceof AbruptCompletion);
             return c;
@@ -414,7 +414,7 @@ export function OrdinaryCallEvaluateBody(
             joinedEffects = Join.joinEffectsAndPromoteNestedReturnCompletions(realm, c, construct_empty_effects(realm));
           }
           if (joinedEffects !== undefined) {
-            let result = joinedEffects[0];
+            let result = joinedEffects.data[0];
             if (result instanceof ReturnCompletion) {
               realm.applyEffects(joinedEffects);
               return result;
@@ -428,7 +428,7 @@ export function OrdinaryCallEvaluateBody(
             // The throw completions must be extracted into a saved possibly normal completion
             // so that the caller can pick them up in its next completion.
             joinedEffects = extractAndSavePossiblyNormalCompletion(result);
-            result = joinedEffects[0];
+            result = joinedEffects.data[0];
             invariant(result instanceof ReturnCompletion);
             realm.applyEffects(joinedEffects);
             return result;

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1141,7 +1141,7 @@ export class FunctionImplementation {
         realm.stopEffectCaptureAndUndoEffects(savedCompletion);
         let joined_effects = Join.joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, c, e);
         realm.applyEffects(joined_effects);
-        let jc = joined_effects[0];
+        let jc = joined_effects.data[0];
         invariant(jc instanceof AbruptCompletion);
         return jc;
       }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -11,7 +11,7 @@
 
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 import { InfeasiblePathError } from "../errors.js";
-import { construct_empty_effects, type Realm } from "../realm.js";
+import { construct_empty_effects, type Realm, Effects } from "../realm.js";
 import type { PropertyKeyValue, CallableObjectValue } from "../types.js";
 import {
   AbstractObjectValue,
@@ -119,7 +119,7 @@ export function OrdinaryGet(
       return desc !== undefined
         ? realm.evaluateForEffects(() => OrdinaryGetHelper(), undefined, "OrdinaryGet/1")
         : construct_empty_effects(realm);
-    });
+    }).data;
   } catch (e) {
     if (e instanceof InfeasiblePathError) {
       // The joinCondition cannot be true in the current path, after all
@@ -136,7 +136,7 @@ export function OrdinaryGet(
       return desc !== undefined
         ? realm.evaluateForEffects(() => OrdinaryGetHelper(), undefined, "OrdinaryGet/2")
         : construct_empty_effects(realm);
-    });
+    }).data;
   } catch (e) {
     if (e instanceof InfeasiblePathError) {
       // The joinCondition cannot be false in the current path, after all
@@ -151,10 +151,10 @@ export function OrdinaryGet(
   let joinedEffects = Join.joinEffects(
     realm,
     joinCondition,
-    [compl1, gen1, bindings1, properties1, createdObj1],
-    [compl2, gen2, bindings2, properties2, createdObj2]
+    new Effects(compl1, gen1, bindings1, properties1, createdObj1),
+    new Effects(compl2, gen2, bindings2, properties2, createdObj2)
   );
-  let completion = joinedEffects[0];
+  let completion = joinedEffects.data[0];
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -11,15 +11,8 @@
 
 import type { Binding } from "../environment.js";
 import { FatalError } from "../errors.js";
-import type {
-  Bindings,
-  BindingEntry,
-  Effects,
-  EvaluationResult,
-  PropertyBindings,
-  CreatedObjects,
-  Realm,
-} from "../realm.js";
+import type { Bindings, BindingEntry, EvaluationResult, PropertyBindings, CreatedObjects, Realm } from "../realm.js";
+import { Effects } from "../realm.js";
 import type { Descriptor, PropertyBinding } from "../types.js";
 
 import {
@@ -113,7 +106,7 @@ export class JoinImplementation {
     realm.stopEffectCaptureAndUndoEffects(c1);
     let joined_effects = this.joinPossiblyNormalCompletionWithAbruptCompletion(realm, c1, c2, e);
     realm.applyEffects(joined_effects);
-    let result = joined_effects[0];
+    let result = joined_effects.data[0];
     invariant(result instanceof AbruptCompletion);
     return result;
   }
@@ -163,8 +156,8 @@ export class JoinImplementation {
     let savedPathConditions = pnc.savedPathConditions;
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
-        let [, g, b, p, o] = pnc.alternateEffects;
-        let newAlternateEffects = [c, g, b, p, o];
+        let [, g, b, p, o] = pnc.alternateEffects.data;
+        let newAlternateEffects = new Effects(c, g, b, p, o);
         return new PossiblyNormalCompletion(
           c.value,
           pnc.joinCondition,
@@ -178,8 +171,8 @@ export class JoinImplementation {
       }
       invariant(pnc.alternate instanceof PossiblyNormalCompletion);
       let new_alternate = this.composePossiblyNormalCompletions(realm, pnc.alternate, c);
-      let [, g, b, p, o] = pnc.alternateEffects;
-      let newAlternateEffects = [new_alternate, g, b, p, o];
+      let [, g, b, p, o] = pnc.alternateEffects.data;
+      let newAlternateEffects = new Effects(new_alternate, g, b, p, o);
       return new PossiblyNormalCompletion(
         new_alternate.value,
         pnc.joinCondition,
@@ -193,8 +186,8 @@ export class JoinImplementation {
     } else {
       invariant(pnc.alternate instanceof AbruptCompletion);
       if (pnc.consequent instanceof Value) {
-        let [, g, b, p, o] = pnc.consequentEffects;
-        let newConsequentEffects = [c, g, b, p, o];
+        let [, g, b, p, o] = pnc.consequentEffects.data;
+        let newConsequentEffects = new Effects(c, g, b, p, o);
         return new PossiblyNormalCompletion(
           c.value,
           pnc.joinCondition,
@@ -208,8 +201,8 @@ export class JoinImplementation {
       }
       invariant(pnc.consequent instanceof PossiblyNormalCompletion);
       let new_consequent = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
-      let [, g, b, p, o] = pnc.consequentEffects;
-      let newConsequentEffects = [new_consequent, g, b, p, o];
+      let [, g, b, p, o] = pnc.consequentEffects.data;
+      let newConsequentEffects = new Effects(new_consequent, g, b, p, o);
       return new PossiblyNormalCompletion(
         new_consequent.value,
         pnc.joinCondition,
@@ -228,13 +221,13 @@ export class JoinImplementation {
     pnc: PossiblyNormalCompletion,
     subsequentEffects: Effects
   ) {
-    let v = subsequentEffects[0];
+    let v = subsequentEffects.data[0];
     invariant(v instanceof Value);
     pnc.value = v;
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
         pnc.alternate = v;
-        pnc.alternateEffects[0] = v;
+        pnc.alternateEffects.data[0] = v;
         pnc.alternateEffects = realm.composeEffects(pnc.alternateEffects, subsequentEffects);
       } else {
         invariant(pnc.alternate instanceof PossiblyNormalCompletion);
@@ -243,7 +236,7 @@ export class JoinImplementation {
     } else {
       if (pnc.consequent instanceof Value) {
         pnc.consequent = v;
-        pnc.consequentEffects[0] = v;
+        pnc.consequentEffects.data[0] = v;
         pnc.consequentEffects = realm.composeEffects(pnc.consequentEffects, subsequentEffects);
       } else {
         invariant(pnc.consequent instanceof PossiblyNormalCompletion);
@@ -257,7 +250,7 @@ export class JoinImplementation {
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
         pnc.alternate = v;
-        pnc.alternateEffects[0] = v;
+        pnc.alternateEffects.data[0] = v;
       } else {
         invariant(pnc.alternate instanceof PossiblyNormalCompletion);
         this.updatePossiblyNormalCompletionWithValue(realm, pnc.alternate, v);
@@ -265,7 +258,7 @@ export class JoinImplementation {
     } else {
       if (pnc.consequent instanceof Value) {
         pnc.consequent = v;
-        pnc.consequentEffects[0] = v;
+        pnc.consequentEffects.data[0] = v;
       } else {
         invariant(pnc.consequent instanceof PossiblyNormalCompletion);
         this.updatePossiblyNormalCompletionWithValue(realm, pnc.consequent, v);
@@ -286,7 +279,7 @@ export class JoinImplementation {
     e: Effects
   ): Effects {
     // set up e with ac as the completion. It's OK to do this repeatedly since ac is not changed by recursive calls.
-    e[0] = ac;
+    e.data[0] = ac;
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
         return this.joinEffects(
@@ -328,7 +321,7 @@ export class JoinImplementation {
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
         pnc.alternate = this.joinValuesAsConditional(realm, joinCondition, pnc.alternate, v);
-        pnc.alternateEffects[0] = pnc.alternate;
+        pnc.alternateEffects.data[0] = pnc.alternate;
       } else {
         invariant(pnc.alternate instanceof PossiblyNormalCompletion);
         this.joinPossiblyNormalCompletionWithValue(realm, joinCondition, pnc.alternate, v);
@@ -336,7 +329,7 @@ export class JoinImplementation {
     } else {
       if (pnc.consequent instanceof Value) {
         pnc.consequent = this.joinValuesAsConditional(realm, joinCondition, pnc.consequent, v);
-        pnc.consequentEffects[0] = pnc.consequent;
+        pnc.consequentEffects.data[0] = pnc.consequent;
       } else {
         invariant(pnc.consequent instanceof PossiblyNormalCompletion);
         this.joinPossiblyNormalCompletionWithValue(realm, joinCondition, pnc.consequent, v);
@@ -353,7 +346,7 @@ export class JoinImplementation {
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof Value) {
         pnc.alternate = this.joinValuesAsConditional(realm, joinCondition, v, pnc.alternate);
-        pnc.alternateEffects[0] = pnc.alternate;
+        pnc.alternateEffects.data[0] = pnc.alternate;
       } else {
         invariant(pnc.alternate instanceof PossiblyNormalCompletion);
         this.joinValueWithPossiblyNormalCompletion(realm, joinCondition, pnc.alternate, v);
@@ -361,7 +354,7 @@ export class JoinImplementation {
     } else {
       if (pnc.consequent instanceof Value) {
         pnc.consequent = this.joinValuesAsConditional(realm, joinCondition, v, pnc.consequent);
-        pnc.consequentEffects[0] = pnc.consequent;
+        pnc.consequentEffects.data[0] = pnc.consequent;
       } else {
         invariant(pnc.consequent instanceof PossiblyNormalCompletion);
         this.joinValueWithPossiblyNormalCompletion(realm, joinCondition, pnc.consequent, v);
@@ -407,9 +400,9 @@ export class JoinImplementation {
     let [ae1, ae2] = ap;
     let rce = this.joinEffects(realm, joinCondition, ce1, ce2);
     let rae = this.joinEffects(realm, joinCondition, ae1, ae2);
-    let rc = rce[0];
+    let rc = rce.data[0];
     invariant(rc instanceof Value || rc instanceof Completion);
-    let ra = rae[0];
+    let ra = rae.data[0];
     invariant(ra instanceof Value || ra instanceof Completion);
     let rv = ra instanceof PossiblyNormalCompletion ? ra.value : ra;
     invariant(rv instanceof Value);
@@ -438,11 +431,13 @@ export class JoinImplementation {
     if (c instanceof PossiblyNormalCompletion) {
       let e1 = this.joinEffectsAndPromoteNestedReturnCompletions(realm, c.consequent, e, c.consequentEffects);
       let e2 = this.joinEffectsAndPromoteNestedReturnCompletions(realm, c.alternate, e, c.alternateEffects);
-      if (e1[0] instanceof AbruptCompletion) {
-        if (e2[0] instanceof Value) e2[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
+      if (e1.data[0] instanceof AbruptCompletion) {
+        if (e2.data[0] instanceof Value)
+          e2.data[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
         return this.joinEffects(realm, c.joinCondition, e1, e2);
-      } else if (e2[0] instanceof AbruptCompletion) {
-        if (e1[0] instanceof Value) e1[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
+      } else if (e2.data[0] instanceof AbruptCompletion) {
+        if (e1.data[0] instanceof Value)
+          e1.data[0] = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
         return this.joinEffects(realm, c.joinCondition, e1, e2);
       }
     }
@@ -450,7 +445,7 @@ export class JoinImplementation {
     // e will be ignored in the calls below since the branches are all abrupt.
     let e1 = this.joinEffectsAndPromoteNestedReturnCompletions(realm, c.consequent, e, c.consequentEffects);
     let e2 = this.joinEffectsAndPromoteNestedReturnCompletions(realm, c.alternate, e, c.alternateEffects);
-    let [r1, r2] = [e1[0], e2[0]];
+    let [r1, r2] = [e1.data[0], e2.data[0]];
     if (r1 instanceof ReturnCompletion) {
       // this can happen because joinEffectsAndPromoteNestedReturnCompletions above both had nested ReturnCompletions
       if (r2 instanceof ReturnCompletion) {
@@ -459,14 +454,14 @@ export class JoinImplementation {
       if (r2 instanceof JoinedAbruptCompletions) {
         if (r2.consequent instanceof ReturnCompletion) {
           let r1jr2c = this.joinEffects(realm, c.joinCondition, e1, r2.consequentEffects);
-          invariant(r1jr2c[0] instanceof ReturnCompletion);
+          invariant(r1jr2c.data[0] instanceof ReturnCompletion);
           let or = AbstractValue.createFromLogicalOp(realm, "||", c.joinCondition, r2.joinCondition);
           invariant(or instanceof AbstractValue);
           return this.joinEffects(realm, or, r1jr2c, r2.alternateEffects);
         }
         if (r2.alternate instanceof ReturnCompletion) {
           let r1jr2a = this.joinEffects(realm, c.joinCondition, e1, r2.alternateEffects);
-          invariant(r1jr2a[0] instanceof ReturnCompletion);
+          invariant(r1jr2a.data[0] instanceof ReturnCompletion);
           let notR2jc = AbstractValue.createFromUnaryOp(realm, "!", r2.joinCondition);
           let or = AbstractValue.createFromLogicalOp(realm, "||", c.joinCondition, notR2jc);
           invariant(or instanceof AbstractValue);
@@ -478,7 +473,7 @@ export class JoinImplementation {
       if (r1 instanceof JoinedAbruptCompletions) {
         if (r1.consequent instanceof ReturnCompletion) {
           let r2jr1c = this.joinEffects(realm, c.joinCondition, r1.consequentEffects, e2);
-          invariant(r2jr1c[0] instanceof ReturnCompletion);
+          invariant(r2jr1c.data[0] instanceof ReturnCompletion);
           let or = AbstractValue.createFromLogicalOp(realm, "||", c.joinCondition, r1.joinCondition);
           invariant(or instanceof AbstractValue);
           return this.joinEffects(realm, or, r2jr1c, r1.alternateEffects);
@@ -486,7 +481,7 @@ export class JoinImplementation {
         if (r1.alternate instanceof ReturnCompletion) {
           let r2jr1a = this.joinEffects(realm, c.joinCondition, r1.alternateEffects, e2);
           let notR1jc = AbstractValue.createFromUnaryOp(realm, "!", r1.joinCondition);
-          invariant(r2jr1a[0] instanceof ReturnCompletion);
+          invariant(r2jr1a.data[0] instanceof ReturnCompletion);
           let or = AbstractValue.createFromLogicalOp(realm, "||", c.joinCondition, notR1jc);
           invariant(or instanceof AbstractValue);
           return this.joinEffects(realm, or, r2jr1a, r1.consequentEffects);
@@ -494,7 +489,7 @@ export class JoinImplementation {
       }
     }
     let e3 = this.joinEffects(realm, c.joinCondition, e1, e2);
-    let [r3] = e3;
+    let [r3] = e3.data;
     if (r3 instanceof JoinedAbruptCompletions) {
       let [joinedEffects, possiblyNormalCompletion] = this.unbundleReturnCompletion(realm, r3);
       realm.composeWithSavedCompletion(possiblyNormalCompletion);
@@ -552,18 +547,18 @@ export class JoinImplementation {
   }
 
   joinEffects(realm: Realm, joinCondition: AbstractValue, e1: Effects, e2: Effects): Effects {
-    let [result1, gen1, bindings1, properties1, createdObj1] = e1;
-    let [result2, gen2, bindings2, properties2, createdObj2] = e2;
+    let [result1, gen1, bindings1, properties1, createdObj1] = e1.data;
+    let [result2, gen2, bindings2, properties2, createdObj2] = e2.data;
 
     let result = this.joinResults(realm, joinCondition, result1, result2, e1, e2);
     if (result1 instanceof AbruptCompletion) {
       if (!(result2 instanceof AbruptCompletion)) {
         invariant(result instanceof PossiblyNormalCompletion);
-        return [result, gen2, bindings2, properties2, createdObj2];
+        return new Effects(result, gen2, bindings2, properties2, createdObj2);
       }
     } else if (result2 instanceof AbruptCompletion) {
       invariant(result instanceof PossiblyNormalCompletion);
-      return [result, gen1, bindings1, properties1, createdObj1];
+      return new Effects(result, gen1, bindings1, properties1, createdObj1);
     }
 
     let bindings = this.joinBindings(realm, joinCondition, bindings1, bindings2);
@@ -585,7 +580,7 @@ export class JoinImplementation {
 
     let generator = joinGenerators(realm, joinCondition, gen1, gen2);
 
-    return [result, generator, bindings, properties, createdObjects];
+    return new Effects(result, generator, bindings, properties, createdObjects);
   }
 
   joinNestedEffects(realm: Realm, c: Completion | Value, precedingEffects?: Effects): Effects {
@@ -596,7 +591,7 @@ export class JoinImplementation {
     }
     if (precedingEffects !== undefined) return precedingEffects;
     let result = construct_empty_effects(realm);
-    result[0] = c;
+    result.data[0] = c;
     return result;
   }
 

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
-import { construct_empty_effects, type Realm } from "../realm.js";
+import { construct_empty_effects, type Realm, Effects } from "../realm.js";
 import type { Descriptor, PropertyBinding, PropertyKeyValue } from "../types.js";
 import {
   AbstractObjectValue,
@@ -303,23 +303,23 @@ export class PropertiesImplementation {
         return ownDesc !== undefined
           ? realm.evaluateForEffects(() => new BooleanValue(realm, OrdinarySetHelper()), undefined, "OrdinarySet/1")
           : construct_empty_effects(realm);
-      });
+      }).data;
       ownDesc = descriptor2;
       let [compl2, gen2, bindings2, properties2, createdObj2] = Path.withInverseCondition(joinCondition, () => {
         return ownDesc !== undefined
           ? realm.evaluateForEffects(() => new BooleanValue(realm, OrdinarySetHelper()), undefined, "OrdinarySet/2")
           : construct_empty_effects(realm);
-      });
+      }).data;
 
       // Join the effects, creating an abstract view of what happened, regardless
       // of the actual value of ownDesc.joinCondition.
       let joinedEffects = Join.joinEffects(
         realm,
         joinCondition,
-        [compl1, gen1, bindings1, properties1, createdObj1],
-        [compl2, gen2, bindings2, properties2, createdObj2]
+        new Effects(compl1, gen1, bindings1, properties1, createdObj1),
+        new Effects(compl2, gen2, bindings2, properties2, createdObj2)
       );
-      let completion = joinedEffects[0];
+      let completion = joinedEffects.data[0];
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
         // not all control flow branches join into one flow at this point.

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -11,6 +11,7 @@
 
 import type { BabelNodeCallExpression, BabelNodeExpression, BabelNodeStatement } from "babel-types";
 import type { Realm } from "../realm.js";
+import { Effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
 import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
@@ -105,21 +106,21 @@ function callBothFunctionsAndJoinTheirEffects(
     () => EvaluateCall(func1, func1, ast, argVals, strictCode, env, realm),
     undefined,
     "callBothFunctionsAndJoinTheirEffects/1"
-  );
+  ).data;
 
   let [compl2, gen2, bindings2, properties2, createdObj2] = realm.evaluateForEffects(
     () => EvaluateCall(func2, func2, ast, argVals, strictCode, env, realm),
     undefined,
     "callBothFunctionsAndJoinTheirEffects/2"
-  );
+  ).data;
 
   let joinedEffects = Join.joinEffects(
     realm,
     cond,
-    [compl1, gen1, bindings1, properties1, createdObj1],
-    [compl2, gen2, bindings2, properties2, createdObj2]
+    new Effects(compl1, gen1, bindings1, properties1, createdObj1),
+    new Effects(compl2, gen2, bindings2, properties2, createdObj2)
   );
-  let joinedCompletion = joinedEffects[0];
+  let joinedCompletion = joinedEffects.data[0];
   if (joinedCompletion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -12,6 +12,7 @@
 import type { BabelNodeIfStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
+import { Effects } from "../realm.js";
 
 import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
 import { Reference } from "../environment.js";
@@ -64,14 +65,14 @@ export default function(
 
   // Evaluate consequent and alternate in sandboxes and get their effects.
   let [consequentEffects, conAst, conIO] = realm.partiallyEvaluateNodeForEffects(ast.consequent, strictCode, env);
-  let [conCompl, gen1, bindings1, properties1, createdObj1] = consequentEffects;
+  let [conCompl, gen1, bindings1, properties1, createdObj1] = consequentEffects.data;
   let consequentAst = (conAst: any);
   if (conIO.length > 0) consequentAst = t.blockStatement(conIO.concat(consequentAst));
 
   let [alternateEffects, altAst, altIO] = ast.alternate
     ? realm.partiallyEvaluateNodeForEffects(ast.alternate, strictCode, env)
     : [construct_empty_effects(realm), undefined, []];
-  let [altCompl, gen2, bindings2, properties2, createdObj2] = alternateEffects;
+  let [altCompl, gen2, bindings2, properties2, createdObj2] = alternateEffects.data;
   let alternateAst = (altAst: any);
   if (altIO.length > 0) alternateAst = t.blockStatement(altIO.concat(alternateAst));
 
@@ -80,10 +81,10 @@ export default function(
   let joinedEffects = Join.joinEffects(
     realm,
     exprValue,
-    [conCompl, gen1, bindings1, properties1, createdObj1],
-    [altCompl, gen2, bindings2, properties2, createdObj2]
+    new Effects(conCompl, gen1, bindings1, properties1, createdObj1),
+    new Effects(altCompl, gen2, bindings2, properties2, createdObj2)
   );
-  completion = joinedEffects[0];
+  completion = joinedEffects.data[0];
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { Realm, type Effects } from "../realm.js";
+import { Realm, Effects } from "../realm.js";
 import { Reference } from "../environment.js";
 import { Completion, PossiblyNormalCompletion, AbruptCompletion } from "../completions.js";
 import type { BabelNode, BabelNodeJSXIdentifier } from "babel-types";
@@ -546,14 +546,16 @@ export function evaluateWithNestedEffects(
     modifiedBindings,
     modifiedProperties: Map<PropertyBinding, void | Descriptor>,
     createdObjects,
-  ] = effects;
-  realm.applyEffects([
-    value,
-    new Generator(realm, "evaluateWithNestedEffects"),
-    modifiedBindings,
-    modifiedProperties,
-    createdObjects,
-  ]);
+  ] = effects.data;
+  realm.applyEffects(
+    new Effects(
+      value,
+      new Generator(realm, "evaluateWithNestedEffects"),
+      modifiedBindings,
+      modifiedProperties,
+      createdObjects
+    )
+  );
   try {
     if (nextEffects.length === 0) {
       return f(generator, value);
@@ -811,7 +813,7 @@ export function getValueFromFunctionCall(
     throw error;
   }
 
-  let completion = effects[0];
+  let completion = effects.data[0];
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/realm.js
+++ b/src/realm.js
@@ -67,7 +67,19 @@ export type EvaluationResult = Completion | Reference | Value;
 export type PropertyBindings = Map<PropertyBinding, void | Descriptor>;
 
 export type CreatedObjects = Set<ObjectValue>;
-export type Effects = [EvaluationResult, Generator, Bindings, PropertyBindings, CreatedObjects];
+export class Effects {
+  constructor(
+    result: EvaluationResult,
+    generator: Generator,
+    bindings: Bindings,
+    propertyBindings: PropertyBindings,
+    createdObjects: CreatedObjects
+  ) {
+    this.data = arguments;
+  }
+
+  data: [EvaluationResult, Generator, Bindings, PropertyBindings, CreatedObjects];
+}
 
 export class Tracer {
   beginEvaluateForEffects(state: any) {}
@@ -147,7 +159,13 @@ export class ExecutionContext {
 }
 
 export function construct_empty_effects(realm: Realm): Effects {
-  return [realm.intrinsics.empty, new Generator(realm, "construct_empty_effects"), new Map(), new Map(), new Set()];
+  return new Effects(
+    realm.intrinsics.empty,
+    new Generator(realm, "construct_empty_effects"),
+    new Map(),
+    new Map(),
+    new Set()
+  );
 }
 
 export class Realm {
@@ -415,16 +433,17 @@ export class Realm {
 
   clearBlockBindingsFromCompletion(completion: Completion, environmentRecord: DeclarativeEnvironmentRecord) {
     if (completion instanceof PossiblyNormalCompletion) {
-      this.clearBlockBindings(completion.alternateEffects[2], environmentRecord);
-      this.clearBlockBindings(completion.consequentEffects[2], environmentRecord);
-      if (completion.savedEffects !== undefined) this.clearBlockBindings(completion.savedEffects[2], environmentRecord);
+      this.clearBlockBindings(completion.alternateEffects.data[2], environmentRecord);
+      this.clearBlockBindings(completion.consequentEffects.data[2], environmentRecord);
+      if (completion.savedEffects !== undefined)
+        this.clearBlockBindings(completion.savedEffects.data[2], environmentRecord);
       if (completion.alternate instanceof Completion)
         this.clearBlockBindingsFromCompletion(completion.alternate, environmentRecord);
       if (completion.consequent instanceof Completion)
         this.clearBlockBindingsFromCompletion(completion.consequent, environmentRecord);
     } else if (completion instanceof JoinedAbruptCompletions) {
-      this.clearBlockBindings(completion.alternateEffects[2], environmentRecord);
-      this.clearBlockBindings(completion.consequentEffects[2], environmentRecord);
+      this.clearBlockBindings(completion.alternateEffects.data[2], environmentRecord);
+      this.clearBlockBindings(completion.consequentEffects.data[2], environmentRecord);
       if (completion.alternate instanceof Completion)
         this.clearBlockBindingsFromCompletion(completion.alternate, environmentRecord);
       if (completion.consequent instanceof Completion)
@@ -469,16 +488,16 @@ export class Realm {
 
   clearFunctionBindingsFromCompletion(completion: Completion, funcVal: FunctionValue) {
     if (completion instanceof PossiblyNormalCompletion) {
-      this.clearFunctionBindings(completion.alternateEffects[2], funcVal);
-      this.clearFunctionBindings(completion.consequentEffects[2], funcVal);
-      if (completion.savedEffects !== undefined) this.clearFunctionBindings(completion.savedEffects[2], funcVal);
+      this.clearFunctionBindings(completion.alternateEffects.data[2], funcVal);
+      this.clearFunctionBindings(completion.consequentEffects.data[2], funcVal);
+      if (completion.savedEffects !== undefined) this.clearFunctionBindings(completion.savedEffects.data[2], funcVal);
       if (completion.alternate instanceof Completion)
         this.clearFunctionBindingsFromCompletion(completion.alternate, funcVal);
       if (completion.consequent instanceof Completion)
         this.clearFunctionBindingsFromCompletion(completion.consequent, funcVal);
     } else if (completion instanceof JoinedAbruptCompletions) {
-      this.clearFunctionBindings(completion.alternateEffects[2], funcVal);
-      this.clearFunctionBindings(completion.consequentEffects[2], funcVal);
+      this.clearFunctionBindings(completion.alternateEffects.data[2], funcVal);
+      this.clearFunctionBindings(completion.consequentEffects.data[2], funcVal);
       if (completion.alternate instanceof Completion)
         this.clearFunctionBindingsFromCompletion(completion.alternate, funcVal);
       if (completion.consequent instanceof Completion)
@@ -649,8 +668,8 @@ export class Realm {
         result = func(effects);
         return this.intrinsics.undefined;
       } finally {
-        this.restoreBindings(effects[2]);
-        this.restoreProperties(effects[3]);
+        this.restoreBindings(effects.data[2]);
+        this.restoreProperties(effects.data[3]);
       }
     });
     invariant(result !== undefined, "If we get here, func must have returned undefined.");
@@ -732,14 +751,14 @@ export class Realm {
         */
 
         // Return the captured state changes and evaluation result
-        result = [c, astGenerator, astBindings, astProperties, astCreatedObjects];
+        result = new Effects(c, astGenerator, astBindings, astProperties, astCreatedObjects);
         return result;
       } finally {
         // Roll back the state changes
         if (this.savedCompletion !== undefined) this.stopEffectCaptureAndUndoEffects(this.savedCompletion);
         if (result !== undefined) {
-          this.restoreBindings(result[2]);
-          this.restoreProperties(result[3]);
+          this.restoreBindings(result.data[2]);
+          this.restoreProperties(result.data[3]);
         } else {
           this.restoreBindings(this.modifiedBindings);
           this.restoreProperties(this.modifiedProperties);
@@ -780,7 +799,7 @@ export class Realm {
         undefined,
         "evaluateWithUndo"
       );
-      return effects[0] instanceof Value ? effects[0] : defaultValue;
+      return effects.data[0] instanceof Value ? effects.data[0] : defaultValue;
     } finally {
       this.errorHandler = oldErrorHandler;
     }
@@ -797,7 +816,7 @@ export class Realm {
       };
       let effects = this.evaluateForEffects(f, undefined, "evaluateWithUndoForDiagnostic");
       this.applyEffects(effects);
-      let resultVal = effects[0];
+      let resultVal = effects.data[0];
       if (resultVal instanceof AbruptCompletion) throw resultVal;
       if (resultVal instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
@@ -828,16 +847,16 @@ export class Realm {
       };
       let effects1 = this.evaluateForEffects(f, undefined, "evaluateForFixpointEffects/1");
       while (true) {
-        this.restoreBindings(effects1[2]);
-        this.restoreProperties(effects1[3]);
+        this.restoreBindings(effects1.data[2]);
+        this.restoreProperties(effects1.data[3]);
         let effects2 = this.evaluateForEffects(f, undefined, "evaluateForFixpointEffects/2");
-        this.restoreBindings(effects1[2]);
-        this.restoreProperties(effects1[3]);
+        this.restoreBindings(effects1.data[2]);
+        this.restoreProperties(effects1.data[3]);
         if (Widen.containsEffects(effects1, effects2)) {
           // effects1 includes every value present in effects2, so doing another iteration using effects2 will not
           // result in any more values being added to abstract domains and hence a fixpoint has been reached.
           // Generate code using effects2 because its expressions have not been widened away.
-          let [, gen, bindings2, pbindings2, createdObjects2] = effects2;
+          let [, gen, bindings2, pbindings2, createdObjects2] = effects2.data;
           this._applyPropertiesToNewlyCreatedObjects(pbindings2, createdObjects2);
           this._emitPropertAssignments(gen, pbindings2, createdObjects2);
           this._emitLocalAssignments(gen, bindings2, createdObjects2);
@@ -987,14 +1006,14 @@ export class Realm {
   }
 
   composeEffects(priorEffects: Effects, subsequentEffects: Effects): Effects {
-    let [, pg, pb, pp, po] = priorEffects;
-    let [sc, sg, sb, sp, so] = subsequentEffects;
+    let [, pg, pb, pp, po] = priorEffects.data;
+    let [sc, sg, sb, sp, so] = subsequentEffects.data;
     let result = construct_empty_effects(this);
-    let [, , rb, rp, ro] = result;
+    let [, , rb, rp, ro] = result.data;
 
-    result[0] = sc;
+    result.data[0] = sc;
 
-    result[1] = Join.composeGenerators(this, pg || result[1], sg);
+    result.data[1] = Join.composeGenerators(this, pg || result.data[1], sg);
 
     if (pb) {
       pb.forEach((val, key, m) => rb.set(key, val));
@@ -1036,7 +1055,7 @@ export class Realm {
     } else {
       invariant(this.savedCompletion.savedEffects !== undefined);
       invariant(this.generator !== undefined);
-      this.savedCompletion.savedEffects[1].appendGenerator(this.generator, "composeWithSavedCompletion");
+      this.savedCompletion.savedEffects.data[1].appendGenerator(this.generator, "composeWithSavedCompletion");
       this.generator = new Generator(this, "composeWithSavedCompletion");
       invariant(this.savedCompletion !== undefined);
       this.savedCompletion = Join.composePossiblyNormalCompletions(this, this.savedCompletion, completion);
@@ -1064,11 +1083,11 @@ export class Realm {
       invariant(priorCompletion.savedEffects !== undefined);
       let savedEffects = this.savedCompletion.savedEffects;
       invariant(savedEffects !== undefined);
-      this.restoreBindings(savedEffects[2]);
-      this.restoreProperties(savedEffects[3]);
+      this.restoreBindings(savedEffects.data[2]);
+      this.restoreProperties(savedEffects.data[3]);
       Join.updatePossiblyNormalCompletionWithSubsequentEffects(this, priorCompletion, savedEffects);
-      this.restoreBindings(savedEffects[2]);
-      this.restoreProperties(savedEffects[3]);
+      this.restoreBindings(savedEffects.data[2]);
+      this.restoreProperties(savedEffects.data[3]);
       invariant(this.savedCompletion !== undefined);
       this.savedCompletion.savedEffects = undefined;
       this.savedCompletion = Join.composePossiblyNormalCompletions(this, priorCompletion, this.savedCompletion);
@@ -1080,13 +1099,13 @@ export class Realm {
       // Already called captureEffects, just carry on
       return;
     }
-    completion.savedEffects = [
+    completion.savedEffects = new Effects(
       this.intrinsics.undefined,
       (this.generator: any),
       (this.modifiedBindings: any),
       (this.modifiedProperties: any),
-      (this.createdObjects: any),
-    ];
+      (this.createdObjects: any)
+    );
     this.generator = new Generator(this, "captured");
     this.modifiedBindings = new Map();
     this.modifiedProperties = new Map();
@@ -1100,7 +1119,7 @@ export class Realm {
     invariant(this.modifiedBindings !== undefined);
     invariant(this.modifiedProperties !== undefined);
     invariant(this.createdObjects !== undefined);
-    return [v, this.generator, this.modifiedBindings, this.modifiedProperties, this.createdObjects];
+    return new Effects(v, this.generator, this.modifiedBindings, this.modifiedProperties, this.createdObjects);
   }
 
   stopEffectCapture(completion: PossiblyNormalCompletion) {
@@ -1118,7 +1137,7 @@ export class Realm {
 
     // Restore saved state
     if (completion.savedEffects !== undefined) {
-      let [c, g, b, p, o] = completion.savedEffects;
+      let [c, g, b, p, o] = completion.savedEffects.data;
       c;
       completion.savedEffects = undefined;
       this.generator = g;
@@ -1132,7 +1151,7 @@ export class Realm {
 
   // Apply the given effects to the global state
   applyEffects(effects: Effects, leadingComment: string = "", appendGenerator: boolean = true) {
-    let [, generator, bindings, properties, createdObjects] = effects;
+    let [, generator, bindings, properties, createdObjects] = effects.data;
 
     // Add generated code for property modifications
     if (appendGenerator) this.appendGenerator(generator, leadingComment);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1890,7 +1890,7 @@ export class ResidualHeapSerializer {
       return;
     }
     this.rewrittenAdditionalFunctions.set(additionalFunctionValue, []);
-    let createdObjects = effects[4];
+    let createdObjects = effects.data[4];
     let nestedFunctions = new Set([...createdObjects].filter(object => object instanceof FunctionValue));
     // Allows us to emit function declarations etc. inside of this additional
     // function instead of adding them at global scope

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1084,7 +1084,7 @@ export class ResidualHeapVisitor {
   ): void {
     this.generatorParents.set(generator, parent);
     if (generator.effectsToApply)
-      for (const createdObject of generator.effectsToApply[4]) {
+      for (const createdObject of generator.effectsToApply.data[4]) {
         // TODO: Unfortunately, the following invariant doesn't hold. This is concerning.
         // invariant(!this.createdObjects.has(createdObject) || this.createdObjects.get(createdObject) === generator);
         if (!this.createdObjects.has(createdObject)) this.createdObjects.set(createdObject, generator);
@@ -1121,7 +1121,7 @@ export class ResidualHeapVisitor {
     this.reactElementEquivalenceSet = new ReactElementSet(this.realm, this.equivalenceSet);
 
     let modifiedBindingInfo = new Map();
-    let [result] = additionalEffects.effects;
+    let [result] = additionalEffects.effects.data;
 
     invariant(funcInstance !== undefined);
     invariant(functionInfo !== undefined);

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -133,7 +133,7 @@ export class Functions {
     parentAdditionalFunction: FunctionValue | void = undefined
   ): AdditionalFunctionEffects | null {
     let realm = this.realm;
-    let [pncResult] = effects;
+    let [pncResult] = effects.data;
     if (pncResult instanceof PossiblyNormalCompletion || pncResult instanceof JoinedAbruptCompletions) {
       // The completion is not the end of function execution, but a fork point for separate threads of control.
       // The effects of all of these threads need to get joined up and rolled into the top level effects,
@@ -147,7 +147,7 @@ export class Functions {
               pncResult,
               new ReturnCompletion(pncResult.value),
               construct_empty_effects(realm)
-            );
+            ).data;
           }
           invariant(pncResult instanceof JoinedAbruptCompletions);
           let completionEffects = Join.joinNestedEffects(realm, pncResult);
@@ -186,7 +186,7 @@ export class Functions {
       evaluatedNode.status = "UNSUPPORTED_COMPLETION";
       return;
     }
-    let value = effects[0];
+    let value = effects.data[0];
 
     if (value === this.realm.intrinsics.undefined) {
       // if we get undefined, then this component tree failed and a message was already logged
@@ -233,11 +233,12 @@ export class Functions {
     nestedEffects: Array<Effects>,
     evaluatedNode: ReactEvaluatedNode
   ): boolean {
-    let recentBindings = effects[2];
+    let recentBindings = effects.data[2];
     let ignoreBindings = new Set();
     let failed = false;
 
-    for (let [, , nestedBindingsToIgnore] of nestedEffects) {
+    for (let nestedEffect of nestedEffects) {
+      let nestedBindingsToIgnore = nestedEffect.data[2];
       for (let [binding] of nestedBindingsToIgnore) {
         ignoreBindings.add(binding);
       }
@@ -481,7 +482,7 @@ export class Functions {
       for (let [additionalFunctionValue, additionalEffects] of this.writeEffects) {
         // CreatedObjects is all objects created by this additional function but not
         // nested additional functions.
-        let createdObjects = additionalEffects.effects[4];
+        let createdObjects = additionalEffects.effects.data[4];
         if (createdObjects.has(functionValue)) return additionalFunctionValue;
       }
     };
@@ -490,7 +491,7 @@ export class Functions {
       additionalFunctionStack.push(functionValue);
       invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
       let call = this._callOfFunction(functionValue);
-      let effects = this.realm.evaluatePure(() =>
+      let effects: Effects = this.realm.evaluatePure(() =>
         this.realm.evaluateForEffectsInGlobalEnv(call, undefined, "additional function")
       );
       invariant(effects);
@@ -505,7 +506,7 @@ export class Functions {
       this.writeEffects.set(functionValue, additionalFunctionEffects);
 
       // look for newly registered optimized functions
-      let modifiedProperties = effects[3];
+      let modifiedProperties = effects.data[3];
       // Conceptually this will ensure that the nested additional function is defined
       // although for later cases, we'll apply the effects of the parents only.
       this.realm.withEffectsAppliedInGlobalEnv(() => {
@@ -513,7 +514,7 @@ export class Functions {
           let descriptor = propertyBinding.descriptor;
           if (descriptor && propertyBinding.object === optimizedFunctionsObject) {
             let newValue = descriptor.value;
-            invariant(newValue);
+            invariant(newValue instanceof Value);
             let newEntry = this.__optimizedFunctionEntryOfValue(newValue);
             if (newEntry) {
               additionalFunctions.add(newEntry.value);
@@ -544,10 +545,10 @@ export class Functions {
       invariant(additionalFunctionEffects !== undefined);
       let e1 = additionalFunctionEffects.effects;
       invariant(e1 !== undefined);
-      if (e1[0] instanceof Completion && !e1[0] instanceof PossiblyNormalCompletion) {
+      if (e1.data[0] instanceof Completion && !e1.data[0] instanceof PossiblyNormalCompletion) {
         let error = new CompilerDiagnostic(
           `Additional function ${fun1Name} may terminate abruptly`,
-          e1[0].location,
+          e1.data[0].location,
           "PP1002",
           "FatalError"
         );
@@ -558,7 +559,7 @@ export class Functions {
         if (fun1 === fun2) continue;
         invariant(fun2 instanceof FunctionValue);
         let reportFn = () => {
-          this.reportWriteConflicts(fun1Name, conflicts, e1[3], this._callOfFunction(fun2));
+          this.reportWriteConflicts(fun1Name, conflicts, e1.data[3], this._callOfFunction(fun2));
           return null;
         };
         let fun2Effects = this.writeEffects.get(fun2);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -286,7 +286,7 @@ class PossiblyNormalReturnEntry extends GeneratorEntry {
 
     // The effects of the normal path have already been applied to generator
     let empty_effects = construct_empty_effects(realm);
-    empty_effects[0] = completion.value;
+    empty_effects.data[0] = completion.value;
     let consequentEffects =
       completion.consequent instanceof AbruptCompletion ? completion.consequentEffects : empty_effects;
     this.consequentGenerator = Generator.fromEffects(consequentEffects, realm, "ConsequentEffects");
@@ -395,7 +395,7 @@ export class Generator {
   pathConditions: Array<AbstractValue>;
 
   static _generatorOfEffects(realm: Realm, name: string, environmentRecordIdAfterGlobalCode: number, effects: Effects) {
-    let [result, generator, modifiedBindings, modifiedProperties, createdObjects] = effects;
+    let [result, generator, modifiedBindings, modifiedProperties, createdObjects] = effects.data;
 
     let output = new Generator(realm, name, effects);
     output.appendGenerator(generator, "");

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -64,7 +64,7 @@ export class Logger {
         undefined,
         "tryQuery"
       );
-      invariant(effects[0] === realm.intrinsics.undefined);
+      invariant(effects.data[0] === realm.intrinsics.undefined);
       return ((result: any): T);
     } finally {
       realm.errorHandler = oldErrorHandler;

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -151,7 +151,7 @@ export class ModuleTracer extends Tracer {
       }
 
       acceleratedModuleIds = [];
-      if (isTopLevelRequire && effects !== undefined && !(effects[0] instanceof AbruptCompletion)) {
+      if (isTopLevelRequire && effects !== undefined && !(effects.data[0] instanceof AbruptCompletion)) {
         // We gathered all effects, but didn't apply them yet.
         // Let's check if there was any call to `require` in a
         // evaluate-for-effects context. If so, try to initialize
@@ -177,7 +177,7 @@ export class ModuleTracer extends Tracer {
           if (
             this.modules.accelerateUnsupportedRequires &&
             nestedEffects !== undefined &&
-            nestedEffects[0] instanceof Value &&
+            nestedEffects.data[0] instanceof Value &&
             this.modules.isModuleInitialized(nestedModuleId)
           ) {
             acceleratedModuleIds.push(nestedModuleId);
@@ -231,7 +231,7 @@ export class ModuleTracer extends Tracer {
           this.requireSequence.push(moduleIdValue);
           const previousNumDelayedModules = this.statistics.delayedModules;
           let effects = this._callRequireAndAccelerate(isTopLevelRequire, moduleIdValue, performCall);
-          if (effects === undefined || effects[0] instanceof AbruptCompletion) {
+          if (effects === undefined || effects.data[0] instanceof AbruptCompletion) {
             console.log(`delaying require(${moduleIdValue})`);
             this.statistics.delayedModules = previousNumDelayedModules + 1;
             // So we are about to emit a delayed require(...) call.
@@ -263,7 +263,7 @@ export class ModuleTracer extends Tracer {
               t.callExpression(t.identifier("require"), [t.valueToNode(moduleIdValue)])
             );
           } else {
-            result = effects[0];
+            result = effects.data[0];
             if (result instanceof Value) {
               realm.applyEffects(effects, `initialization of module ${moduleIdValue}`);
               this.modules.recordModuleInitialized(moduleIdValue, result);
@@ -607,7 +607,7 @@ export class Modules {
       if (this.initializedModules.has(moduleId)) continue;
       let effects = this.tryInitializeModule(moduleId, `Speculative initialization of module ${moduleId}`);
       if (effects === undefined) continue;
-      let result = effects[0];
+      let result = effects.data[0];
       if (!(result instanceof Value)) continue; // module might throw
       count++;
       this.initializedModules.set(moduleId, result);
@@ -623,7 +623,7 @@ export class Modules {
     try {
       let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
 
-      let [compl, generator, bindings, properties, createdObjects] = realm.evaluateNodeForEffectsInGlobalEnv(node);
+      let [compl, generator, bindings, properties, createdObjects] = realm.evaluateNodeForEffectsInGlobalEnv(node).data;
       // for lint unused
       invariant(bindings);
 


### PR DESCRIPTION
Release Notes: None

There are various reasons we want `Effects` to be a class. It will allow for better encapsulation as well as testing of some invariants. This is the simplest/most mechanical way I could think of to transform `Effects` into a class. Subsequent refactors should make the class more than a wrapper for the original array.