### PR TITLE
Special case switch over abstract value with known values domain

### DIFF
--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -108,6 +108,20 @@ function pushPathCondition(condition: Value) {
     invariant(left instanceof AbstractValue); // it is a mistake to create an abstract value when concrete value will do
     pushPathCondition(left);
     pushPathCondition(right);
+  } else if (condition.kind === "===") {
+    let [left, right] = condition.args;
+    if (right instanceof AbstractValue && right.kind === "conditional") [left, right] === [right, left];
+    if (left instanceof AbstractValue && left.kind === "conditional") {
+      let [cond, x, y] = left.args;
+      if (right instanceof ConcreteValue && x instanceof ConcreteValue && y instanceof ConcreteValue) {
+        if (right.equals(x) && !right.equals(y)) {
+          pushPathCondition(cond);
+        } else if (!right.equals(x) && right.equals(y)) {
+          pushInversePathCondition(cond);
+        }
+      }
+    }
+    realm.pathConditions.push(condition);
   } else {
     if (condition.kind === "!=" || condition.kind === "==") {
       let left = condition.args[0];

--- a/test/serializer/abstract/Switch3.js
+++ b/test/serializer/abstract/Switch3.js
@@ -1,0 +1,11 @@
+// Copies of value = 42:1
+let input = global.__abstract ? __abstract("boolean", "true") : true;
+
+let selector = input ? "A" : "B";
+let value = input ? 21 : 23;
+switch (selector) {
+  case "A": value = value * 2; break;
+  case "B": value = value + 19; break;
+}
+
+inspect = function() { return value; }


### PR DESCRIPTION
Release note: none

Addresses issue: #1763

If the abstract selector value of a switch statement has a known values domain and ranges over a small set of values, we can generate better code by not having to join up all the case blocks in the switch.

