### PR TITLE
The catch should rethrow error if it cannot handle it

### DIFF
--- a/src/react/components.js
+++ b/src/react/components.js
@@ -381,7 +381,9 @@ export function applyGetDerivedStateFromProps(
           );
           newState.makeSimple();
           newState.makePartial();
+          return newState;
         }
+        throw e;
       }
       return newState;
     } else {


### PR DESCRIPTION
Release notes: none

Fix for a try/catch block that should rethrow an error if it cannot handle it.