### PR TITLE
Don't treat original constructor specially in the visitor.

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1057,18 +1057,8 @@ export class ResidualHeapVisitor {
     } else {
       invariant(val instanceof ObjectValue);
 
-      // Prototypes are reachable via function declarations, and those get hoisted, so we need to move
-      // prototype initialization to the common scope code as well.
-      if (val.originalConstructor !== undefined) {
-        this._enqueueWithUnrelatedScope(this._getCommonScope(), () => {
-          invariant(val instanceof ObjectValue);
-          if (this.preProcessValue(val)) this.visitValueObject(val);
-          this.postProcessValue(val);
-        });
-      } else {
-        if (this.preProcessValue(val)) this.visitValueObject(val);
-        this.postProcessValue(val);
-      }
+      if (this.preProcessValue(val)) this.visitValueObject(val);
+      this.postProcessValue(val);
     }
   }
 

--- a/test/serializer/additional-functions/RegressionTestForIssue1957.js
+++ b/test/serializer/additional-functions/RegressionTestForIssue1957.js
@@ -1,0 +1,20 @@
+(function () {
+    function f(c) {
+        function g() {}
+        g.magic = 23;
+        if (c) {
+            throw new g();
+        }
+        return 42;
+    }
+    if (global.__optimize) __optimize(f);
+    global.f = f;
+    inspect = function() { 
+        try {
+            f(true);
+        } catch (e) {
+            return f(false) + "/" + e.constructor.magic;
+        }
+    };
+})();
+


### PR DESCRIPTION
Release notes: None

This fixes #1957.
Turns out that the special case is no longer needed, and just removing that code fixes the issue now.
Adding regression test.