### PR TITLE
Follow up to UpdateExpression

### DIFF
--- a/test/serializer/additional-functions/UpdateExpression.js
+++ b/test/serializer/additional-functions/UpdateExpression.js
@@ -1,7 +1,6 @@
 
 function additional1(x) {
-  x++
-  return x;
+  return x++;
 }
 
 function additional2(x) {

--- a/test/serializer/additional-functions/UpdateExpression2.js
+++ b/test/serializer/additional-functions/UpdateExpression2.js
@@ -1,0 +1,26 @@
+
+function additional1(obj) {
+  var tmp = {x:obj.x};
+  tmp.x++;
+  return tmp;
+}
+
+function additional2(obj) {
+  var v = obj.x;
+  var tmp = {x:v};
+  ++tmp.x;
+  tmp.y = v;
+  return tmp;
+}
+
+if (global.__optimize) {
+  __optimize(additional1);
+  __optimize(additional2);
+}
+
+inspect = function() {
+  var obj = {x:4};
+  let o1 = additional1(obj);
+  let o2 = additional2(obj);
+  return JSON.stringify({ obj, o1, o2 });
+}


### PR DESCRIPTION
Follow up to #1839

It's not safe to mutate an expression in a build function. Those needs to be emitted as statements.

We don't have to deal with the assignment part of it though. We can just calculate the new value and deal with the fact that ToNumber might throw or mutate.

The new value we can just pass to PutValue which takes care of the rest.
