### PR TITLE
Fixing equals

### DIFF
--- a/src/values/NumberValue.js
+++ b/src/values/NumberValue.js
@@ -22,7 +22,7 @@ export class NumberValue extends PrimitiveValue {
   value: number;
 
   equals(x: Value): boolean {
-    return x instanceof NumberValue && this.value === x.value;
+    return x instanceof NumberValue && Object.is(this.value, x.value);
   }
 
   getHash(): number {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -291,7 +291,7 @@ export default class ObjectValue extends ConcreteValue {
   refuseSerialization: boolean;
 
   equals(x: Value): boolean {
-    return x instanceof ObjectValue && this.getHash() === x.getHash();
+    return this === x;
   }
 
   getHash(): number {

--- a/src/values/SymbolValue.js
+++ b/src/values/SymbolValue.js
@@ -23,12 +23,12 @@ export default class SymbolValue extends PrimitiveValue {
   hashValue: void | number;
 
   equals(x: Value): boolean {
-    return x instanceof SymbolValue && this.hashValue === x.hashValue && this.$Description === x.$Description;
+    return this === x;
   }
 
   getHash(): number {
     if (!this.hashValue) {
-      this.hashValue = this.$Description ? this.$Description.getHash() : ++this.$Realm.symbolCount;
+      this.hashValue = ++this.$Realm.symbolCount;
     }
     return this.hashValue;
   }

--- a/test/serializer/abstract/SymbolEqualityRegressionTest.js
+++ b/test/serializer/abstract/SymbolEqualityRegressionTest.js
@@ -1,0 +1,10 @@
+// add at runtime:var c=false;var description="whatever";
+(function () {
+    let c = global.__abstract ? __abstract("boolean", "c") : false;
+    let description = global.__abstract ? __abstract("string", "description") : "whatever";
+    let s = Symbol(description);
+    let t = Symbol(description);
+    let u = c ? s : t;
+    let bug = s === u;
+    inspect = function() { return bug; }
+})();


### PR DESCRIPTION
Fixing equals() on Values

Release notes: None

I found the following bugs in equals():
- For numbers, it didn't take into account NaN.
- For symbols, it was too optimistic.
And for objects, it was overly complicated.

Adding regression test for symbols. Could produce a regression test for numbers, but file a related issue for NaN values.