### PR TITLE
Ensure we visit ReactLibrary with React.Fragment usage

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3660,6 +3660,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 22 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -7377,6 +7401,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 22 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -11059,6 +11107,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 22 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output fb-www mocks repl example 1`] = `
 ReactStatistics {
   "componentsEvaluated": 7,
@@ -14727,6 +14799,30 @@ ReactStatistics {
           "children": Array [],
           "message": "",
           "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 22 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "React.Fragment",
           "status": "INLINED",
         },
       ],

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -761,6 +761,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "fb20.js");
       });
 
+      it("fb-www 22", async () => {
+        await runTest(directory, "fb22.js");
+      });
+
       it("repl example", async () => {
         await runTest(directory, "repl-example.js");
       });

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -63,7 +63,7 @@ import {
   withDescriptorValue,
 } from "./utils.js";
 import { Environment, To } from "../singletons.js";
-import { isReactElement, valueIsReactLibraryObject } from "../react/utils.js";
+import { getProperty, getReactSymbol, isReactElement, valueIsReactLibraryObject } from "../react/utils.js";
 import { canHoistReactElement } from "../react/hoisting.js";
 import ReactElementSet from "../react/ReactElementSet.js";
 
@@ -797,7 +797,11 @@ export class ResidualHeapVisitor {
       case "ArrayBuffer":
         return;
       case "ReactElement":
-        if (this.realm.react.output === "create-element") {
+        let typeValue = getProperty(this.realm, val, "type");
+        let isReactFragment =
+          typeValue instanceof SymbolValue && typeValue === getReactSymbol("react.fragment", this.realm);
+
+        if (this.realm.react.output === "create-element" || isReactFragment) {
           this.someReactElement = val;
         }
         // check we can hoist a React Element

--- a/test/react/mocks/fb22.js
+++ b/test/react/mocks/fb22.js
@@ -1,0 +1,30 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+if (!this.__evaluatePureFunction) {
+  this.__evaluatePureFunction = function(f) {
+    return f();
+  };
+}
+
+__evaluatePureFunction(function() {
+  var React = require("react");
+
+  function App(props) {
+    return React.createElement(React.Fragment, null, "123");
+  }
+
+  App.getTrials = function(renderer, Root) {
+    renderer.update(<Root />);
+    return [["fb22 mocks", renderer.toJSON()]];
+  };
+
+  if (this.__optimizeReactComponentTree) {
+    __optimizeReactComponentTree(App, {
+      firstRenderOnly: true
+    });
+  }
+
+  module.exports = App;
+});


### PR DESCRIPTION
Release notes: none

This PR ensures we visit the React library when `React.Fragment` is used in a ReactElement. Fixes https://github.com/facebook/prepack/issues/1831.