### PR TITLE
Fix havoc logic for conditional abstracts

### DIFF
--- a/test/serializer/optimized-functions/RegressionTestForIssue1883.js
+++ b/test/serializer/optimized-functions/RegressionTestForIssue1883.js
@@ -1,0 +1,30 @@
+(function() {
+  function save(obj, x) {
+    if (!obj[x]) {
+      obj[x] = x;
+    }
+  }
+  
+  function fn(arg) {
+    var obj = {};
+    if (arg != null) {
+      save(obj);
+    } else {
+      save(obj, arg === 1 ? 'a' : 'b');
+      save(obj);
+    }
+    return obj;
+  }
+
+  if (global.__optimize) __optimize(fn);
+
+  global.inspect = function() {
+    return JSON.stringify([
+      fn(null),
+      fn(undefined),
+      fn(1),
+      fn({})
+    ]);
+  };
+
+})();


### PR DESCRIPTION
Fixes https://github.com/facebook/prepack/issues/1883.

As I noted there,

>This seems to happen because the logic in `visitObjectPropertiesWithComputedNames` hasn't been updated in the same way that [its twin in the residual heap visitor has been](https://github.com/facebook/prepack/blob/aa700a2667f5c28754ae2dad2a64a3ad4191276a/src/serializer/ResidualHeapVisitor.js#L361-L388).

This brings them in line.

Regression case included. It used to fail with bad output even after this change, but https://github.com/facebook/prepack/pull/1937 fixed that, so now it passes.