### PR TITLE
Refactored ReactElement visiting logic into its own class

### DIFF
--- a/src/react/hoisting.js
+++ b/src/react/hoisting.js
@@ -183,10 +183,7 @@ export function canHoistReactElement(
   let key = getProperty(realm, reactElement, "key");
   let props = getProperty(realm, reactElement, "props");
 
-  if (visitedValues === undefined) {
-    visitedValues = new Set();
-    visitedValues.add(reactElement);
-  }
+  visitedValues.add(reactElement);
   if (
     canHoistValue(realm, type, residualHeapVisitor, visitedValues) &&
     // we can't hoist string "refs" or if they're abstract, as they might be abstract strings
@@ -201,4 +198,12 @@ export function canHoistReactElement(
   }
   realm.react.hoistableReactElements.set(reactElement, false);
   return false;
+}
+
+export function determineIfReactElementCanBeHoisted(
+  realm: Realm,
+  reactElement: ObjectValue,
+  residualHeapVisitor: ResidualHeapVisitor
+): void {
+  canHoistReactElement(realm, reactElement, residualHeapVisitor, new Set());
 }

--- a/src/react/hoisting.js
+++ b/src/react/hoisting.js
@@ -169,7 +169,7 @@ export function canHoistReactElement(
   realm: Realm,
   reactElement: ObjectValue,
   residualHeapVisitor?: ResidualHeapVisitor,
-  visitedValues: Set<Value> | void
+  visitedValues?: Set<Value> | void
 ): boolean {
   if (realm.react.hoistableReactElements.has(reactElement)) {
     // cast because Flow thinks that we may have set a value to be something other than a boolean?
@@ -183,7 +183,10 @@ export function canHoistReactElement(
   let key = getProperty(realm, reactElement, "key");
   let props = getProperty(realm, reactElement, "props");
 
-  visitedValues.add(reactElement);
+  if (visitedValues === undefined) {
+    visitedValues = new Set();
+    visitedValues.add(reactElement);
+  }
   if (
     canHoistValue(realm, type, residualHeapVisitor, visitedValues) &&
     // we can't hoist string "refs" or if they're abstract, as they might be abstract strings
@@ -205,5 +208,5 @@ export function determineIfReactElementCanBeHoisted(
   reactElement: ObjectValue,
   residualHeapVisitor: ResidualHeapVisitor
 ): void {
-  canHoistReactElement(realm, reactElement, residualHeapVisitor, new Set());
+  canHoistReactElement(realm, reactElement, residualHeapVisitor);
 }

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -29,7 +29,6 @@ import {
 import { To } from "../singletons.js";
 import invariant from "../invariant.js";
 import { Logger } from "../utils/logger.js";
-import { isReactElement } from "../react/utils.js";
 
 type TargetIntegrityCommand = "freeze" | "seal" | "preventExtensions" | "";
 
@@ -130,15 +129,6 @@ export class ResidualHeapInspector {
     if (IsArray(this.realm, val)) {
       if (key === "length" && desc.writable === targetDescriptor.writable && !desc.enumerable && !desc.configurable) {
         // length property has the correct descriptor values
-        return true;
-      }
-    } else if (isReactElement(val)) {
-      // we don't want to visit/serialize $$typeof, _owner and _store properties
-      // as these are all internals of JSX/createElement
-      if (key === "$$typeof" || key === "_owner" || key === "_store") {
-        return true;
-      }
-      if ((key === "ref" || key === "key") && desc.value === this.realm.intrinsics.null) {
         return true;
       }
     } else if (val instanceof FunctionValue) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -286,9 +286,6 @@ export class ResidualHeapVisitor {
 
     // prototype
     if (!skipPrototype) {
-      // we don't want to the ReactElement prototype visited
-      // as this is contained within the JSXElement, otherwise
-      // they we be need to be emitted during serialization
       this.visitObjectPrototype(obj);
     }
     if (obj instanceof FunctionValue) {

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -177,6 +177,11 @@ export class ResidualReactElementSerializer {
           originalCreateElementIdentifier
         );
       } else {
+        // Note: it can be expected that we assign to the same variable multiple times
+        // this is due to fact ReactElements are immutable objects and the fact that
+        // when we inline/fold logic, the same ReactElements are referenced at different
+        // points with different attributes. Given we can't mutate an immutable object,
+        // we instead create new objects and assign to the same binding
         if (reactElement.declared) {
           this.residualHeapSerializer.emitter.emit(
             t.expressionStatement(t.assignmentExpression("=", id, reactElementAstNode))

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -12,7 +12,6 @@
 import { Realm } from "../realm.js";
 import { AbstractValue, ArrayValue, NumberValue, ObjectValue, SymbolValue, Value } from "../values/index.js";
 import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
-import { canHoistReactElement } from "../react/hoisting.js";
 import { getProperty, getReactSymbol } from "../react/utils.js";
 import ReactElementSet from "../react/ReactElementSet.js";
 import type { ReactOutputTypes } from "../options.js";
@@ -112,8 +111,6 @@ export class ResidualReactElementVisitor {
     if (this.realm.react.output === "create-element" || isReactFragment) {
       this.someReactElement = reactElement;
     }
-    // check we can hoist a React Element
-    canHoistReactElement(this.realm, reactElement, this.residualHeapVisitor);
   }
 
   withCleanEquivilanceSet(func: () => void) {

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -12,6 +12,7 @@
 import { Realm } from "../realm.js";
 import { AbstractValue, ArrayValue, NumberValue, ObjectValue, SymbolValue, Value } from "../values/index.js";
 import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
+import { determineIfReactElementCanBeHoisted } from "../react/hoisting.js";
 import { getProperty, getReactSymbol } from "../react/utils.js";
 import ReactElementSet from "../react/ReactElementSet.js";
 import type { ReactOutputTypes } from "../options.js";
@@ -111,6 +112,8 @@ export class ResidualReactElementVisitor {
     if (this.realm.react.output === "create-element" || isReactFragment) {
       this.someReactElement = reactElement;
     }
+    // determine if this ReactElement node tree is going to be hoistable
+    determineIfReactElementCanBeHoisted(this.realm, reactElement, this.residualHeapVisitor);
   }
 
   withCleanEquivilanceSet(func: () => void) {

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { Realm } from "../realm.js";
+import { AbstractValue, ArrayValue, NumberValue, ObjectValue, SymbolValue, Value } from "../values/index.js";
+import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
+import { canHoistReactElement } from "../react/hoisting.js";
+import { getProperty, getReactSymbol } from "../react/utils.js";
+import ReactElementSet from "../react/ReactElementSet.js";
+import type { ReactOutputTypes } from "../options.js";
+import invariant from "../invariant.js";
+
+export class ResidualReactElementVisitor {
+  constructor(realm: Realm, residualHeapVisitor: ResidualHeapVisitor) {
+    this.realm = realm;
+    this.residualHeapVisitor = residualHeapVisitor;
+    this.reactOutput = realm.react.output || "create-element";
+    this.someReactElement = undefined;
+    this.equivalenceSet = new ReactElementSet(realm, residualHeapVisitor.equivalenceSet);
+  }
+
+  realm: Realm;
+  residualHeapVisitor: ResidualHeapVisitor;
+  reactOutput: ReactOutputTypes;
+  someReactElement: void | ObjectValue;
+  equivalenceSet: ReactElementSet;
+
+  _visitReactElementAttributes(reactElement: ObjectValue): void {
+    let keyValue = getProperty(this.realm, reactElement, "key");
+    let refValue = getProperty(this.realm, reactElement, "ref");
+    let propsValue = getProperty(this.realm, reactElement, "props");
+
+    if (keyValue !== this.realm.intrinsics.null && keyValue !== this.realm.intrinsics.undefined) {
+      this.residualHeapVisitor.visitValue(keyValue);
+    }
+    if (refValue !== this.realm.intrinsics.null && refValue !== this.realm.intrinsics.undefined) {
+      this.residualHeapVisitor.visitValue(refValue);
+    }
+
+    if (propsValue instanceof AbstractValue) {
+      // visit object, as it's going to be spread
+      this.residualHeapVisitor.visitValue(propsValue);
+    } else if (propsValue instanceof ObjectValue) {
+      if (propsValue.isPartialObject()) {
+        this.residualHeapVisitor.visitValue(propsValue);
+      } else {
+        // given that props is a concrete object, it should never be serialized
+        // as we'll be doing it directly with the ReactElementSerializer
+        // so we make the object as refusing serialization
+        propsValue.refuseSerialization = true;
+        for (let [propName, binding] of propsValue.properties) {
+          if (binding.descriptor !== undefined && propName !== "children") {
+            let propValue = getProperty(this.realm, propsValue, propName);
+            this.residualHeapVisitor.visitValue(propValue);
+          }
+        }
+      }
+    }
+  }
+
+  _visitReactElementChildren(reactElement: ObjectValue): void {
+    let propsValue = getProperty(this.realm, reactElement, "props");
+    if (!(propsValue instanceof ObjectValue)) {
+      return;
+    }
+    // handle children
+    if (propsValue.properties.has("children")) {
+      let childrenValue = getProperty(this.realm, propsValue, "children");
+      if (childrenValue !== this.realm.intrinsics.undefined && childrenValue !== this.realm.intrinsics.null) {
+        if (childrenValue instanceof ArrayValue && !childrenValue.intrinsicName) {
+          let childrenLength = getProperty(this.realm, childrenValue, "length");
+          let childrenLengthValue = 0;
+          if (childrenLength instanceof NumberValue) {
+            childrenLengthValue = childrenLength.value;
+            for (let i = 0; i < childrenLengthValue; i++) {
+              let child = getProperty(this.realm, childrenValue, "" + i);
+              invariant(
+                child instanceof Value,
+                `ReactElement "props.children[${i}]" failed to visit due to a non-value`
+              );
+              this.residualHeapVisitor.visitValue(child);
+            }
+          }
+        } else {
+          this.residualHeapVisitor.visitValue(childrenValue);
+        }
+      }
+    }
+  }
+
+  visitReactElement(reactElement: ObjectValue): void {
+    let typeValue = getProperty(this.realm, reactElement, "type");
+    let isReactFragment =
+      typeValue instanceof SymbolValue && typeValue === getReactSymbol("react.fragment", this.realm);
+
+    // we don't want to visit fragments as they are internal values
+    if (!isReactFragment) {
+      this.residualHeapVisitor.visitValue(typeValue);
+    }
+
+    this._visitReactElementAttributes(reactElement);
+    this._visitReactElementChildren(reactElement);
+
+    if (this.realm.react.output === "create-element" || isReactFragment) {
+      this.someReactElement = reactElement;
+    }
+    // check we can hoist a React Element
+    canHoistReactElement(this.realm, reactElement, this.residualHeapVisitor);
+  }
+
+  withCleanEquivilanceSet(func: () => void) {
+    let oldReactElementEquivalenceSet = this.equivalenceSet;
+    this.equivalenceSet = new ReactElementSet(this.realm, this.residualHeapVisitor.equivalenceSet);
+    func();
+    // Cleanup
+    this.equivalenceSet = oldReactElementEquivalenceSet;
+  }
+}


### PR DESCRIPTION
Release notes: none

I noticed there's quite a bit of confusion surrounding how ReactElements get serialized and visited. Much of the confusion is hidden in how ReactElements are visited. They already have a dedicated serialization logic, but they didn't have dedicated visiting logic. This PR breaks out all the mixed logic and puts it together in a new ReactElement visitor class. This simplified a lot of parts and made things much easier to consume – plus it should make bug finding easier to deal with going forward.