### PR TITLE
Generalize temporal unknown property assignments

### DIFF
--- a/test/serializer/optimized-functions/UnknownProperty2.js
+++ b/test/serializer/optimized-functions/UnknownProperty2.js
@@ -1,0 +1,11 @@
+var cache = {};
+function f(x, y) {
+  cache[x] = y;
+  cache[x+1] = y*2;
+}
+if (global.__optimize) __optimize(f);
+
+inspect = function() {
+  f(42, 5);
+  return cache[42] + " " + cache[43];
+};


### PR DESCRIPTION
Release note: Support multiple assignments to unknown properties in optimized functions

Issue #1818.

The code in #1822 can only deal correctly with a single assignment. This generalizes that code to generate separate assignments for each different (key, value) pair found in the conditional value tree that is used to model a group of assignments to unknown properties of known objects.