### PR TITLE
Change Get -> getProperty in sanitizeReactElementForFirstRenderOnly

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -840,7 +840,7 @@ export function sanitizeReactElementForFirstRenderOnly(realm: Realm, reactElemen
   setProperty(reactElement, "ref", realm.intrinsics.null);
   // when dealing with host nodes, we want to sanitize them futher
   if (typeValue instanceof StringValue) {
-    let propsValue = Get(realm, reactElement, "props");
+    let propsValue = getProperty(realm, reactElement, "props");
     if (propsValue instanceof ObjectValue) {
       // remove all values apart from string/number/boolean
       for (let [propName] of propsValue.properties) {


### PR DESCRIPTION
Release notes: none

Noticed this when looking through our internal bug list and noticed that this `Get` should be `getProperty` as it's accessing an internal property on the `ReactElement`. No repro, as this only came up with an internal FB bundle.