### PR TITLE
Simplify things by removing an unnecessary evaluateForEffects call.

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -797,26 +797,21 @@ export function getValueFromFunctionCall(
   invariant(func.$Call, "Expected function to be a FunctionValue with $Call method");
   let funcCall = func.$Call;
   let newCall = func.$Construct;
-  let effects;
+  let completion;
   try {
-    effects = realm.evaluateForEffects(
-      () => {
-        invariant(func);
-        if (isConstructor) {
-          invariant(newCall);
-          return newCall(args, func);
-        } else {
-          return funcCall(funcThis, args);
-        }
-      },
-      null,
-      "getValueFromFunctionCall"
-    );
+    if (isConstructor) {
+      invariant(newCall);
+      completion = newCall(args, func);
+    } else {
+      completion = funcCall(funcThis, args);
+    }
   } catch (error) {
-    throw error;
+    if (error instanceof AbruptCompletion) {
+      completion = error;
+    } else {
+      throw error;
+    }
   }
-
-  let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
     // not all control flow branches join into one flow at this point.
@@ -824,9 +819,6 @@ export function getValueFromFunctionCall(
     // all the branches come together into one.
     completion = realm.composeWithSavedCompletion(completion);
   }
-  // Note that the effects of (non joining) abrupt branches are not included
-  // in joinedEffects, but are tracked separately inside completion.
-  realm.applyEffects(effects);
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof Value);


### PR DESCRIPTION
Release note: none

Resolves issue #1799

react/utils/getValueFromFunctionCall is called from within an evaluateForEffects and is expected to produce a current state that has the effects of the call applied to it. It therefore makes no sense to use evaluateForEffects within the implementation of getValueFromFunctionCall.

Making this simpler also resolves #1799. The reason for this is commented on in the code.

