### PR TITLE
Do not simplify c ? NaN : y to y if the path implies (c ? NaN : y) !== NaN.

### DIFF
--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -154,8 +154,8 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       if (Path.implies(notc)) return y;
       if (!isCondition) {
         if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, x))) return x;
-        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, x))) return y;
-        if (Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, y))) return x;
+        if (!x.mightBeNumber() && Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, x))) return y;
+        if (!y.mightBeNumber() && Path.implies(AbstractValue.createFromBinaryOp(realm, "!==", value, y))) return x;
         if (Path.implies(AbstractValue.createFromBinaryOp(realm, "===", value, y))) return y;
       }
       // c ? x : x <=> x

--- a/test/serializer/optimizations/simplify10.js
+++ b/test/serializer/optimizations/simplify10.js
@@ -1,0 +1,7 @@
+// add at runtime:var c=true;
+let c = global.__abstract ? __abstract("boolean", "c") : true;
+let s = NaN;
+let u = c ? s : 42;
+let v = c ? 43 : s;
+
+inspect = function() { return u + " " + v; }


### PR DESCRIPTION
Release note: Fixes simplification bug involving comparisons with NaN

Issue: #1790 

Simplification operations that reduce conditional expressions based on inequalities, must guard agains comparisons with NaN.