### PR TITLE
Allocate by using `new Array(n)`

### DIFF
--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -384,7 +384,7 @@ let reactCode = `
       if (childrenLength === 1) {
         props.children = children;
       } else if (childrenLength > 1) {
-        var childArray = Array(childrenLength);
+        var childArray = new Array(childrenLength);
         for (var i = 0; i < childrenLength; i++) {
           childArray[i] = arguments[i + 2];
         }

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -263,7 +263,7 @@ export class Referentializer {
     return t.variableDeclaration("var", [
       t.variableDeclarator(
         this._getReferentializationState(referentializationScope).capturedScopesArray,
-        t.callExpression(t.identifier("Array"), [
+        t.newExpression(t.identifier("Array"), [
           t.numericLiteral(this._getReferentializationState(referentializationScope).capturedScopeInstanceIdx),
         ])
       ),


### PR DESCRIPTION
Array(n) is causing some deopts in v8 - https://github.com/babel/babel/issues/6233#issuecomment-329055890

I've also noticed that there is a `Array(n)` call [here](https://github.com/facebook/prepack/blob/32d9973c304ec02205683622184a64ba40d809f3/src/intrinsics/fb-www/react-mocks.js#L387) but as this is some kind of mock file I'm not sure if I should change it too.