### PR TITLE
Fix frozen lazy objects

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1563,7 +1563,11 @@ export class ResidualHeapSerializer {
   }
 
   // Overridable.
-  serializeValueRawObject(val: ObjectValue, skipPrototype: boolean): BabelNodeExpression {
+  serializeValueRawObject(
+    val: ObjectValue,
+    skipPrototype: boolean,
+    emitIntegrityCommand: void | (SerializedBody => void)
+  ): BabelNodeExpression {
     let remainingProperties = new Map(val.properties);
     const dummyProperties = new Set();
     let props = [];
@@ -1650,7 +1654,10 @@ export class ResidualHeapSerializer {
     }
   }
 
-  serializeValueObject(val: ObjectValue): BabelNodeExpression | void {
+  serializeValueObject(
+    val: ObjectValue,
+    emitIntegrityCommand: void | (SerializedBody => void)
+  ): BabelNodeExpression | void {
     // If this object is a prototype object that was implicitly created by the runtime
     // for a constructor, then we can obtain a reference to this object
     // in a special way that's handled alongside function serialization.
@@ -1741,7 +1748,7 @@ export class ResidualHeapSerializer {
 
         return createViaAuxiliaryConstructor || _constructor
           ? this._serializeValueObjectViaConstructor(val, skipPrototype, _constructor)
-          : this.serializeValueRawObject(val, skipPrototype);
+          : this.serializeValueRawObject(val, skipPrototype, emitIntegrityCommand);
     }
   }
 
@@ -1857,6 +1864,7 @@ export class ResidualHeapSerializer {
 
     let objectSemaphore;
     let targetCommand = this.residualHeapInspector.getTargetIntegrityCommand(obj);
+    let emitIntegrityCommand;
     if (targetCommand) {
       let body = this.emitter.getBody();
       objectSemaphore = new CountingSemaphore(() => {
@@ -1874,6 +1882,14 @@ export class ResidualHeapSerializer {
         );
       });
       this._objectSemaphores.set(obj, objectSemaphore);
+      emitIntegrityCommand = alternateBody => {
+        if (objectSemaphore !== undefined) {
+          if (alternateBody !== undefined) body = alternateBody;
+          objectSemaphore.releaseOne();
+          this._objectSemaphores.delete(obj);
+        }
+        objectSemaphore = undefined;
+      };
     }
     let res;
     if (IsArray(this.realm, obj)) {
@@ -1881,12 +1897,9 @@ export class ResidualHeapSerializer {
     } else if (obj instanceof FunctionValue) {
       res = this._serializeValueFunction(obj);
     } else {
-      res = this.serializeValueObject(obj);
+      res = this.serializeValueObject(obj, emitIntegrityCommand);
     }
-    if (objectSemaphore !== undefined) {
-      objectSemaphore.releaseOne();
-      this._objectSemaphores.delete(obj);
-    }
+    if (emitIntegrityCommand !== undefined) emitIntegrityCommand();
     return res;
   }
 

--- a/test/serializer/basic/FrozenLazyObject.js
+++ b/test/serializer/basic/FrozenLazyObject.js
@@ -1,0 +1,6 @@
+(function() {
+    let o = {foo: 42};
+    Object.freeze(o);
+    global.o = o;
+    inspect = function() { return o.foo; }
+})();


### PR DESCRIPTION
Release notes: None

The `Object.freeze` command (or similar) was put into the body
where the object was allocated, not where it got initialized.
This would cause the initialization code to silently fail later on when the object was used for the first time.

This fixes it, and adds a regression test.