### PR TITLE
Log the correct component name

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1173,7 +1173,7 @@ export class Reconciler {
             evaluatedChildNode
           );
           if (this.realm.react.verbose && evaluatedChildNode.status === "INLINED") {
-            this.logger.logInformation(`    ✔ ${evaluatedNode.name} (inlined)`);
+            this.logger.logInformation(`    ✔ ${evaluatedChildNode.name} (inlined)`);
           }
           evaluatedNode.children.push(evaluatedChildNode);
           result = render.result;


### PR DESCRIPTION
Release notes: none

Follow up to https://github.com/facebook/prepack/pull/1862. Fix on the correct component name to log in verbose mode.