### PR TITLE
Fix ESLint crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint": "^4.18.2",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-flow-header": "^0.1.1",
-    "eslint-plugin-flowtype": "^2.20.0",
+    "eslint-plugin-flowtype": "^2.40.0",
     "eslint-plugin-header": "^1.0.0",
     "eslint-plugin-prettier": "^2.1.2",
     "flow-bin": "^0.71.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,9 +3133,9 @@ eslint-plugin-flow-vars@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-flow-vars/-/eslint-plugin-flow-vars-0.1.3.tgz#50f70bffde5f1d438e1e474200540fd343919204"
 
-eslint-plugin-flowtype@^2.20.0:
-  version "2.35.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.0.tgz#d17494f0ae8b727c632d8b9d4b4a848e7e0c04af"
+eslint-plugin-flowtype@^2.40.0:
+  version "2.46.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.46.3.tgz#7e84131d87ef18b496b1810448593374860b4e8e"
   dependencies:
     lodash "^4.15.0"
 


### PR DESCRIPTION
Release note: None
ESLint crashes with the flow fix I did earlier. Turns out updating ESLint to latest version fixed it.