### PR TITLE
Prevent CSE from hoisting Object.assign calls.

### DIFF
--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -746,6 +746,7 @@ export default class AbstractValue extends Value {
     let types = new TypesDomain(resultType);
     let Constructor = Value.isTypeCompatibleWith(resultType, ObjectValue) ? AbstractObjectValue : AbstractValue;
     let [hash, args] = hashCall(resultType.name + (kind || ""), ...(operands || []));
+    if (resultType === ObjectValue) hash = ++realm.objectCount;
     let result = new Constructor(realm, types, ValuesDomain.topVal, hash, args);
     if (kind) result.kind = kind;
     result.expressionLocation = realm.currentLocation;

--- a/test/serializer/optimized-functions/PropertyDeref.js
+++ b/test/serializer/optimized-functions/PropertyDeref.js
@@ -1,0 +1,14 @@
+function fn(arg) {
+  return arg != null && arg.x && arg.y; // needs both conjunctions to repro. Happens because of scope promotion
+};
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify([
+    fn(null),
+    // fn(undefined),
+    // fn({x: false, y: 5}),
+    // fn({x: 5, y: 10}),
+  ])
+}

--- a/test/serializer/optimized-functions/PropertyDeref.js
+++ b/test/serializer/optimized-functions/PropertyDeref.js
@@ -7,8 +7,8 @@ if (global.__optimize) __optimize(fn);
 inspect = function() {
   return JSON.stringify([
     fn(null),
-    // fn(undefined),
-    // fn({x: false, y: 5}),
-    // fn({x: 5, y: 10}),
+    fn(undefined),
+    fn({x: false, y: 5}),
+    fn({x: 5, y: 10}),
   ])
 }

--- a/test/serializer/optimized-functions/PropertyDeref.js
+++ b/test/serializer/optimized-functions/PropertyDeref.js
@@ -1,5 +1,5 @@
 function fn(arg) {
-  return arg != null && arg.x && arg.y; // needs both conjunctions to repro. Happens because of scope promotion
+  return arg != null && arg.x && arg.y;
 };
 
 if (global.__optimize) __optimize(fn);


### PR DESCRIPTION
Release note: none

Resolves issue #1865 

Abstract values that are known to result in objects (of unknown identity) should not be eligible for Common Subexpression Elimination (CSE).