### PR TITLE
Put EmptyValue into correct join branch

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -923,8 +923,8 @@ export class JoinImplementation {
     let getAbstractValue = (v1: void | Value, v2: void | Value) => {
       return this.joinValuesAsConditional(realm, joinCondition, v1, v2);
     };
-    let clone_with_abstract_value = (useD1: Boolean) => {
-      const d: Descriptor = useD1 ? d1 : d2;
+    let clone_with_abstract_value = (d: Descriptor) => {
+      invariant(d === d1 || d === d2);
       if (!IsDataDescriptor(realm, d)) {
         let d3: Descriptor = {};
         d3.joinCondition = joinCondition;
@@ -938,40 +938,43 @@ export class JoinImplementation {
         let elem0 = dcValue[0];
         if (elem0 instanceof Value) {
           dc.value = dcValue.map(e => {
-            return useD1
+            return d === d1
               ? getAbstractValue((e: any), realm.intrinsics.empty)
               : getAbstractValue(realm.intrinsics.empty, (e: any));
           });
         } else {
           dc.value = dcValue.map(e => {
             let { $Key: key1, $Value: val1 } = (e: any);
-            let key3 = useD1
-              ? getAbstractValue(key1, realm.intrinsics.empty)
-              : getAbstractValue(realm.intrinsics.empty, key1);
-            let val3 = useD1
-              ? getAbstractValue(val1, realm.intrinsics.empty)
-              : getAbstractValue(realm.intrinsics.empty, val1);
+            let key3 =
+              d === d1
+                ? getAbstractValue(key1, realm.intrinsics.empty)
+                : getAbstractValue(realm.intrinsics.empty, key1);
+            let val3 =
+              d === d1
+                ? getAbstractValue(val1, realm.intrinsics.empty)
+                : getAbstractValue(realm.intrinsics.empty, val1);
             return { $Key: key3, $Value: val3 };
           });
         }
       } else {
         invariant(dcValue === undefined || dcValue instanceof Value);
-        dc.value = useD1
-          ? getAbstractValue(dcValue, realm.intrinsics.empty)
-          : getAbstractValue(realm.intrinsics.empty, dcValue);
+        dc.value =
+          d === d1
+            ? getAbstractValue(dcValue, realm.intrinsics.empty)
+            : getAbstractValue(realm.intrinsics.empty, dcValue);
       }
       return dc;
     };
     if (d1 === undefined) {
       if (d2 === undefined) return undefined;
       // d2 is a new property created in only one branch, join with empty
-      let d3 = clone_with_abstract_value(false);
+      let d3 = clone_with_abstract_value(d2);
       if (!IsDataDescriptor(realm, d2)) d3.descriptor2 = d2;
       return d3;
     } else if (d2 === undefined) {
       invariant(d1 !== undefined);
       // d1 is a new property created in only one branch, join with empty
-      let d3 = clone_with_abstract_value(true);
+      let d3 = clone_with_abstract_value(d1);
       if (!IsDataDescriptor(realm, d1)) d3.descriptor1 = d1;
       return d3;
     } else {

--- a/test/serializer/abstract/ConditionalEmptyProperty.js
+++ b/test/serializer/abstract/ConditionalEmptyProperty.js
@@ -1,0 +1,22 @@
+(function() {
+  function fn(arg) {
+    var obj1 = {};
+    var obj2 = {};
+    if (arg) {
+      obj2.bar = true;
+    } else {
+      obj1.foo = true;
+    }
+    return {obj1, obj2};
+  }
+
+  if (global.__optimize) __optimize(fn);
+
+  global.inspect = function() {
+    return JSON.stringify([
+      fn(null),
+      fn(undefined),
+      fn(10),
+    ]);
+  }
+})();


### PR DESCRIPTION
Fixes https://github.com/facebook/prepack/issues/1935.
The issue was that we'd always put `EmptyValue` into the right branch even if it happened in the left one.

Adds a regression test.