### PR TITLE
Do not emit joined generators into optimized function bodies

### DIFF
--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -186,7 +186,7 @@ export class Functions {
       evaluatedNode.status = "UNSUPPORTED_COMPLETION";
       return;
     }
-    let value = effects.data[0];
+    let value = additionalFunctionEffects.effects.data[0];
 
     if (value === this.realm.intrinsics.undefined) {
       // if we get undefined, then this component tree failed and a message was already logged
@@ -506,7 +506,7 @@ export class Functions {
       this.writeEffects.set(functionValue, additionalFunctionEffects);
 
       // look for newly registered optimized functions
-      let modifiedProperties = effects.data[3];
+      let modifiedProperties = additionalFunctionEffects.effects.data[3];
       // Conceptually this will ensure that the nested additional function is defined
       // although for later cases, we'll apply the effects of the parents only.
       this.realm.withEffectsAppliedInGlobalEnv(() => {
@@ -514,7 +514,7 @@ export class Functions {
           let descriptor = propertyBinding.descriptor;
           if (descriptor && propertyBinding.object === optimizedFunctionsObject) {
             let newValue = descriptor.value;
-            invariant(newValue instanceof Value);
+            invariant(newValue instanceof Value); //todo: this does not seem invariantly true
             let newEntry = this.__optimizedFunctionEntryOfValue(newValue);
             if (newEntry) {
               additionalFunctions.add(newEntry.value);
@@ -525,7 +525,7 @@ export class Functions {
           }
         }
         return null;
-      }, effects);
+      }, additionalFunctionEffects.effects);
       invariant(additionalFunctionStack.pop() === functionValue);
     };
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -398,7 +398,9 @@ export class Generator {
     let [result, generator, modifiedBindings, modifiedProperties, createdObjects] = effects.data;
 
     let output = new Generator(realm, name, effects);
-    output.appendGenerator(generator, "");
+    // joined generators have no entries of their own, so the generators of the components of result can do the job
+    if (!(result instanceof PossiblyNormalCompletion || result instanceof JoinedAbruptCompletions))
+      output.appendGenerator(generator, "");
 
     for (let propertyBinding of modifiedProperties.keys()) {
       let object = propertyBinding.object;

--- a/test/serializer/additional-functions/return-or-throw-simple.js
+++ b/test/serializer/additional-functions/return-or-throw-simple.js
@@ -1,5 +1,6 @@
 // does not contain:z = 5;
-// does contain:15:11
+// does contain:16:11
+// Copies of x = 25: 1
 // add at runtime: x = 3;
 var x;
 if (global.__abstract) x = __abstract("number", "(3)");


### PR DESCRIPTION
Release note: none

Joining effects results in joined generators that contain all of the I/O operations of the argument effects, but does not change the arguments.

Normally, this does not matter because only the joined generator is used. In the case of an optimized function, however, the generator tree is traversed via the effects tree and this resulted in duplicate I/O operations.

To fix this, the tree walk now ignores joined generators. Also included in this PR, some fixes to make sure that only the (joined) effects resulting from _createAdditionalEffects are used, and not the effects that went into it.