### PR TITLE
Ensure StrictMode is set correctly if mixed

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -116,7 +116,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
   if (desc === undefined) {
     // The property is being deleted
     if (O === realm.$GlobalObject) {
-      generator.emitGlobalDelete(P, realm.getRunningContext().isStrict);
+      generator.emitGlobalDelete(P);
     } else {
       generator.emitPropertyDelete(O, P);
     }
@@ -130,7 +130,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
           if (isValidIdentifier(P) && !desc.configurable && desc.enumerable && desc.writable) {
             generator.emitGlobalDeclaration(P, descValue);
           } else if (desc.configurable && desc.enumerable && desc.writable) {
-            generator.emitGlobalAssignment(P, descValue, realm.getRunningContext().isStrict);
+            generator.emitGlobalAssignment(P, descValue);
           } else {
             generator.emitDefineProperty(O, P, desc);
           }
@@ -149,7 +149,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
       if (equalDescriptors(desc, oldDesc)) {
         // only the value is being modified
         if (O === realm.$GlobalObject) {
-          generator.emitGlobalAssignment(P, descValue, realm.getRunningContext().isStrict);
+          generator.emitGlobalAssignment(P, descValue);
         } else {
           generator.emitPropertyAssignment(O, P, descValue);
         }

--- a/test/serializer/basic/GlobalStrict.js
+++ b/test/serializer/basic/GlobalStrict.js
@@ -1,0 +1,9 @@
+(function () {
+  "use strict";
+  let moduleTable = {};
+  function require(id) {
+    return {};
+  }
+  global.require = require;
+})();
+three = require("three");


### PR DESCRIPTION
Release notes: default to StrictMode when mixed StrictMode is serialized between function entries

Fixes https://github.com/facebook/prepack/issues/1890. When we have a single entry on a generator, we need to ensure we default to using StrictMode for all other entries in the same body for that generator.