### PR TITLE
isReactElement should check for type and props on the obj

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3528,6 +3528,16 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 19 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -7113,6 +7123,16 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 19 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -10663,6 +10683,16 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 19 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -14210,6 +14240,16 @@ ReactStatistics {
   "inlinedComponents": 3,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 19 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
 }
 `;
 

--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3528,16 +3528,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with JSX input, JSX output fb-www mocks fb-www 19 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 0,
-  "evaluatedRootNodes": Array [],
-  "inlinedComponents": 0,
-  "optimizedNestedClosures": 0,
-  "optimizedTrees": 0,
-}
-`;
-
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -7123,16 +7113,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with JSX input, create-element output fb-www mocks fb-www 19 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 0,
-  "evaluatedRootNodes": Array [],
-  "inlinedComponents": 0,
-  "optimizedNestedClosures": 0,
-  "optimizedTrees": 0,
-}
-`;
-
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -10683,16 +10663,6 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with create-element input, JSX output fb-www mocks fb-www 19 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 0,
-  "evaluatedRootNodes": Array [],
-  "inlinedComponents": 0,
-  "optimizedNestedClosures": 0,
-  "optimizedTrees": 0,
-}
-`;
-
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -14240,16 +14210,6 @@ ReactStatistics {
   "inlinedComponents": 3,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
-}
-`;
-
-exports[`Test React with create-element input, create-element output fb-www mocks fb-www 19 1`] = `
-ReactStatistics {
-  "componentsEvaluated": 0,
-  "evaluatedRootNodes": Array [],
-  "inlinedComponents": 0,
-  "optimizedNestedClosures": 0,
-  "optimizedTrees": 0,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -741,6 +741,11 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb17.js");
       });
 
+      // fails due to Invariant Violation: an abstract value with an identifier "_$1" was referenced before being declared
+      // it("fb-www 19", async () => {
+      //   await runTest(directory, "fb19.js");
+      // });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -65,7 +65,7 @@ export function isReactElement(val: Value): boolean {
   }
   let $$typeof = Get(realm, val, "$$typeof");
   let globalObject = realm.$GlobalObject;
-  let globalSymbolValue = Get(realm, globalObject, "Symbol");
+  let globalSymbolValue = getProperty(realm, globalObject, "Symbol");
 
   if (globalSymbolValue === realm.intrinsics.undefined) {
     if ($$typeof instanceof NumberValue) {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -60,23 +60,24 @@ export function isReactElement(val: Value): boolean {
   if (realm.react.reactElements.has(val)) {
     return true;
   }
-  if (val.properties.has("$$typeof")) {
-    let $$typeof = Get(realm, val, "$$typeof");
-    let globalObject = realm.$GlobalObject;
-    let globalSymbolValue = Get(realm, globalObject, "Symbol");
+  if (!val.properties.has("type") || !val.properties.has("props") || !val.properties.has("$$typeof")) {
+    return false;
+  }
+  let $$typeof = Get(realm, val, "$$typeof");
+  let globalObject = realm.$GlobalObject;
+  let globalSymbolValue = Get(realm, globalObject, "Symbol");
 
-    if (globalSymbolValue === realm.intrinsics.undefined) {
-      if ($$typeof instanceof NumberValue) {
-        return $$typeof.value === 0xeac7;
-      }
-    } else if ($$typeof instanceof SymbolValue) {
-      let symbolFromRegistry = realm.globalSymbolRegistry.find(e => e.$Symbol === $$typeof);
-      let _isReactElement = symbolFromRegistry !== undefined && symbolFromRegistry.$Key === "react.element";
-      if (_isReactElement) {
-        // add to Set to speed up future lookups
-        realm.react.reactElements.add(val);
-        return true;
-      }
+  if (globalSymbolValue === realm.intrinsics.undefined) {
+    if ($$typeof instanceof NumberValue) {
+      return $$typeof.value === 0xeac7;
+    }
+  } else if ($$typeof instanceof SymbolValue) {
+    let symbolFromRegistry = realm.globalSymbolRegistry.find(e => e.$Symbol === $$typeof);
+    let _isReactElement = symbolFromRegistry !== undefined && symbolFromRegistry.$Key === "react.element";
+    if (_isReactElement) {
+      // add to Set to speed up future lookups
+      realm.react.reactElements.add(val);
+      return true;
     }
   }
   return false;

--- a/test/react/mocks/fb19.js
+++ b/test/react/mocks/fb19.js
@@ -1,0 +1,48 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+__evaluatePureFunction(function() {
+
+  function FbtResult() {}
+  FbtResult.prototype.$$typeof = Symbol.for("react.element");
+
+  function fbt() {};
+  function param() {};
+  function plural(shouldThrow) {
+    if (shouldThrow) {
+      throw new Error('no');
+    }
+  }
+
+  var React = require('react');
+
+  function App(props) {
+   return React.createElement(
+     'div',
+     new FbtResult(
+       {},
+       [param(props.foo), plural(props.bar)],
+     )
+   );
+ }
+
+ App.getTrials = function(renderer, Root) {
+  renderer.update(<Root bar={false} />);
+  return [['fb19 mocks', renderer.toJSON()]];
+  };
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App, {
+      firstRenderOnly: true,
+    });
+  }
+
+  module.exports = App;
+});


### PR DESCRIPTION
Release notes: none

This adds more validation that something definitely is a ReactElement, as found from the issue https://github.com/facebook/prepack/issues/1802. Unfortunately, the test in that case does not pass, it fails due to an invariant:

`Invariant Violation: an abstract value with an identifier "_$1" was referenced before being declared`