### PR TITLE
Don't treat makePartial() as a mutation in havoc checker

### DIFF
--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -150,7 +150,18 @@ export default class ObjectValue extends ConcreteValue {
           // To check if we are still initializing, guard the call by looking at
           // whether this.$IsClassPrototype has been initialized as a proxy for
           // object initialization in general.
-          invariant(this.$IsClassPrototype === undefined || !this.isHavocedObject(), "cannot mutate a havoced object");
+          invariant(
+            // We're still initializing so we can set a property.
+            this.$IsClassPrototype === undefined ||
+            // It's not havoced so we can set a property.
+            !this.isHavocedObject() ||
+            // Object.assign() implementation needs to temporarily
+            // make potentially havoced objects non-partial and back.
+            // We don't gain anything from checking whether it's havoced
+            // before calling makePartial() so we'll whitelist this property.
+            propBindingName === "_isPartial_binding",
+            "cannot mutate a havoced object"
+          );
           let binding = this[propBindingName];
           if (binding === undefined) {
             let desc = { writeable: true, value: undefined };

--- a/test/serializer/pure-functions/ObjectAssign2.js
+++ b/test/serializer/pure-functions/ObjectAssign2.js
@@ -1,0 +1,22 @@
+(function() {
+  var someAbstract = global.__abstract ? __abstract("function", '(function() {})') : () => {};
+  var evaluatePureFunction = global.__evaluatePureFunction || (f => f());
+
+  var result;
+  evaluatePureFunction(() => {
+    function calculate(y) {
+      var z = {c: 3, e: 1};
+      if (global.__makePartial) __makePartial(z);
+      if (global.__makeSimple) __makeSimple(z);
+      someAbstract(z);
+
+      var x = {a: 1, b: 1, c: 1};
+      return Object.assign(x, y, z);
+    }
+    result = calculate({b: 2, d: 1});
+  });
+
+  global.inspect = function() {
+    return JSON.stringify(result);
+  };
+})();


### PR DESCRIPTION
Fixes https://github.com/facebook/prepack/issues/1931.

The issue is that this call may happen on a havoced object:

https://github.com/facebook/prepack/blob/41e9dcb39837618bbe7376d42db0b92ae8d24a7e/src/intrinsics/ecma262/Object.js#L98-L100

That fails. But I'm not sure it makes sense to even check havocing for internal properties like `_isPartial_binding`.

Maybe there's a deeper problem here. I don't see it but at least this gets the ball rolling.