### PR TITLE
Fixing AbstractObjectValue's $Get

### DIFF
--- a/test/serializer/abstract/ConditionalAbstractObjectValueGet.js
+++ b/test/serializer/abstract/ConditionalAbstractObjectValueGet.js
@@ -1,0 +1,7 @@
+(function () {
+    let c = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let o = c ? {} : {};
+    global.foo = o.bar;
+    inspect = function() { return global.foo; };
+})();
+

--- a/test/serializer/abstract/ConditionalAbstractObjectValueGetWithPrototype.js
+++ b/test/serializer/abstract/ConditionalAbstractObjectValueGetWithPrototype.js
@@ -1,0 +1,10 @@
+(function () {
+    let c = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let o1 = {};
+    o1.__proto__ = { bar: 42 };
+    let o2 = {};
+    let o = c ? o1 : o2;
+    global.foo = o.bar;
+    inspect = function() { return global.foo; };
+})();
+


### PR DESCRIPTION
Release notes: None

It used to bail out for conditional abstract values when accessing
a prototype that existed on neither side of the condition. No more.
Also, things used to be wrong in the presence of object prototypes.
That's also getting fixed.

Adding regression tests.