### PR TITLE
Handle abstract conditional break inside definite for loop

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -43,13 +43,13 @@ export class ThrowCompletion extends AbruptCompletion {
 }
 export class ContinueCompletion extends AbruptCompletion {
   constructor(value: Value, location: ?BabelNodeSourceLocation, target: ?string) {
-    super(value, location, target);
+    super(value, location, target || null);
   }
 }
 
 export class BreakCompletion extends AbruptCompletion {
   constructor(value: Value, location: ?BabelNodeSourceLocation, target: ?string) {
-    super(value, location, target);
+    super(value, location, target || null);
   }
 }
 

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -149,7 +149,7 @@ export function ForInOfHeadEvaluation(
     // a. If exprValue.[[Value]] is null or undefined, then
     if (exprValue instanceof NullValue || exprValue instanceof UndefinedValue) {
       // i. Return Completion{[[Type]]: break, [[Value]]: empty, [[Target]]: empty}.
-      throw new BreakCompletion(realm.intrinsics.empty, expr.loc, undefined);
+      throw new BreakCompletion(realm.intrinsics.empty, expr.loc, null);
     }
 
     // b. Let obj be ToObject(exprValue).

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -409,9 +409,10 @@ export function OrdinaryCallEvaluateBody(
             } else {
               e = construct_empty_effects(realm);
             }
-            joinedEffects = Join.joinEffectsAndPromoteNestedReturnCompletions(realm, c, e);
+            joinedEffects = Join.joinEffectsAndPromoteNested(ReturnCompletion, realm, c, e);
           } else if (c instanceof JoinedAbruptCompletions) {
-            joinedEffects = Join.joinEffectsAndPromoteNestedReturnCompletions(realm, c, construct_empty_effects(realm));
+            let e = construct_empty_effects(realm);
+            joinedEffects = Join.joinEffectsAndPromoteNested(ReturnCompletion, realm, c, e);
           }
           if (joinedEffects !== undefined) {
             let result = joinedEffects.result;
@@ -448,7 +449,7 @@ export function OrdinaryCallEvaluateBody(
     // We need to carry on in normal mode (after arranging to capturing effects)
     // while stashing away the throw completions so that the next completion we return
     // incorporates them.
-    let [joinedEffects, possiblyNormalCompletion] = Join.unbundleReturnCompletion(realm, c);
+    let [joinedEffects, possiblyNormalCompletion] = Join.unbundle(ReturnCompletion, realm, c);
     realm.composeWithSavedCompletion(possiblyNormalCompletion);
     return joinedEffects;
   }

--- a/src/types.js
+++ b/src/types.js
@@ -732,14 +732,19 @@ export type JoinType = {
     v: Value
   ): void,
 
-  joinEffectsAndPromoteNestedReturnCompletions(
+  joinEffectsAndPromoteNested(
+    CompletionType: typeof Completion,
     realm: Realm,
     c: Completion | Value,
     e: Effects,
     nested_effects?: Effects
   ): Effects,
 
-  unbundleReturnCompletion(realm: Realm, c: JoinedAbruptCompletions): [Effects, PossiblyNormalCompletion],
+  unbundle(
+    CompletionType: typeof Completion,
+    realm: Realm,
+    c: JoinedAbruptCompletions
+  ): [Effects, PossiblyNormalCompletion],
 
   removeNormalEffects(realm: Realm, c: PossiblyNormalCompletion): Effects,
 

--- a/test/error-handler/forLoop1.js
+++ b/test/error-handler/forLoop1.js
@@ -1,0 +1,13 @@
+// expected errors: [{"location":{"start":{"line":9,"column":17},"end":{"line":9,"column":32},"source":"test/error-handler/forLoop1.js"},"severity":"FatalError","errorCode":"PP0034"}]
+
+var x = global.__abstract ? x = __abstract("number", "(1)") : 1;
+let i;
+let j;
+
+label: for (i = 0; i < 2; i++) {
+  for (j = 0; j < 2; j++) {
+    if (i === x) continue label;
+  }
+}
+
+inspect = function() { return j; }

--- a/test/serializer/abstract/ForLoop.js
+++ b/test/serializer/abstract/ForLoop.js
@@ -1,0 +1,8 @@
+var x = global.__abstract ? x = __abstract("number", "(1)") : 1;
+let i;
+
+for (i = 0; i < 2; i++) {
+  if (i === x) break;
+}
+
+inspect = function() { return i; }

--- a/test/serializer/abstract/ForLoop1.js
+++ b/test/serializer/abstract/ForLoop1.js
@@ -1,0 +1,11 @@
+var x = global.__abstract ? x = __abstract("number", "(2)") : 2;
+let i;
+let j = 100;
+
+label: for (i = 0; i < 3; i++) {
+  if (i == x - 1) continue label;
+  if (i === x) continue;
+  j += 100;
+}
+
+inspect = function() { return j; }

--- a/test/serializer/optimized-functions/ForLoop.js
+++ b/test/serializer/optimized-functions/ForLoop.js
@@ -1,0 +1,15 @@
+var x = global.__abstract ? x = __abstract("number", "(3)") : 3;
+
+function func1() {
+  for (let i = 0; i < 10; i++) {
+    if (i === x) {
+      break;
+    }
+    if (i === 4) {
+      throw new Error("X is 4");
+    }
+  }
+}
+
+if (global.__optimize)
+  __optimize(func1);


### PR DESCRIPTION
Release note: Allow break/continue to be guarded by abstract conditions inside loops

This addresses the first example in issue: #1764

Loops represent join points for break and continue completions. They need to be handled much like the return completions that join at function end. The main difficulty is that break and continue can specify a target. For now, we punt on that and give a compile time error.