### PR TITLE
Forcing clearing traverse cache after each traversal.

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -282,6 +282,7 @@ export function convertSimpleClassComponentToFunctionalComponent(
       (undefined: any),
       undefined
     );
+    traverse.clearCache();
   });
 }
 

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -428,6 +428,7 @@ export class ResidualFunctions {
                   factoryFunctionInfos,
                 }
               );
+              traverse.clearCache();
               // add the class method to the class expression node body
               if (isConstructor) {
                 funcOrClassNode.body.body.unshift(classMethod);
@@ -468,6 +469,7 @@ export class ResidualFunctions {
               ]),
               factoryFunctionInfos,
             });
+            traverse.clearCache();
           }
           let id = this.locationService.getLocation(functionValue);
           invariant(id !== undefined);
@@ -577,6 +579,7 @@ export class ResidualFunctions {
           ),
           factoryFunctionInfos,
         });
+        traverse.clearCache();
 
         for (let instance of normalInstances) {
           let { functionValue, residualFunctionBindings, insertionPoint } = instance;

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -529,6 +529,7 @@ export class ResidualHeapVisitor {
         null,
         state
       );
+      traverse.clearCache();
       this.functionInfos.set(code, functionInfo);
 
       if (val.isResidual && functionInfo.unbound.size) {

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -75,4 +75,5 @@ export function stripFlowTypeAnnotations(ast: BabelNode): void {
     (undefined: any),
     undefined
   );
+  traverse.clearCache();
 }

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -97,6 +97,7 @@ function getHavocedFunctionInfo(value: FunctionValue) {
     null,
     functionInfo
   );
+  traverse.clearCache();
   return functionInfo;
 }
 


### PR DESCRIPTION
Release notes: Use 66% less memory, run 42% faster

For a large internal benchmark, this...
- reduces peak memory usage from 9605Mb to 3307Mb,
- reduces run time from 216s to 125s.
The wins come from the visit and serialization phases, where we call Babel's traverse functionality.

Internally, it seems to me that the Babel traverse cache aims at using a WeakMap.
It is not clear to me what exactly is going wrong (is some non-ES6 WeakMap
implementation kicking in?), but this effectively fixes it in any case.

I suspect that the gains in run time come from simply no longer triggering
excessive numbers of GCs due to extremely high memory usage, and apparently 
there is little purpose of the cache between traverse calls.