### PR TITLE
Don't generate unnecessary Object.assign() calls

### DIFF
--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -363,9 +363,11 @@ export default function(realm: Realm): NativeFunctionValue {
     // If we're in pure scope and the items are completely abstract,
     // then create an abstract temporal with an array kind
     if (realm.isInPureScope() && obj instanceof AbstractObjectValue) {
+      // Use original object because Object.keys() call does an implicit conversion
+      let unwrapped = O;
       let array = ArrayValue.createTemporalWithWidenedNumericProperty(
         realm,
-        [objectKeys, obj],
+        [objectKeys, unwrapped],
         ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
       );
       return array;

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -486,10 +486,16 @@ export default class AbstractObjectValue extends AbstractValue {
       let generateAbstractGet = () => {
         let type = Value;
         if (P === "length" && Value.isTypeCompatibleWith(this.getType(), ArrayValue)) type = NumberValue;
+        let unwrapped = this;
+        if (this.kind === "explicit conversion to object") {
+          // We can unwrap because the generated property access
+          // will implicitly convert it to an object.
+          unwrapped = this.args[0];
+        }
         return AbstractValue.createTemporalFromBuildFunction(
           this.$Realm,
           type,
-          [this],
+          [unwrapped],
           ([o]) => {
             invariant(typeof P === "string");
             return t.isValidIdentifier(P)

--- a/test/serializer/abstract/NoExtraneousAssign.js
+++ b/test/serializer/abstract/NoExtraneousAssign.js
@@ -1,0 +1,26 @@
+// does not contain:assign
+(function() {
+  function fn(arg) {
+    let a = {x: Object.keys(arg) };
+    let b = Object.prototype.hasOwnProperty.call(arg, 'foo');
+    let c = arg.foo;
+    return {a, b, c};
+  }
+
+  if (global.__optimize) global.__optimize(fn);
+
+  global.inspect = function() {
+    let err;
+    try {
+      fn(null);
+    } catch (e) {
+      err = e;
+    }
+    return JSON.stringify([
+      fn(2),
+      fn({}),
+      fn({foo: 'bar'}),
+      err.message
+    ]);
+  };
+})();


### PR DESCRIPTION
This is intended to improve the output (not a correctness issue).

`ToObject` currently generates an `Object.assign` call as an enforcement. But this is unnecessary if we’re emitting an operation that already enforces object-ness by itself. In #1690, we already “unwrapped” the object back in one such case: https://github.com/facebook/prepack/commit/88fbdcc47b15a38ac4369b7eeb893e2d62eedba2#diff-5cb5f0c9909e8738d567acfaff9bb980R115.

In this PR, I'm attempting to do so for a few more cases:

* Property access like `foo.bar`
* `Object.keys(foo)`
* `Object.prototype.hasOwnProperty.call(foo)`

I add a serializer test for these cases that fails if the output contains an `assign` call.

Note that if this lands, we'll need to make the regression test for https://github.com/facebook/prepack/pull/1878 use some other pattern that would still cause `ToObject` enforcement.