### PR TITLE
add reading wiki link to places

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+To read more about the project, check out this [suggested reading wiki](https://github.com/facebook/prepack/wiki/Suggested-reading)
+
 ## Code of Conduct
 
 Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ In order to run the website locally at [localhost:8000](http://localhost:8000):
 
 ## How to contribute
 
+To read more about the project, check out this [suggested reading wiki](https://github.com/facebook/prepack/wiki/Suggested-reading)
+
 For more information about contributing pull requests and issues, see our [Contribution Guidelines](./CONTRIBUTING.md).
 
 ## License

--- a/website/index.html
+++ b/website/index.html
@@ -383,6 +383,18 @@ __optimize(global.f);
             </div>
           </div>
         </div>
+
+        <div class="section">
+          <div class="content-container">
+            <h2>Contributing</h2>
+            <div class="align-left">
+
+              <p>
+                You can follow the <a href="https://github.com/facebook/prepack/blob/master/CONTRIBUTING.md">contributing guidelines</a>. There is also a <a href="https://github.com/facebook/prepack/wiki/Suggested-reading">suggested reading list </a> to learn more about the internals of the project.
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Release Note: none

I just wanted to add the reading links as suggested in #1887 

arrived to the wiki from Twitter -> the issue -> to the Wiki :)

Let me know if you want the copy updated and shifted around anywhere. 