### PR TITLE
Improve code generation in presence of exceptions

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -398,12 +398,10 @@ export class Generator {
       output.emitReturnValue(result);
     } else if (result instanceof ReturnCompletion) {
       output.emitReturnValue(result.value);
-    } else if (result instanceof PossiblyNormalCompletion) {
-      output.emitPossiblyNormalReturn(result, realm);
+    } else if (result instanceof PossiblyNormalCompletion || result instanceof JoinedAbruptCompletions) {
+      output.emitIfThenElse(result, realm);
     } else if (result instanceof ThrowCompletion) {
       output.emitThrow(result.value);
-    } else if (result instanceof JoinedAbruptCompletions) {
-      output.emitJoinedAbruptCompletions(result, realm);
     } else {
       invariant(false);
     }
@@ -472,11 +470,7 @@ export class Generator {
     this._entries.push(new ReturnValueEntry(this, result));
   }
 
-  emitPossiblyNormalReturn(result: PossiblyNormalCompletion, realm: Realm) {
-    this._entries.push(new IfThenElseEntry(this, result, realm));
-  }
-
-  emitJoinedAbruptCompletions(result: JoinedAbruptCompletions, realm: Realm) {
+  emitIfThenElse(result: PossiblyNormalCompletion | JoinedAbruptCompletions, realm: Realm) {
     this._entries.push(new IfThenElseEntry(this, result, realm));
   }
 
@@ -634,8 +628,7 @@ export class Generator {
       } else if (branch instanceof ThrowCompletion) {
         result.emitThrow(branch.value);
       } else {
-        const value = branch instanceof ReturnCompletion ? branch.value : branch;
-        invariant(value instanceof Value);
+        invariant(branch instanceof ReturnCompletion || branch instanceof Value);
       }
       return result;
     };

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -632,8 +632,7 @@ export class Generator {
       if (branch instanceof JoinedAbruptCompletions || branch instanceof PossiblyNormalCompletion) {
         result.emitConditionalThrow(branch.joinCondition, branch.consequent, branch.alternate);
       } else if (branch instanceof ThrowCompletion) {
-        this._issueThrowCompilerDiagnostic(branch.value);
-        result.emitStatement([branch.value], ([arg]) => t.throwStatement(arg));
+        result.emitThrow(branch.value);
       } else {
         const value = branch instanceof ReturnCompletion ? branch.value : branch;
         invariant(value instanceof Value);


### PR DESCRIPTION
Release Note: none

Addresses #1870 by making `emitConditionalThrow` use `joinGenerators` rather than `_deconstruct` (which is then also no longer referenced).

Resulting code for example in issue:
``` JS
(function () {
  var $$0 = {
    enumerable: false,
    configurable: true,
    writable: true
  };

  var _$0 = this;

  var _$1 = _$0.Error;
  var _$2 = _$1.prototype;
  var _$3 = _$0.Object;
  var _$4 = _$3.defineProperty;

  var _4 = function () {
    return 42;
  };

  var __constructor = function () {};

  inspect = _4;
  var _0 = false;
  var _3 = _$2;

  if (_0) {
    var _1 = (__constructor.prototype = _3, new __constructor());

    $$0.value = "Error\n    at no-filename-specified:4:18\n    at no-filename-specified:1:1", _$4(_1, "stack", $$0);
    throw _1;
  }
}).call(this);
```