### PR TITLE
Capture prefix effects when composing pnc

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -1109,12 +1109,19 @@ export class Realm {
       this.pathConditions = [].concat(this.pathConditions);
       this.captureEffects(completion);
     } else {
-      invariant(this.savedCompletion.savedEffects !== undefined);
+      let savedCompletion = this.savedCompletion;
+      invariant(savedCompletion.savedEffects !== undefined);
       invariant(this.generator !== undefined);
-      this.savedCompletion.savedEffects.generator.appendGenerator(this.generator, "composeWithSavedCompletion");
+      savedCompletion.savedEffects.generator.appendGenerator(this.generator, "composeWithSavedCompletion");
       this.generator = new Generator(this, "composeWithSavedCompletion");
       invariant(this.savedCompletion !== undefined);
-      this.savedCompletion = Join.composePossiblyNormalCompletions(this, this.savedCompletion, completion);
+      let e = this.getCapturedEffects(savedCompletion);
+      invariant(e !== undefined);
+      this.stopEffectCaptureAndUndoEffects(savedCompletion);
+      savedCompletion = Join.composePossiblyNormalCompletions(this, savedCompletion, completion, e);
+      this.applyEffects(e);
+      this.captureEffects(savedCompletion);
+      this.savedCompletion = savedCompletion;
     }
     pushPathConditionsLeadingToNormalCompletion(completion);
     return completion.value;

--- a/src/types.js
+++ b/src/types.js
@@ -693,7 +693,8 @@ export type JoinType = {
   composePossiblyNormalCompletions(
     realm: Realm,
     pnc: PossiblyNormalCompletion,
-    c: PossiblyNormalCompletion
+    c: PossiblyNormalCompletion,
+    priorEffects?: Effects
   ): PossiblyNormalCompletion,
 
   updatePossiblyNormalCompletionWithSubsequentEffects(

--- a/test/serializer/abstract/Return6a.js
+++ b/test/serializer/abstract/Return6a.js
@@ -1,0 +1,14 @@
+let x = global.__abstract ? __abstract("number", "(1)") : 1
+
+let i = 0;
+
+function f() {
+  if (i === x) return 10;
+  i++;
+  if (i === x) return 11;
+  i++;
+}
+
+f();
+
+inspect = function() { return i; }


### PR DESCRIPTION
Release note: none

When composing a newly constructed PossiblyNormalCompletion with saved one, the resulting completion needs to capture the effects that happened on the normal branch, in between the saved fork point and the fork point of the newly constructed completion, because these effects also apply to the abrupt part of the new completion.

When joining up such a composed completion, the effects need to be applied (and later reversed), otherwise the nested joins might capture values as they were before the first fork, rather than as there were at the time of the nested fork.