### PR TITLE
Fixes issues with React reconcilers abstract conditional evaluator

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2317,6 +2317,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple 12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Author",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -6105,6 +6129,30 @@ ReactStatistics {
   "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple 12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Author",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
 }
 `;
 
@@ -9899,6 +9947,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Simple 12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Author",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -13652,6 +13724,30 @@ ReactStatistics {
   "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 2,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple 12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Author",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -285,6 +285,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-11.js");
       });
 
+      it("Simple 12", async () => {
+        await runTest(directory, "simple-12.js");
+      });
+
       it("Handle mapped arrays", async () => {
         await runTest(directory, "array-map.js");
       });

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1295,7 +1295,6 @@ export class Reconciler {
     } else {
       // handle abrupt completions
       if (error instanceof AbruptCompletion) {
-        debugger;
         let evaluatedChildNode = createReactEvaluatedNode("ABRUPT_COMPLETION", getComponentName(this.realm, typeValue));
         evaluatedNode.children.push(evaluatedChildNode);
       } else {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -882,6 +882,48 @@ export class Reconciler {
     return "NORMAL";
   }
 
+  _resolveAbstractConditionalValue(
+    componentType: Value,
+    condValue: AbstractValue,
+    consequentVal: Value,
+    alternateVal: Value,
+    context: ObjectValue | AbstractObjectValue,
+    branchStatus: BranchStatusEnum,
+    branchState: BranchState | null,
+    evaluatedNode: ReactEvaluatedNode
+  ) {
+    let newBranchState = new BranchState();
+    let value = AbstractValue.evaluateWithAbstractConditional(
+      this.realm,
+      condValue,
+      () => {
+        return this.realm.evaluateForEffects(
+          () => this._resolveDeeply(componentType, consequentVal, context, "NEW_BRANCH", newBranchState, evaluatedNode),
+          null,
+          "_resolveAbstractConditionalValue consequent"
+        );
+      },
+      () => {
+        invariant(false, "TODO");
+      },
+      () => {
+        return this.realm.evaluateForEffects(
+          () => this._resolveDeeply(componentType, alternateVal, context, "NEW_BRANCH", newBranchState, evaluatedNode),
+          null,
+          "_resolveAbstractConditionalValue consequent"
+        );
+      },
+      () => {
+        invariant(false, "TODO");
+      }
+    );
+    let didBranch = newBranchState.applyBranchedLogic(this.realm, this.reactSerializerState);
+    if (didBranch && branchState !== null) {
+      branchState.mergeBranchedLogic(newBranchState);
+    }
+    return value;
+  }
+
   _resolveAbstractValue(
     componentType: Value,
     value: AbstractValue,
@@ -891,37 +933,19 @@ export class Reconciler {
     evaluatedNode: ReactEvaluatedNode
   ): Value {
     invariant(this.realm.generator);
-    let length = value.args.length;
     // TODO investigate what other kinds than "conditional" might be safe to deeply resolve
-    if (length === 3 && value.kind === "conditional") {
-      let newBranchState = new BranchState();
-      let args = [];
-      let shouldCreateNewAbstract = false;
-      for (let i = 0; i < length; i++) {
-        let arg = this._resolveDeeply(
-          componentType,
-          value.args[i],
-          context,
-          "NEW_BRANCH",
-          newBranchState,
-          evaluatedNode
-        );
-        args.push(arg);
-        if (value.args[i] !== arg) {
-          shouldCreateNewAbstract = true;
-        }
-      }
-      let didBranch = newBranchState.applyBranchedLogic(this.realm, this.reactSerializerState);
-      if (didBranch && branchState !== null) {
-        branchState.mergeBranchedLogic(newBranchState);
-      }
-      if (shouldCreateNewAbstract) {
-        let [condition, left, right] = args;
-        // value.args[0] is guaranteed to be abstract and _resolveDeeply returns an abstract
-        // when called on an abstract
-        invariant(condition instanceof AbstractValue);
-        return AbstractValue.createFromConditionalOp(this.realm, condition, left, right);
-      }
+    if (value.kind === "conditional") {
+      let [condValue, consequentVal, alternateVal] = value.args;
+      return this._resolveAbstractConditionalValue(
+        componentType,
+        condValue,
+        consequentVal,
+        alternateVal,
+        context,
+        branchStatus,
+        branchState,
+        evaluatedNode
+      );
     } else {
       this.componentTreeState.deadEnds++;
     }
@@ -1271,6 +1295,7 @@ export class Reconciler {
     } else {
       // handle abrupt completions
       if (error instanceof AbruptCompletion) {
+        debugger;
         let evaluatedChildNode = createReactEvaluatedNode("ABRUPT_COMPLETION", getComponentName(this.realm, typeValue));
         evaluatedNode.children.push(evaluatedChildNode);
       } else {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -936,6 +936,7 @@ export class Reconciler {
     // TODO investigate what other kinds than "conditional" might be safe to deeply resolve
     if (value.kind === "conditional") {
       let [condValue, consequentVal, alternateVal] = value.args;
+      invariant(condValue instanceof AbstractValue);
       return this._resolveAbstractConditionalValue(
         componentType,
         condValue,

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -543,7 +543,7 @@ export default class AbstractObjectValue extends AbstractValue {
       let d2 = ob2.$GetOwnProperty(P);
       let d2val =
         d2 === undefined ? this.$Realm.intrinsics.undefined : IsDataDescriptor(this.$Realm, d2) ? d2.value : undefined;
-      if (d1val === undefined || d2val === undefined) {
+      if (d1val === undefined || d2val === undefined || (d1 === undefined && d2 === undefined)) {
         AbstractValue.reportIntrospectionError(this, P);
         throw new FatalError();
       }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -9,6 +9,7 @@
 
 /* @flow */
 
+import { Effects } from "../realm.js";
 import type {
   BabelBinaryOperator,
   BabelNodeExpression,
@@ -17,7 +18,7 @@ import type {
   BabelNodeSourceLocation,
   BabelUnaryOperator,
 } from "babel-types";
-import { FatalError, CompilerDiagnostic } from "../errors.js";
+import { CompilerDiagnostic, FatalError, InfeasiblePathError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
 import { PreludeGenerator } from "../utils/generator.js";
@@ -39,6 +40,8 @@ import {
 import { hashString, hashBinary, hashCall, hashTernary, hashUnary } from "../methods/index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import invariant from "../invariant.js";
+import { Join, Path } from "../singletons.js";
+import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 
 import * as t from "babel-types";
 
@@ -943,5 +946,63 @@ export default class AbstractValue extends Value {
 
   static makeKind(prefix: AbstractValueKindPrefix, suffix: string): AbstractValueKind {
     return ((`${prefix}:${suffix}`: any): AbstractValueKind);
+  }
+
+  static evaluateWithAbstractConditional(
+    realm: Realm,
+    condValue: AbstractValue,
+    consequentEffectsFunc: () => Effects,
+    consequentInfeasibleFunc: () => Value,
+    alternateEffectsFunc: () => Effects,
+    alternateInfeasibleFunc: () => Value
+  ): Value {
+    // Evaluate consequent and alternate in sandboxes and get their effects.
+    let compl1, gen1, bindings1, properties1, createdObj1;
+    try {
+      [compl1, gen1, bindings1, properties1, createdObj1] = Path.withCondition(condValue, consequentEffectsFunc).data;
+    } catch (e) {
+      if (e instanceof InfeasiblePathError) {
+        return consequentInfeasibleFunc();
+      }
+      throw e;
+    }
+
+    let compl2, gen2, bindings2, properties2, createdObj2;
+    try {
+      [compl2, gen2, bindings2, properties2, createdObj2] = Path.withInverseCondition(
+        condValue,
+        alternateEffectsFunc
+      ).data;
+    } catch (e) {
+      if (e instanceof InfeasiblePathError) {
+        return alternateInfeasibleFunc();
+      }
+      throw e;
+    }
+
+    // Join the effects, creating an abstract view of what happened, regardless
+    // of the actual value of condValue.
+    let joinedEffects = Join.joinEffects(
+      realm,
+      condValue,
+      new Effects(compl1, gen1, bindings1, properties1, createdObj1),
+      new Effects(compl2, gen2, bindings2, properties2, createdObj2)
+    );
+    let completion = joinedEffects.result;
+    if (completion instanceof PossiblyNormalCompletion) {
+      // in this case one of the branches may complete abruptly, which means that
+      // not all control flow branches join into one flow at this point.
+      // Consequently we have to continue tracking changes until the point where
+      // all the branches come together into one.
+      completion = realm.composeWithSavedCompletion(completion);
+    }
+    // Note that the effects of (non joining) abrupt branches are not included
+    // in joinedEffects, but are tracked separately inside completion.
+    realm.applyEffects(joinedEffects);
+
+    // return or throw completion
+    if (completion instanceof AbruptCompletion) throw completion;
+    invariant(completion instanceof Value);
+    return completion;
   }
 }

--- a/test/react/functional-components/simple-12.js
+++ b/test/react/functional-components/simple-12.js
@@ -1,0 +1,31 @@
+var React = require("react");
+this["React"] = React;
+
+function Author(props) {
+  return props.author.name || "Unnamed";
+}
+
+function App(props) {
+  var comment = props.comment;
+  var author = comment != null ? comment.author : null;
+  return author ? React.createElement(Author, { author: author }) : "Unknown";
+}
+
+App.getTrials = function(renderer, Root) {
+  let results = [];
+  renderer.update(<Root comment={{ author: { name: "Jo" } }} />);
+  results.push(["full", renderer.toJSON()]);
+  renderer.update(<Root comment={{ author: {} }} />);
+  results.push(["no name", renderer.toJSON()]);
+  renderer.update(<Root comment={{ author: null }} />);
+  results.push(["no author", renderer.toJSON()]);
+  renderer.update(<Root comment={null} />);
+  results.push(["no comment", renderer.toJSON()]);
+  return results;
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This fixes https://github.com/facebook/prepack/issues/1866. The React reconciler previously had somewhat broken logic when dealing with conditional that may require effects being joined together for things such as if statements. This re-uses the logic in `IfStatement` to ensure we get it right. Furthermore, I found a bug in `fb20.js` that failed unless we made sure we throw a `FatalError` in `AbstractObjectValue` where both consequent and alternate values are not found – like done in other methods in `AbstractObjectValue` joining together a value in this scenario actually generated broken output.