### PR TITLE
Fix _WrapAbstractInObject to deal with mixed primitive types

### DIFF
--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -433,11 +433,14 @@ export class ToImplementation {
 
       case UndefinedValue:
       case NullValue:
-        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+      case PrimitiveValue:
+        if (arg.mightBeNull() || arg.mightHaveBeenDeleted() || arg.mightBeUndefined())
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
 
+      /*eslint-disable */
       default:
+        /*eslint-enable */
         if (realm.isInPureScope()) {
-          invariant(arg.getType() === Value); // Can't be primitive or object for sure, which leaves just Value.
           // will be serialized as Object.assign(serialized_arg)
           obj = AbstractValue.createFromType(realm, ObjectValue, "explicit conversion to object", [arg]);
           invariant(obj instanceof AbstractObjectValue);

--- a/test/serializer/additional-functions/ToObject.js
+++ b/test/serializer/additional-functions/ToObject.js
@@ -1,0 +1,24 @@
+(function() {
+  function URIBase(uri) {
+    if (uri instanceof URIBase) {
+      serialize(uri.x);
+      this.x = undefined;
+    }
+  }
+
+  function serialize(obj) {
+    for (var k in obj) {
+    }
+  }
+
+  function App(props) {
+    new URIBase(new URIBase(props));
+    return null;
+  }
+
+  if (global.__optimize) __optimize(App);
+
+  global.App = App;
+
+  inspect = function() { return true; } // just make sure Prepack doesn't crash while generating code
+})();


### PR DESCRIPTION
Release note: Fixed bug with implicitly converting unknown values to Object

Resolves #1845 

Joined values can be of type PrimitiveValue, so the invariant in the default case of the switch in _WrapAbstractInObject is actually not true. 

Added handling for this case, throwing an error if the joined value might be null, undefined or missing and converting it lazily to Object otherwise.