### PR TITLE
Add all missing console methods

### DIFF
--- a/src/intrinsics/common/console.js
+++ b/src/intrinsics/common/console.js
@@ -12,23 +12,34 @@
 import type { Realm } from "../../realm.js";
 import { ObjectValue } from "../../values/index.js";
 
+const consoleMethods = [
+  "assert",
+  "clear",
+  "count",
+  "dir",
+  "dirxml",
+  "error",
+  "group",
+  "groupCollapsed",
+  "groupEnd",
+  "info",
+  "log",
+  "table",
+  "time",
+  "timeEnd",
+  "trace",
+  "warn",
+];
+
 export default function(realm: Realm): ObjectValue {
   let obj = new ObjectValue(realm, realm.intrinsics.ObjectPrototype, "console");
 
-  obj.defineNativeMethod("log", 0, (context, args) => {
-    realm.outputToConsole("log", args);
-    return realm.intrinsics.undefined;
-  });
-
-  obj.defineNativeMethod("error", 0, (context, args) => {
-    realm.outputToConsole("error", args);
-    return realm.intrinsics.undefined;
-  });
-
-  obj.defineNativeMethod("warn", 0, (context, args) => {
-    realm.outputToConsole("warn", args);
-    return realm.intrinsics.undefined;
-  });
+  for (let method of consoleMethods) {
+    obj.defineNativeMethod(method, 0, (context, args) => {
+      realm.outputToConsole(method, args);
+      return realm.intrinsics.undefined;
+    });
+  }
 
   return obj;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -10,11 +10,12 @@
 /* @flow */
 
 import type {
+  ClassComponentMetadata,
+  ConsoleMethodTypes,
+  DebugServerType,
+  Descriptor,
   Intrinsics,
   PropertyBinding,
-  Descriptor,
-  DebugServerType,
-  ClassComponentMetadata,
   ReactHint,
 } from "./types.js";
 import { RealmStatistics } from "./statistics.js";
@@ -1265,7 +1266,7 @@ export class Realm {
     }
   }
 
-  outputToConsole(method: "log" | "warn" | "error", args: Array<string | ConcreteValue>): void {
+  outputToConsole(method: ConsoleMethodTypes, args: Array<string | ConcreteValue>): void {
     if (this.isReadOnly) {
       // This only happens during speculative execution and is reported elsewhere
       throw new FatalError("Trying to create console output in read-only realm");
@@ -1274,6 +1275,7 @@ export class Realm {
       invariant(this.generator !== undefined);
       this.generator.emitConsoleLog(method, args);
     } else {
+      // $FlowFixMe: Flow doesn't have type data for all the console methods yet
       console[method](getString(this, args));
     }
 

--- a/src/types.js
+++ b/src/types.js
@@ -62,6 +62,24 @@ export const ElementSize = {
   Uint8Clamped: 1,
 };
 
+export type ConsoleMethodTypes =
+  | "assert"
+  | "clear"
+  | "count"
+  | "dir"
+  | "dirxml"
+  | "error"
+  | "group"
+  | "groupCollapsed"
+  | "groupEnd"
+  | "info"
+  | "log"
+  | "table"
+  | "time"
+  | "timeEnd"
+  | "trace"
+  | "warn";
+
 export type IterationKind = "key+value" | "value" | "key";
 
 export type SourceType = "module" | "script";

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -9,8 +9,8 @@
 
 /* @flow */
 
-import type { Realm, Effects } from "../realm.js";
-import type { PropertyBinding, Descriptor } from "../types.js";
+import type { Effects, Realm } from "../realm.js";
+import type { ConsoleMethodTypes, Descriptor, PropertyBinding } from "../types.js";
 import type { ResidualFunctionBinding } from "../serializer/types.js";
 import type { Binding } from "../environment.js";
 import {
@@ -598,7 +598,7 @@ export class Generator {
     });
   }
 
-  emitConsoleLog(method: "log" | "warn" | "error", args: Array<string | ConcreteValue>) {
+  emitConsoleLog(method: ConsoleMethodTypes, args: Array<string | ConcreteValue>) {
     this.emitCall(
       () => t.memberExpression(t.identifier("console"), t.identifier(method)),
       args.map(v => (typeof v === "string" ? new StringValue(this.realm, v) : v))


### PR DESCRIPTION
Release notes: adds support for more `console` methods

This adds all the other console methods that I could see on MDN.