### PR TITLE
Fix while and for loops with unlabeled breaks

### DIFF
--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -270,6 +270,13 @@ function ForBodyEvaluation(
       invariant(c === valueOrCompletionAtUnconditionalExit);
     }
     if (valueOrCompletionAtUnconditionalExit instanceof Value) return valueOrCompletionAtUnconditionalExit;
+
+    // ECMA262 13.1.7
+    if (valueOrCompletionAtUnconditionalExit instanceof BreakCompletion) {
+      if (!valueOrCompletionAtUnconditionalExit.target)
+        return (UpdateEmpty(realm, valueOrCompletionAtUnconditionalExit, V): any).value;
+    }
+
     throw valueOrCompletionAtUnconditionalExit;
   }
 

--- a/test/serializer/abstract/ForLoop2.js
+++ b/test/serializer/abstract/ForLoop2.js
@@ -1,0 +1,3 @@
+for (;true;) {
+  break; 
+}

--- a/test/serializer/abstract/WhileLoop.js
+++ b/test/serializer/abstract/WhileLoop.js
@@ -1,0 +1,3 @@
+while (true) {
+  break;
+}


### PR DESCRIPTION
BreakCompletions that were not joined previously fall through joinAllLoops. This change converts such cases to NormalCompletions. Without this change, prepacking fails with an invariant failure.