### PR TITLE
Check additional invariants on created objects.

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -393,12 +393,26 @@ export class Generator {
       output.emitBindingModification(modifiedBinding);
     }
 
+    let includesCreatedObjects = (outer: Effects, inner: Effects) => {
+      for (let createdObject of inner.createdObjects) if (!outer.createdObjects.has(createdObject)) return false;
+      return true;
+    };
+
+    let disjointCreatedObjects = (x: Effects, y: Effects) => {
+      for (let createdObject of x.createdObjects) if (y.createdObjects.has(createdObject)) return false;
+      for (let createdObject of y.createdObjects) if (x.createdObjects.has(createdObject)) return false;
+      return true;
+    };
+
     if (result instanceof UndefinedValue) return output;
     if (result instanceof Value) {
       output.emitReturnValue(result);
     } else if (result instanceof ReturnCompletion) {
       output.emitReturnValue(result.value);
     } else if (result instanceof PossiblyNormalCompletion || result instanceof JoinedAbruptCompletions) {
+      invariant(includesCreatedObjects(effects, result.consequentEffects));
+      invariant(includesCreatedObjects(effects, result.alternateEffects));
+      invariant(disjointCreatedObjects(result.consequentEffects, result.alternateEffects));
       output.emitIfThenElse(result, realm);
     } else if (result instanceof ThrowCompletion) {
       output.emitThrow(result.value);


### PR DESCRIPTION
Release notes: None

For PossiblyNormalCompletion and JoinedAbruptCompletions, this checks that
- nested created objects appear in the created objects lists of the parent
- nested objects are mutually exclusive

This addresses #1855; the issue it uncovered is tracked in #1902.