### PR TITLE
ToObject serialization fix

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1688,9 +1688,7 @@ export class ResidualHeapSerializer {
       return serializedArgs[abstractIndex];
     }
     if (val.kind === "explicit conversion to object") {
-      let ob = serializedArgs[0];
-      invariant(ob !== undefined);
-      return t.callExpression(this.preludeGenerator.memoizeReference("Object.assign"), [ob]);
+      return serializedArgs[0];
     } else if (val.kind === "template for prototype member expression") {
       let obj = this.serializeValue(val.args[0]);
       let prop = this.serializeValue(val.args[1]);

--- a/test/serializer/abstract/NoExtraneousAssign.js
+++ b/test/serializer/abstract/NoExtraneousAssign.js
@@ -1,0 +1,26 @@
+// does not contain:assign
+(function() {
+  function fn(arg) {
+    let a = {x: Object.keys(arg) };
+    let b = Object.prototype.hasOwnProperty.call(arg, 'foo');
+    let c = arg.foo;
+    return {a, b, c};
+  }
+
+  if (global.__optimize) global.__optimize(fn);
+
+  global.inspect = function() {
+    let err;
+    try {
+      fn(null);
+    } catch (e) {
+      err = e;
+    }
+    return JSON.stringify([
+      fn(2),
+      fn({}),
+      fn({foo: 'bar'}),
+      err.message
+    ]);
+  };
+})();

--- a/test/serializer/additional-functions/ToObjectEquivalence.js
+++ b/test/serializer/additional-functions/ToObjectEquivalence.js
@@ -1,0 +1,13 @@
+(function() {
+  function fn(arg) {
+    var a = arg ? arg.a : null;
+    var b = arg ? arg.b : null;
+    return { a, b };
+  }
+
+  if (global.__optimize) global.__optimize(fn);
+
+  global.inspect = function() {
+    return JSON.stringify([fn(null), fn({ a: 1, b: 1 })]);
+  };
+})();

--- a/test/serializer/additional-functions/ToObjectEquivalence2.js
+++ b/test/serializer/additional-functions/ToObjectEquivalence2.js
@@ -1,0 +1,16 @@
+(function() {
+  function fn(arg) {
+    return arg != null && arg.x && arg.y;
+  };
+
+  if (global.__optimize) __optimize(fn);
+
+  global.inspect = function() {
+    return JSON.stringify([
+      fn(null),
+      fn(undefined),
+      fn({x: false, y: 5}),
+      fn({x: 5, y: 10}),
+    ])
+  }
+})();


### PR DESCRIPTION
Release notes: simplify the `ToObject` serialization output

This is probably the most simple and yet (unconsidered?) fix. We don't serialize with `Object.assign` and simply just reference the original object. We do end up creating an extra `var` assignment, but any decent minifier will just remove that and inline the contents.

I looked through all the old PRs and added all their tests – they all pass great. including this test: @sebmarkbage https://github.com/facebook/prepack/pull/1690/files#diff-881abe5d6b0da3c006b3ab24a5cdbf5eR1

I belive https://github.com/facebook/prepack/pull/1879 can rebase on top of this too.