### PR TITLE
Don't emit object property modifications to dead objects.

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1820,7 +1820,8 @@ export class ResidualHeapSerializer {
       emitPropertyModification: (propertyBinding: PropertyBinding) => {
         let object = propertyBinding.object;
         invariant(object instanceof ObjectValue);
-        this._emitProperty(object, propertyBinding.key, propertyBinding.descriptor, true);
+        if (this.residualValues.has(object))
+          this._emitProperty(object, propertyBinding.key, propertyBinding.descriptor, true);
       },
       options: this._options,
     };

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1229,14 +1229,13 @@ export class ResidualHeapVisitor {
           if (s instanceof Generator) {
             let effectsToApply = s.effectsToApply;
             if (effectsToApply) {
-              let outer = withEffectsAppliedInGlobalEnv;
-              withEffectsAppliedInGlobalEnv = f =>
-                outer(() => {
-                  this.realm.withEffectsAppliedInGlobalEnv(() => {
-                    f();
-                    return null;
-                  }, effectsToApply);
-                });
+              let inner = withEffectsAppliedInGlobalEnv;
+              withEffectsAppliedInGlobalEnv = f => {
+                this.realm.withEffectsAppliedInGlobalEnv(() => {
+                  inner(f);
+                  return null;
+                }, effectsToApply);
+              };
             }
             s = this.generatorParents.get(s);
           } else if (s instanceof FunctionValue) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1040,8 +1040,17 @@ export class ResidualHeapVisitor {
           action: () => entry.visit(callbacks, generator),
         });
       },
-      visitObjectProperty: (binding: PropertyBinding) => {
-        this.visitObjectProperty(binding);
+      visitModifiedObjectProperty: (binding: PropertyBinding) => {
+        let fixpoint_rerun = () => {
+          if (this.values.has(binding.object)) {
+            this.visitObjectProperty(binding);
+            return true;
+          } else {
+            this._enqueueWithUnrelatedScope(this.scope, fixpoint_rerun);
+            return false;
+          }
+        };
+        fixpoint_rerun();
       },
       visitModifiedBinding: (modifiedBinding: Binding) => {
         invariant(additionalFunctionInfo);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -77,7 +77,7 @@ export type VisitEntryCallbacks = {|
   canSkip: AbstractValue => boolean,
   recordDeclaration: AbstractValue => void,
   recordDelayedEntry: (Generator, GeneratorEntry) => void,
-  visitObjectProperty: PropertyBinding => void,
+  visitModifiedObjectProperty: PropertyBinding => void,
   visitModifiedBinding: Binding => [ResidualFunctionBinding, Value],
 |};
 
@@ -197,7 +197,7 @@ class ModifiedPropertyEntry extends GeneratorEntry {
     );
     let desc = this.propertyBinding.descriptor;
     invariant(desc === this.newDescriptor);
-    context.visitObjectProperty(this.propertyBinding);
+    context.visitModifiedObjectProperty(this.propertyBinding);
     return true;
   }
 }

--- a/test/serializer/additional-functions/DeadOuterObject.js
+++ b/test/serializer/additional-functions/DeadOuterObject.js
@@ -1,0 +1,9 @@
+(function () {
+    let outer = {};
+    function f(x) {
+        outer.x = x;
+    }
+    if (global.__optimize) __optimize(f);
+    global.f = f;
+    inspect = function() { return true; }
+})();


### PR DESCRIPTION
Release notes: None

This fixes #1771.

When an optimized function modifies properties of objects
created outside of its scope, we can omit such property modifications
if the modified object is not used.
This nicely fits in with the fixed point model of the visitor.
(The objects involved in object property modification used to complete bypass the whole visiting process, resulting in the crash.)
Note that as a positive side effect certain double-mutation errors won't be issued to the user.

Added simple regression test.

Manually verified that this also makes the larger React test mentioned in the issue pass.

Also fixed ordering ordering of effects applications when processing queue in residual heap visitor. This bug existed for a while, but was only brought out by the existing serializer tests after the more aggressive queueing of modified object property binding visitng.