### PR TITLE
Follow up to ConditionalExpression changes

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -1362,7 +1362,7 @@ export class LexicalEnvironment {
     throw new TypeError(`Unsupported node type ${ast.type}`);
   }
 
-  evaluateDeref(ast: BabelNode, strictCode: boolean, metadata?: any): AbruptCompletion | Value {
+  evaluateDeref(ast: BabelNode, strictCode: boolean, metadata?: any): Value {
     let result = this.evaluate(ast, strictCode, metadata);
     if (result instanceof Reference) result = Environment.GetValue(this.realm, result);
     return result;

--- a/src/environment.js
+++ b/src/environment.js
@@ -1362,6 +1362,12 @@ export class LexicalEnvironment {
     throw new TypeError(`Unsupported node type ${ast.type}`);
   }
 
+  evaluateDeref(ast: BabelNode, strictCode: boolean, metadata?: any): AbruptCompletion | Value {
+    let result = this.evaluate(ast, strictCode, metadata);
+    if (result instanceof Reference) result = Environment.GetValue(this.realm, result);
+    return result;
+  }
+
   partiallyEvaluate(
     ast: BabelNode,
     strictCode: boolean,

--- a/src/evaluators/ConditionalExpression.js
+++ b/src/evaluators/ConditionalExpression.js
@@ -48,28 +48,20 @@ export default function(
       return realm.evaluateNodeForEffects(consequent, strictCode, env);
     },
     () => {
-      let completion = env.evaluateCompletion(alternate, strictCode);
+      let completion = env.evaluateCompletionDeref(alternate, strictCode);
       if (completion instanceof AbruptCompletion) {
         throw completion;
       }
-      if (completion instanceof Reference) {
-        return Environment.GetValue(realm, completion);
-      }
-      invariant(completion instanceof Value);
       return completion;
     },
     () => {
       return alternate ? realm.evaluateNodeForEffects(alternate, strictCode, env) : construct_empty_effects(realm);
     },
     () => {
-      let completion = env.evaluate(consequent, strictCode);
+      let completion = env.evaluateCompletionDeref(consequent, strictCode);
       if (completion instanceof AbruptCompletion) {
         throw completion;
       }
-      if (completion instanceof Reference) {
-        return Environment.GetValue(realm, completion);
-      }
-      invariant(completion instanceof Value);
       return completion;
     }
   );

--- a/src/evaluators/ConditionalExpression.js
+++ b/src/evaluators/ConditionalExpression.js
@@ -10,9 +10,8 @@
 /* @flow */
 
 import type { LexicalEnvironment } from "../environment.js";
-import { AbruptCompletion } from "../completions.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";
-import { Reference } from "../environment.js";
+import type { Reference } from "../environment.js";
 import { construct_empty_effects } from "../realm.js";
 import { Environment, To } from "../singletons.js";
 import type { BabelNodeConditionalExpression } from "babel-types";
@@ -48,21 +47,13 @@ export default function(
       return realm.evaluateNodeForEffects(consequent, strictCode, env);
     },
     () => {
-      let completion = env.evaluateCompletionDeref(alternate, strictCode);
-      if (completion instanceof AbruptCompletion) {
-        throw completion;
-      }
-      return completion;
+      return env.evaluateDeref(alternate, strictCode);
     },
     () => {
       return alternate ? realm.evaluateNodeForEffects(alternate, strictCode, env) : construct_empty_effects(realm);
     },
     () => {
-      let completion = env.evaluateCompletionDeref(consequent, strictCode);
-      if (completion instanceof AbruptCompletion) {
-        throw completion;
-      }
-      return completion;
+      return env.evaluateDeref(consequent, strictCode);
     }
   );
 }

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -113,7 +113,7 @@ export function evaluateWithAbstractConditional(
       return alternate ? realm.evaluateNodeForEffects(alternate, strictCode, env) : construct_empty_effects(realm);
     },
     () => {
-      let stmtCompletion = env.evaluate(consequent, strictCode);
+      let stmtCompletion = env.evaluateCompletion(consequent, strictCode);
       invariant(!(stmtCompletion instanceof Reference));
       stmtCompletion = UpdateEmpty(realm, stmtCompletion, realm.intrinsics.undefined);
       if (stmtCompletion instanceof AbruptCompletion) {


### PR DESCRIPTION
Followup to https://github.com/facebook/prepack/pull/1954 comments.

Also changes `IfStatement` to use `evaluateCompletion()` instead of `evaluate()` since presumably that was the original intent (?) If not then we should remove the `AbruptCompletion` check.