### PR TITLE
Replace expensive second babel-traverse pass with fast custom visitor.

### DIFF
--- a/flow-typed/npm/babel-types_vx.x.x.js
+++ b/flow-typed/npm/babel-types_vx.x.x.js
@@ -201,7 +201,7 @@ declare module "babel-types" {
 
   declare class BabelNodeArrayExpression extends BabelNode {
     type: "ArrayExpression";
-    elements?: Array<void | BabelNodeExpression | BabelNodeSpreadElement>;
+    elements: Array<void | BabelNodeExpression | BabelNodeSpreadElement>;
   }
 
   declare class BabelNodeAssignmentExpression extends BabelNode {
@@ -1066,7 +1066,7 @@ declare module "babel-types" {
   declare type BabelNodeJSX = BabelNodeJSXAttribute | BabelNodeJSXClosingElement | BabelNodeJSXElement | BabelNodeJSXEmptyExpression | BabelNodeJSXExpressionContainer | BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression | BabelNodeJSXNamespacedName | BabelNodeJSXOpeningElement | BabelNodeJSXSpreadAttribute | BabelNodeJSXText;
 
   declare function anyTypeAnnotation(): BabelNodeAnyTypeAnnotation;
-  declare function arrayExpression(elements?: Array<null | BabelNodeExpression | BabelNodeSpreadElement>): BabelNodeArrayExpression;
+  declare function arrayExpression(elements: Array<null | BabelNodeExpression | BabelNodeSpreadElement>): BabelNodeArrayExpression;
   declare function arrayPattern(elements: Array<BabelNodeExpression>, typeAnnotation: any, decorators?: Array<BabelNodeDecorator>): BabelNodeArrayPattern;
   declare function arrayTypeAnnotation(elementType: any): BabelNodeArrayTypeAnnotation;
   declare function arrowFunctionExpression(params: Array<BabelNodeLVal>, body: BabelNodeBlockStatement | BabelNodeExpression, async?: boolean, returnType?: any, typeParameters?: any): BabelNodeArrowFunctionExpression;

--- a/src/serializer/ResidualFunctionInstantiator.js
+++ b/src/serializer/ResidualFunctionInstantiator.js
@@ -1,0 +1,315 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import * as t from "babel-types";
+import { convertExpressionToJSXIdentifier } from "../react/jsx";
+import type Value from "../values/Value.js";
+import type {
+  BabelNodeBinaryExpression,
+  BabelNodeCallExpression,
+  BabelNodeFunctionExpression,
+  BabelNodeExpression,
+  BabelNodeClassMethod,
+  BabelNodeWhileStatement,
+  BabelNodeJSXIdentifier,
+  BabelNodeJSXMemberExpression,
+  BabelNodeConditionalExpression,
+  BabelNodeIfStatement,
+  BabelNodeLogicalExpression,
+  BabelNodeBooleanLiteral,
+  BabelNodeNumericLiteral,
+  BabelNodeStringLiteral,
+  BabelNodeUnaryExpression,
+  BabelNodeClassExpression,
+  BabelNodeObjectExpression,
+  BabelNodeArrayExpression,
+  BabelNodeSpreadElement,
+  BabelNodeLabeledStatement,
+} from "babel-types";
+import type { FunctionBodyAstNode } from "../types.js";
+import type { FactoryFunctionInfo } from "./types.js";
+import { nullExpression } from "../utils/internalizer.js";
+
+function canShareFunctionBody(duplicateFunctionInfo: FactoryFunctionInfo): boolean {
+  if (duplicateFunctionInfo.anyContainingAdditionalFunction) {
+    // If the function is referenced by an optimized function,
+    // it may get emitted within that optimized function,
+    // and then the function name is not generally available in arbitrary other code
+    // where we'd like to replace the body with a reference to the extracted function body.
+    // TODO: Revisit interplay of factory function concept, scope concept, and optimized functions.
+    return false;
+  }
+
+  // Only share function when:
+  // 1. it does not access any free variables.
+  // 2. it does not use "this".
+  const { unbound, modified, usesThis } = duplicateFunctionInfo.functionInfo;
+  return unbound.size === 0 && modified.size === 0 && !usesThis;
+}
+
+export type Truthiness = void | boolean; // undefined means unknown
+
+export type Replacement = {
+  node: BabelNodeExpression,
+  truthiness: Truthiness,
+};
+
+export function getReplacement(node: BabelNodeExpression, value: void | Value): Replacement {
+  let truthiness;
+  if (value !== undefined)
+    if (!value.mightNotBeFalse()) truthiness = false;
+    else if (!value.mightNotBeTrue()) truthiness = true;
+  return { node, truthiness };
+}
+
+export function isPure(node: BabelNodeExpression | BabelNodeSpreadElement): boolean {
+  switch (node.type) {
+    case "NullLiteral":
+    case "BooleanLiteral":
+    case "StringLiteral":
+    case "NumericLiteral":
+      return true;
+    case "UnaryExpression":
+    case "SpreadElement":
+      let unaryExpression = ((node: any): BabelNodeUnaryExpression | BabelNodeSpreadElement);
+      return isPure(unaryExpression.argument);
+    case "BinaryExpression":
+    case "LogicalExpression":
+      let binaryExpression = ((node: any): BabelNodeLogicalExpression | BabelNodeBinaryExpression);
+      return isPure(binaryExpression.left) && isPure(binaryExpression.right);
+    default:
+      return false;
+  }
+}
+
+// This class instantiates residual functions by replacing certain nodes,
+// i.e. bindings to captured scopes that need to get renamed to variable ids.
+// The original nodes are never mutated; instead, nodes are cloned as needed.
+// Along the way, some trivial code optimizations are performed as well.
+export class ResidualFunctionInstantiator<T: BabelNodeClassMethod | BabelNodeFunctionExpression> {
+  factoryFunctionInfos: Map<number, FactoryFunctionInfo>;
+  identifierReplacements: Map<BabelNodeIdentifier, Replacement>;
+  callReplacements: Map<BabelNodeCallExpression, Replacement>;
+  root: T;
+
+  constructor(
+    factoryFunctionInfos: Map<number, FactoryFunctionInfo>,
+    identifierReplacements: Map<BabelNodeIdentifier, Replacement>,
+    callReplacements: Map<BabelNodeCallExpression, Replacement>,
+    root: T
+  ) {
+    this.factoryFunctionInfos = factoryFunctionInfos;
+    this.identifierReplacements = identifierReplacements;
+    this.callReplacements = callReplacements;
+    this.root = root;
+  }
+
+  instantiate(): T {
+    return ((this._replace(this.root): any): T);
+  }
+
+  _getLiteralTruthiness(node: BabelNodeExpression): Truthiness {
+    switch (node.type) {
+      case "BooleanLiteral":
+      case "NumericLiteral":
+      case "StringLiteral":
+        return !!((node: any): BabelNodeBooleanLiteral | BabelNodeNumericLiteral | BabelNodeStringLiteral).value;
+      case "Identifier": {
+        let replacement = this.identifierReplacements.get(node);
+        if (replacement !== undefined) return replacement.truthiness;
+        return undefined;
+      }
+      case "CallExpression": {
+        let replacement = this.callReplacements.get(node);
+        if (replacement !== undefined) return replacement.truthiness;
+        return undefined;
+      }
+      case "FunctionExpression":
+      case "ArrowFunctionExpression":
+      case "RegExpLiteral":
+        return true;
+      case "ClassExpression":
+        let classExpression = ((node: any): BabelNodeClassExpression);
+        return classExpression.superClass === null && classExpression.body.body.length === 0 ? true : undefined;
+      case "ObjectExpression":
+        let objectExpression = ((node: any): BabelNodeObjectExpression);
+        return objectExpression.properties.every(property => isPure(property.key) && isPure(property.value))
+          ? true
+          : undefined;
+      case "ArrayExpression":
+        let arrayExpression = ((node: any): BabelNodeArrayExpression);
+        return arrayExpression.elements.every(element => element === undefined || isPure(element)) ? true : undefined;
+      case "NullLiteral":
+        return false;
+      case "UnaryExpression":
+        let unaryExpression = ((node: any): BabelNodeUnaryExpression);
+        return unaryExpression.operator === "void" && isPure(unaryExpression.argument) ? false : undefined;
+      default:
+        return undefined;
+    }
+  }
+
+  _replaceIdentifier(node: BabelNodeIdentifier): BabelNode {
+    let replacement = this.identifierReplacements.get(node);
+    if (replacement !== undefined) return replacement.node;
+    return node; // nothing else to replace in an identifier
+  }
+
+  _replaceJSXIdentifier(node: BabelNodeJSXIdentifier | BabelNodeJSXMemberExpression): BabelNode {
+    let replacement = this.identifierReplacements.get(node);
+    if (replacement !== undefined) return convertExpressionToJSXIdentifier(replacement.node, true);
+    return node; // nothing else to replace in an identifier
+  }
+
+  _replaceLabeledStatement(node: BabelNodeLabeledStatement): BabelNode {
+    // intentionally ignore embedded identifier
+    let newBody = this._replace(node.body);
+    if (newBody !== node.body) {
+      let res = Object.assign({}, node);
+      res.body = newBody;
+      return res;
+    }
+    return node; // nothing else to replace in a labeled statement
+  }
+
+  _replaceCallExpression(node: BabelNodeCallExpression): BabelNode {
+    let replacement = this.callReplacements.get(node);
+    if (replacement !== undefined) return replacement.node;
+    return this._replaceFallback(node);
+  }
+
+  _replaceFunctionExpression(node: BabelNodeFunctionExpression): BabelNode {
+    // Our goal is replacing duplicate nested function so skip root residual function itself.
+    if (this.root !== node) {
+      const functionExpression: BabelNodeFunctionExpression = node;
+      const functionTag = ((functionExpression.body: any): FunctionBodyAstNode).uniqueOrderedTag;
+      // Un-interpreted nested function?
+      if (functionTag !== undefined) {
+        // Un-interpreted nested function.
+
+        const duplicateFunctionInfo = this.factoryFunctionInfos.get(functionTag);
+        if (duplicateFunctionInfo && canShareFunctionBody(duplicateFunctionInfo)) {
+          const { factoryId } = duplicateFunctionInfo;
+          return t.callExpression(t.memberExpression(factoryId, t.identifier("bind")), [nullExpression]);
+        }
+      }
+    }
+
+    return this._replaceFallback(node);
+  }
+
+  _replaceIfStatement(node: BabelNodeIfStatement): BabelNode {
+    let testTruthiness = this._getLiteralTruthiness(node.test);
+    if (testTruthiness === true) {
+      // Strictly speaking this is not safe: Annex B.3.4 allows FunctionDeclarations as the body of IfStatements in sloppy mode,
+      // which have weird hoisting behavior: `console.log(typeof f); if (true) function f(){} console.log(typeof f)` will print 'undefined', 'function', but
+      // `console.log(typeof f); function f(){} console.log(typeof f)` will print 'function', 'function'.
+      // However, Babylon can't parse these, so it doesn't come up.
+      return this._replace(node.consequent);
+    } else if (testTruthiness === false) {
+      if (node.alternate !== null) {
+        return this._replace(node.alternate);
+      } else {
+        return t.emptyStatement();
+      }
+    }
+
+    return this._replaceFallback(node);
+  }
+
+  _replaceConditionalExpression(node: BabelNodeConditionalExpression): BabelNode {
+    let testTruthiness = this._getLiteralTruthiness(node.test);
+    if (testTruthiness !== undefined) {
+      return testTruthiness ? this._replace(node.consequent) : this._replace(node.alternate);
+    }
+
+    return this._replaceFallback(node);
+  }
+
+  _replaceLogicalExpression(node: BabelNodeLogicalExpression): BabelNode {
+    let leftTruthiness = this._getLiteralTruthiness(node.left);
+    if (node.operator === "&&" && leftTruthiness !== undefined) {
+      return leftTruthiness ? this._replace(node.right) : this._replace(node.left);
+    } else if (node.operator === "||" && leftTruthiness !== undefined) {
+      return leftTruthiness ? this._replace(node.left) : this._replace(node.right);
+    }
+
+    return this._replaceFallback(node);
+  }
+
+  _replaceWhileStatement(node: BabelNodeWhileStatement): BabelNode {
+    let testTruthiness = this._getLiteralTruthiness(node.test);
+    if (testTruthiness === false) {
+      return t.emptyStatement();
+    }
+
+    return this._replaceFallback(node);
+  }
+
+  _replaceFallback(node: BabelNode): BabelNode {
+    let newNode;
+    for (let key in node) {
+      let subNode = (node: any)[key];
+      if (!subNode) continue;
+      let newSubNode;
+      if (Array.isArray(subNode)) {
+        let newArray;
+        for (let i = 0; i < subNode.length; i++) {
+          let elementNode = subNode[i];
+          if (!elementNode) continue;
+          let newElementNode = this._replace(elementNode);
+          if (newElementNode !== elementNode) {
+            if (newArray === undefined) newArray = subNode.slice(0);
+            newArray[i] = newElementNode;
+          }
+        }
+        if (newArray === undefined) continue;
+        newSubNode = newArray;
+      } else if (subNode.type) {
+        newSubNode = this._replace(subNode);
+        if (newSubNode === subNode) continue;
+      } else continue;
+
+      if (newNode === undefined) newNode = Object.assign({}, node);
+      newNode[key] = newSubNode;
+    }
+    return newNode || node;
+  }
+
+  _replace(node: BabelNode): BabelNode {
+    switch (node.type) {
+      case "Identifier":
+        return this._replaceIdentifier(node);
+      case "LabeledStatement":
+        return this._replaceLabeledStatement(node);
+      case "BreakStatement":
+      case "ContinueStatement":
+        return node;
+      case "JSXIdentifier":
+      case "JSXMemberExpressions":
+        return this._replaceJSXIdentifier(node);
+      case "CallExpression":
+        return this._replaceCallExpression(node);
+      case "FunctionExpression":
+        return this._replaceFunctionExpression(node);
+      case "IfStatement":
+        return this._replaceIfStatement(node);
+      case "ConditionalExpression":
+        return this._replaceConditionalExpression(node);
+      case "LogicalExpression":
+        return this._replaceLogicalExpression(node);
+      case "WhileStatement":
+        return this._replaceWhileStatement(node);
+      default:
+        return this._replaceFallback(node);
+    }
+  }
+}

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -83,6 +83,7 @@ import type { Binding } from "../environment.js";
 import { DeclarativeEnvironmentRecord } from "../environment.js";
 import type { Referentializer } from "./Referentializer.js";
 import { GeneratorDAG } from "./GeneratorDAG.js";
+import { type Replacement, getReplacement } from "./ResidualFunctionInstantiator";
 
 function commentStatement(text: string) {
   let s = t.emptyStatement();
@@ -228,7 +229,7 @@ export class ResidualHeapSerializer {
   logger: Logger;
   modules: Modules;
   residualHeapValueIdentifiers: ResidualHeapValueIdentifiers;
-  requireReturns: Map<number | string, BabelNodeExpression>;
+  requireReturns: Map<number | string, Replacement>;
   residualHeapInspector: ResidualHeapInspector;
   residualValues: Map<Value, Set<Scope>>;
   residualFunctionInstances: Map<FunctionValue, FunctionInstance>;
@@ -2166,7 +2167,7 @@ export class ResidualHeapSerializer {
     // TODO #21: add event listeners
 
     for (let [moduleId, moduleValue] of this.modules.initializedModules)
-      this.requireReturns.set(moduleId, this.serializeValue(moduleValue));
+      this.requireReturns.set(moduleId, getReplacement(this.serializeValue(moduleValue), moduleValue));
 
     for (let [name, value] of this.declaredGlobalLets) {
       this.emitter.emit(

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -547,16 +547,16 @@ export class ResidualHeapVisitor {
     if (!functionInfo) {
       functionInfo = {
         depth: 0,
-        unbound: new Set(),
+        unbound: new Map(),
+        requireCalls: new Map(),
         modified: new Set(),
         usesArguments: false,
         usesThis: false,
       };
       let state = {
-        tryQuery: this.logger.tryQuery.bind(this.logger),
-        val,
         functionInfo,
         realm: this.realm,
+        getModuleIdIfNodeIsRequireFunction: this.modules.getGetModuleIdIfNodeIsRequireFunction(formalParameters, [val]),
       };
 
       traverse(
@@ -588,7 +588,7 @@ export class ResidualHeapVisitor {
       this._enqueueWithUnrelatedScope(val, () => {
         invariant(this.scope === val);
         invariant(functionInfo);
-        for (let innerName of functionInfo.unbound) {
+        for (let innerName of functionInfo.unbound.keys()) {
           let environment = this.resolveBinding(val, innerName);
           let residualBinding = this.getBinding(val, environment, innerName);
           this.visitBinding(val, residualBinding);
@@ -1190,7 +1190,6 @@ export class ResidualHeapVisitor {
       invariant(functionInfo !== undefined);
       let additionalFunctionInfo = {
         functionValue,
-        captures: functionInfo.unbound,
         modifiedBindings: modifiedBindingInfo,
         instance: funcInstance,
         hasReturn: !(result instanceof UndefinedValue),

--- a/src/serializer/factorify.js
+++ b/src/serializer/factorify.js
@@ -43,7 +43,7 @@ function isSameNode(left, right) {
   }
 
   if (type === "BooleanLiteral" || type === "StringLiteral" || type === "NumericLiteral") {
-    return left.value === right.value;
+    return Object.is(left.value, right.value);
   }
 
   if (type === "UnaryExpression") {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -52,7 +52,6 @@ export type AdditionalFunctionEffects = {
 
 export type AdditionalFunctionInfo = {
   functionValue: FunctionValue,
-  captures: Set<string>,
   // TODO: use for storing modified residual function bindings (captured by other functions)
   modifiedBindings: Map<Binding, ResidualFunctionBinding>,
   instance: FunctionInstance,
@@ -85,7 +84,8 @@ export type FunctionInstance = {
 
 export type FunctionInfo = {
   depth: number,
-  unbound: Set<string>,
+  unbound: Map<string, Array<BabelNodeIdentifier>>,
+  requireCalls: Map<BabelNode, number | string>,
   modified: Set<string>,
   usesArguments: boolean,
   usesThis: boolean,

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -10,248 +10,30 @@
 /* @flow */
 
 import { Realm } from "../realm.js";
-import { FunctionValue } from "../values/index.js";
 import * as t from "babel-types";
-import { convertExpressionToJSXIdentifier } from "../react/jsx";
-import type { BabelNodeExpression, BabelNodeCallExpression, BabelNodeFunctionExpression } from "babel-types";
+import type { BabelNodeCallExpression } from "babel-types";
 import type { BabelTraversePath, BabelTraverseScope } from "babel-traverse";
-import type { FunctionBodyAstNode } from "../types.js";
-import type { TryQuery, FunctionInfo, FactoryFunctionInfo, ResidualFunctionBinding } from "./types.js";
-import type { SerializerStatistics } from "./statistics.js";
-import { nullExpression } from "../utils/internalizer.js";
+import type { FunctionInfo } from "./types.js";
+
+type GetModuleIdIfNodeIsRequireFunction =
+  | void
+  | ((scope: BabelTraverseScope, node: BabelNodeCallExpression) => void | number | string);
 
 export type ClosureRefVisitorState = {
-  tryQuery: TryQuery<*>,
-  val: FunctionValue,
   functionInfo: FunctionInfo,
   realm: Realm,
+  getModuleIdIfNodeIsRequireFunction: GetModuleIdIfNodeIsRequireFunction,
 };
 
-export type ClosureRefReplacerState = {
-  residualFunctionBindings: Map<string, ResidualFunctionBinding>,
-  modified: Set<string>,
-  requireReturns: Map<number | string, BabelNodeExpression>,
-  statistics: SerializerStatistics,
-  getModuleIdIfNodeIsRequireFunction:
-    | void
-    | ((scope: BabelTraverseScope, node: BabelNodeCallExpression) => void | number | string),
-  factoryFunctionInfos: Map<number, FactoryFunctionInfo>,
-  replacedSomething: boolean,
-};
-
-function markVisited(node, data) {
-  (node: any)._renamedOnce = data;
-}
-
-function shouldVisit(node, data) {
-  return (node: any)._renamedOnce !== data;
-}
-
-// replaceWith causes the node to be re-analyzed, so to prevent double replacement
-// we add this property on the node to mark it such that it does not get replaced
-// again on this pass
-// TODO: Make this work when replacing with arbitrary BabelNodeExpressions. Currently
-//       if the node that we're substituting contains identifiers as children,
-//       they will be visited again and possibly transformed.
-//       If necessary we could implement this by following node.parentPath and checking
-//       if any parent nodes are marked visited, but that seem unnecessary right now.let closureRefReplacer = {
-function replaceName(path, residualFunctionBinding, name, data, state) {
-  // Let's skip names that are bound
-  if (path.scope.hasBinding(name, /*noGlobals*/ true)) return;
-
-  // Let's skip bindings that are referring to
-  // 1) something global (without an environment record), and
-  // 2) have not been assigned a value (which would mean that they have a var/let binding and Prepack will take the liberty to rename them).
-  if (residualFunctionBinding.declarativeEnvironmentRecord === null && residualFunctionBinding.value === undefined)
-    return;
-
-  if (shouldVisit(path.node, data)) {
-    let serializedValue = residualFunctionBinding.serializedValue;
-    markVisited(serializedValue, data);
-
-    if (path.node.type === "JSXIdentifier" || path.node.type === "JSXMemberIdentifier") {
-      path.replaceWith(convertExpressionToJSXIdentifier((serializedValue: any), true));
-      state.replacedSomething = true;
-    } else {
-      path.replaceWith(serializedValue);
-      state.replacedSomething = true;
-    }
-  }
-}
-
-function getLiteralTruthiness(node): { known: boolean, value?: boolean } {
-  // In the return value, 'known' is true only if this is a literal of known truthiness and with no side effects; if 'known' is true, 'value' is its truthiness.
-  if (t.isBooleanLiteral(node) || t.isNumericLiteral(node) || t.isStringLiteral(node)) {
-    return { known: true, value: !!node.value };
-  }
-  if (
-    t.isFunctionExpression(node) ||
-    t.isArrowFunctionExpression(node) ||
-    t.isRegExpLiteral(node) ||
-    (t.isClassExpression(node) && node.superClass === null && node.body.body.length === 0) ||
-    (t.isObjectExpression(node) && node.properties.length === 0) ||
-    (t.isArrayExpression(node) && node.elements.length === 0)
-  ) {
-    return { known: true, value: true };
-  }
-  if (t.isNullLiteral(node)) {
-    return { known: true, value: false };
-  }
-  return { known: false };
-}
-
-function canShareFunctionBody(duplicateFunctionInfo: FactoryFunctionInfo): boolean {
-  if (duplicateFunctionInfo.anyContainingAdditionalFunction) {
-    // If the function is referenced by an optimized function,
-    // it may get emitted within that optimized function,
-    // and then the function name is not generally available in arbitrary other code
-    // where we'd like to replace the body with a reference to the extracted function body.
-    // TODO: Revisit interplay of factory function concept, scope concept, and optimized functions.
-    return false;
-  }
-
-  // Only share function when:
-  // 1. it does not access any free variables.
-  // 2. it does not use "this".
-  const { unbound, modified, usesThis } = duplicateFunctionInfo.functionInfo;
-  return unbound.size === 0 && modified.size === 0 && !usesThis;
-}
-
-export let ClosureRefReplacer = {
-  ReferencedIdentifier(path: BabelTraversePath, state: ClosureRefReplacerState) {
-    if (ignorePath(path)) return;
-
-    let residualFunctionBindings = state.residualFunctionBindings;
-    let name = path.node.name;
-    let residualFunctionBinding = residualFunctionBindings.get(name);
-    if (residualFunctionBinding) replaceName(path, residualFunctionBinding, name, residualFunctionBindings, state);
-  },
-
-  CallExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
-    // Here we apply the require optimization by replacing require calls with their
-    // corresponding initialized modules.
-    let requireReturns = state.requireReturns;
-    if (state.getModuleIdIfNodeIsRequireFunction === undefined) return;
-    let moduleId = state.getModuleIdIfNodeIsRequireFunction(path.scope, path.node);
-    if (moduleId === undefined) return;
-
-    state.statistics.requireCalls++;
-    if (state.modified.has(path.node.callee.name)) return;
-
-    let new_node = requireReturns.get("" + moduleId);
-    if (new_node !== undefined) {
-      markVisited(new_node, state.residualFunctionBindings);
-      path.replaceWith(new_node);
-      state.statistics.requireCallsReplaced++;
-      state.replacedSomething = true;
-    }
-  },
-
-  "AssignmentExpression|UpdateExpression"(path: BabelTraversePath, state: ClosureRefReplacerState) {
-    let residualFunctionBindings = state.residualFunctionBindings;
-    let ids = path.getBindingIdentifierPaths();
-    for (let name in ids) {
-      let residualFunctionBinding = residualFunctionBindings.get(name);
-      if (residualFunctionBinding) {
-        let nestedPath = ids[name];
-        replaceName(nestedPath, residualFunctionBinding, name, residualFunctionBindings, state);
-      }
-    }
-  },
-
-  // TODO: handle FunctionDeclaration.
-  // Replace "function () {}" ==> "factory_id.bind(null)".
-  FunctionExpression(path: BabelTraversePath, state: ClosureRefReplacerState) {
-    if (t.isProgram(path.parentPath.parentPath.node)) {
-      // Our goal is replacing duplicate nested function so skip root residual function itself.
-      // This assumes the root function is wrapped with: t.file(t.program([t.expressionStatement(rootFunction).
-      return;
-    }
-
-    const functionExpression: BabelNodeFunctionExpression = path.node;
-    const functionTag = ((functionExpression.body: any): FunctionBodyAstNode).uniqueOrderedTag;
-    if (!functionTag) {
-      // Un-interpreted nested function.
-      return;
-    }
-    const duplicateFunctionInfo = state.factoryFunctionInfos.get(functionTag);
-    if (duplicateFunctionInfo && canShareFunctionBody(duplicateFunctionInfo)) {
-      const { factoryId } = duplicateFunctionInfo;
-      path.replaceWith(t.callExpression(t.memberExpression(factoryId, t.identifier("bind")), [nullExpression]));
-      state.replacedSomething = true;
-    }
-  },
-
-  // A few very simple dead code elimination helpers. Eventually these should be subsumed by the partial evaluators.
-  IfStatement: {
-    exit: function(path: BabelTraversePath, state: ClosureRefReplacerState) {
-      let node = path.node;
-      let testTruthiness = getLiteralTruthiness(node.test);
-      if (testTruthiness.known) {
-        if (testTruthiness.value) {
-          // Strictly speaking this is not safe: Annex B.3.4 allows FunctionDeclarations as the body of IfStatements in sloppy mode,
-          // which have weird hoisting behavior: `console.log(typeof f); if (true) function f(){} console.log(typeof f)` will print 'undefined', 'function', but
-          // `console.log(typeof f); function f(){} console.log(typeof f)` will print 'function', 'function'.
-          // However, Babylon can't parse these, so it doesn't come up.
-          path.replaceWith(node.consequent);
-          state.replacedSomething = true;
-        } else {
-          if (node.alternate !== null) {
-            path.replaceWith(node.alternate);
-            state.replacedSomething = true;
-          } else {
-            path.remove();
-            state.replacedSomething = true;
-          }
-        }
-      }
-    },
-  },
-
-  ConditionalExpression: {
-    exit: function(path: BabelTraversePath, state: ClosureRefReplacerState) {
-      let node = path.node;
-      let testTruthiness = getLiteralTruthiness(node.test);
-      if (testTruthiness.known) {
-        path.replaceWith(testTruthiness.value ? node.consequent : node.alternate);
-        state.replacedSomething = true;
-      }
-    },
-  },
-
-  LogicalExpression: {
-    exit: function(path: BabelTraversePath, state: ClosureRefReplacerState) {
-      let node = path.node;
-      let leftTruthiness = getLiteralTruthiness(node.left);
-      if (node.operator === "&&" && leftTruthiness.known) {
-        path.replaceWith(leftTruthiness.value ? node.right : node.left);
-        state.replacedSomething = true;
-      } else if (node.operator === "||" && leftTruthiness.known) {
-        path.replaceWith(leftTruthiness.value ? node.left : node.right);
-        state.replacedSomething = true;
-      }
-    },
-  },
-
-  WhileStatement: {
-    exit: function(path: BabelTraversePath, state: ClosureRefReplacerState) {
-      let node = path.node;
-      let testTruthiness = getLiteralTruthiness(node.test);
-      if (testTruthiness.known && !testTruthiness.value) {
-        path.remove();
-        state.replacedSomething = true;
-      }
-    },
-  },
-};
-
-function visitName(path, state, name, modified) {
+function visitName(path, state, node, modified) {
   // Is the name bound to some local identifier? If so, we don't need to do anything
-  if (path.scope.hasBinding(name, /*noGlobals*/ true)) return;
+  if (path.scope.hasBinding(node.name, /*noGlobals*/ true)) return;
 
   // Otherwise, let's record that there's an unbound identifier
-  state.functionInfo.unbound.add(name);
-  if (modified) state.functionInfo.modified.add(name);
+  let nodes = state.functionInfo.unbound.get(node.name);
+  if (nodes === undefined) state.functionInfo.unbound.set(node.name, (nodes = []));
+  nodes.push(node);
+  if (modified) state.functionInfo.modified.add(node.name);
 }
 
 function ignorePath(path: BabelTraversePath) {
@@ -269,6 +51,15 @@ export let ClosureRefVisitor = {
     },
   },
 
+  CallExpression(path: BabelTraversePath, state: ClosureRefVisitorState) {
+    // Here we apply the require optimization by replacing require calls with their
+    // corresponding initialized modules.
+    if (state.getModuleIdIfNodeIsRequireFunction === undefined) return;
+    let moduleId = state.getModuleIdIfNodeIsRequireFunction(path.scope, path.node);
+    if (moduleId === undefined) return;
+    state.functionInfo.requireCalls.set(path.node, moduleId);
+  },
+
   ReferencedIdentifier(path: BabelTraversePath, state: ClosureRefVisitorState) {
     if (ignorePath(path)) return;
 
@@ -280,7 +71,7 @@ export let ClosureRefVisitor = {
       // "arguments" bound to local scope. therefore, there's no need to visit this identifier.
       return;
     }
-    visitName(path, state, innerName, false);
+    visitName(path, state, path.node, false);
   },
 
   ThisExpression(path: BabelTraversePath, state: ClosureRefVisitorState) {
@@ -290,8 +81,9 @@ export let ClosureRefVisitor = {
   },
 
   "AssignmentExpression|UpdateExpression"(path: BabelTraversePath, state: ClosureRefVisitorState) {
-    for (let name in path.getBindingIdentifiers()) {
-      visitName(path, state, name, true);
+    let ids = path.getBindingIdentifiers();
+    for (let name in ids) {
+      visitName(path, state, ids[name], true);
     }
   },
 };


### PR DESCRIPTION
Release notes: Speeding up Prepack by 22%, saving 8% memory.

This closes #1812.

This completely refactors the `ClosureRefReplacer` into a new
standalone `ResidualFunctionInstantiator`.

By avoiding babel-traverse, this visitor implementation is way faster.
Also, it only clones those nodes which are being changes, preserving all others,
insteading of cloning an entire function if any node needs to change; in this way,
memory is saved as well.

On a large internal benchmark (27MB minified JavaScript bundle with 31MB sourcemaps file), this change reduces overall time from 200s down to 157s: 22% faster. This due to savings during serialization, which goes down from 71s to 23s (while making the visitor 6s slower due to additional work).

Also, overall memory usage goes down from 3582MB to 3307MB, a 8% savings. Again, mostly due to savings in serialization, where surviving allocations going down from 337MB to 51MB, while slightly increasing allocations in the visitor.