### PR TITLE
Fixes an issue with getDerivedStateFromProps

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -912,6 +912,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output First render only getDerivedStateFromProps 5 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "MyComponent",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding 16.3 refs 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -4323,6 +4340,23 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output First render only getDerivedStateFromProps 5 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "MyComponent",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -7744,6 +7778,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output First render only getDerivedStateFromProps 5 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "MyComponent",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding 16.3 refs 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -11120,6 +11171,23 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output First render only getDerivedStateFromProps 5 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "MyComponent",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -613,6 +613,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "get-derived-state-from-props4.js", true);
       });
 
+      it("getDerivedStateFromProps 5", async () => {
+        await runTest(directory, "get-derived-state-from-props5.js", true);
+      });
+
       it("React Context", async () => {
         await runTest(directory, "react-context.js");
       });

--- a/test/react/first-render-only/get-derived-state-from-props5.js
+++ b/test/react/first-render-only/get-derived-state-from-props5.js
@@ -1,0 +1,97 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+// FB www polyfill
+if (!this.babelHelpers) {
+  this.babelHelpers = {
+    inherits(subClass, superClass) {
+      Object.assign(subClass, superClass);
+      subClass.prototype = Object.create(superClass && superClass.prototype);
+      subClass.prototype.constructor = subClass;
+      subClass.__superConstructor__ = superClass;
+      return superClass;
+    },
+    _extends: Object.assign,
+    extends: Object.assign,
+    objectWithoutProperties(obj, keys) {
+      var target = {};
+      var hasOwn = Object.prototype.hasOwnProperty;
+      for (var i in obj) {
+        if (!hasOwn.call(obj, i) || keys.indexOf(i) >= 0) {
+          continue;
+        }
+        target[i] = obj[i];
+      }
+      return target;
+    },
+    taggedTemplateLiteralLoose(strings, raw) {
+      strings.raw = raw;
+      return strings;
+    },
+    bind: Function.prototype.bind,
+  };
+}
+
+function shallowEqual(objA, objB) {
+  var keysA = Object.keys(objA);
+  var keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+  return true;
+}
+
+var _React$PureComponent, _superProto;
+
+function getStateForProps(props) {
+  if (!props.feedback.is_awesome) {
+    return { label: null, visible: false };
+  }
+  return { label: null, visible: false };
+}
+_React$PureComponent = babelHelpers.inherits(
+  MyComponent,
+  React.PureComponent
+);
+
+_superProto = _React$PureComponent && _React$PureComponent.prototype;
+function MyComponent() {
+  var _superProto$construct;
+  var _temp;
+  for (
+    var _len = arguments.length, args = Array(_len), _key = 0;
+    _key < _len;
+    _key++
+  ) {
+    args[_key] = arguments[_key];
+  }
+  return (
+    (_temp = (_superProto$construct = _superProto.constructor).call.apply(
+      _superProto$construct,
+      [this].concat(args)
+    )),
+    (this.state = getStateForProps(this.props)),
+    _temp
+  );
+}
+MyComponent.getDerivedStateFromProps = function(nextProps, prevState) {
+  var state = getStateForProps(nextProps);
+  return shallowEqual(state, prevState) ? null : state;
+};
+MyComponent.prototype.render = function() {
+  return null;
+};
+
+MyComponent.getTrials = function(renderer, Root) {
+  renderer.update(<Root feedback={{is_awesome: true}} />);
+  return [['render', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(MyComponent, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = MyComponent;


### PR DESCRIPTION
Release notes: none

When doing `Object.assign` in `getDerivedStateFromProps`, we need to add back in the fallback for when it might fail otherwise we end up triggering invariants. This fixes https://github.com/facebook/prepack/issues/1773