### PR TITLE
Fixes an issue in the React reconciler when dealing with abstract values

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3490,6 +3490,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 17 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Inner",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Middle",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Outer",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -7037,6 +7075,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 17 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Inner",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Middle",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Outer",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -10549,6 +10625,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 17 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Inner",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Middle",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Outer",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -14058,6 +14172,44 @@ ReactStatistics {
   "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 17 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Inner",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "Middle",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Outer",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -728,13 +728,17 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb14.js");
       });
 
+      it("fb-www 15", async () => {
+        await runTest(directory, "fb15.js");
+      });
+
       // Skip for now, there's more issues to fix before we can enable
       it.skip("fb-www 16", async () => {
         await runTest(directory, "fb16.js");
       });
 
-      it("fb-www 15", async () => {
-        await runTest(directory, "fb15.js");
+      it("fb-www 17", async () => {
+        await runTest(directory, "fb17.js");
       });
 
       it("repl example", async () => {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -11,19 +11,19 @@
 
 import { Realm, type Effects } from "../realm.js";
 import {
+  AbstractObjectValue,
   AbstractValue,
+  ArrayValue,
+  BooleanValue,
+  BoundFunctionValue,
   ECMAScriptSourceFunctionValue,
+  FunctionValue,
+  NullValue,
+  NumberValue,
+  ObjectValue,
+  StringValue,
   Value,
   UndefinedValue,
-  StringValue,
-  NumberValue,
-  BooleanValue,
-  NullValue,
-  ArrayValue,
-  ObjectValue,
-  AbstractObjectValue,
-  FunctionValue,
-  BoundFunctionValue,
 } from "../values/index.js";
 import { ReactStatistics, type ReactSerializerState, type ReactEvaluatedNode } from "../serializer/types.js";
 import {
@@ -889,7 +889,7 @@ export class Reconciler {
     branchStatus: BranchStatusEnum,
     branchState: BranchState | null,
     evaluatedNode: ReactEvaluatedNode
-  ): AbstractValue {
+  ): Value {
     invariant(this.realm.generator);
     let length = value.args.length;
     // TODO investigate what other kinds than "conditional" might be safe to deeply resolve
@@ -920,9 +920,9 @@ export class Reconciler {
         // value.args[0] is guaranteed to be abstract and _resolveDeeply returns an abstract
         // when called on an abstract
         invariant(condition instanceof AbstractValue);
-        let abstractValue = AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
-        invariant(abstractValue instanceof AbstractValue);
-        return abstractValue;
+        let refinedValue = AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
+        invariant(refinedValue instanceof Value);
+        return refinedValue;
       }
     } else {
       this.componentTreeState.deadEnds++;
@@ -937,7 +937,7 @@ export class Reconciler {
     branchStatus: BranchStatusEnum,
     branchState: BranchState | null,
     evaluatedNode: ReactEvaluatedNode
-  ) {
+  ): Value {
     let typeValue = getProperty(this.realm, reactElement, "type");
     let propsValue = getProperty(this.realm, reactElement, "props");
     let keyValue = getProperty(this.realm, reactElement, "key");

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -920,9 +920,7 @@ export class Reconciler {
         // value.args[0] is guaranteed to be abstract and _resolveDeeply returns an abstract
         // when called on an abstract
         invariant(condition instanceof AbstractValue);
-        let refinedValue = AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
-        invariant(refinedValue instanceof Value);
-        return refinedValue;
+        return AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
       }
     } else {
       this.componentTreeState.deadEnds++;
@@ -943,7 +941,7 @@ export class Reconciler {
     let keyValue = getProperty(this.realm, reactElement, "key");
     let refValue = getProperty(this.realm, reactElement, "ref");
 
-    const resolveBranch = (abstract: AbstractValue): AbstractValue => {
+    const resolveBranch = (abstract: AbstractValue): Value => {
       invariant(abstract.kind === "conditional", "the reconciler tried to resolve a non conditional abstract");
       let condition = abstract.args[0];
       invariant(condition instanceof AbstractValue);
@@ -962,13 +960,10 @@ export class Reconciler {
         invariant(propsValue instanceof ObjectValue || propsValue instanceof AbstractValue);
         right = createInternalReactElement(this.realm, right, keyValue, refValue, propsValue);
       }
-      let val = AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
-      invariant(val instanceof AbstractValue);
-      return val;
+      return AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
     };
     invariant(typeValue instanceof AbstractValue);
-
-    return this._resolveAbstractValue(
+    return this._resolveDeeply(
       componentType,
       resolveBranch(typeValue),
       context,

--- a/test/react/mocks/fb17.js
+++ b/test/react/mocks/fb17.js
@@ -1,0 +1,60 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+__evaluatePureFunction(function() {
+  function Inner(props) {
+    return props.children();
+  }
+
+  function Middle(props) {
+    var bar = props.bar;
+    if (!bar) {
+      return null;
+    }
+    return props.children();
+  }
+
+  function Outer(props) {
+    return React.createElement(
+      Middle,
+      {
+        bar: props.foo
+      },
+      function() {
+        return React.createElement(Inner, props);
+      }
+    );
+  }
+
+  function App(props) {
+    return React.createElement(
+      Outer,
+      {
+        foo: props.foo
+      },
+      function() {
+        return null;
+      }
+    );
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root foo={true} />);
+    return [['fb17 mocks', renderer.toJSON()]];
+  };
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App, {
+      firstRenderOnly: true,
+    });
+  }
+
+  module.exports = App;
+});


### PR DESCRIPTION
Release notes: none

This PR fixes an issue where the React reconciler incorrectly assumed that `createFromConditionalOp` always returned an `AbstractValue`. This changes that and adds the failing test for a regression test.

Fixes https://github.com/facebook/prepack/issues/1804 and https://github.com/facebook/prepack/issues/1792.