### PR TITLE
Fixing mutations of objects-from-outer-scope in optimized functions.

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1916,7 +1916,7 @@ export class ResidualHeapSerializer {
   // PropertyBindings -- visit any property bindings that aren't to createdobjects
   // CreatedObjects -- should take care of itself
   _serializeAdditionalFunction(additionalFunctionValue: FunctionValue, additionalEffects: AdditionalFunctionEffects) {
-    let { effects, transforms, generator } = additionalEffects;
+    let { effects, transforms, generator, additionalRoots } = additionalEffects;
     // No function info means the function is dead code, also break recursive cycles where we've already started
     // serializing this value
     if (
@@ -1926,6 +1926,12 @@ export class ResidualHeapSerializer {
       return;
     }
     this.rewrittenAdditionalFunctions.set(additionalFunctionValue, []);
+
+    // visit all additional roots before going into the additional functions;
+    // this ensures that those potentially stateful additional roots will get
+    // initially serialized with the right initial effects applied.
+    for (let additionalRoot of additionalRoots) this.serializeValue(additionalRoot);
+
     let createdObjects = effects.createdObjects;
     let nestedFunctions = new Set([...createdObjects].filter(object => object instanceof FunctionValue));
     // Allows us to emit function declarations etc. inside of this additional

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1646,14 +1646,15 @@ export class ResidualHeapSerializer {
         invariant(kind === "Object", "invariant established by visitor");
 
         let proto = val.$Prototype;
+        let { skipPrototype, constructor: _constructor } = getObjectPrototypeMetadata(this.realm, val);
         let createViaAuxiliaryConstructor =
           val.temporalAlias === undefined &&
           proto !== this.realm.intrinsics.ObjectPrototype &&
           this._findLastObjectPrototype(val) === this.realm.intrinsics.ObjectPrototype &&
-          proto instanceof ObjectValue;
-        let { skipPrototype, constructor: _constructor } = getObjectPrototypeMetadata(this.realm, val);
+          proto instanceof ObjectValue &&
+          !skipPrototype;
 
-        return createViaAuxiliaryConstructor
+        return createViaAuxiliaryConstructor || _constructor
           ? this._serializeValueObjectViaConstructor(val, skipPrototype, _constructor)
           : this.serializeValueRawObject(val, skipPrototype);
     }

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -168,6 +168,7 @@ export class Functions {
       effects,
       transforms: [],
       generator: Generator.fromEffects(effects, this.realm, name, environmentRecordIdAfterGlobalCode),
+      additionalRoots: new Set(),
     };
     return retValue;
   }

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -46,6 +46,7 @@ export type AdditionalFunctionEffects = {
   effects: Effects,
   generator: Generator,
   transforms: Array<Function>,
+  additionalRoots: Set<ObjectValue>,
 };
 
 export type AdditionalFunctionInfo = {

--- a/test/serializer/abstract/MutatingObjectsFromOuterScope.js
+++ b/test/serializer/abstract/MutatingObjectsFromOuterScope.js
@@ -1,0 +1,10 @@
+(function () {
+    let outer = {};
+    function f(x) {
+        outer.x = x;
+        return outer;
+    }
+    if (global.__optimize) __optimize(f);
+    global.f = f;
+    inspect = function() { return f(42).x; }
+})();

--- a/test/serializer/additional-functions/OuterScopeCacheRegressionTest.js
+++ b/test/serializer/additional-functions/OuterScopeCacheRegressionTest.js
@@ -1,0 +1,15 @@
+var cache = {};
+
+function additional1(x, y) {
+    if (!cache[x]) {
+        cache[x] = y;
+    }
+    return cache[x];
+}
+
+if (global.__optimize)
+    __optimize(additional1);
+
+inspect = function inspect() {
+    return additional1("a", 5);
+}


### PR DESCRIPTION
Release notes: None

This fixes #1789.

The visitor already computed the right scopes for all objects,
which the serializer then used to figure out in which code block
to emit an object.
However, the serializer didn't take into account that the wrong
effects might be applied when serializing values in a simple
recursive manner, finding an object from an outer scope while
serializing an optimized function.
To fix this, (re-)introduce an additional roots set which is used
to ensure that all objects belonging to an outer scope get serialized
before we enter an additional function where effects might get applied.

Adding regression test case.