### PR TITLE
Implement const/let pattern declarations (ES6 destructuring)

### DIFF
--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -636,7 +636,7 @@ function handleFinished(args: MasterProgramArgs, groups: GroupsMap, earlierNumSk
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 11738 || numPassedES6 < 3981 || numTimeouts > 0)) {
+  if (!args.filterString && (numPassedES5 < 11738 || numPassedES6 < 5684 || numTimeouts > 0)) {
     console.error(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {
@@ -1161,7 +1161,6 @@ function filterFeatures(data: BannerData): boolean {
   if (features.includes("atomics")) return false;
   if (features.includes("u180e")) return false;
   if (features.includes("Symbol.isConcatSpreadable")) return false;
-  if (features.includes("destructuring-binding")) return false;
   if (features.includes("IsHTMLDDA")) return false;
   if (features.includes("regexp-unicode-property-escapes")) return false;
   if (features.includes("regexp-named-groups")) return false;

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -636,7 +636,7 @@ function handleFinished(args: MasterProgramArgs, groups: GroupsMap, earlierNumSk
   }
 
   // exit status
-  if (!args.filterString && (numPassedES5 < 11738 || numPassedES6 < 5684 || numTimeouts > 0)) {
+  if (!args.filterString && (numPassedES5 < 11738 || numPassedES6 < 5406 || numTimeouts > 0)) {
     console.error(chalk.red("Overall failure. Expected more tests to pass!"));
     return 1;
   } else {

--- a/src/environment.js
+++ b/src/environment.js
@@ -1206,7 +1206,10 @@ export class LexicalEnvironment {
       this.realm.popContext(context);
       this.realm.onDestroyScope(context.lexicalEnvironment);
       if (!this.destroyed) this.realm.onDestroyScope(this);
-      invariant(this.realm.activeLexicalEnvironments.size === 0);
+      invariant(
+        this.realm.activeLexicalEnvironments.size === 0,
+        `expected 0 active lexical environments, got ${this.realm.activeLexicalEnvironments.size}`
+      );
     }
     if (res instanceof AbruptCompletion) return [res, code];
 
@@ -1231,7 +1234,10 @@ export class LexicalEnvironment {
       this.realm.popContext(context);
       this.realm.onDestroyScope(context.lexicalEnvironment);
       if (!this.destroyed) this.realm.onDestroyScope(this);
-      invariant(this.realm.activeLexicalEnvironments.size === 0);
+      invariant(
+        this.realm.activeLexicalEnvironments.size === 0,
+        `expected 0 active lexical environments, got ${this.realm.activeLexicalEnvironments.size}`
+      );
     }
     invariant(partialAST.type === "File");
     let fileAst = ((partialAST: any): BabelNodeFile);
@@ -1271,7 +1277,10 @@ export class LexicalEnvironment {
       this.realm.popContext(context);
       // Avoid destroying "this" scope as execute may be called many times.
       if (context.lexicalEnvironment !== this) this.realm.onDestroyScope(context.lexicalEnvironment);
-      invariant(this.realm.activeLexicalEnvironments.size === 1);
+      invariant(
+        this.realm.activeLexicalEnvironments.size === 1,
+        `expected 1 active lexical environment, got ${this.realm.activeLexicalEnvironments.size}`
+      );
     }
     if (res instanceof AbruptCompletion) return res;
 

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -27,7 +27,7 @@ function letAndConst(
 ): Value {
   for (let declar of ast.declarations) {
     let Initializer = declar.init;
-    if (!Initializer) {
+    if (declar.id.type === "Identifier" && !Initializer) {
       invariant(ast.kind !== "const", "const without an initializer");
 
       // 1. Let lhs be ResolveBinding(StringValue of BindingIdentifier).
@@ -37,7 +37,7 @@ function letAndConst(
       // 2. Return InitializeReferencedBinding(lhs, undefined).
       Environment.InitializeReferencedBinding(realm, lhs, realm.intrinsics.undefined);
       continue;
-    } else if (declar.id.type === "Identifier") {
+    } else if (declar.id.type === "Identifier" && Initializer) {
       // 1. Let bindingId be StringValue of BindingIdentifier.
       let bindingId = declar.id.name;
 
@@ -63,7 +63,7 @@ function letAndConst(
 
       // 6. Return InitializeReferencedBinding(lhs, value).
       Environment.InitializeReferencedBinding(realm, lhs, value);
-    } else if (declar.id.type === "ObjectPattern" || declar.id.type === "ArrayPattern") {
+    } else if ((declar.id.type === "ObjectPattern" || declar.id.type === "ArrayPattern") && Initializer) {
       // 1. Let rhs be the result of evaluating Initializer.
       let rhs = env.evaluate(Initializer, strictCode);
 


### PR DESCRIPTION
This should resolve #415.

## Details
Relevant part of the spec here: https://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations-runtime-semantics-evaluation

For `// 3. Let env be the running execution context’s LexicalEnvironment.`, I assumed that the `env` variable passed to the function already fulfills and it's not necessary to retrieve it here.

I've omitted the `ReturnIfAbrupt(Value)` steps from the spec, as this is also done for the rest of the implementation in this file.

## Testing
test262 has one additional test pass as a result of this change, though somewhat surprisingly it's for `for`.
I've verified in the command line REPL that destructuring assignment works as expected in the basic case.