### PR TITLE
Properly strips on* events in first render and fixes tests

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -183,7 +183,9 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
     for (let i = 0; i < resultA.length; i++) {
       let [nameA, valueA] = resultA[i];
       let [nameB, valueB] = resultB[i];
-      expect(mergeAdacentJSONTextNodes(valueB)).toEqual(mergeAdacentJSONTextNodes(valueA));
+      expect(mergeAdacentJSONTextNodes(valueB, firstRenderOnly)).toEqual(
+        mergeAdacentJSONTextNodes(valueA, firstRenderOnly)
+      );
       expect(nameB).toEqual(nameA);
     }
   }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -849,7 +849,7 @@ export function sanitizeReactElementForFirstRenderOnly(realm: Realm, reactElemen
       for (let [propName] of propsValue.properties) {
         // check for onSomething prop event handlers, i.e. onClick
         if (isEventProp(propName)) {
-          deleteProperty(reactElement, "ref");
+          deleteProperty(propsValue, propName);
         }
       }
     }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -12,7 +12,7 @@ type JSONValue = Array<JSONValue> | string | number | JSON;
 type JSON = { [key: string]: JSONValue };
 
 // this will mutate the original JSON object
-export function mergeAdacentJSONTextNodes(node: JSON, visitedNodes?: Set<JSON>) {
+export function mergeAdacentJSONTextNodes(node: JSON, removeFunctions: boolean, visitedNodes?: Set<JSON>) {
   if (visitedNodes === undefined) {
     visitedNodes = new Set();
   }
@@ -41,7 +41,7 @@ export function mergeAdacentJSONTextNodes(node: JSON, visitedNodes?: Set<JSON>) 
           arr.push(concatString);
           concatString = null;
         }
-        arr.push(mergeAdacentJSONTextNodes(child, visitedNodes));
+        arr.push(mergeAdacentJSONTextNodes(child, removeFunctions, visitedNodes));
       }
     }
     if (concatString !== null) {
@@ -52,9 +52,13 @@ export function mergeAdacentJSONTextNodes(node: JSON, visitedNodes?: Set<JSON>) 
     for (let key in node) {
       let value = node[key];
       if (typeof value === "function") {
-        node[key] = "function";
+        if (removeFunctions) {
+          delete node[key];
+        } else {
+          node[key] = "function";
+        }
       } else if (typeof value === "object" && value !== null) {
-        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), visitedNodes);
+        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), removeFunctions, visitedNodes);
       }
     }
   }


### PR DESCRIPTION
Release notes: fixes a regression where on* events would not be stripped in React firstRender mode

This PR fixes a recent regression in the stripping of onEvent names in React compiler's firstRender mode. The associated tests have been updated so the snapshots should pick up this regression in the future.