### PR TITLE
Special handling for temporal assignments to unknown properties

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,9 +25,9 @@ test:
     - yarn test-sourcemaps
     - yarn test-std-in
     - yarn test-residual
-    - yarn test-test262 -- --statusFile $CIRCLE_ARTIFACTS/test262-status.txt --timeout 120 --cpuScale 0.25 --verbose:
+    - yarn test-test262 --statusFile $CIRCLE_ARTIFACTS/test262-status.txt --timeout 120 --cpuScale 0.25 --verbose:
         timeout: 1800
-    # - yarn test-test262-new -- --statusFile $CIRCLE_ARTIFACTS/test262-new-status.txt --timeout 120 --verbose:
+    # - yarn test-test262-new --statusFile $CIRCLE_ARTIFACTS/test262-new-status.txt --timeout 120 --verbose:
     #     timeout: 1800
   post:
     - mv coverage/lcov-report $CIRCLE_ARTIFACTS/coverage-report

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -328,28 +328,31 @@ export class ResidualHeapVisitor {
   visitObjectPropertiesWithComputedNames(absVal: AbstractValue): void {
     if (absVal.kind === "widened property") return;
     if (absVal.kind === "template for prototype member expression") return;
-    invariant(absVal.args.length === 3);
-    let cond = absVal.args[0];
-    invariant(cond instanceof AbstractValue);
-    if (cond.kind === "template for property name condition") {
-      let P = cond.args[0];
-      invariant(P instanceof AbstractValue);
-      let V = absVal.args[1];
-      let earlier_props = absVal.args[2];
-      if (earlier_props instanceof AbstractValue) this.visitObjectPropertiesWithComputedNames(earlier_props);
-      this.visitValue(P);
-      this.visitValue(V);
+    if (absVal.kind === "conditional") {
+      let cond = absVal.args[0];
+      invariant(cond instanceof AbstractValue);
+      if (cond.kind === "template for property name condition") {
+        let P = cond.args[0];
+        invariant(P instanceof AbstractValue);
+        let V = absVal.args[1];
+        let earlier_props = absVal.args[2];
+        if (earlier_props instanceof AbstractValue) this.visitObjectPropertiesWithComputedNames(earlier_props);
+        this.visitValue(P);
+        this.visitValue(V);
+      } else {
+        // conditional assignment
+        absVal.args[0] = this.visitEquivalentValue(cond);
+        let consequent = absVal.args[1];
+        if (consequent instanceof AbstractValue) {
+          this.visitObjectPropertiesWithComputedNames(consequent);
+        }
+        let alternate = absVal.args[2];
+        if (alternate instanceof AbstractValue) {
+          this.visitObjectPropertiesWithComputedNames(alternate);
+        }
+      }
     } else {
-      // conditional assignment
-      absVal.args[0] = this.visitEquivalentValue(cond);
-      let consequent = absVal.args[1];
-      if (consequent instanceof AbstractValue) {
-        this.visitObjectPropertiesWithComputedNames(consequent);
-      }
-      let alternate = absVal.args[2];
-      if (alternate instanceof AbstractValue) {
-        this.visitObjectPropertiesWithComputedNames(alternate);
-      }
+      this.visitValue(absVal);
     }
   }
 
@@ -1063,6 +1066,7 @@ export class ResidualHeapVisitor {
       visitModifiedObjectProperty: (binding: PropertyBinding) => {
         let fixpoint_rerun = () => {
           if (this.values.has(binding.object)) {
+            if (binding.key instanceof Value) this.visitValue(binding.key);
             this.visitObjectProperty(binding);
             return true;
           } else {

--- a/test/serializer/optimized-functions/UnknownProperty.js
+++ b/test/serializer/optimized-functions/UnknownProperty.js
@@ -1,0 +1,10 @@
+var cache = {};
+function f(x, y) {
+  cache[x] = y;
+}
+if (global.__optimize) __optimize(f);
+
+inspect = function() {
+  f(42, 5);
+  return cache[42];
+};


### PR DESCRIPTION
Release note: Support temporal assignment to object properties using unknown property names

Resolves issue: #1818

There was no code for dealing with assignments using unknown property names that showed up in generator entries.