### PR TITLE
Turn array accesses into property accesses on getters/setters

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -109,8 +109,8 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
-    invariant(consequent === consequentEffects.data[0]);
-    invariant(alternate === alternateEffects.data[0]);
+    invariant(consequent === consequentEffects.result);
+    invariant(alternate === alternateEffects.result);
     invariant(
       consequent instanceof NormalCompletion ||
         consequent instanceof Value ||

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -217,7 +217,7 @@ export function computeBinary(
     }
 
     if (isPure && effects) {
-      let completion = effects.data[0];
+      let completion = effects.result;
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
         // not all control flow branches join into one flow at this point.

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -84,7 +84,7 @@ function callBothFunctionsAndJoinTheirEffects(
     new Effects(compl1, gen1, bindings1, properties1, createdObj1),
     new Effects(compl2, gen2, bindings2, properties2, createdObj2)
   );
-  let completion = joinedEffects.data[0];
+  let completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.
@@ -180,7 +180,7 @@ function tryToEvaluateCallOrLeaveAsAbstract(
   } finally {
     realm.suppressDiagnostics = savedSuppressDiagnostics;
   }
-  let completion = effects.data[0];
+  let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -140,7 +140,7 @@ export function evaluateWithAbstractConditional(
     new Effects(compl1, gen1, bindings1, properties1, createdObj1),
     new Effects(compl2, gen2, bindings2, properties2, createdObj2)
   );
-  let completion = joinedEffects.data[0];
+  let completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -93,7 +93,7 @@ export default function(
       new Effects(compl2, gen2, bindings2, properties2, createdObj2)
     );
   }
-  let completion = joinedEffects.data[0];
+  let completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case the evaluation of ast.right may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -111,7 +111,7 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
       throw error;
     }
   }
-  let completion = effects.data[0];
+  let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -173,7 +173,7 @@ function AbstractCaseBlockEvaluation(
       invariant(trueEffects !== undefined);
       invariant(falseEffects !== undefined);
       let joinedEffects = Join.joinEffects(realm, selectionResult, trueEffects, falseEffects);
-      let completion = joinedEffects.data[0];
+      let completion = joinedEffects.result;
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
         // not all control flow branches join into one flow at this point.

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -58,7 +58,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       }
       // All of the forked threads of control are now joined together and the global state reflects their joint effects
       let handlerEffects = composeNestedThrowEffectsWithHandler(blockRes);
-      handlerRes = handlerEffects.data[0];
+      handlerRes = handlerEffects.result;
       if (handlerRes instanceof Value) {
         // This can happen if all of the abrupt completions in blockRes were throw completions
         // and if the handler does not introduce any abrupt completions of its own.
@@ -81,7 +81,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       // The current global state is a the point of the fork that led to blockRes
       // All subsequent effects are kept inside the branches of blockRes.
       let finalizerEffects = composeNestedEffectsWithFinalizer(blockRes);
-      finalizerRes = finalizerEffects.data[0];
+      finalizerRes = finalizerEffects.result;
       // The result may become abrupt because of the finalizer, but it cannot become normal.
       invariant(!(finalizerRes instanceof Value));
     } else {
@@ -165,7 +165,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         undefined,
         "composeNestedEffectsWithFinalizer/1"
       );
-      if (!(consequentEffects.data[0] instanceof AbruptCompletion)) consequentEffects.data[0] = consequent;
+      if (!(consequentEffects.result instanceof AbruptCompletion)) consequentEffects.result = consequent;
     }
     priorEffects.pop();
     let alternate = c.alternate;
@@ -183,7 +183,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         undefined,
         "composeNestedThrowEffectsWithHandler"
       );
-      if (!(alternateEffects.data[0] instanceof AbruptCompletion)) alternateEffects.data[0] = alternate;
+      if (!(alternateEffects.result instanceof AbruptCompletion)) alternateEffects.result = alternate;
     }
     priorEffects.pop();
     return Join.joinEffects(realm, c.joinCondition, consequentEffects, alternateEffects);

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -129,7 +129,7 @@ function tryToEvaluateOperationOrLeaveAsAbstract(
       throw error;
     }
   }
-  let completion = effects.data[0];
+  let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -342,7 +342,7 @@ export function OrdinaryCallEvaluateBody(
           //todo: need to emit a specialized function that temporally captures the heap state at this point
         } else {
           realm.applyEffects(effects);
-          let c = effects.data[0];
+          let c = effects.result;
           return processResult(() => {
             invariant(c instanceof Value || c instanceof AbruptCompletion);
             return c;
@@ -414,7 +414,7 @@ export function OrdinaryCallEvaluateBody(
             joinedEffects = Join.joinEffectsAndPromoteNestedReturnCompletions(realm, c, construct_empty_effects(realm));
           }
           if (joinedEffects !== undefined) {
-            let result = joinedEffects.data[0];
+            let result = joinedEffects.result;
             if (result instanceof ReturnCompletion) {
               realm.applyEffects(joinedEffects);
               return result;
@@ -428,7 +428,7 @@ export function OrdinaryCallEvaluateBody(
             // The throw completions must be extracted into a saved possibly normal completion
             // so that the caller can pick them up in its next completion.
             joinedEffects = extractAndSavePossiblyNormalCompletion(result);
-            result = joinedEffects.data[0];
+            result = joinedEffects.result;
             invariant(result instanceof ReturnCompletion);
             realm.applyEffects(joinedEffects);
             return result;

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1141,7 +1141,7 @@ export class FunctionImplementation {
         realm.stopEffectCaptureAndUndoEffects(savedCompletion);
         let joined_effects = Join.joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, c, e);
         realm.applyEffects(joined_effects);
-        let jc = joined_effects.data[0];
+        let jc = joined_effects.result;
         invariant(jc instanceof AbruptCompletion);
         return jc;
       }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -154,7 +154,7 @@ export function OrdinaryGet(
     new Effects(compl1, gen1, bindings1, properties1, createdObj1),
     new Effects(compl2, gen2, bindings2, properties2, createdObj2)
   );
-  let completion = joinedEffects.data[0];
+  let completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -319,7 +319,7 @@ export class PropertiesImplementation {
         new Effects(compl1, gen1, bindings1, properties1, createdObj1),
         new Effects(compl2, gen2, bindings2, properties2, createdObj2)
       );
-      let completion = joinedEffects.data[0];
+      let completion = joinedEffects.result;
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
         // not all control flow branches join into one flow at this point.

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -120,7 +120,7 @@ function callBothFunctionsAndJoinTheirEffects(
     new Effects(compl1, gen1, bindings1, properties1, createdObj1),
     new Effects(compl2, gen2, bindings2, properties2, createdObj2)
   );
-  let joinedCompletion = joinedEffects.data[0];
+  let joinedCompletion = joinedEffects.result;
   if (joinedCompletion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -84,7 +84,7 @@ export default function(
     new Effects(conCompl, gen1, bindings1, properties1, createdObj1),
     new Effects(altCompl, gen2, bindings2, properties2, createdObj2)
   );
-  completion = joinedEffects.data[0];
+  completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -813,7 +813,7 @@ export function getValueFromFunctionCall(
     throw error;
   }
 
-  let completion = effects.data[0];
+  let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.

--- a/src/realm.js
+++ b/src/realm.js
@@ -81,31 +81,31 @@ export class Effects {
   // TODO: Make these into properties
   data: [EvaluationResult, Generator, Bindings, PropertyBindings, CreatedObjects];
 
-  get result() {
+  get result(): EvaluationResult {
     return this.data[0];
   }
   set result(newVal: EvaluationResult) {
     this.data[0] = newVal;
   }
-  get generator() {
+  get generator(): Generator {
     return this.data[1];
   }
   set generator(newVal: Generator) {
     this.data[1] = newVal;
   }
-  get modifiedBindings() {
+  get modifiedBindings(): Bindings {
     return this.data[2];
   }
   set modifiedBindings(newVal: Bindings) {
     this.data[2] = newVal;
   }
-  get modifiedProperties() {
+  get modifiedProperties(): PropertyBindings {
     return this.data[3];
   }
   set modifiedProperties(newVal: PropertyBindings) {
     this.data[3] = newVal;
   }
-  get createdObjects() {
+  get createdObjects(): CreatedObjects {
     return this.data[4];
   }
   set createdObjects(newVal: CreatedObjects) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -78,7 +78,39 @@ export class Effects {
     this.data = arguments;
   }
 
+  // TODO: Make these into properties
   data: [EvaluationResult, Generator, Bindings, PropertyBindings, CreatedObjects];
+
+  get result() {
+    return this.data[0];
+  }
+  set result(newVal: EvaluationResult) {
+    this.data[0] = newVal;
+  }
+  get generator() {
+    return this.data[1];
+  }
+  set generator(newVal: Generator) {
+    this.data[1] = newVal;
+  }
+  get modifiedBindings() {
+    return this.data[2];
+  }
+  set modifiedBindings(newVal: Bindings) {
+    this.data[2] = newVal;
+  }
+  get modifiedProperties() {
+    return this.data[3];
+  }
+  set modifiedProperties(newVal: PropertyBindings) {
+    this.data[3] = newVal;
+  }
+  get createdObjects() {
+    return this.data[4];
+  }
+  set createdObjects(newVal: CreatedObjects) {
+    this.data[4] = newVal;
+  }
 }
 
 export class Tracer {
@@ -433,17 +465,17 @@ export class Realm {
 
   clearBlockBindingsFromCompletion(completion: Completion, environmentRecord: DeclarativeEnvironmentRecord) {
     if (completion instanceof PossiblyNormalCompletion) {
-      this.clearBlockBindings(completion.alternateEffects.data[2], environmentRecord);
-      this.clearBlockBindings(completion.consequentEffects.data[2], environmentRecord);
+      this.clearBlockBindings(completion.alternateEffects.modifiedBindings, environmentRecord);
+      this.clearBlockBindings(completion.consequentEffects.modifiedBindings, environmentRecord);
       if (completion.savedEffects !== undefined)
-        this.clearBlockBindings(completion.savedEffects.data[2], environmentRecord);
+        this.clearBlockBindings(completion.savedEffects.modifiedBindings, environmentRecord);
       if (completion.alternate instanceof Completion)
         this.clearBlockBindingsFromCompletion(completion.alternate, environmentRecord);
       if (completion.consequent instanceof Completion)
         this.clearBlockBindingsFromCompletion(completion.consequent, environmentRecord);
     } else if (completion instanceof JoinedAbruptCompletions) {
-      this.clearBlockBindings(completion.alternateEffects.data[2], environmentRecord);
-      this.clearBlockBindings(completion.consequentEffects.data[2], environmentRecord);
+      this.clearBlockBindings(completion.alternateEffects.modifiedBindings, environmentRecord);
+      this.clearBlockBindings(completion.consequentEffects.modifiedBindings, environmentRecord);
       if (completion.alternate instanceof Completion)
         this.clearBlockBindingsFromCompletion(completion.alternate, environmentRecord);
       if (completion.consequent instanceof Completion)
@@ -488,16 +520,17 @@ export class Realm {
 
   clearFunctionBindingsFromCompletion(completion: Completion, funcVal: FunctionValue) {
     if (completion instanceof PossiblyNormalCompletion) {
-      this.clearFunctionBindings(completion.alternateEffects.data[2], funcVal);
-      this.clearFunctionBindings(completion.consequentEffects.data[2], funcVal);
-      if (completion.savedEffects !== undefined) this.clearFunctionBindings(completion.savedEffects.data[2], funcVal);
+      this.clearFunctionBindings(completion.alternateEffects.modifiedBindings, funcVal);
+      this.clearFunctionBindings(completion.consequentEffects.modifiedBindings, funcVal);
+      if (completion.savedEffects !== undefined)
+        this.clearFunctionBindings(completion.savedEffects.modifiedBindings, funcVal);
       if (completion.alternate instanceof Completion)
         this.clearFunctionBindingsFromCompletion(completion.alternate, funcVal);
       if (completion.consequent instanceof Completion)
         this.clearFunctionBindingsFromCompletion(completion.consequent, funcVal);
     } else if (completion instanceof JoinedAbruptCompletions) {
-      this.clearFunctionBindings(completion.alternateEffects.data[2], funcVal);
-      this.clearFunctionBindings(completion.consequentEffects.data[2], funcVal);
+      this.clearFunctionBindings(completion.alternateEffects.modifiedBindings, funcVal);
+      this.clearFunctionBindings(completion.consequentEffects.modifiedBindings, funcVal);
       if (completion.alternate instanceof Completion)
         this.clearFunctionBindingsFromCompletion(completion.alternate, funcVal);
       if (completion.consequent instanceof Completion)
@@ -668,8 +701,8 @@ export class Realm {
         result = func(effects);
         return this.intrinsics.undefined;
       } finally {
-        this.restoreBindings(effects.data[2]);
-        this.restoreProperties(effects.data[3]);
+        this.restoreBindings(effects.modifiedBindings);
+        this.restoreProperties(effects.modifiedProperties);
       }
     });
     invariant(result !== undefined, "If we get here, func must have returned undefined.");
@@ -757,8 +790,8 @@ export class Realm {
         // Roll back the state changes
         if (this.savedCompletion !== undefined) this.stopEffectCaptureAndUndoEffects(this.savedCompletion);
         if (result !== undefined) {
-          this.restoreBindings(result.data[2]);
-          this.restoreProperties(result.data[3]);
+          this.restoreBindings(result.modifiedBindings);
+          this.restoreProperties(result.modifiedProperties);
         } else {
           this.restoreBindings(this.modifiedBindings);
           this.restoreProperties(this.modifiedProperties);
@@ -799,7 +832,7 @@ export class Realm {
         undefined,
         "evaluateWithUndo"
       );
-      return effects.data[0] instanceof Value ? effects.data[0] : defaultValue;
+      return effects.result instanceof Value ? effects.result : defaultValue;
     } finally {
       this.errorHandler = oldErrorHandler;
     }
@@ -816,7 +849,7 @@ export class Realm {
       };
       let effects = this.evaluateForEffects(f, undefined, "evaluateWithUndoForDiagnostic");
       this.applyEffects(effects);
-      let resultVal = effects.data[0];
+      let resultVal = effects.result;
       if (resultVal instanceof AbruptCompletion) throw resultVal;
       if (resultVal instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
@@ -847,11 +880,11 @@ export class Realm {
       };
       let effects1 = this.evaluateForEffects(f, undefined, "evaluateForFixpointEffects/1");
       while (true) {
-        this.restoreBindings(effects1.data[2]);
-        this.restoreProperties(effects1.data[3]);
+        this.restoreBindings(effects1.modifiedBindings);
+        this.restoreProperties(effects1.modifiedProperties);
         let effects2 = this.evaluateForEffects(f, undefined, "evaluateForFixpointEffects/2");
-        this.restoreBindings(effects1.data[2]);
-        this.restoreProperties(effects1.data[3]);
+        this.restoreBindings(effects1.modifiedBindings);
+        this.restoreProperties(effects1.modifiedProperties);
         if (Widen.containsEffects(effects1, effects2)) {
           // effects1 includes every value present in effects2, so doing another iteration using effects2 will not
           // result in any more values being added to abstract domains and hence a fixpoint has been reached.
@@ -1011,9 +1044,9 @@ export class Realm {
     let result = construct_empty_effects(this);
     let [, , rb, rp, ro] = result.data;
 
-    result.data[0] = sc;
+    result.result = sc;
 
-    result.data[1] = Join.composeGenerators(this, pg || result.data[1], sg);
+    result.generator = Join.composeGenerators(this, pg || result.generator, sg);
 
     if (pb) {
       pb.forEach((val, key, m) => rb.set(key, val));
@@ -1069,7 +1102,7 @@ export class Realm {
     } else {
       invariant(this.savedCompletion.savedEffects !== undefined);
       invariant(this.generator !== undefined);
-      this.savedCompletion.savedEffects.data[1].appendGenerator(this.generator, "composeWithSavedCompletion");
+      this.savedCompletion.savedEffects.generator.appendGenerator(this.generator, "composeWithSavedCompletion");
       this.generator = new Generator(this, "composeWithSavedCompletion");
       invariant(this.savedCompletion !== undefined);
       this.savedCompletion = Join.composePossiblyNormalCompletions(this, this.savedCompletion, completion);
@@ -1097,11 +1130,11 @@ export class Realm {
       invariant(priorCompletion.savedEffects !== undefined);
       let savedEffects = this.savedCompletion.savedEffects;
       invariant(savedEffects !== undefined);
-      this.restoreBindings(savedEffects.data[2]);
-      this.restoreProperties(savedEffects.data[3]);
+      this.restoreBindings(savedEffects.modifiedBindings);
+      this.restoreProperties(savedEffects.modifiedProperties);
       Join.updatePossiblyNormalCompletionWithSubsequentEffects(this, priorCompletion, savedEffects);
-      this.restoreBindings(savedEffects.data[2]);
-      this.restoreProperties(savedEffects.data[3]);
+      this.restoreBindings(savedEffects.modifiedBindings);
+      this.restoreProperties(savedEffects.modifiedProperties);
       invariant(this.savedCompletion !== undefined);
       this.savedCompletion.savedEffects = undefined;
       this.savedCompletion = Join.composePossiblyNormalCompletions(this, priorCompletion, this.savedCompletion);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1890,7 +1890,7 @@ export class ResidualHeapSerializer {
       return;
     }
     this.rewrittenAdditionalFunctions.set(additionalFunctionValue, []);
-    let createdObjects = effects.data[4];
+    let createdObjects = effects.createdObjects;
     let nestedFunctions = new Set([...createdObjects].filter(object => object instanceof FunctionValue));
     // Allows us to emit function declarations etc. inside of this additional
     // function instead of adding them at global scope

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1084,7 +1084,7 @@ export class ResidualHeapVisitor {
   ): void {
     this.generatorParents.set(generator, parent);
     if (generator.effectsToApply)
-      for (const createdObject of generator.effectsToApply.data[4]) {
+      for (const createdObject of generator.effectsToApply.createdObjects) {
         // TODO: Unfortunately, the following invariant doesn't hold. This is concerning.
         // invariant(!this.createdObjects.has(createdObject) || this.createdObjects.get(createdObject) === generator);
         if (!this.createdObjects.has(createdObject)) this.createdObjects.set(createdObject, generator);

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -127,6 +127,8 @@ export class Functions {
     return recordedAdditionalFunctions;
   }
 
+  // NB: effects that are returned may be different than the effects passed in, so after this call, you may no longer
+  // use the effects object you passed into this function.
   _createAdditionalEffects(
     effects: Effects,
     fatalOnAbrupt: boolean,
@@ -188,7 +190,8 @@ export class Functions {
       evaluatedNode.status = "UNSUPPORTED_COMPLETION";
       return;
     }
-    let value = additionalFunctionEffects.effects.result;
+    effects = additionalFunctionEffects.effects;
+    let value = effects.result;
 
     if (value === this.realm.intrinsics.undefined) {
       // if we get undefined, then this component tree failed and a message was already logged
@@ -527,6 +530,7 @@ export class Functions {
         getDeclaringAdditionalFunction(functionValue)
       );
       invariant(additionalFunctionEffects);
+      effects = additionalFunctionEffects.effects;
       this.writeEffects.set(functionValue, additionalFunctionEffects);
 
       // look for newly registered optimized functions

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -286,7 +286,7 @@ class PossiblyNormalReturnEntry extends GeneratorEntry {
 
     // The effects of the normal path have already been applied to generator
     let empty_effects = construct_empty_effects(realm);
-    empty_effects.data[0] = completion.value;
+    empty_effects.result = completion.value;
     let consequentEffects =
       completion.consequent instanceof AbruptCompletion ? completion.consequentEffects : empty_effects;
     this.consequentGenerator = Generator.fromEffects(consequentEffects, realm, "ConsequentEffects");

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -64,7 +64,7 @@ export class Logger {
         undefined,
         "tryQuery"
       );
-      invariant(effects.data[0] === realm.intrinsics.undefined);
+      invariant(effects.result === realm.intrinsics.undefined);
       return ((result: any): T);
     } finally {
       realm.errorHandler = oldErrorHandler;

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -151,7 +151,7 @@ export class ModuleTracer extends Tracer {
       }
 
       acceleratedModuleIds = [];
-      if (isTopLevelRequire && effects !== undefined && !(effects.data[0] instanceof AbruptCompletion)) {
+      if (isTopLevelRequire && effects !== undefined && !(effects.result instanceof AbruptCompletion)) {
         // We gathered all effects, but didn't apply them yet.
         // Let's check if there was any call to `require` in a
         // evaluate-for-effects context. If so, try to initialize
@@ -177,7 +177,7 @@ export class ModuleTracer extends Tracer {
           if (
             this.modules.accelerateUnsupportedRequires &&
             nestedEffects !== undefined &&
-            nestedEffects.data[0] instanceof Value &&
+            nestedEffects.result instanceof Value &&
             this.modules.isModuleInitialized(nestedModuleId)
           ) {
             acceleratedModuleIds.push(nestedModuleId);
@@ -231,7 +231,7 @@ export class ModuleTracer extends Tracer {
           this.requireSequence.push(moduleIdValue);
           const previousNumDelayedModules = this.statistics.delayedModules;
           let effects = this._callRequireAndAccelerate(isTopLevelRequire, moduleIdValue, performCall);
-          if (effects === undefined || effects.data[0] instanceof AbruptCompletion) {
+          if (effects === undefined || effects.result instanceof AbruptCompletion) {
             console.log(`delaying require(${moduleIdValue})`);
             this.statistics.delayedModules = previousNumDelayedModules + 1;
             // So we are about to emit a delayed require(...) call.
@@ -263,7 +263,7 @@ export class ModuleTracer extends Tracer {
               t.callExpression(t.identifier("require"), [t.valueToNode(moduleIdValue)])
             );
           } else {
-            result = effects.data[0];
+            result = effects.result;
             if (result instanceof Value) {
               realm.applyEffects(effects, `initialization of module ${moduleIdValue}`);
               this.modules.recordModuleInitialized(moduleIdValue, result);
@@ -607,7 +607,7 @@ export class Modules {
       if (this.initializedModules.has(moduleId)) continue;
       let effects = this.tryInitializeModule(moduleId, `Speculative initialization of module ${moduleId}`);
       if (effects === undefined) continue;
-      let result = effects.data[0];
+      let result = effects.result;
       if (!(result instanceof Value)) continue; // module might throw
       count++;
       this.initializedModules.set(moduleId, result);


### PR DESCRIPTION
Release Notes: None

Now that `Effects` is a class, we should be able to access things like `effects.result` instead of `effects.data[0]`.