### PR TITLE
Don't serialize changes to property bindings that represent internal slots

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1094,6 +1094,17 @@ export class ResidualHeapVisitor {
       visitModifiedObjectProperty: (binding: PropertyBinding) => {
         let fixpoint_rerun = () => {
           if (this.values.has(binding.object)) {
+            if (binding.internalSlot) {
+              invariant(typeof binding.key === "string");
+              let error = new CompilerDiagnostic(
+                `Internal slot ${binding.key} modified in a nested context. This is not yet supported.`,
+                binding.object.expressionLocation,
+                "PP1006",
+                "FatalError"
+              );
+              this.realm.handleError(error) === "Fail";
+              throw new FatalError();
+            }
             this.visitValue(binding.object);
             if (binding.key instanceof Value) this.visitValue(binding.key);
             this.visitObjectProperty(binding);

--- a/src/types.js
+++ b/src/types.js
@@ -138,6 +138,7 @@ export type PropertyBinding = {
   key: void | string | SymbolValue | AbstractValue, // where an abstract value must be of type String or Number or Symbol
   // contains a build node that produces a member expression that resolves to this property binding (location)
   pathNode?: AbstractValue,
+  internalSlot?: boolean,
 };
 
 export type LexicalEnvironmentTypes = "global" | "module" | "script" | "function" | "block" | "catch" | "loop" | "with";

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -750,7 +750,7 @@ export class Generator {
         message += `
   ${objectStack.value}`;
     }
-    const diagnostic = new CompilerDiagnostic(message, value.expressionLocation, "PP1023", "Warning");
+    const diagnostic = new CompilerDiagnostic(message, value.expressionLocation, "PP0023", "Warning");
     this.realm.handleError(diagnostic);
   }
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -158,6 +158,7 @@ export default class ObjectValue extends ConcreteValue {
               descriptor: desc,
               object: this,
               key: propName,
+              internalSlot: true,
             };
           }
           this.$Realm.recordModifiedProperty(binding);

--- a/test/error-handler/ModifiedObjectPropertyLimitation.js
+++ b/test/error-handler/ModifiedObjectPropertyLimitation.js
@@ -1,0 +1,13 @@
+// expected errors: [{"location":{"start":{"line":5,"column":16},"end":{"line":5,"column":18},"source":"test/error-handler/ModifiedObjectPropertyLimitation.js"},"severity":"Warning","errorCode":"PP0023","callStack":"Error\n    "},{"location":{"start":{"line":5,"column":16},"end":{"line":5,"column":18},"source":"test/error-handler/ModifiedObjectPropertyLimitation.js"},"severity":"FatalError","errorCode":"PP1006","callStack":"Error\n    "}]
+(function () {
+    let p = {};
+    function f(c) {
+        let o = {};
+        if (c) {
+            o.__proto__ = p;
+            throw o;
+        }
+    }
+    if (global.__optimize) __optimize(f);
+    inspect = function() { try { f(true); } catch (e) { return e.$Prototype === p; } }
+})();


### PR DESCRIPTION
Release notes: None

This fixes #1856, at least in the sense that Prepack won't silently generate wrong code.
Instead, Prepack will now issue an error indicating that a Prepack limitation was hit.

Adding error-handler regression test.

Also fixed reference to PP1023 (no wiki page) to be PP0023 (matching wiki page) instead.