### PR TITLE
 Objects that are temporal should set _isScopedTemplate to true

### DIFF
--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -873,7 +873,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // if there is an initialValue, then the call will likely
     // have side-effects so this is not supported for now
     if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O)) {
-      if (initialValue || initialValue instanceof UndefinedValue) {
+      if (initialValue && !(initialValue instanceof UndefinedValue)) {
         let diagnostic = new CompilerDiagnostic(
           "array reduce with initial value is not supported",
           realm.currentLocation,
@@ -983,7 +983,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // if there is an initialValue, then the call will likely
     // have side-effects so this is not supported for now
     if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O)) {
-      if (initialValue || initialValue instanceof UndefinedValue) {
+      if (initialValue && !(initialValue instanceof UndefinedValue)) {
         let diagnostic = new CompilerDiagnostic(
           "array reduceRight with initial value is not supported",
           realm.currentLocation,

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -870,29 +870,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 1. Let O be ? ToObject(this value).
     let O = To.ToObject(realm, context);
 
-    // if there is an initialValue, then the call will likely
-    // have side-effects so this is not supported for now
-    if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O)) {
-      if (initialValue && !(initialValue instanceof UndefinedValue)) {
-        let diagnostic = new CompilerDiagnostic(
-          "array reduce with initial value is not supported",
-          realm.currentLocation,
-          "PP0035",
-          "FatalError"
-        );
-        realm.handleError(diagnostic);
-        throw new FatalError();
-      }
-      let args = [O, callbackfn];
-      return ArrayValue.createTemporalWithWidenedNumericProperty(
-        realm,
-        args,
-        ([objNode, ..._args]) =>
-          t.callExpression(t.memberExpression(objNode, t.identifier("reduce")), ((_args: any): Array<any>)),
-        { func: callbackfn, thisVal: realm.intrinsics.undefined }
-      );
-    }
-
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
 
@@ -979,29 +956,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
   obj.defineNativeMethod("reduceRight", 1, (context, [callbackfn, initialValue]) => {
     // 1. Let O be ? ToObject(this value).
     let O = To.ToObject(realm, context);
-
-    // if there is an initialValue, then the call will likely
-    // have side-effects so this is not supported for now
-    if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O)) {
-      if (initialValue && !(initialValue instanceof UndefinedValue)) {
-        let diagnostic = new CompilerDiagnostic(
-          "array reduceRight with initial value is not supported",
-          realm.currentLocation,
-          "PP0035",
-          "FatalError"
-        );
-        realm.handleError(diagnostic);
-        throw new FatalError();
-      }
-      let args = [O, callbackfn];
-      return ArrayValue.createTemporalWithWidenedNumericProperty(
-        realm,
-        args,
-        ([objNode, ..._args]) =>
-          t.callExpression(t.memberExpression(objNode, t.identifier("reduceRight")), ((_args: any): Array<any>)),
-        { func: callbackfn, thisVal: realm.intrinsics.undefined }
-      );
-    }
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -35,7 +35,6 @@ import {
   HasSomeCompatibleType,
 } from "../../methods/index.js";
 import { Create, Properties, To } from "../../singletons.js";
-import { FatalError, CompilerDiagnostic } from "../../errors.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.31

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -422,21 +422,23 @@ export default function(realm: Realm): NativeFunctionValue {
       // 1. Let obj be ? ToObject(O).
       let obj = To.ToObject(realm, O);
 
-      // If we're in pure scope and the items are completely abstract,
-      // then create an abstract temporal with an array kind
-      if (realm.isInPureScope() && obj instanceof AbstractObjectValue) {
-        let array = ArrayValue.createTemporalWithWidenedNumericProperty(
-          realm,
-          [objectValues, obj],
-          ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
-        );
-        return array;
-      } else if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(obj)) {
-        return ArrayValue.createTemporalWithWidenedNumericProperty(
-          realm,
-          [objectValues, obj],
-          ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
-        );
+      if (realm.isInPureScope()) {
+        // If we're in pure scope and the items are completely abstract,
+        // then create an abstract temporal with an array kind
+        if (obj instanceof AbstractObjectValue) {
+          let array = ArrayValue.createTemporalWithWidenedNumericProperty(
+            realm,
+            [objectValues, obj],
+            ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
+          );
+          return array;
+        } else if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(obj)) {
+          return ArrayValue.createTemporalWithWidenedNumericProperty(
+            realm,
+            [objectValues, obj],
+            ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
+          );
+        }
       }
 
       // 2. Let nameList be ? EnumerableOwnProperties(obj, "value").

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -403,6 +403,10 @@ export default function(realm: Realm): NativeFunctionValue {
         ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
       );
       return array;
+    } else if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(obj)) {
+      return ArrayValue.createTemporalWithWidenedNumericProperty(realm, [objectKeys, obj], ([methodNode, objNode]) =>
+        t.callExpression(methodNode, [objNode])
+      );
     }
 
     // 2. Let nameList be ? EnumerableOwnProperties(obj, "key").
@@ -413,10 +417,27 @@ export default function(realm: Realm): NativeFunctionValue {
   });
 
   // ECMA262 9.1.2.16
-  if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
-    func.defineNativeMethod("values", 1, (context, [O]) => {
+  if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile")) {
+    let objectValues = func.defineNativeMethod("values", 1, (context, [O]) => {
       // 1. Let obj be ? ToObject(O).
       let obj = To.ToObject(realm, O);
+
+      // If we're in pure scope and the items are completely abstract,
+      // then create an abstract temporal with an array kind
+      if (realm.isInPureScope() && obj instanceof AbstractObjectValue) {
+        let array = ArrayValue.createTemporalWithWidenedNumericProperty(
+          realm,
+          [objectValues, obj],
+          ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
+        );
+        return array;
+      } else if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(obj)) {
+        return ArrayValue.createTemporalWithWidenedNumericProperty(
+          realm,
+          [objectValues, obj],
+          ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
+        );
+      }
 
       // 2. Let nameList be ? EnumerableOwnProperties(obj, "value").
       let nameList = EnumerableOwnProperties(realm, obj.throwIfNotConcreteObject(), "value");
@@ -424,12 +445,30 @@ export default function(realm: Realm): NativeFunctionValue {
       // 3. Return CreateArrayFromList(nameList).
       return Create.CreateArrayFromList(realm, nameList);
     });
+  }
 
   // ECMA262 19.1.2.17
-  if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
-    func.defineNativeMethod("entries", 1, (context, [O]) => {
+  if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile")) {
+    let objectEntries = func.defineNativeMethod("entries", 1, (context, [O]) => {
       // 1. Let obj be ? ToObject(O).
       let obj = To.ToObject(realm, O);
+
+      // If we're in pure scope and the items are completely abstract,
+      // then create an abstract temporal with an array kind
+      if (realm.isInPureScope() && obj instanceof AbstractObjectValue) {
+        let array = ArrayValue.createTemporalWithWidenedNumericProperty(
+          realm,
+          [objectEntries, obj],
+          ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
+        );
+        return array;
+      } else if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(obj)) {
+        return ArrayValue.createTemporalWithWidenedNumericProperty(
+          realm,
+          [objectEntries, obj],
+          ([methodNode, objNode]) => t.callExpression(methodNode, [objNode])
+        );
+      }
 
       // 2. Let nameList be ? EnumerableOwnProperties(obj, "key+value").
       let nameList = EnumerableOwnProperties(realm, obj.throwIfNotConcreteObject(), "key+value");
@@ -437,6 +476,7 @@ export default function(realm: Realm): NativeFunctionValue {
       // 3. Return CreateArrayFromList(nameList).
       return Create.CreateArrayFromList(realm, nameList);
     });
+  }
 
   // ECMA262 19.1.2.18
   func.defineNativeMethod("preventExtensions", 1, (context, [O]) => {

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1231,7 +1231,11 @@ export class PropertiesImplementation {
         }
         AbstractValue.reportIntrospectionError(O, P);
         throw new FatalError();
-      } else if (realm.invariantLevel >= 2 && O.isIntrinsic()) {
+      } else if (
+        realm.invariantLevel >= 2 &&
+        O.isIntrinsic() &&
+        !ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O)
+      ) {
         let realmGenerator = realm.generator;
         // TODO: Because global variables are special, checking for missing global object properties doesn't quite work yet.
         if (

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -889,6 +889,7 @@ export class Generator {
     let value = buildValue(id.name);
     if (value instanceof ObjectValue) {
       value.intrinsicNameGenerated = true;
+      value._isScopedTemplate = true; // because this object doesn't exist ahead of time, and the visitor would otherwise declare it in the common scope
     }
     this._addEntry({
       isPure: optionalArgs ? optionalArgs.isPure : undefined,

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -13,7 +13,7 @@ import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor, ObjectKind } from "../types.js";
 import { AbstractValue, ObjectValue, StringValue, NumberValue, Value } from "./index.js";
 import { IsAccessorDescriptor, IsPropertyKey, IsArrayIndex } from "../methods/is.js";
-import { Properties, To } from "../singletons.js";
+import { Create, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeExpression } from "babel-types";
 
@@ -102,7 +102,11 @@ export default class ArrayValue extends ObjectValue {
   ): ArrayValue {
     invariant(realm.generator !== undefined);
     let value = realm.generator.deriveConcrete(
-      intrinsicName => new ArrayValue(realm, intrinsicName),
+      intrinsicName => {
+        let a = Create.ArrayCreate(realm, 0);
+        a.intrinsicName = intrinsicName;
+        return a;
+      },
       args,
       buildFunction,
       { isPure: true }
@@ -116,6 +120,13 @@ export default class ArrayValue extends ObjectValue {
       },
       object: value,
     };
+    // Make length abstract
+    Properties.ArraySetLength(realm, value, {
+      value: AbstractValue.createFromType(realm, NumberValue),
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
     if (realm.react.enabled && reactArrayHint !== undefined) {
       realm.react.arrayHints.set(value, reactArrayHint);
     }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -661,14 +661,7 @@ export default class ObjectValue extends ConcreteValue {
           // these are safe methods to allow, as they return a new array
           // so we use the ordinary get for these cases. Reduce can be
           // unsafe, but we check for that in the prototype method
-          if (
-            propName === "map" ||
-            propName === "reduce" ||
-            propName === "reduceRight" ||
-            propName === "slice" ||
-            propName === "filter" ||
-            propName === "concat"
-          ) {
+          if (propName === "map" || propName === "slice" || propName === "filter" || propName === "concat") {
             invariant(Receiver instanceof ObjectValue);
             return OrdinaryGet(this.$Realm, Receiver, P, Receiver);
           }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -646,16 +646,49 @@ export default class ObjectValue extends ConcreteValue {
       invariant(desc !== undefined);
       let val = desc.value;
       invariant(val instanceof AbstractValue);
-      let propName;
+      let propValue;
       if (P instanceof StringValue) {
-        propName = P;
+        propValue = P;
       } else if (typeof P === "string") {
-        propName = new StringValue(this.$Realm, P);
-      } else {
+        propValue = new StringValue(this.$Realm, P);
+      }
+
+      if (val.kind === "widened numeric property") {
+        let propName;
+
+        if (propValue instanceof StringValue) {
+          propName = propValue.value;
+          // these are safe methods to allow, as they return a new array
+          // so we use the ordinary get for these cases. Reduce can be
+          // unsafe, but we check for that in the prototype method
+          if (
+            propName === "map" ||
+            propName === "reduce" ||
+            propName === "reduceRight" ||
+            propName === "slice" ||
+            propName === "filter" ||
+            propName === "concat"
+          ) {
+            invariant(Receiver instanceof ObjectValue);
+            return OrdinaryGet(this.$Realm, Receiver, P, Receiver);
+          }
+        } else if (P instanceof SymbolValue) {
+          propValue = P;
+        }
+        invariant(propValue);
+        return AbstractValue.createTemporalFromBuildFunction(
+          this.$Realm,
+          val.getType(),
+          [Receiver, propValue],
+          ([o, p]) => {
+            return t.memberExpression(o, p, true);
+          }
+        );
+      } else if (!propValue) {
         AbstractValue.reportIntrospectionError(val, "abstract computed property name");
         throw new FatalError();
       }
-      return this.specializeJoin(val, Receiver, propName);
+      return this.specializeJoin(val, propValue);
     }
 
     // 1. Return ? OrdinaryGet(O, P, Receiver).
@@ -754,7 +787,7 @@ export default class ObjectValue extends ConcreteValue {
       if (desc !== undefined) {
         let val = desc.value;
         invariant(val instanceof AbstractValue);
-        result = this.specializeJoin(val, Receiver, P);
+        result = this.specializeJoin(val, P);
       }
     }
     // Join in all of the other values that were written to the object with
@@ -778,7 +811,7 @@ export default class ObjectValue extends ConcreteValue {
     return result;
   }
 
-  specializeJoin(absVal: AbstractValue, Receiver: Value, propName: Value): Value {
+  specializeJoin(absVal: AbstractValue, propName: Value): Value {
     if (absVal.kind === "widened property") {
       let ob = absVal.args[0];
       if (propName instanceof StringValue) {
@@ -789,31 +822,13 @@ export default class ObjectValue extends ConcreteValue {
       return AbstractValue.createTemporalFromBuildFunction(this.$Realm, absVal.getType(), [ob, propName], ([o, p]) => {
         return t.memberExpression(o, p, true);
       });
-    } else if (absVal.kind === "widened numeric property") {
-      invariant(propName instanceof StringValue);
-      let P = propName.value;
-      // these are safe methods to allow, as they return a new array
-      // so we use the ordinary get for these cases. Reduce can be
-      // unsafe, but we check for that in the prototype method
-      if (P === "map" || P === "reduce" || P === "slice" || P === "filter" || P === "concat") {
-        invariant(Receiver instanceof ObjectValue);
-        return OrdinaryGet(this.$Realm, Receiver, P, Receiver);
-      }
-      return AbstractValue.createTemporalFromBuildFunction(
-        this.$Realm,
-        absVal.getType(),
-        [Receiver, propName],
-        ([o, p]) => {
-          return t.memberExpression(o, p, true);
-        }
-      );
     }
     invariant(absVal.args.length === 3 && absVal.kind === "conditional");
     let generic_cond = absVal.args[0];
     invariant(generic_cond instanceof AbstractValue);
     let cond = this.specializeCond(generic_cond, propName);
     let arg1 = absVal.args[1];
-    if (arg1 instanceof AbstractValue && arg1.args.length === 3) arg1 = this.specializeJoin(arg1, Receiver, propName);
+    if (arg1 instanceof AbstractValue && arg1.args.length === 3) arg1 = this.specializeJoin(arg1, propName);
     let arg2 = absVal.args[2];
     if (arg2 instanceof AbstractValue) {
       if (arg2.kind === "template for prototype member expression") {
@@ -822,7 +837,7 @@ export default class ObjectValue extends ConcreteValue {
           t.memberExpression(o, p, true)
         );
       } else if (arg2.args.length === 3) {
-        arg2 = this.specializeJoin(arg2, Receiver, propName);
+        arg2 = this.specializeJoin(arg2, propName);
       }
     }
     return AbstractValue.createFromConditionalOp(this.$Realm, cond, arg1, arg2, absVal.expressionLocation);

--- a/test/serializer/additional-functions/ArrayConcat.js
+++ b/test/serializer/additional-functions/ArrayConcat.js
@@ -1,0 +1,14 @@
+
+function fn(arg) {
+  var x = Array.from(arg).map(x => x);
+  return ["start"].concat(x).concat(["end"]);
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify([
+    fn([1, 2, 3]),
+    fn([4, 5, 6]),
+  ])
+};

--- a/test/serializer/additional-functions/FunctionApply.js
+++ b/test/serializer/additional-functions/FunctionApply.js
@@ -1,0 +1,21 @@
+function inner(a, b, c) {
+  return {
+    a,
+    b,
+    c,
+  };
+}
+
+function fn(arg) {
+  var x = Array.from(arg).map(x => x);
+  return inner.apply(null, x);
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify([
+    fn([1, 2, 3]),
+    fn([4, 5, 6]),
+  ])
+};

--- a/test/serializer/optimized-functions/ArrayFrom.js
+++ b/test/serializer/optimized-functions/ArrayFrom.js
@@ -1,0 +1,32 @@
+function inner(props) {
+  var foo = Array.from(props.foo);
+  var bar = foo.filter(Boolean);
+
+  bar[0];
+
+  if (bar.length === 0) {
+    return null;
+  }
+
+  return 42;
+}
+
+function fn(arg) {
+  if (!arg.condition) {
+    return null
+  }
+  return inner(arg)
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify([
+    fn({condition: false}),
+    fn({condition: true, foo: []}),
+    fn({condition: true, foo: [false]}),
+    fn({condition: true, foo: [true]}),
+    fn({condition: true, foo: [false, 5]}),
+    fn({condition: true, foo: [true, 5]}),
+  ])
+};


### PR DESCRIPTION
Release note: Fixes problem with result of Array.filter (and similar) applied to arrays with unknown properties

Closes: #1924

Generator.deriveConcrete can result in temporal object values. These must be marked with _isScopedTemplate to prevent them from being hoisted.