### PR TITLE
Tidies up the React mock logic + ReactDOM mocks + few tweaks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
 test262
 lib
-fb-www
+/fb-www
 underscore-with-tests.js
 flow-typed
 test/**/*.js

--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3660,6 +3660,42 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 21 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -7377,6 +7413,42 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 21 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -11059,6 +11131,42 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 21 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -14736,6 +14844,42 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 21 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "A",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "B",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "C",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -14,6 +14,7 @@ let path = require("path");
 let { prepackSources } = require("../lib/prepack-node.js");
 let babel = require("babel-core");
 let React = require("react");
+let ReactDOM = require("react-dom");
 let PropTypes = require("prop-types");
 let ReactRelay = require("react-relay");
 let ReactTestRenderer = require("react-test-renderer");
@@ -121,6 +122,9 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         case "React":
         case "react":
           return React;
+        case "react-dom":
+        case "ReactDOM":
+          return ReactDOM;
         case "PropTypes":
         case "prop-types":
           return PropTypes;
@@ -509,14 +513,18 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-classes-3.js");
       });
 
-      // These fail due to a nested optimized function bug
-      // it("Simple classes with Array.from", async () => {
-      //   await runTest(directory, "array-from.js");
-      // });
+      // awaiting PR on nested additional support #1626,
+      // issues is that both the parent and child additional
+      // function share the same variable, so the serializer
+      // incorrectly emits it in the MainGenerator scope
+      it.skip("Simple classes with Array.from", async () => {
+        await runTest(directory, "array-from.js");
+      });
 
-      // it("Simple classes with Array.from 2", async () => {
-      //   await runTest(directory, "array-from2.js");
-      // });
+      // same issue as last test
+      it.skip("Simple classes with Array.from 2", async () => {
+        await runTest(directory, "array-from2.js");
+      });
 
       it("Inheritance chaining", async () => {
         await runTest(directory, "inheritance-chain.js");
@@ -761,6 +769,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb20.js");
       });
 
+      it("fb-www 21", async () => {
+        await runTest(directory, "fb21.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });
@@ -770,10 +782,6 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "hacker-news.js", false, data);
       });
 
-      // awaiting PR on nested additional support #1626,
-      // issues is that both the parent and child additional
-      // function share the same variable, so the serializer
-      // incorrectly emits it in the MainGenerator scope
       it("Function bind", async () => {
         await runTest(directory, "function-bind.js");
       });

--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -13,7 +13,6 @@ import type { Realm } from "../../realm.js";
 import {
   ArrayValue,
   AbstractValue,
-  type AbstractValueKind,
   FunctionValue,
   AbstractObjectValue,
   NativeFunctionValue,
@@ -220,7 +219,10 @@ function createBootloader(realm: Realm, global: ObjectValue | AbstractObjectValu
   let loadModules = new NativeFunctionValue(realm, "loadModules", "loadModules", 1, (context, args) => {
     invariant(context.$Realm.generator);
     let val = AbstractValue.createTemporalFromBuildFunction(realm, FunctionValue, args, _args =>
-      t.callExpression(t.memberExpression(t.identifier("Bootloader"), t.identifier("loadModules")), ((_args: any): Array<any>))
+      t.callExpression(
+        t.memberExpression(t.identifier("Bootloader"), t.identifier("loadModules")),
+        ((_args: any): Array<any>)
+      )
     );
     invariant(val instanceof AbstractValue);
     return val;

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NativeFunctionValue, StringValue, ObjectValue } from "../../values/index.js";
-import { createMockReact } from "./react-mocks.js";
+import { createMockReact, createMockReactDOM } from "./react-mocks.js";
 import { createMockReactRelay } from "./relay-mocks.js";
 import { createAbstract } from "../prepack/utils.js";
 import { createFbMocks } from "./fb-mocks.js";
@@ -54,6 +54,13 @@ export default function(realm: Realm): void {
           return react;
         }
         return realm.fbLibraries.react;
+      } else if (requireNameValValue === "react-dom" || requireNameValValue === "ReactDOM") {
+        if (realm.fbLibraries.reactDom === undefined) {
+          let reactDom = createMockReactDOM(realm, requireNameValValue);
+          realm.fbLibraries.reactDom = reactDom;
+          return reactDom;
+        }
+        return realm.fbLibraries.reactDom;
       } else if (requireNameValValue === "react-relay" || requireNameValValue === "RelayModern") {
         if (realm.fbLibraries.reactRelay === undefined) {
           let reactRelay = createMockReactRelay(realm, requireNameValValue);

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -614,7 +614,7 @@ export function createMockReactDOM(realm: Realm, reactDomRequireName: string): O
       FunctionValue,
       [funcVal, ...args],
       ([renderNode, ..._args]) => {
-        return t.callExpression(renderNode, _args);
+        return t.callExpression(renderNode, ((_args: any): Array<any>));
       }
     );
     invariant(reactDomMethod instanceof AbstractObjectValue);

--- a/src/intrinsics/fb-www/utils.js
+++ b/src/intrinsics/fb-www/utils.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import type { Realm } from "../../realm.js";
 import { ObjectValue, NativeFunctionValue, Value } from "../../values/index.js";
 import { Get } from "../../methods/index.js";
 import invariant from "../../invariant.js";
@@ -33,6 +34,7 @@ export function updateIntrinsicNames(
         invariant(val instanceof Value);
         val.intrinsicName = `require("${requireName}").${name}`;
         if (updatePrototype) {
+          invariant(val instanceof ObjectValue);
           let proto = Get(realm, val, "prototype");
           proto.intrinsicName = `require("${requireName}").${name}.prototype`;
         }

--- a/src/intrinsics/fb-www/utils.js
+++ b/src/intrinsics/fb-www/utils.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { ObjectValue, NativeFunctionValue, Value } from "../../values/index.js";
+import { Get } from "../../methods/index.js";
+import invariant from "../../invariant.js";
+
+export function updateIntrinsicNames(
+  realm: Realm,
+  obj: ObjectValue,
+  requireName: string,
+  properties?: Array<string | { name: string, updatePrototype: boolean }>
+): void {
+  obj.intrinsicName = `require("${requireName}")`;
+  if (properties) {
+    for (let property of properties) {
+      if (typeof property === "string") {
+        let val = Get(realm, obj, property);
+        invariant(val instanceof Value);
+        val.intrinsicName = `require("${requireName}").${property}`;
+      } else if (typeof property === "object" && property !== null) {
+        let { name, updatePrototype } = property;
+
+        let val = Get(realm, obj, name);
+        invariant(val instanceof Value);
+        val.intrinsicName = `require("${requireName}").${name}`;
+        if (updatePrototype) {
+          let proto = Get(realm, val, "prototype");
+          proto.intrinsicName = `require("${requireName}").${name}.prototype`;
+        }
+      }
+    }
+  }
+}
+
+export function addMockFunctionToObject(
+  realm: Realm,
+  obj: ObjectValue,
+  requireName: string,
+  funcName: string,
+  func: (funcValue: NativeFunctionValue, args: Array<Value>) => Value
+): void {
+  let funcValue = new NativeFunctionValue(realm, undefined, funcName, 0, (context, args) => func(funcValue, args));
+
+  obj.$DefineOwnProperty(funcName, {
+    value: funcValue,
+    writable: false,
+    enumerable: false,
+    configurable: true,
+  });
+  funcValue.intrinsicName = `require("${requireName}").${funcName}`;
+}

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -63,7 +63,7 @@ export function isReactElement(val: Value): boolean {
   if (!val.properties.has("type") || !val.properties.has("props") || !val.properties.has("$$typeof")) {
     return false;
   }
-  let $$typeof = Get(realm, val, "$$typeof");
+  let $$typeof = getProperty(realm, val, "$$typeof");
   let globalObject = realm.$GlobalObject;
   let globalSymbolValue = getProperty(realm, globalObject, "Symbol");
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -277,6 +277,7 @@ export class Realm {
     this.fbLibraries = {
       other: new Map(),
       react: undefined,
+      reactDom: undefined,
       reactRelay: undefined,
     };
 
@@ -353,6 +354,7 @@ export class Realm {
   fbLibraries: {
     other: Map<string, AbstractValue>,
     react: void | ObjectValue,
+    reactDom: void | ObjectValue,
     reactRelay: void | ObjectValue,
   };
 

--- a/test/react/mocks/fb21.js
+++ b/test/react/mocks/fb21.js
@@ -1,0 +1,40 @@
+var React = require('react');
+var ReactDOM = require('react-dom');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function A(props) {
+  return <div>Hello {props.x}</div>;
+}
+
+function B() {
+  return <div>World</div>;
+}
+
+function C() {
+  return "!";
+}
+
+function App() {
+  return (
+    <div>
+      <A x={42} />
+      <B />
+      <C />
+    </div>
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['simple render', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+var x = document.createElement("div");
+
+ReactDOM.render(App, x);
+ReactDOM.hydrate(App, x);


### PR DESCRIPTION
Release notes: adds ReactDOM mocks to fb-www compatibility mode

This PR aims to do a bunch of things:
- Tidy up the spaghetti React mock logic by adding in some helper functions
- Add ReactDOM mocks, pathing the way for greater optimizations for first render
- Swap the `Get` to a `getProperty` in `isReactElement` function
- Make the fb-www mocks not ignored by eslint and fix the eslint issues after doing so