### PR TITLE
Ensure that the right effects are applied when visiting bindings.

### DIFF
--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -107,7 +107,8 @@ export class ResidualFunctionInitializers {
     // to figure out if initialization needs to run.
     let location;
     for (let value of initializedValues) {
-      if (!value.mightBeUndefined()) {
+      // function declarations get hoisted, so let's not use their initialization state as a marker
+      if (!value.mightBeUndefined() && !(value instanceof FunctionValue)) {
         location = this.locationService.getLocation(value);
         if (location !== undefined) break;
       }

--- a/test/serializer/additional-functions/ResidualFunctionBindingsMutatedByOptimizedFunctionRegressionTest.js
+++ b/test/serializer/additional-functions/ResidualFunctionBindingsMutatedByOptimizedFunctionRegressionTest.js
@@ -1,0 +1,11 @@
+(function() {
+    let x = 23;
+    function g() { return x; }
+    function f() {
+        x = 42;
+        return g;
+    };
+    if (global.__optimize) __optimize(f);
+    global.f = f;
+    inspect = function() { return x + "+19=" + f()(); }
+})();


### PR DESCRIPTION
Release notes: None

This fixes #1798, and it almost fixes #1797 by reducing it to #1799, and it unblocks #1794.

When the visitor looks at (initial) function bindings, it does so with additional functions still applied if that additional function happens to be the first thing that pull on the function value.
This is being fixed, as well as generally turning _withScope uses into _enqueueWithUnrelatedScope calls which ensure that the right effects are in place.

Added additional output to the serializer runner - it now shows a summary of which tests failed, ordered by their size.

Added regression test.