### PR TITLE
Do not apply joined generators in incorporateSavedCompletion

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -266,7 +266,7 @@ function runTest(name, code, options: PrepackOptions, args) {
   let compatibility = code.includes("// jsc") ? "jsc-600-1-4-17" : undefined;
   let initializeMoreModules = code.includes("// initialize more modules");
   let delayUnsupportedRequires = code.includes("// delay unsupported requires");
-  if (code.includes("// inline expressions")) options.inlineExpressions = true;
+  if (args.verbose || code.includes("// inline expressions")) options.inlineExpressions = true;
   if (code.includes("// do not inline expressions")) options.inlineExpressions = false;
   options.invariantLevel = code.includes("// omit invariants") || args.verbose ? 0 : 99;
   if (code.includes("// emit concrete model")) options.emitConcreteModel = true;

--- a/test/serializer/abstract/Throw6b.js
+++ b/test/serializer/abstract/Throw6b.js
@@ -1,0 +1,10 @@
+// Copies of _\$0 = _\$1.Date.now():1
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+
+function foo(b) {
+  if (b) throw new Error("" + Date.now());
+  return "is false";
+}
+let z = foo(!x);
+
+inspect = function() { return z; }


### PR DESCRIPTION
Release note: Fixed code duplication bug

Issue: #1829 

When joining up a saved possibly abrupt completion with the current completion (in Functions.incorporateSavedCompletion), the state must be updated with the effects of the normal part of the join. The normal part of the join does not include the joined generator, so that must be explicitly excluded when applying the effects.

The subtle reason for this is that the type of join point is only known to the caller of incorporateSavedCompletion and, depending on the type of join point, some parts of the joined completion may be excised from the join and put back into a saved completion. This means that only the caller knows exactly which parts of the abrupt completions should have their effects (and generators) reflected in the current state.
