### PR TITLE
Support null/undefined config object for React.createElement

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -1742,6 +1742,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Null or undefined props 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding React.cloneElement 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -5069,6 +5086,23 @@ ReactStatistics {
   "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Null or undefined props 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
 }
 `;
 
@@ -8402,6 +8436,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Null or undefined props 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding React.cloneElement 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -11694,6 +11745,23 @@ ReactStatistics {
   "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Null or undefined props 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -429,6 +429,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "return-undefined.js");
       });
 
+      it("Null or undefined props", async () => {
+        await runTest(directory, "null-or-undefined-props.js");
+      });
+
       it("Event handlers", async () => {
         await runTest(directory, "event-handlers.js");
       });

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -506,6 +506,10 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
     0,
     (context, [type, config, ...children]) => {
       invariant(type instanceof Value);
+      // if config is undefined/null, use an empy object
+      if (config === realm.intrinsics.undefined || config === realm.intrinsics.null || config === undefined) {
+        config = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
+      }
       invariant(
         config instanceof ObjectValue ||
           config instanceof AbstractObjectValue ||

--- a/test/react/functional-components/null-or-undefined-props.js
+++ b/test/react/functional-components/null-or-undefined-props.js
@@ -1,0 +1,30 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App() {
+  return (
+    <div>
+      {
+        React.createElement("div")
+      }
+      {
+        React.createElement("div", undefined)
+      }
+      {
+        React.createElement("div", null)
+      }
+    </div>
+  )
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['null or undefined props', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

When a `null` or `undefined` value is passed as the `config` for `createElement`, then we need to create an empty object to be used instead.