### PR TITLE
Fix various issues in serializer and emitter around target body selection.

### DIFF
--- a/src/serializer/GeneratorDAG.js
+++ b/src/serializer/GeneratorDAG.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import invariant from "../invariant.js";
+import { FunctionValue, ObjectValue } from "../values/index.js";
+import { Generator } from "../utils/generator.js";
+
+// This class maintains a DAG containing all generators known so far,
+// and information about the most specific generator that created any
+// particular object.
+// New sub-DAGs are added in chunks, at the beginning for the global generator,
+// and every time the visitor handles another additional function.
+// NOTE: The serializer can only properly handle Generator trees, not actual DAGs.
+export class GeneratorDAG {
+  parents: Map<Generator, Array<Generator | FunctionValue | "GLOBAL">>;
+  createdObjects: Map<ObjectValue, Generator>;
+
+  constructor() {
+    this.parents = new Map();
+    this.createdObjects = new Map();
+  }
+
+  // DAG TODO: This function is dubious in the presence of actual dags.
+  getParent(generator: Generator): Generator | FunctionValue | "GLOBAL" {
+    let a = this.parents.get(generator);
+    invariant(a !== undefined && a.length >= 1);
+    return a[0];
+  }
+
+  isParent(parent: Generator | FunctionValue | "GLOBAL", generator: Generator): boolean {
+    let a = this.parents.get(generator);
+    return a !== undefined && a.includes(parent);
+  }
+
+  getCreator(value: ObjectValue): Generator | void {
+    return this.createdObjects.get(value);
+  }
+
+  add(parent: FunctionValue | "GLOBAL", generator: Generator) {
+    this._add(parent, generator);
+  }
+
+  _add(parent: Generator | FunctionValue | "GLOBAL", generator: Generator) {
+    let a = this.parents.get(generator);
+    if (a === undefined) this.parents.set(generator, (a = []));
+    if (!a.includes(parent)) a.push(parent);
+    let effects = generator.effectsToApply;
+    if (effects !== undefined)
+      for (let createdObject of effects.createdObjects) {
+        let isValidPreviousCreator = previousCreator => {
+          // It's okay if we don't know about any previous creator.
+          if (previousCreator === undefined) return true;
+
+          // If we already recorded a newly-created object, then we must have done so for our parent
+          if (previousCreator === parent) return true;
+
+          // Since we are dealing with a DAG, and not a tree, we might have already the current generator as the creator
+          if (previousCreator === generator) return true;
+
+          // TODO: There's something else going on that is not yet understood.
+          // Fix the return value once #1901 is understood and landed.
+          return true; // false
+        };
+
+        invariant(isValidPreviousCreator(this.createdObjects.get(createdObject)));
+
+        // Update the created objects mapping to the most specific generator
+        this.createdObjects.set(createdObject, generator);
+      }
+
+    for (let dependency of generator.getDependencies()) this._add(generator, dependency);
+  }
+}

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -41,6 +41,7 @@ import { getOrDefault } from "./utils.js";
 import type { DeclarativeEnvironmentRecord } from "../environment.js";
 import type { Referentializer } from "./Referentializer.js";
 import { Generator } from "../utils/generator.js";
+import { GeneratorDAG } from "./GeneratorDAG.js";
 
 const LAZY_OBJECTS_SERIALIZER_BODY_TYPE = "LazyObjectInitializer";
 
@@ -72,7 +73,7 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>,
     react: ReactSerializerState,
     referentializer: Referentializer,
-    generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">,
+    generatorDAG: GeneratorDAG,
     conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
     additionalGeneratorRoots: Map<Generator, Set<ObjectValue>>
   ) {
@@ -93,7 +94,7 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       declarativeEnvironmentRecordsBindings,
       react,
       referentializer,
-      generatorParents,
+      generatorDAG,
       conditionalFeasibility,
       additionalGeneratorRoots
     );

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -73,7 +73,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     react: ReactSerializerState,
     referentializer: Referentializer,
     generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">,
-    conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>
+    conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
+    additionalGeneratorRoots: Map<Generator, Set<ObjectValue>>
   ) {
     super(
       realm,
@@ -93,7 +94,8 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       react,
       referentializer,
       generatorParents,
-      conditionalFeasibility
+      conditionalFeasibility,
+      additionalGeneratorRoots
     );
     this._lazyObjectIdSeed = 1;
     this._valueLazyIds = new Map();

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1906,7 +1906,7 @@ export class ResidualHeapSerializer {
 
   _annotateGeneratorStatements(generator: Generator, statements: Array<BabelNodeStatement>) {
     let comment = `generator "${generator.getName()}"`;
-    let parent = this.generatorParents.get(generator);
+    let parent = this.generatorDAG.getParent.get(generator);
     if (parent instanceof Generator) {
       comment = `${comment} with parent "${parent.getName()}"`;
     } else if (parent instanceof FunctionValue) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -223,10 +223,10 @@ export class ResidualHeapVisitor {
       // Also check if object is used in some nested generator scope that involved
       // applying effects; if so, store additional information that the serializer
       // can use to proactive serialize such objects from within the right generator
-      let anyEffectsToApply = false;
+      let anyRelevantEffects = false;
       for (let g = usageScope; g instanceof Generator; g = this.generatorParents.get(g)) {
         if (g === creationGenerator) {
-          if (anyEffectsToApply) {
+          if (anyRelevantEffects) {
             let s = this.additionalGeneratorRoots.get(g);
             if (s === undefined) this.additionalGeneratorRoots.set(g, (s = new Set()));
             if (!s.has(value)) {
@@ -236,7 +236,13 @@ export class ResidualHeapVisitor {
           }
           break;
         }
-        if (g.effectsToApply) anyEffectsToApply = true;
+        let effectsToApply = g.effectsToApply;
+        if (effectsToApply)
+          for (let pb of effectsToApply.modifiedProperties.keys())
+            if (pb.object === value) {
+              anyRelevantEffects = true;
+              break;
+            }
       }
     }
   }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -65,6 +65,7 @@ import {
 import { Environment, To } from "../singletons.js";
 import { isReactElement, valueIsReactLibraryObject } from "../react/utils.js";
 import { ResidualReactElementVisitor } from "./ResidualReactElementVisitor.js";
+import { GeneratorDAG } from "./GeneratorDAG.js";
 
 export type Scope = FunctionValue | Generator;
 type BindingState = {|
@@ -110,13 +111,12 @@ export class ResidualHeapVisitor {
     this.equivalenceSet = new HashSet();
     this.additionalFunctionValueInfos = new Map();
     this.functionToCapturedScopes = new Map();
-    this.generatorParents = new Map();
     let environment = realm.$GlobalEnv.environmentRecord;
     invariant(environment instanceof GlobalEnvironmentRecord);
     this.globalEnvironmentRecord = environment;
-    this.createdObjects = new Map();
     this.additionalGeneratorRoots = new Map();
     this.residualReactElementVisitor = new ResidualReactElementVisitor(this.realm, this);
+    this.generatorDAG = new GeneratorDAG();
   }
 
   realm: Realm;
@@ -145,10 +145,8 @@ export class ResidualHeapVisitor {
   equivalenceSet: HashSet<AbstractValue>;
   classMethodInstances: Map<FunctionValue, ClassMethodInstance>;
   // Parents will always be a generator, optimized function value or "GLOBAL"
-  generatorParents: Map<Generator, Generator | FunctionValue | "GLOBAL">;
-  createdObjects: Map<ObjectValue, Generator>;
   additionalGeneratorRoots: Map<Generator, Set<ObjectValue>>;
-
+  generatorDAG: GeneratorDAG;
   globalEnvironmentRecord: GlobalEnvironmentRecord;
   residualReactElementVisitor: ResidualReactElementVisitor;
 
@@ -157,13 +155,13 @@ export class ResidualHeapVisitor {
   _getCommonScope(): FunctionValue | Generator {
     let s = this.scope;
     while (true) {
-      if (s instanceof Generator) s = this.generatorParents.get(s);
+      if (s instanceof Generator) s = this.generatorDAG.getParent(s);
       else if (s instanceof FunctionValue) {
         // Did we find an additional function?
         if (this.additionalFunctionValuesAndEffects.has(s)) return s;
 
         // Did the function itself get created by a generator we can chase?
-        s = this.createdObjects.get(s) || "GLOBAL";
+        s = this.generatorDAG.getCreator(s) || "GLOBAL";
       } else {
         invariant(s === "GLOBAL");
         let generator = this.globalGenerator;
@@ -185,7 +183,7 @@ export class ResidualHeapVisitor {
   // created --- this causes the value later to be serialized in its
   // creation scope, ensuring that the value has the right creation / life time.
   _registerAdditionalRoot(value: ObjectValue) {
-    let creationGenerator = this.createdObjects.get(value) || this.globalGenerator;
+    let creationGenerator = this.generatorDAG.getCreator(value) || this.globalGenerator;
 
     let additionalFunction = this._getAdditionalFunctionOfScope() || "GLOBAL";
     let targetAdditionalFunction;
@@ -194,7 +192,7 @@ export class ResidualHeapVisitor {
     } else {
       let s = creationGenerator;
       while (s instanceof Generator) {
-        s = this.generatorParents.get(s);
+        s = this.generatorDAG.getParent(s);
         invariant(s !== undefined);
       }
       invariant(s === "GLOBAL" || s instanceof FunctionValue);
@@ -212,7 +210,7 @@ export class ResidualHeapVisitor {
       additionalFVEffects.additionalRoots.add(value);
 
       this._visitInUnrelatedScope(creationGenerator, value);
-      usageScope = this.createdObjects.get(value) || this.globalGenerator;
+      usageScope = this.generatorDAG.getCreator(value) || this.globalGenerator;
     }
 
     usageScope = this.scope;
@@ -221,7 +219,7 @@ export class ResidualHeapVisitor {
       // applying effects; if so, store additional information that the serializer
       // can use to proactive serialize such objects from within the right generator
       let anyRelevantEffects = false;
-      for (let g = usageScope; g instanceof Generator; g = this.generatorParents.get(g)) {
+      for (let g = usageScope; g instanceof Generator; g = this.generatorDAG.getParent(g)) {
         if (g === creationGenerator) {
           if (anyRelevantEffects) {
             let s = this.additionalGeneratorRoots.get(g);
@@ -1034,7 +1032,7 @@ export class ResidualHeapVisitor {
       if (this.preProcessValue(val)) this.visitValueProxy(val);
       this.postProcessValue(val);
     } else if (val instanceof FunctionValue) {
-      let creationGenerator = this.createdObjects.get(val) || this.globalGenerator;
+      let creationGenerator = this.generatorDAG.getCreator(val) || this.globalGenerator;
 
       // 1. Visit function in its creation scope
       this._enqueueWithUnrelatedScope(creationGenerator, () => {
@@ -1078,9 +1076,8 @@ export class ResidualHeapVisitor {
     let callbacks = {
       visitEquivalentValue: this.visitEquivalentValue.bind(this),
       visitGenerator: (generator, parent) => {
-        // TODO: The serializer assumes that each generator has a unique parent; however, in the presence of conditional exceptions that is not actually true.
-        // invariant(!this.generatorParents.has(generator));
-        this.visitGenerator(generator, parent, additionalFunctionInfo);
+        invariant(this.generatorDAG.isParent(parent, generator));
+        this.visitGenerator(generator, additionalFunctionInfo);
       },
       canSkip: (value: AbstractValue | ConcreteValue): boolean => {
         return !this.referencedDeclaredValues.has(value) && !this.values.has(value);
@@ -1146,50 +1143,7 @@ export class ResidualHeapVisitor {
     return callbacks;
   }
 
-  _validateCreatedObjectsAddition(createdObject: ObjectValue, generator: Generator) {
-    let creatingGenerator = this.createdObjects.get(createdObject);
-    // If there is already an entry in createdObjects, it must be for a generator that is a parent of this generator
-    // This is because createdObjects of nested effects of optimized functions are strict subsets of the
-    // optimized function's createdObjects set.
-    if (creatingGenerator && creatingGenerator !== generator) {
-      let currentScope = generator;
-      // Walk up generator parent chain to make sure that creatingGenerator is a parent of generator.
-      while (currentScope !== creatingGenerator) {
-        if (currentScope instanceof Generator) {
-          currentScope = this.generatorParents.get(currentScope);
-        } else if (currentScope instanceof FunctionValue) {
-          // We're trying to walk up generatorParents and should only be falling into this case if we hit an
-          // optimized function value as a generator parent. Optimized function values must always have generator
-          // or "GLOBAL" parents
-          invariant(this.additionalFunctionValuesAndEffects.has(currentScope));
-          currentScope = this.createdObjects.get(currentScope) || "GLOBAL";
-        }
-        invariant(currentScope !== undefined, "Should have already encountered all parents of this generator.");
-        invariant(
-          currentScope !== "GLOBAL",
-          "If an object is in two generators' effects' createdObjects, the second must be a child of the first."
-        );
-      }
-    }
-  }
-
-  visitGenerator(
-    generator: Generator,
-    parent: Generator | FunctionValue | "GLOBAL",
-    additionalFunctionInfo?: AdditionalFunctionInfo
-  ): void {
-    if (parent instanceof FunctionValue)
-      invariant(
-        this.additionalFunctionValuesAndEffects.has(parent),
-        "Generator parents may only be generators, additional function values or 'GLOBAL'"
-      );
-    this.generatorParents.set(generator, parent);
-    if (generator.effectsToApply)
-      for (const createdObject of generator.effectsToApply.createdObjects) {
-        this._validateCreatedObjectsAddition(createdObject, generator);
-        if (!this.createdObjects.has(createdObject)) this.createdObjects.set(createdObject, generator);
-      }
-
+  visitGenerator(generator: Generator, additionalFunctionInfo?: AdditionalFunctionInfo): void {
     this._withScope(generator, () => {
       generator.visit(this.createGeneratorVisitCallbacks(additionalFunctionInfo));
     });
@@ -1233,12 +1187,14 @@ export class ResidualHeapVisitor {
       this.additionalFunctionValueInfos.set(functionValue, additionalFunctionInfo);
 
       let effectsGenerator = additionalEffects.generator;
-      this.visitGenerator(effectsGenerator, functionValue, additionalFunctionInfo);
+      this.generatorDAG.add(functionValue, effectsGenerator);
+      this.visitGenerator(effectsGenerator, additionalFunctionInfo);
     });
   }
 
   visitRoots(): void {
-    this.visitGenerator(this.globalGenerator, "GLOBAL");
+    this.generatorDAG.add("GLOBAL", this.globalGenerator);
+    this.visitGenerator(this.globalGenerator);
     for (let moduleValue of this.modules.initializedModules.values()) this.visitValue(moduleValue);
 
     if (this.realm.react.enabled) {
@@ -1274,7 +1230,7 @@ export class ResidualHeapVisitor {
       let actionsByGenerator = new Map();
       for (let { scope, action } of this.delayedActions.reverse()) {
         let generator;
-        if (scope instanceof FunctionValue) generator = this.createdObjects.get(scope) || this.globalGenerator;
+        if (scope instanceof FunctionValue) generator = this.generatorDAG.getCreator(scope) || this.globalGenerator;
         else if (scope === "GLOBAL") generator = this.globalGenerator;
         else {
           invariant(scope instanceof Generator);
@@ -1304,10 +1260,10 @@ export class ResidualHeapVisitor {
                 }, effectsToApply);
               };
             }
-            s = this.generatorParents.get(s);
+            s = this.generatorDAG.getParent(s);
           } else if (s instanceof FunctionValue) {
             invariant(this.additionalFunctionValuesAndEffects.has(s));
-            s = this.createdObjects.get(s) || "GLOBAL";
+            s = this.generatorDAG.getCreator(s) || "GLOBAL";
           }
           invariant(s instanceof Generator || s instanceof FunctionValue || s === "GLOBAL");
         }

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -143,60 +143,68 @@ export class ResidualReactElementSerializer {
     // this name is used when hoisting, and is passed into the factory function, rather than the original
     let hoistedCreateElementIdentifier = null;
     let reactElementAstNode;
-    let depedencies = [typeValue, keyValue, refValue, propsValue, value];
+    let dependencies = [typeValue, keyValue, refValue, propsValue, value];
     let createElement;
 
     if (this.reactOutput === "create-element") {
       createElement = this._getReactCreateElementValue();
-      depedencies.push(createElement);
+      dependencies.push(createElement);
     }
 
-    this.residualHeapSerializer.emitter.emitNowOrAfterWaitingForDependencies(depedencies, () => {
-      if (this.reactOutput === "jsx") {
-        reactElementAstNode = this._serializeReactElementToJSXElement(value, reactElement);
-      } else if (this.reactOutput === "create-element") {
-        originalCreateElementIdentifier = this.residualHeapSerializer.serializeValue(createElement);
+    this.residualHeapSerializer.emitter.emitNowOrAfterWaitingForDependencies(
+      dependencies,
+      () => {
+        if (this.reactOutput === "jsx") {
+          reactElementAstNode = this._serializeReactElementToJSXElement(value, reactElement);
+        } else if (this.reactOutput === "create-element") {
+          originalCreateElementIdentifier = this.residualHeapSerializer.serializeValue(createElement);
 
-        if (shouldHoist) {
-          // if we haven't created a _lazilyHoistedNodes before, then this is the first time
-          // so we only create the hoisted identifier once
-          if (this._lazilyHoistedNodes === undefined) {
-            // create a new unique instance
-            hoistedCreateElementIdentifier = t.identifier(
-              this.residualHeapSerializer.intrinsicNameGenerator.generate()
-            );
-          } else {
-            hoistedCreateElementIdentifier = this._lazilyHoistedNodes.createElementIdentifier;
+          if (shouldHoist) {
+            // if we haven't created a _lazilyHoistedNodes before, then this is the first time
+            // so we only create the hoisted identifier once
+            if (this._lazilyHoistedNodes === undefined) {
+              // create a new unique instance
+              hoistedCreateElementIdentifier = t.identifier(
+                this.residualHeapSerializer.intrinsicNameGenerator.generate()
+              );
+            } else {
+              hoistedCreateElementIdentifier = this._lazilyHoistedNodes.createElementIdentifier;
+            }
           }
-        }
 
-        let createElementIdentifier = shouldHoist ? hoistedCreateElementIdentifier : originalCreateElementIdentifier;
-        reactElementAstNode = this._serializeReactElementToCreateElement(value, reactElement, createElementIdentifier);
-      } else {
-        invariant(false, "Unknown reactOutput specified");
-      }
-      // if we are hoisting this React element, put the assignment in the body
-      // also ensure we are in an additional function
-      if (shouldHoist) {
-        this._emitHoistedReactElement(
-          id,
-          reactElementAstNode,
-          hoistedCreateElementIdentifier,
-          originalCreateElementIdentifier
-        );
-      } else {
-        if (reactElement.declared) {
-          this.residualHeapSerializer.emitter.emit(
-            t.expressionStatement(t.assignmentExpression("=", id, reactElementAstNode))
+          let createElementIdentifier = shouldHoist ? hoistedCreateElementIdentifier : originalCreateElementIdentifier;
+          reactElementAstNode = this._serializeReactElementToCreateElement(
+            value,
+            reactElement,
+            createElementIdentifier
           );
         } else {
-          reactElement.declared = true;
-          this.residualHeapSerializer.emitter.emit(
-            t.variableDeclaration("var", [t.variableDeclarator(id, reactElementAstNode)])
-          );
+          invariant(false, "Unknown reactOutput specified");
         }
-      }
-    });
+        // if we are hoisting this React element, put the assignment in the body
+        // also ensure we are in an additional function
+        if (shouldHoist) {
+          this._emitHoistedReactElement(
+            id,
+            reactElementAstNode,
+            hoistedCreateElementIdentifier,
+            originalCreateElementIdentifier
+          );
+        } else {
+          if (reactElement.declared) {
+            this.residualHeapSerializer.emitter.emit(
+              t.expressionStatement(t.assignmentExpression("=", id, reactElementAstNode))
+            );
+          } else {
+            reactElement.declared = true;
+            this.residualHeapSerializer.emitter.emit(
+              t.variableDeclaration("var", [t.variableDeclarator(id, reactElementAstNode)])
+            );
+          }
+        }
+      },
+      this.residualHeapSerializer.emitter.getBody()
+    );
     return id;
   }
 
@@ -213,10 +221,15 @@ export class ResidualReactElementSerializer {
     };
 
     if (reason) {
-      this.residualHeapSerializer.emitter.emitAfterWaiting(reason, [value], () => {
-        serialize();
-        this._emitReactElement(reactElement);
-      });
+      this.residualHeapSerializer.emitter.emitAfterWaiting(
+        reason,
+        [value],
+        () => {
+          serialize();
+          this._emitReactElement(reactElement);
+        },
+        this.residualHeapSerializer.emitter.getBody()
+      );
     } else {
       serialize();
     }

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -221,7 +221,7 @@ export class Serializer {
               residualHeapVisitor.declarativeEnvironmentRecordsBindings,
               this.react,
               referentializer,
-              residualHeapVisitor.generatorParents,
+              residualHeapVisitor.generatorDAG,
               residualHeapVisitor.conditionalFeasibility,
               residualHeapVisitor.additionalGeneratorRoots
             ).serialize();
@@ -252,7 +252,7 @@ export class Serializer {
             residualHeapVisitor.declarativeEnvironmentRecordsBindings,
             this.react,
             referentializer,
-            residualHeapVisitor.generatorParents,
+            residualHeapVisitor.generatorDAG,
             residualHeapVisitor.conditionalFeasibility,
             residualHeapVisitor.additionalGeneratorRoots
           ).serialize()

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -222,7 +222,8 @@ export class Serializer {
               this.react,
               referentializer,
               residualHeapVisitor.generatorParents,
-              residualHeapVisitor.conditionalFeasibility
+              residualHeapVisitor.conditionalFeasibility,
+              residualHeapVisitor.additionalGeneratorRoots
             ).serialize();
           });
           if (this.logger.hasErrors()) return undefined;
@@ -252,7 +253,8 @@ export class Serializer {
             this.react,
             referentializer,
             residualHeapVisitor.generatorParents,
-            residualHeapVisitor.conditionalFeasibility
+            residualHeapVisitor.conditionalFeasibility,
+            residualHeapVisitor.additionalGeneratorRoots
           ).serialize()
         );
       })();

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -37,6 +37,7 @@ export type SerializedBody = {
   declaredAbstractValues?: Map<AbstractValue, SerializedBody>,
   parentBody?: SerializedBody,
   nestingLevel?: number,
+  processing?: boolean,
 };
 
 export type AdditionalFunctionEffects = {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -61,6 +61,8 @@ export type SerializationContext = {|
   serializeValue: Value => BabelNodeExpression,
   serializeBinding: Binding => BabelNodeIdentifier | BabelNodeMemberExpression,
   serializeGenerator: (Generator, Set<AbstractValue>) => Array<BabelNodeStatement>,
+  initGenerator: Generator => void,
+  finalizeGenerator: Generator => void,
   emitDefinePropertyBody: (ObjectValue, string | SymbolValue, Descriptor) => BabelNodeStatement,
   emit: BabelNodeStatement => void,
   processValues: (Set<AbstractValue>) => void,
@@ -1082,7 +1084,9 @@ export class Generator {
 
   serialize(context: SerializationContext) {
     let serializeFn = () => {
+      context.initGenerator(this);
       for (let entry of this._entries) entry.serialize(context);
+      context.finalizeGenerator(this);
       return null;
     };
     if (this.effectsToApply) {

--- a/test/serializer/additional-functions/Issue1821RegressionTest.js
+++ b/test/serializer/additional-functions/Issue1821RegressionTest.js
@@ -1,0 +1,20 @@
+(function() {
+    function URI(other) {
+        if (other) {
+            throw new Error();
+        }
+        this.foo = other.noSuchMethod();
+    }
+
+    function fn(arg) {
+        var first = new URI(arg);
+        return function() {
+            new URI(first);
+        };
+    }
+
+    if (global.__optimize) __optimize(fn);
+
+    global.fn = fn;
+    inspect = function() { return 42; } // just don't crash the serializer
+})();

--- a/test/serializer/additional-functions/ObjectCreationGeneratorRegressionTest.js
+++ b/test/serializer/additional-functions/ObjectCreationGeneratorRegressionTest.js
@@ -1,0 +1,17 @@
+function nullthrows(x) {
+    if (x != null) {
+        return x;
+    }
+    throw new Error('no');
+};
+
+function App(props) {
+    nullthrows(props.className);
+    return {
+        className: props.className,
+            };
+}
+
+if (global.__optimize) __optimize(App);
+
+inspect = function() { return 42; } // just make sure no invariants in Prepack blow up


### PR DESCRIPTION
Release notes: None

This fixes #1821.

Improve tracking of target bodies in Emitter,
which is necessary now that generators can have effects
and one should not attempt to emit into a body
with the wrong effects in place; removed some dubious code there.

It turned out that the exact placement of `Object.freeze` and similar statements
was always a bit fragile; this issue came out after fixing the Emitter, and so
this is made robust by keeping track of the
emission of all other object property mutations, and only emitting the
`Object.freeze` after they are all done.

When visiting modified property bindings, re-visit object in case it was
previously visited from a different scope.

For objects visited (only) in scopes where additional generator effects have been
applied, record additional information for serialization to ensure that these
objects get serialized in their creation scopes, so that the initial values
of the object properties are not polluted by the additional generator effects
of some nested scope.

Adding regression test.