### PR TITLE
Keep generator entries that do not come from joins

### DIFF
--- a/test/serializer/optimized-functions/ThrowOrReturn.js
+++ b/test/serializer/optimized-functions/ThrowOrReturn.js
@@ -1,0 +1,13 @@
+var x = global.__abstract ? x = __abstract(undefined, "({ check: false })") : { check: false };
+
+function func1() {
+  if (x.check) {
+    throw new Error("This should never happen");
+  }
+  return 1;
+}
+
+if (global.__optimize)
+  __optimize(func1);
+
+inspect = function () { return func1(); }


### PR DESCRIPTION
Release note: none

Fixes issue: #1766

Generators that result from joining two blocks of code have lots of entries that are the joins of the generators of the individual blocks. When generating code for optimized functions, these entries need to get ignored since they will be visited while recursing through the top level result. That much was achieved with the PR #1758.

That turned out to be too simplistic since joined generator entries can get appended into generators with existing entries. This PR restores visiting generators from effects with joined results, but purges them of entries that resulted from the join.

This is somewhat brittle and we need to revisit the entire generator design at some point, but this PR gets us unblocked and does seem to make things strictly better.