### PR TITLE
fix: coerce abstract values into strings for the Error constructor

### DIFF
--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -736,8 +736,10 @@ export class ToImplementation {
       let primValue = this.ToPrimitiveOrAbstract(realm, val, "string");
       if (primValue.getType() === StringValue) return primValue;
       str = this.ToStringPartial(realm, primValue);
+    } else if (val instanceof AbstractValue) {
+      return this.ToStringAbstract(realm, val);
     } else {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to string");
+      invariant(false, "unknown value type, can't coerce to string");
     }
     return new StringValue(realm, str);
   }

--- a/test/serializer/abstract/ErrorMessageStringCoercion.js
+++ b/test/serializer/abstract/ErrorMessageStringCoercion.js
@@ -1,0 +1,4 @@
+let num = global.__abstract ? __abstract("number", "42") : 42;
+let err = new Error(num);
+
+inspect = function() { return "" + err; };


### PR DESCRIPTION
Release Notes: Fix abstract values not being coerced into strings for the Error constructor

Fixes #1827 @NTillmann
The exact example from the issue now prepacks to
```javascript
(function () {
  var _0 = function () {
    return 42;
  };

  inspect = _0;
})();
```

I'm new here, so if this approach is completely wrong, please do notify me and guide me the way to a better one ;)