### PR TITLE
Represent abstract arguments as abstract values with identifiers.

### DIFF
--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -26,7 +26,6 @@ import { To } from "../../singletons.js";
 import AbstractObjectValue from "../../values/AbstractObjectValue";
 import { CompilerDiagnostic, FatalError } from "../../errors.js";
 import { Utils } from "../../singletons";
-import type { BabelNodeSourceLocation } from "babel-types";
 import invariant from "../../invariant.js";
 
 const throwTemplateSrc = "(function(){throw new global.Error('abstract value defined at ' + A);})()";
@@ -62,26 +61,6 @@ export function parseTypeNameOrTemplate(
   } else {
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "typeNameOrTemplate has unsupported type");
   }
-}
-
-export function createAbstractArgument(
-  realm: Realm,
-  name: string,
-  location: ?BabelNodeSourceLocation,
-  type: typeof Value = Value
-) {
-  if (!realm.useAbstractInterpretation) {
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
-  }
-
-  let locString;
-  if (location) locString = describeLocation(realm, undefined, undefined, location);
-  let locVal = new StringValue(realm, locString || "(unknown location)");
-  let kind = AbstractValue.makeKind("abstractCounted", (realm.objectCount++).toString()); // need not be an object, but must be unique
-  let result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(name), type, [locVal], kind);
-  result.intrinsicName = name;
-
-  return result;
 }
 
 export function createAbstract(

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -62,7 +62,6 @@ import { ExpectedBailOut, SimpleClassBailOut, NewComponentTreeBranch } from "./e
 import { AbruptCompletion, Completion } from "../completions.js";
 import { Logger } from "../utils/logger.js";
 import type { ClassComponentMetadata, ReactComponentTreeConfig, ReactHint } from "../types.js";
-import { createAbstractArgument } from "../intrinsics/prepack/utils.js";
 import { createInternalReactElement } from "./elements.js";
 
 type ComponentResolutionStrategy =
@@ -247,7 +246,7 @@ export class Reconciler {
           if (t.isIdentifier(parameterId)) {
             // Create an AbstractValue similar to __abstract being called
             args.push(
-              createAbstractArgument(
+              AbstractValue.createAbstractArgument(
                 this.realm,
                 ((parameterId: any): BabelNodeIdentifier).name,
                 targetFunc.expressionLocation

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -61,7 +61,8 @@ export class Emitter {
   constructor(
     residualFunctions: ResidualFunctions,
     referencedDeclaredValues: Map<AbstractValue, void | FunctionValue>,
-    conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>
+    conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
+    derivedIds: Map<string, Array<Value>>
   ) {
     this._mainBody = { type: "MainGenerator", parentBody: undefined, entries: [], done: false };
     this._waitingForValues = new Map();
@@ -82,6 +83,7 @@ export class Emitter {
       onAbstractValueWithIdentifier: val => {
         // If the value hasn't been declared yet, then we should wait for it.
         if (
+          derivedIds.has(val.getIdentifier().name) &&
           !this.cannotDeclare() &&
           !this.hasBeenDeclared(val) &&
           (!this.emittingToAdditionalFunction() || referencedDeclaredValues.get(val) !== undefined)

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -163,7 +163,12 @@ export class ResidualHeapSerializer {
       this.additionalFunctionValueNestedFunctions,
       referentializer
     );
-    this.emitter = new Emitter(this.residualFunctions, referencedDeclaredValues, conditionalFeasibility);
+    this.emitter = new Emitter(
+      this.residualFunctions,
+      referencedDeclaredValues,
+      conditionalFeasibility,
+      this.preludeGenerator.derivedIds
+    );
     this.mainBody = this.emitter.getBody();
     this.residualHeapInspector = residualHeapInspector;
     this.residualValues = residualValues;

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -46,7 +46,6 @@ import {
   convertConfigObjectToReactComponentTreeConfig,
 } from "../react/utils.js";
 import * as t from "babel-types";
-import { createAbstractArgument } from "../intrinsics/prepack/utils.js";
 
 type AdditionalFunctionEntry = {
   value: ECMAScriptSourceFunctionValue | AbstractValue,
@@ -466,7 +465,7 @@ export class Functions {
         if (t.isIdentifier(parameterId)) {
           // Create an AbstractValue similar to __abstract being called
           args.push(
-            createAbstractArgument(
+            AbstractValue.createAbstractArgument(
               this.realm,
               ((parameterId: any): BabelNodeIdentifier).name,
               funcValue.expressionLocation
@@ -486,7 +485,7 @@ export class Functions {
       }
     }
 
-    let thisArg = createAbstractArgument(this.realm, "this", funcValue.expressionLocation, ObjectValue);
+    let thisArg = AbstractValue.createAbstractArgument(this.realm, "this", funcValue.expressionLocation, ObjectValue);
     return call.bind(this, thisArg, args);
   }
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -36,7 +36,7 @@ import {
   UndefinedValue,
   Value,
 } from "./index.js";
-import { hashBinary, hashCall, hashTernary, hashUnary } from "../methods/index.js";
+import { hashString, hashBinary, hashCall, hashTernary, hashUnary } from "../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
 
@@ -858,6 +858,28 @@ export default class AbstractValue extends Value {
     result.kind = "widened";
     result.mightBeEmpty = value1.mightHaveBeenDeleted() || value2.mightHaveBeenDeleted();
     result.expressionLocation = value1.expressionLocation;
+    return result;
+  }
+
+  static createAbstractArgument(
+    realm: Realm,
+    name: string,
+    location: ?BabelNodeSourceLocation,
+    type: typeof Value = Value
+  ) {
+    if (!realm.useAbstractInterpretation) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
+    }
+
+    let realmPreludeGenerator = realm.preludeGenerator;
+    invariant(realmPreludeGenerator);
+    let id = t.identifier(name);
+    let types = new TypesDomain(type);
+    let values = ValuesDomain.topVal;
+    let Constructor = Value.isTypeCompatibleWith(type, ObjectValue) ? AbstractObjectValue : AbstractValue;
+    let result = new Constructor(realm, types, values, 943586754858 + hashString(name), [], id);
+    result.kind = AbstractValue.makeKind("abstractCounted", (realm.objectCount++).toString()); // need not be an object, but must be unique
+    result.expressionLocation = location;
     return result;
   }
 


### PR DESCRIPTION
Release notes: None

Before, they had a real build node, and an extra statement was emitted
to bind the argument name to another name. This ends that silliness,
resulting in nicer code.

Also, moved createAbstractArgument to AbstractValue where all other
abstract value factories reside.