### PR TITLE
Always apply effects before combining their results with saved_result

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -217,6 +217,9 @@ export function computeBinary(
     }
 
     if (isPure && effects) {
+      // Note that the effects of (non joining) abrupt branches are not included
+      // in effects, but are tracked separately inside completion.
+      realm.applyEffects(effects);
       let completion = effects.result;
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
@@ -225,9 +228,6 @@ export function computeBinary(
         // all the branches come together into one.
         completion = realm.composeWithSavedCompletion(completion);
       }
-      // Note that the effects of (non joining) abrupt branches are not included
-      // in effects, but are tracked separately inside completion.
-      realm.applyEffects(effects);
       // return or throw completion
       if (completion instanceof AbruptCompletion) throw completion;
       invariant(completion instanceof Value);

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -180,6 +180,9 @@ function tryToEvaluateCallOrLeaveAsAbstract(
   } finally {
     realm.suppressDiagnostics = savedSuppressDiagnostics;
   }
+  // Note that the effects of (non joining) abrupt branches are not included
+  // in effects, but are tracked separately inside completion.
+  realm.applyEffects(effects);
   let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
@@ -188,9 +191,6 @@ function tryToEvaluateCallOrLeaveAsAbstract(
     // all the branches come together into one.
     completion = realm.composeWithSavedCompletion(completion);
   }
-  // Note that the effects of (non joining) abrupt branches are not included
-  // in effects, but are tracked separately inside completion.
-  realm.applyEffects(effects);
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof Value);

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -111,6 +111,9 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
       throw error;
     }
   }
+  // Note that the effects of (non joining) abrupt branches are not included
+  // in joinedEffects, but are tracked separately inside completion.
+  realm.applyEffects(effects);
   let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
@@ -120,9 +123,6 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
     completion = realm.composeWithSavedCompletion(completion);
   }
 
-  // Note that the effects of (non joining) abrupt branches are not included
-  // in joinedEffects, but are tracked separately inside completion.
-  realm.applyEffects(effects);
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof ObjectValue || completion instanceof AbstractObjectValue);

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -129,6 +129,9 @@ function tryToEvaluateOperationOrLeaveAsAbstract(
       throw error;
     }
   }
+  // Note that the effects of (non joining) abrupt branches are not included
+  // in joinedEffects, but are tracked separately inside completion.
+  realm.applyEffects(effects);
   let completion = effects.result;
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that
@@ -138,9 +141,6 @@ function tryToEvaluateOperationOrLeaveAsAbstract(
     completion = realm.composeWithSavedCompletion(completion);
   }
 
-  // Note that the effects of (non joining) abrupt branches are not included
-  // in joinedEffects, but are tracked separately inside completion.
-  realm.applyEffects(effects);
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof Value);

--- a/test/serializer/optimized-functions/NullThrows.js
+++ b/test/serializer/optimized-functions/NullThrows.js
@@ -1,0 +1,24 @@
+var x = global.__abstract ? x = __abstract(undefined, "({ check: true })") : { check: true };
+
+function nullthrows(x) {
+  var message = arguments.length <= 1 || arguments[1] === undefined ? 'Got unexpected null or undefined' : arguments[1];
+  if (x != null) {
+    return x;
+  }
+  var error = new Error(message);
+
+  error.framesToPop = 1;
+  throw error;
+};
+
+function func1() {
+  nullthrows(x.check);
+  return {
+    check: x.check,
+  };
+}
+
+if (global.__optimize)
+  __optimize(func1);
+
+inspect = function () { return func1(); }


### PR DESCRIPTION
Release note: Resolves issues with outer declarations moving into nested scopes

Issues: #1802 #1808

The fix identified in #1805, needs to be applied in a number of other contexts as well.