### PR TITLE
Use actual location as cache key if available

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1134,16 +1134,18 @@ export class LexicalEnvironment {
         if (e instanceof ThrowCompletion) {
           let error = e.value;
           if (error instanceof ObjectValue) {
-            let message = error.$Get("message", error);
-            message.value = `Syntax error: ${message.value}`;
-            e.location.source = source.filePath;
-            // the position was not located properly on the
-            // syntax errors happen on one given position, so start position = end position
-            e.location.start = { line: e.location.line, column: e.location.column };
-            e.location.end = { line: e.location.line, column: e.location.column };
-            let diagnostic = new CompilerDiagnostic(message.value, e.location, "PP1004", "FatalError");
-            this.realm.handleError(diagnostic);
-            throw new FatalError(message.value);
+            let message = error._SafeGetDataPropertyValue("message");
+            if (message instanceof StringValue) {
+              message.value = `Syntax error: ${message.value}`;
+              e.location.source = source.filePath;
+              // the position was not located properly on the
+              // syntax errors happen on one given position, so start position = end position
+              e.location.start = { line: e.location.line, column: e.location.column };
+              e.location.end = { line: e.location.line, column: e.location.column };
+              let diagnostic = new CompilerDiagnostic(message.value, e.location, "PP1004", "FatalError");
+              this.realm.handleError(diagnostic);
+              throw new FatalError(message.value);
+            }
           }
         }
         throw e;

--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -29,22 +29,25 @@ export function describeLocation(
 ): void | string {
   let locString = "";
   let displayName = "";
+  let key = loc || callerFn;
 
   // check if we've already encountered the callFn and if so
   // re-use that described location. plus we may get stuck trying
   // to get the location by recursively checking the same fun
   // so this also prevents a stack overflow
-  if (callerFn) {
-    if (realm.alreadyDescribedLocations.has(callerFn)) {
-      return realm.alreadyDescribedLocations.get(callerFn);
+  if (key) {
+    if (realm.alreadyDescribedLocations.has(key)) {
+      return realm.alreadyDescribedLocations.get(key);
     }
-    realm.alreadyDescribedLocations.set(callerFn, undefined);
+    realm.alreadyDescribedLocations.set(key, undefined);
+  }
 
+  if (callerFn) {
     if (callerFn instanceof NativeFunctionValue) {
       locString = "native";
     }
 
-    let name = callerFn.$Get("name", callerFn);
+    let name = callerFn._SafeGetDataPropertyValue("name");
     if (!name.mightBeUndefined()) displayName = To.ToStringPartial(realm, name);
     else name.throwIfNotConcrete();
 
@@ -67,8 +70,8 @@ export function describeLocation(
   } else {
     location = `at ${locString}`;
   }
-  if (callerFn) {
-    realm.alreadyDescribedLocations.set(callerFn, location);
+  if (key) {
+    realm.alreadyDescribedLocations.set(key, location);
   }
   return location;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -289,7 +289,7 @@ export class Realm {
     symbols: Map<ReactSymbolTypes, SymbolValue>,
     verbose: boolean,
   };
-  alreadyDescribedLocations: WeakMap<FunctionValue, string | void>;
+  alreadyDescribedLocations: WeakMap<FunctionValue | BabelNodeSourceLocation, string | void>;
   stripFlow: boolean;
 
   fbLibraries: {
@@ -1404,7 +1404,7 @@ export class Realm {
   handleError(diagnostic: CompilerDiagnostic): ErrorHandlerResult {
     if (!diagnostic.callStack && this.contextStack.length > 0) {
       let error = Construct(this, this.intrinsics.Error);
-      let stack = error.$Get("stack", error);
+      let stack = error._SafeGetDataPropertyValue("stack");
       if (stack instanceof StringValue) diagnostic.callStack = stack.value;
     }
     // Default behaviour is to bail on the first error

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1055,9 +1055,9 @@ export class ResidualHeapVisitor {
         residualBinding.modified = true;
         let otherFunc = residualBinding.additionalFunctionOverridesValue;
         if (otherFunc !== undefined && otherFunc !== functionValue) {
-          let otherNameVal = otherFunc.$Get("name", otherFunc);
+          let otherNameVal = otherFunc._SafeGetDataPropertyValue("name");
           let otherNameStr = otherNameVal instanceof StringValue ? otherNameVal.value : "unknown function";
-          let funcNameVal = functionValue.$Get("name", functionValue);
+          let funcNameVal = functionValue._SafeGetDataPropertyValue("name");
           let funNameStr = funcNameVal instanceof StringValue ? funcNameVal.value : "unknown function";
           let error = new CompilerDiagnostic(
             `Variable ${modifiedBinding.name} written to in optimized function ${funNameStr} conflicts with write in another optimized function ${otherNameStr}`,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -701,9 +701,9 @@ export class Generator {
     let message = "Program may terminate with exception";
     if (value instanceof ObjectValue) {
       let object = ((value: any): ObjectValue);
-      let objectMessage = this.realm.evaluateWithUndo(() => object.$Get("message", value));
+      let objectMessage = this.realm.evaluateWithUndo(() => object._SafeGetDataPropertyValue("message"));
       if (objectMessage instanceof StringValue) message += `: ${objectMessage.value}`;
-      const objectStack = this.realm.evaluateWithUndo(() => object.$Get("stack", value));
+      const objectStack = this.realm.evaluateWithUndo(() => object._SafeGetDataPropertyValue("stack"));
       if (objectStack instanceof StringValue)
         message += `
   ${objectStack.value}`;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -641,6 +641,17 @@ export default class ObjectValue extends ConcreteValue {
     return OrdinaryGet(this.$Realm, this, P, Receiver);
   }
 
+  _SafeGetDataPropertyValue(P: PropertyKeyValue): Value {
+    let savedInvariantLevel = this.$Realm.invariantLevel;
+    try {
+      this.$Realm.invariantLevel = 0;
+      let desc = this.$GetOwnProperty(P);
+      return desc !== undefined && desc.value instanceof Value ? desc.value : this.$Realm.intrinsics.undefined;
+    } finally {
+      this.$Realm.invariantLevel = savedInvariantLevel;
+    }
+  }
+
   $GetPartial(P: AbstractValue | PropertyKeyValue, Receiver: Value): Value {
     if (Receiver instanceof AbstractValue && Receiver.getType() === StringValue && P === "length") {
       return AbstractValue.createFromTemplate(this.$Realm, lengthTemplate, NumberValue, [Receiver], lengthTemplateSrc);

--- a/test/serializer/additional-functions/return-or-throw-simple.js
+++ b/test/serializer/additional-functions/return-or-throw-simple.js
@@ -1,4 +1,5 @@
 // does not contain:z = 5;
+// does contain:15:11
 // add at runtime: x = 3;
 var x;
 if (global.__abstract) x = __abstract("number", "(3)");


### PR DESCRIPTION
Release note: none

I noticed that the stack properties for Error objects were being set to the same value even when the objects were constructed in separate lines.

It turns out that some recent caching logic used the containing function as key and thus unified all error location descriptions encountered in the same function to a single value. So part of this PR is just a fix that uses the actual location, if available, as the cache key.

This unmasked another recently introduced problem: There are now invariant checks that happen if you get a property from the global object. The function where the checks are triggered is called as part of the describe logic. This logic was largely disabled because of the caching bug, so the checks did not fire in any test case and we missed out on the fact that the check don't work if the property get logic is not part of the source program.

To fix that, all calls to $Get that are done for internal purposes have now been replaced by calls to _SafeGetDataPropertyValue.