### PR TITLE
Do not apply the effects of JoinedAbruptCompletions.

### DIFF
--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -10,10 +10,10 @@
 /* @flow */
 
 import type { BabelNodeSourceLocation } from "babel-types";
-import { Completion, JoinedAbruptCompletions, PossiblyNormalCompletion, ReturnCompletion } from "../completions.js";
+import { Completion, JoinedAbruptCompletions, PossiblyNormalCompletion } from "../completions.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import invariant from "../invariant.js";
-import { construct_empty_effects, type Effects, type PropertyBindings, Realm } from "../realm.js";
+import { type Effects, type PropertyBindings, Realm } from "../realm.js";
 import type { Binding } from "../environment.js";
 import type { PropertyBinding, ReactComponentTreeConfig, FunctionBodyAstNode } from "../types.js";
 import { ignoreErrorsIn } from "../utils/errors.js";
@@ -136,38 +136,16 @@ export class Functions {
     parentAdditionalFunction: FunctionValue | void = undefined
   ): AdditionalFunctionEffects | null {
     let realm = this.realm;
-    let [result, generator] = effects.data;
+    let result = effects.result;
+    let generator = Generator.fromEffects(effects, this.realm, name, environmentRecordIdAfterGlobalCode);
     if (result instanceof PossiblyNormalCompletion || result instanceof JoinedAbruptCompletions) {
-      // joined generators have joined entries that will get visited recursively via result, so get rid of them here
-      generator.purgeEntriesWithGeneratorDepencies();
-      // The completion is not the end of function execution, but a fork point for separate threads of control.
-      // The effects of all of these threads need to get joined up and rolled into the top level effects,
-      // so that applying the effects before serializing the body will fully initialize all variables and objects.
-      effects = realm.evaluateForEffects(
-        () => {
-          realm.applyEffects(effects, "_createAdditionalEffects/1", true);
-          if (result instanceof PossiblyNormalCompletion) {
-            result = Join.joinPossiblyNormalCompletionWithAbruptCompletion(
-              realm,
-              result,
-              new ReturnCompletion(result.value),
-              construct_empty_effects(realm)
-            ).result;
-          }
-          invariant(result instanceof JoinedAbruptCompletions);
-          let completionEffects = Join.joinNestedEffects(realm, result);
-          realm.applyEffects(completionEffects, "_createAdditionalEffects/2", false);
-          return result;
-        },
-        undefined,
-        "_createAdditionalEffects"
-      );
+      effects = Join.joinNestedEffects(realm, result);
     }
     let retValue: AdditionalFunctionEffects = {
       parentAdditionalFunction,
       effects,
       transforms: [],
-      generator: Generator.fromEffects(effects, this.realm, name, environmentRecordIdAfterGlobalCode),
+      generator,
       additionalRoots: new Set(),
     };
     return retValue;

--- a/test/serializer/optimized-functions/CallWithThrow.js
+++ b/test/serializer/optimized-functions/CallWithThrow.js
@@ -1,0 +1,32 @@
+function URI(uri) {
+  this.a = "";
+  var b = bar(uri) || {};
+  if (b.foo && b.foo()) {
+    throw new Error("foo");
+  }
+  this.a = b;
+  return this;
+}
+
+function bar(uri) {
+  var str = "";
+  if (uri.a) {
+    str += uri.a;
+  }
+  return str;
+};
+
+function fn(arg) {
+  new URI(new URI(arg));
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function () {
+  try {
+    fn({ a: "hello" });
+    return "ok";
+  } catch (err) {
+    return err;
+  }
+}


### PR DESCRIPTION
Release note: Fix problems with duplicated and missing statements

Resolves issue: #1842

Code duplication happened because the joined effects of two abrupt completions were applied first in aggregate and then again individually.

While debugging through this, I found it much simpler to understand Generator.fromEffects when applied to an Effects that has not been joined, so now things are closer to what they were before I started trying to hack past issues. The main difference is that a fully joined up set of effects is applied before serializing the result from Generator.fromEffects.

All of this caused and invariant to fail during a test. The invariant is complicated, fails in other new scenarios and is being reworked by Nikolai, so I've removed it for now in order to get these fixes in so that we are all on the same page again.