### PR TITLE
Better handling of this with simple React class components

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -318,6 +318,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Class component folding Simple classes with Array.from 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -3729,6 +3746,23 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Class component folding Simple classes with Array.from 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -7150,6 +7184,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Class component folding Simple classes with Array.from 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -10526,6 +10577,23 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Class component folding Simple classes with Array.from 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -335,6 +335,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Class component folding Simple classes with Array.from 2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -3752,6 +3769,23 @@ ReactStatistics {
 `;
 
 exports[`Test React with JSX input, create-element output Class component folding Simple classes with Array.from 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Class component folding Simple classes with Array.from 2 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
   "evaluatedRootNodes": Array [
@@ -7201,6 +7235,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Class component folding Simple classes with Array.from 2 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Factory class component folding Simple factory classes 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -10583,6 +10634,23 @@ ReactStatistics {
 `;
 
 exports[`Test React with create-element input, create-element output Class component folding Simple classes with Array.from 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Class component folding Simple classes with Array.from 2 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
   "evaluatedRootNodes": Array [

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -495,6 +495,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-classes-3.js");
       });
 
+      it("Simple classes with Array.from", async () => {
+        await runTest(directory, "array-from.js");
+      });
+
       it("Inheritance chaining", async () => {
         await runTest(directory, "inheritance-chain.js");
       });

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -499,6 +499,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "array-from.js");
       });
 
+      it("Simple classes with Array.from 2", async () => {
+        await runTest(directory, "array-from2.js");
+      });
+
       it("Inheritance chaining", async () => {
         await runTest(directory, "inheritance-chain.js");
       });

--- a/test/react/class-components/array-from.js
+++ b/test/react/class-components/array-from.js
@@ -1,0 +1,35 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <span>{props.title} {props.foo}</span>;
+}
+
+class App extends React.Component {
+  render() {
+    return (
+      <div>
+        {Array.from(this.props.items, function(item) {
+          return <A title={item.title} key={item.id} foo={this.props.foo} />
+        }.bind(this))}
+      </div>
+    );
+  }
+}
+
+App.getTrials = function(renderer, Root) {
+  let items = [
+    { title: "Hello world 1", id: 0 },
+    { title: "Hello world 2", id: 1 },
+    { title: "Hello world 3", id: 2 },
+  ];
+  renderer.update(<Root  items={items} foo={123} />);
+  return [['simple render array map', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/class-components/array-from2.js
+++ b/test/react/class-components/array-from2.js
@@ -1,0 +1,36 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <span>{props.title} {props.foo}</span>;
+}
+
+class App extends React.Component {
+  render() {
+    let self = this;
+    return (
+      <div>
+        {Array.from(this.props.items, function(item) {
+          return <A title={item.title} key={item.id} foo={self.props.foo} />
+        })}
+      </div>
+    );
+  }
+}
+
+App.getTrials = function(renderer, Root) {
+  let items = [
+    { title: "Hello world 1", id: 0 },
+    { title: "Hello world 2", id: 1 },
+    { title: "Hello world 3", id: 2 },
+  ];
+  renderer.update(<Root  items={items} foo={123} />);
+  return [['simple render array map', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This fixes bugs around detecting independent dangling `this` keywords in methods of a React class component and correctly bailing out upon finding them. This is typically used in cases where we'd want to bail out, for example:

```js
let self = this;
let handleClick = function () { console.log(self.x) };
return <div onClick={handleClick} />
```

or:

```js
let handleClick = function () { console.log(this.x) };
return <div onClick={handleClick.bind(this)} />
```