### PR TITLE
Properly serialize object of modified object property

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1861,9 +1861,11 @@ export class ResidualHeapSerializer {
           if (desc !== undefined) dependencies.push(...this._getDescriptorValues(desc));
           dependencies.push(object);
           if (key instanceof Value) dependencies.push(key);
-          this.emitter.emitNowOrAfterWaitingForDependencies(dependencies, () =>
-            this._emitProperty(object, key, desc, true)
-          );
+          this.emitter.emitNowOrAfterWaitingForDependencies(dependencies, () => {
+            // separate serialize object, as _emitProperty assumes that this already happened
+            this.serializeValue(object);
+            this._emitProperty(object, key, desc, true);
+          });
         }
       },
       options: this._options,

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1059,6 +1059,7 @@ export class ResidualHeapVisitor {
       visitModifiedObjectProperty: (binding: PropertyBinding) => {
         let fixpoint_rerun = () => {
           if (this.values.has(binding.object)) {
+            this.visitValue(binding.object);
             if (binding.key instanceof Value) this.visitValue(binding.key);
             this.visitObjectProperty(binding);
             return true;

--- a/test/serializer/additional-functions/ModifiedObjectProperty.js
+++ b/test/serializer/additional-functions/ModifiedObjectProperty.js
@@ -1,0 +1,12 @@
+(function () {
+    let p = {};
+    function f(c) {
+        let o = {};
+        if (c) {
+            o.foo = 42;
+            throw o;
+        }
+    }
+    if (global.__optimize) __optimize(f);
+    inspect = function() { try { f(true); } catch (o) { return o.foo; } }
+})();


### PR DESCRIPTION
Release notes: None

This fixes #1857.

The implementation to serialize modified object properties
didn't actually kick off serialization of the modified object.

Added regression test.