### PR TITLE
Run test-react before serializer tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,11 +20,11 @@ test:
     - yarn lint
     - yarn flow
     - yarn depcheck
+    - yarn test-react
     - yarn test-serializer-with-coverage
     - yarn test-sourcemaps
     - yarn test-std-in
     - yarn test-residual
-    - yarn test-react
     - yarn test-test262 -- --statusFile $CIRCLE_ARTIFACTS/test262-status.txt --timeout 120 --cpuScale 0.25 --verbose:
         timeout: 1800
     # - yarn test-test262-new -- --statusFile $CIRCLE_ARTIFACTS/test262-new-status.txt --timeout 120 --verbose:


### PR DESCRIPTION
Release notes: `test-react` now gets run before `test-serializer-with-coverage` on the CI

In order to get better CI feedback and fail faster and earlier if possible, run the React tests first. They only take ~90s, compared to ~22m it takes for the serializer tests.