### PR TITLE
Promote empty to undefined for optimized function return values

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -255,7 +255,7 @@ class ModifiedBindingEntry extends GeneratorEntry {
 class ReturnValueEntry extends GeneratorEntry {
   constructor(generator: Generator, returnValue: Value) {
     super();
-    this.returnValue = returnValue;
+    this.returnValue = returnValue.promoteEmptyToUndefined();
     this.containingGenerator = generator;
   }
 

--- a/test/serializer/optimized-functions/Empty.js
+++ b/test/serializer/optimized-functions/Empty.js
@@ -1,0 +1,11 @@
+var x = global.__abstract ? x = __abstract("boolean", "true") : true;
+
+function foo() {
+  let ob = {};
+  if (!x) ob.bar = 123;
+  return ob.bar;
+}
+
+if (global.__optimize) __optimize(foo);
+
+inspect = function() { return foo(); }


### PR DESCRIPTION
Release note: none

EmptyValue is a signal that the property that (might) have the value could in fact not actually be there. This matters when constructing objects at runtime, since code has to be emitted to deal with the case where the property will not be created at all, due to a runtime switch.

On the other hand, when the value of a missing property is *used*, it should be the undefined value. For that scenario, there is a promoteEmptyToUndefined on Value and this should be called before serializing empty values that are actually used.

This was not done for values returned from optimized functions. This PR plugs that hole.