### PR TITLE
Fix hoisting invariant bug

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -343,12 +343,6 @@ ReactStatistics {
       "children": Array [
         Object {
           "children": Array [],
-          "message": "",
-          "name": "FactoryComponent",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
           "message": "non-root factory class components are not suppoted",
           "name": "FactoryComponent",
           "status": "BAIL-OUT",
@@ -3359,6 +3353,36 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "Outer",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -3757,12 +3781,6 @@ ReactStatistics {
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "FactoryComponent",
-          "status": "INLINED",
-        },
         Object {
           "children": Array [],
           "message": "non-root factory class components are not suppoted",
@@ -6775,6 +6793,36 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "Outer",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -7173,12 +7221,6 @@ ReactStatistics {
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "FactoryComponent",
-          "status": "INLINED",
-        },
         Object {
           "children": Array [],
           "message": "non-root factory class components are not suppoted",
@@ -10156,6 +10198,36 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "Outer",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -10554,12 +10626,6 @@ ReactStatistics {
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "FactoryComponent",
-          "status": "INLINED",
-        },
         Object {
           "children": Array [],
           "message": "non-root factory class components are not suppoted",
@@ -13534,6 +13600,36 @@ ReactStatistics {
   "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+        Object {
+          "children": Array [],
+          "message": "evaluation failed",
+          "name": "Inner",
+          "status": "BAIL-OUT",
+        },
+      ],
+      "message": "",
+      "name": "Outer",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -707,6 +707,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb14.js");
       });
 
+      it("fb-www 15", async () => {
+        await runTest(directory, "fb15.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/src/react/errors.js
+++ b/src/react/errors.js
@@ -9,6 +9,8 @@
 
 /* @flow */
 
+import { type ReactEvaluatedNode } from "../serializer/types.js";
+
 // ExpectedBailOut is like an error, that gets thrown during the reconcilation phase
 // allowing the reconcilation to continue on other branches of the tree, the message
 // given to ExpectedBailOut will be assigned to the value.$BailOutReason property and serialized
@@ -23,4 +25,10 @@ export class SimpleClassBailOut extends Error {}
 
 // NewComponentTreeBranch only occur when a complex class is found in a
 // component tree and the reconciler can no longer fold the component of that branch
-export class NewComponentTreeBranch extends Error {}
+export class NewComponentTreeBranch extends Error {
+  constructor(evaluatedNode: ReactEvaluatedNode) {
+    super();
+    this.evaluatedNode = evaluatedNode;
+  }
+  evaluatedNode: ReactEvaluatedNode;
+}

--- a/src/react/hoisting.js
+++ b/src/react/hoisting.js
@@ -95,6 +95,9 @@ export function canHoistFunction(
       // if declarativeEnvironmentRecord is null, it's likely a global binding
       // so we can assume that we can still hoist this function
       if (declarativeEnvironmentRecord !== null) {
+        if (!value) {
+          return false;
+        }
         invariant(value instanceof Value);
         if (!canHoistValue(realm, value, residualHeapVisitor, visitedValues)) {
           return false;

--- a/src/react/hoisting.js
+++ b/src/react/hoisting.js
@@ -95,7 +95,7 @@ export function canHoistFunction(
       // if declarativeEnvironmentRecord is null, it's likely a global binding
       // so we can assume that we can still hoist this function
       if (declarativeEnvironmentRecord !== null) {
-        if (!value) {
+        if (value === undefined) {
           return false;
         }
         invariant(value instanceof Value);

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1169,7 +1169,6 @@ export class Reconciler {
             return this._resolveUnknownComponentType(reactElement, evaluatedNode);
           }
           let evaluatedChildNode = createReactEvaluatedNode("INLINED", getComponentName(this.realm, typeValue));
-          evaluatedNode.children.push(evaluatedChildNode);
           let render = this._renderComponent(
             typeValue,
             propsValue,
@@ -1178,6 +1177,7 @@ export class Reconciler {
             null,
             evaluatedChildNode
           );
+          evaluatedNode.children.push(evaluatedChildNode);
           result = render.result;
           this.statistics.inlinedComponents++;
           break;

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -364,7 +364,7 @@ export class Reconciler {
       } else {
         this._queueNewComponentTree(componentType, evaluatedNode);
         evaluatedNode.status = "NEW_TREE";
-        throw new NewComponentTreeBranch();
+        throw new NewComponentTreeBranch(evaluatedNode);
       }
     }
     this.componentTreeState.status = "COMPLEX";
@@ -790,7 +790,7 @@ export class Reconciler {
       this._queueNewComponentTree(componentType, evaluatedNode);
       evaluatedNode.status = "NEW_TREE";
       evaluatedNode.message = "RelayContainer";
-      throw new NewComponentTreeBranch();
+      throw new NewComponentTreeBranch(evaluatedNode);
     }
     invariant(componentType instanceof ECMAScriptSourceFunctionValue);
     let value;
@@ -1268,6 +1268,7 @@ export class Reconciler {
     // assign a bail out message
     if (error instanceof NewComponentTreeBranch) {
       this._findReactComponentTrees(propsValue, evaluatedNode, "NORMAL_FUNCTIONS");
+      evaluatedNode.children.push(error.evaluatedNode);
       // NO-OP (we don't queue a newComponentTree as this was already done)
     } else {
       // handle abrupt completions

--- a/test/react/mocks/fb15.js
+++ b/test/react/mocks/fb15.js
@@ -1,0 +1,107 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+// FB www polyfill
+if (!this.babelHelpers) {
+  this.babelHelpers = {
+    inherits(subClass, superClass) {
+      Object.assign(subClass, superClass);
+      subClass.prototype = Object.create(superClass && superClass.prototype);
+      subClass.prototype.constructor = subClass;
+      subClass.__superConstructor__ = superClass;
+      return superClass;
+    },
+    _extends: Object.assign,
+    extends: Object.assign,
+    objectWithoutProperties(obj, keys) {
+      var target = {};
+      var hasOwn = Object.prototype.hasOwnProperty;
+      for (var i in obj) {
+        if (!hasOwn.call(obj, i) || keys.indexOf(i) >= 0) {
+          continue;
+        }
+        target[i] = obj[i];
+      }
+      return target;
+    },
+    taggedTemplateLiteralLoose(strings, raw) {
+      strings.raw = raw;
+      return strings;
+    },
+    bind: Function.prototype.bind,
+  };
+}
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+module.exports = this.__evaluatePureFunction(() => {
+  function memoize(f) {
+    var f1 = f;
+    var result = void 0;
+    return function() {
+      if (f1) {
+        result = f1();
+        f1 = null;
+      }
+      return result;
+    };
+  }
+
+  var getMemoizedArray = memoize(function() {
+    return [];
+  });
+
+  var React = require("react");
+
+  var _React$Component, _superProto;
+  _React$Component = babelHelpers.inherits(Inner, React.Component);
+  _superProto = _React$Component && _React$Component.prototype;
+  function Inner() {
+    var _superProto$construct;
+    var _temp;
+    for (
+      var _len = arguments.length, args = Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    ) {
+      args[_key] = arguments[_key];
+    }
+    return (
+      (_temp = (_superProto$construct = _superProto.constructor).call.apply(
+        _superProto$construct,
+        [this].concat(args)
+      )),
+      (this.state = {}),
+      _temp
+    );
+  }
+  Inner.prototype.render = function() {
+    var res = "Loading...".split("").map(getMemoizedArray);
+    return React.createElement("div", null, res);
+  };
+
+  function Outer(props) {
+    var isChronologicalOrder = props.foo === 42;
+    var inner1 = React.createElement(Inner, props.bar);
+    var inner2 = React.createElement(Inner, props.bar);
+    return isChronologicalOrder ? inner1 : inner2;
+  }
+
+  Outer.getTrials = function(renderer, Root) {
+    renderer.update(<Root />);
+    return [['fb15 mocks', renderer.toJSON()]];
+  };
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(Outer, {
+      firstRenderOnly: true,
+    });
+  }
+
+  return Outer;
+});


### PR DESCRIPTION
Release notes: none

There was a case where an invariant was firing in the hoisting logic due to a binding value being undefined. This PR stops the invariant from firing in such cases, and includes the regression test. I also found another issue in the evaluatedReactNode debugging output and fixed that too so it was easier to see what was going on with this and other issues.

This fixes https://github.com/facebook/prepack/issues/1775