### PR TITLE
Deal with possibly normal completions from joined switch

### DIFF
--- a/test/serializer/abstract/Switch4.js
+++ b/test/serializer/abstract/Switch4.js
@@ -1,0 +1,10 @@
+let input = global.__abstract ? __abstract("boolean", "true") : true;
+
+let selector = input ? "A" : "B";
+let value = 1;
+switch (selector) {
+  case "A": value = 2; throw 123;
+  case "B": value = 3; break;
+}
+
+inspect = function() { return value; }


### PR DESCRIPTION
Release note: Support switch statements where the switch value is abstract and one or more cases throw

Resolves #1838 

When only some of the cases in a switch statement throws, the join results in a possibly normal completion and this has to get composed with the saved completion.

The test case also revealed that the join was happening in the wrong order, so that is fixed as well.