### PR TITLE
Refine type of PropertyBinding.key

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -1041,7 +1041,7 @@ export class Realm {
           return r;
         });
       } else {
-        // TODO: What is keyKey is undefined?
+        // TODO: What if keyKey is undefined?
         invariant(keyKey instanceof Value);
         gen.emitStatement([key.object, keyKey, tval || value, this.intrinsics.empty], ([o, p, v, e]) => {
           invariant(path !== undefined);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1853,8 +1853,10 @@ export class ResidualHeapSerializer {
       emitPropertyModification: (propertyBinding: PropertyBinding) => {
         let object = propertyBinding.object;
         invariant(object instanceof ObjectValue);
-        if (this.residualValues.has(object))
+        if (this.residualValues.has(object)) {
+          invariant(propertyBinding.key !== undefined, "established by visitor");
           this._emitProperty(object, propertyBinding.key, propertyBinding.descriptor, true);
+        }
       },
       options: this._options,
     };

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -237,9 +237,14 @@ export class ResidualHeapVisitor {
     let desc = binding.descriptor;
     if (desc === undefined) return; //deleted
     let obj = binding.object;
-    if (obj instanceof AbstractObjectValue || !this.inspector.canIgnoreProperty(obj, binding.key)) {
+    invariant(binding.key !== undefined, "Undefined keys should never make it here.");
+    if (
+      obj instanceof AbstractObjectValue ||
+      !(typeof binding.key === "string" && this.inspector.canIgnoreProperty(obj, binding.key))
+    ) {
       this.visitDescriptor(desc);
     }
+    if (binding.key instanceof Value) this.visitValue(binding.key);
   }
 
   visitObjectProperties(obj: ObjectValue, kind?: ObjectKind): void {

--- a/src/types.js
+++ b/src/types.js
@@ -135,7 +135,7 @@ export type FunctionBodyAstNode = {
 export type PropertyBinding = {
   descriptor?: Descriptor,
   object: ObjectValue | AbstractObjectValue,
-  key: any,
+  key: void | string | SymbolValue | AbstractValue, // where an abstract value must be of type String or Number or Symbol
   // contains a build node that produces a member expression that resolves to this property binding (location)
   pathNode?: AbstractValue,
 };

--- a/test/serializer/additional-functions/ModifiedObjectPropertyWithAbstractKey.js
+++ b/test/serializer/additional-functions/ModifiedObjectPropertyWithAbstractKey.js
@@ -1,0 +1,20 @@
+(function() {
+    var cache = {};
+    function fn(args) {
+        var maybeTrue = args.unknown === 42;
+        var maybeNull = maybeTrue ? {} : null;
+
+        var cacheKey = maybeNull.foo;
+        var cachedValue = cache[cacheKey];
+        if (cachedValue) {
+            return cachedValue;
+        }
+
+        var result;
+        cache[cacheKey] = result;
+        return result;
+    }
+    if (global.__optimize) __optimize(fn);
+    global.fn = fn;
+    inspect = function() { try { fn(23); return "impossible"; } catch (e) { return e instanceof TypeError; } }
+})();


### PR DESCRIPTION
Release notes: None

This fixes #1771.

The `PropertyBinding` `key` type used to be just `any`; not sure what the historical story here is,
but the visitor was unaware that this in fact could be an `AbstractValue` as well as a `string`.
This meant that some keys might not get visited when they should have been.

This refines the key type and accounts for the different possible types in all referencing places.