### PR TITLE
Stop processing statements after program terminating exception

### DIFF
--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -251,6 +251,7 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
         } else {
           invariant(false); // other kinds of abrupt completions should not get this far
         }
+        break;
       }
       if (!(res instanceof EmptyValue)) {
         val = res;

--- a/test/serializer/abstract/DoWhile2a.js
+++ b/test/serializer/abstract/DoWhile2a.js
@@ -1,3 +1,4 @@
+// does not contain:inspect
 let n = global.__abstract ? __abstract("number", "10") : 10;
 let o = {};
 let i = 0;


### PR DESCRIPTION
Release note: Do not generate code for unreachable global code statements

Resolves issue #1906

If an unconditional throw is encountered, it does not make sense to keep processing top level statements.
