### PR TITLE
Add a serializer regression test for #1832

### DIFF
--- a/test/serializer/optimized-functions/ForLoop2.js
+++ b/test/serializer/optimized-functions/ForLoop2.js
@@ -1,0 +1,17 @@
+(function() {
+  function fn() {
+    var arr = [0];
+    for (var i = 0; i < arr.length; i++) {
+      break;
+    }
+    return 10;
+  }
+
+  if (global.__optimize) {
+    __optimize(fn);
+  }
+
+  global.inspect = function() {
+    return fn();
+  }
+})();


### PR DESCRIPTION
Adds a regression test for https://github.com/facebook/prepack/issues/1832.

It was fixed in https://github.com/facebook/prepack/pull/1863 but the regression tests in it didn't cover against the specific invariant I was bumping into.

I checked this test fails before the fix.