### PR TITLE
Always emit globals safe for strict mode

### DIFF
--- a/scripts/generate-sourcemaps-test.js
+++ b/scripts/generate-sourcemaps-test.js
@@ -77,7 +77,7 @@ function generateTest(name: string, test_path: string, code: string): boolean {
       process.exit(1);
       invariant(false);
     }
-    newCode2 = s.code + "\nf();\n\n//# sourceMappingURL=" + name + ".new2.js.map\n";
+    newCode2 = s.code + "\nthis.f();\n\n//# sourceMappingURL=" + name + ".new2.js.map\n";
     fs.writeFileSync(name + ".new2.js", newCode2);
     newMap2 = s.map;
     fs.writeFileSync(name + ".new2.js.map", JSON.stringify(newMap2));

--- a/scripts/test-sourcemaps.sh
+++ b/scripts/test-sourcemaps.sh
@@ -1,5 +1,5 @@
 node Stacktrace.js.new2.js 2>&1 >/dev/null | grep "Stacktrace.js:2" > /dev/null
-X=$?
+_$0.f=$?
 rm Stacktrace.js.new1.js
 rm Stacktrace.js.new1.js.map
 rm Stacktrace.js.new2.js

--- a/scripts/test-sourcemaps.sh
+++ b/scripts/test-sourcemaps.sh
@@ -1,5 +1,5 @@
 node Stacktrace.js.new2.js 2>&1 >/dev/null | grep "Stacktrace.js:2" > /dev/null
-_$0.f=$?
+X=$?
 rm Stacktrace.js.new1.js
 rm Stacktrace.js.new1.js.map
 rm Stacktrace.js.new2.js

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -116,7 +116,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
   if (desc === undefined) {
     // The property is being deleted
     if (O === realm.$GlobalObject) {
-      generator.emitGlobalDelete(P, realm.getRunningContext().isStrict);
+      generator.emitGlobalDelete(P);
     } else {
       generator.emitPropertyDelete(O, P);
     }
@@ -130,7 +130,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
           if (isValidIdentifier(P) && !desc.configurable && desc.enumerable && desc.writable) {
             generator.emitGlobalDeclaration(P, descValue);
           } else if (desc.configurable && desc.enumerable && desc.writable) {
-            generator.emitGlobalAssignment(P, descValue, realm.getRunningContext().isStrict);
+            generator.emitGlobalAssignment(P, descValue);
           } else {
             generator.emitDefineProperty(O, P, desc);
           }
@@ -149,7 +149,7 @@ function InternalUpdatedProperty(realm: Realm, O: ObjectValue, P: PropertyKeyVal
       if (equalDescriptors(desc, oldDesc)) {
         // only the value is being modified
         if (O === realm.$GlobalObject) {
-          generator.emitGlobalAssignment(P, descValue, realm.getRunningContext().isStrict);
+          generator.emitGlobalAssignment(P, descValue);
         } else {
           generator.emitPropertyAssignment(O, P, descValue);
         }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -533,15 +533,15 @@ export class Generator {
 
   emitGlobalDeclaration(key: string, value: Value) {
     this.preludeGenerator.declaredGlobals.add(key);
-    if (!(value instanceof UndefinedValue)) this.emitGlobalAssignment(key, value, true);
+    if (!(value instanceof UndefinedValue)) this.emitGlobalAssignment(key, value);
   }
 
-  emitGlobalAssignment(key: string, value: Value, strictMode: boolean) {
+  emitGlobalAssignment(key: string, value: Value) {
     this._addEntry({
       args: [value],
       buildNode: ([valueNode]) =>
         t.expressionStatement(
-          t.assignmentExpression("=", this.preludeGenerator.globalReference(key, !strictMode), valueNode)
+          t.assignmentExpression("=", this.preludeGenerator.globalReference(key, false), valueNode)
         ),
     });
   }
@@ -556,11 +556,11 @@ export class Generator {
     });
   }
 
-  emitGlobalDelete(key: string, strictMode: boolean) {
+  emitGlobalDelete(key: string) {
     this._addEntry({
       args: [],
       buildNode: ([]) =>
-        t.expressionStatement(t.unaryExpression("delete", this.preludeGenerator.globalReference(key, !strictMode))),
+        t.expressionStatement(t.unaryExpression("delete", this.preludeGenerator.globalReference(key, false))),
     });
   }
 

--- a/test/serializer/basic/ClosureRefVisitor2.js
+++ b/test/serializer/basic/ClosureRefVisitor2.js
@@ -1,4 +1,3 @@
-// does not contain:call
 // omit invariants
 (function() {
     var f = function() {

--- a/test/serializer/basic/StrictGlobals.js
+++ b/test/serializer/basic/StrictGlobals.js
@@ -1,0 +1,9 @@
+(function () {
+  "use strict";
+  let moduleTable = {};
+  function require(id) {
+    return {};
+  }
+  global.require = require;
+})();
+three = require("three");

--- a/test/serializer/basic/StrictGlobals.js
+++ b/test/serializer/basic/StrictGlobals.js
@@ -6,4 +6,5 @@
   }
   global.require = require;
 })();
+
 three = require("three");


### PR DESCRIPTION
Release notes: all globals emitted reference the global identifier

This is a PR to replace https://github.com/facebook/prepack/pull/1894 that fixes #1890. I found a much simpler fix was to ensure we always treat emitted globals as safe for strict mode regardless. I had to change a test that went against this assumption, but we end up with code that better conforms to strict mode without large changes under the hood to Prepack.