### PR TITLE
Extend invariant check in AbstractObjectValue

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3636,6 +3636,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 20 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -7329,6 +7353,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 20 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -10987,6 +11035,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 20 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -14640,6 +14712,30 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 20 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -757,6 +757,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb19.js");
       });
 
+      it("fb-www 20", async () => {
+        await runTest(directory, "fb20.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -305,12 +305,12 @@ export default class AbstractObjectValue extends AbstractValue {
       }
       invariant(false);
     } else if (this.kind === "conditional") {
-      // this is the join of two concrete objects
+      // this is the join of two concrete/abstract objects
       // use this join condition for the join of the two property values
       let [cond, ob1, ob2] = this.args;
       invariant(cond instanceof AbstractValue);
-      invariant(ob1 instanceof ObjectValue);
-      invariant(ob2 instanceof ObjectValue);
+      invariant(ob1 instanceof ObjectValue || ob1 instanceof AbstractObjectValue);
+      invariant(ob2 instanceof ObjectValue || ob2 instanceof AbstractObjectValue);
       let d1 = ob1.$GetOwnProperty(P);
       let d2 = ob2.$GetOwnProperty(P);
       if (d1 === undefined || d2 === undefined || !equalDescriptors(d1, d2)) {

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -237,12 +237,12 @@ export default class AbstractObjectValue extends AbstractValue {
       }
       invariant(false);
     } else if (this.kind === "conditional") {
-      // this is the join of two concrete objects
+      // this is the join of two concrete/abstract objects
       // use this join condition for the join of the two property values
       let [cond, ob1, ob2] = this.args;
       invariant(cond instanceof AbstractValue);
-      invariant(ob1 instanceof ObjectValue);
-      invariant(ob2 instanceof ObjectValue);
+      invariant(ob1 instanceof ObjectValue || ob1 instanceof AbstractObjectValue);
+      invariant(ob2 instanceof ObjectValue || ob2 instanceof AbstractObjectValue);
       let p1 = ob1.$GetPrototypeOf();
       let p2 = ob2.$GetPrototypeOf();
       let joinedObject = Join.joinValuesAsConditional(realm, cond, p1, p2);
@@ -531,7 +531,7 @@ export default class AbstractObjectValue extends AbstractValue {
       }
       invariant(false);
     } else if (this.kind === "conditional") {
-      // this is the join of two concrete objects
+      // this is the join of two concrete/abstract objects
       // use this join condition for the join of the two property values
       let [cond, ob1, ob2] = this.args;
       invariant(cond instanceof AbstractValue);

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -535,8 +535,8 @@ export default class AbstractObjectValue extends AbstractValue {
       // use this join condition for the join of the two property values
       let [cond, ob1, ob2] = this.args;
       invariant(cond instanceof AbstractValue);
-      invariant(ob1 instanceof ObjectValue);
-      invariant(ob2 instanceof ObjectValue);
+      invariant(ob1 instanceof ObjectValue || ob1 instanceof AbstractObjectValue);
+      invariant(ob2 instanceof ObjectValue || ob2 instanceof AbstractObjectValue);
       let d1 = ob1.$GetOwnProperty(P);
       let d1val =
         d1 === undefined ? this.$Realm.intrinsics.undefined : IsDataDescriptor(this.$Realm, d1) ? d1.value : undefined;

--- a/test/react/mocks/fb19.js
+++ b/test/react/mocks/fb19.js
@@ -1,6 +1,6 @@
-var React = require('React');
+var React = require("React");
 // the JSX transform converts to React, so we need to add it back in
-this['React'] = React;
+this["React"] = React;
 
 if (!this.__evaluatePureFunction) {
   this.__evaluatePureFunction = function(f) {
@@ -9,38 +9,34 @@ if (!this.__evaluatePureFunction) {
 }
 
 __evaluatePureFunction(function() {
-
   function FbtResult() {}
   FbtResult.prototype.$$typeof = Symbol.for("react.element");
 
-  function fbt() {};
-  function param() {};
+  function fbt() {}
+  function param() {}
   function plural(shouldThrow) {
     if (shouldThrow) {
-      throw new Error('no');
+      throw new Error("no");
     }
   }
 
-  var React = require('react');
+  var React = require("react");
 
   function App(props) {
-   return React.createElement(
-     'div',
-     new FbtResult(
-       {},
-       [param(props.foo), plural(props.bar)],
-     )
-   );
- }
+    return React.createElement(
+      "div",
+      new FbtResult({}, [param(props.foo), plural(props.bar)])
+    );
+  }
 
- App.getTrials = function(renderer, Root) {
-  renderer.update(<Root bar={false} />);
-  return [['fb19 mocks', renderer.toJSON()]];
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root bar={false} />);
+    return [["fb19 mocks", renderer.toJSON()]];
   };
 
   if (this.__optimizeReactComponentTree) {
     __optimizeReactComponentTree(App, {
-      firstRenderOnly: true,
+      firstRenderOnly: true
     });
   }
 

--- a/test/react/mocks/fb20.js
+++ b/test/react/mocks/fb20.js
@@ -1,0 +1,51 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+__evaluatePureFunction(function() {
+  function URI() {}
+
+  URI.prototype.method = function() {
+    return 123;
+  };
+
+  function Child(props) {
+    return props.children();
+  }
+
+  function App(props) {
+    var obj = new URI();
+    if (props.cond1) {
+      return null;
+    }
+    if (props.cond2) {
+      obj = new URI();
+    }
+    return (
+      <Child>
+        {function() {
+          return obj.method();
+        }}
+      </Child>
+    );
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root cond1={false} cond2={true} />);
+    return [["fb20 mocks", renderer.toJSON()]];
+  };
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App, {
+      firstRenderOnly: true
+    });
+  }
+
+  module.exports = App;
+});


### PR DESCRIPTION
Release notes: none

This PR fixes https://github.com/facebook/prepack/issues/1819. It expands on the existing invariant check in `AbstractObjectValue` by also allowing abstract object values to pass through.