### PR TITLE
Further follow-up Array.from fixes

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -68,7 +68,7 @@ function deriveGetBinding(realm: Realm, binding: Binding) {
 export function havocBinding(binding: Binding) {
   let realm = binding.environment.realm;
   let value = binding.value;
-  if (!binding.hasLeaked && !(value instanceof ObjectValue && value.isFinalObject)) {
+  if (!binding.hasLeaked && !(value instanceof ObjectValue && value.isFinalObject())) {
     realm.recordModifiedBinding(binding).hasLeaked = true;
   }
 }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -850,7 +850,7 @@ export class ResidualHeapSerializer {
     // which is related to one of the scopes this value is used by.
     let notYetDoneBodies = new Set();
     this.emitter.dependenciesVisitor(val, {
-      onValueWithIdentifier: dependency => {
+      onAbstractValueWithIdentifier: dependency => {
         if (trace) console.log(`  depending on abstract value with identifier ${dependency.intrinsicName || "?"}`);
         invariant(
           referencingOnlyAdditionalFunction === undefined || this.emitter.emittingToAdditionalFunction(),

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -850,7 +850,7 @@ export class ResidualHeapSerializer {
     // which is related to one of the scopes this value is used by.
     let notYetDoneBodies = new Set();
     this.emitter.dependenciesVisitor(val, {
-      onAbstractValueWithIdentifier: dependency => {
+      onValueWithIdentifier: dependency => {
         if (trace) console.log(`  depending on abstract value with identifier ${dependency.intrinsicName || "?"}`);
         invariant(
           referencingOnlyAdditionalFunction === undefined || this.emitter.emittingToAdditionalFunction(),
@@ -1983,7 +1983,7 @@ export class ResidualHeapSerializer {
   _withGeneratorScope(
     type: "Generator" | "AdditionalFunction",
     generator: Generator,
-    valuesToProcess: void | Set<AbstractValue>,
+    valuesToProcess: void | Set<AbstractValue | ConcreteValue>,
     callback: SerializedBody => void,
     isChildOverride?: boolean
   ): Array<BabelNodeStatement> {
@@ -2008,7 +2008,10 @@ export class ResidualHeapSerializer {
     let context = {
       serializeValue: this.serializeValue.bind(this),
       serializeBinding: this.serializeBinding.bind(this),
-      serializeGenerator: (generator: Generator, valuesToProcess: Set<AbstractValue>): Array<BabelNodeStatement> =>
+      serializeGenerator: (
+        generator: Generator,
+        valuesToProcess: Set<AbstractValue | ConcreteValue>
+      ): Array<BabelNodeStatement> =>
         this._withGeneratorScope("Generator", generator, valuesToProcess, () => generator.serialize(context)),
       initGenerator: (generator: Generator) => {
         let activeGeneratorBody = this._getActiveBodyOfGenerator(generator);
@@ -2024,7 +2027,7 @@ export class ResidualHeapSerializer {
       emit: (statement: BabelNodeStatement) => {
         this.emitter.emit(statement);
       },
-      processValues: (valuesToProcess: Set<AbstractValue>) => {
+      processValues: (valuesToProcess: Set<AbstractValue | ConcreteValue>) => {
         this.emitter.processValues(valuesToProcess);
       },
       emitDefinePropertyBody: this.emitDefinePropertyBody.bind(this, false, undefined),

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -34,7 +34,7 @@ export type SerializedBody = {
   type: SerializedBodyType,
   entries: Array<BabelNodeStatement>,
   done: boolean,
-  declaredAbstractValues?: Map<AbstractValue, SerializedBody>,
+  declaredValues?: Map<AbstractValue | ConcreteValue, SerializedBody>,
   parentBody?: SerializedBody,
   nestingLevel?: number,
   processing?: boolean,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -58,12 +58,12 @@ import type { SerializerOptions } from "../options.js";
 export type SerializationContext = {|
   serializeValue: Value => BabelNodeExpression,
   serializeBinding: Binding => BabelNodeIdentifier | BabelNodeMemberExpression,
-  serializeGenerator: (Generator, Set<AbstractValue>) => Array<BabelNodeStatement>,
+  serializeGenerator: (Generator, Set<AbstractValue | ConcreteValue>) => Array<BabelNodeStatement>,
   initGenerator: Generator => void,
   finalizeGenerator: Generator => void,
   emitDefinePropertyBody: (ObjectValue, string | SymbolValue, Descriptor) => BabelNodeStatement,
   emit: BabelNodeStatement => void,
-  processValues: (Set<AbstractValue>) => void,
+  processValues: (Set<AbstractValue | ConcreteValue>) => void,
   canOmit: (AbstractValue | ConcreteValue) => boolean,
   declare: (AbstractValue | ConcreteValue) => void,
   emitPropertyModification: PropertyBinding => void,
@@ -83,13 +83,13 @@ export type VisitEntryCallbacks = {|
 export type DerivedExpressionBuildNodeFunction = (
   Array<BabelNodeExpression>,
   SerializationContext,
-  Set<AbstractValue>
+  Set<AbstractValue | ConcreteValue>
 ) => BabelNodeExpression;
 
 export type GeneratorBuildNodeFunction = (
   Array<BabelNodeExpression>,
   SerializationContext,
-  Set<AbstractValue>
+  Set<AbstractValue | ConcreteValue>
 ) => BabelNodeStatement;
 
 export class GeneratorEntry {
@@ -340,7 +340,7 @@ class IfThenElseEntry extends GeneratorEntry {
 function serializeBody(
   generator: Generator,
   context: SerializationContext,
-  valuesToProcess: Set<AbstractValue>
+  valuesToProcess: Set<AbstractValue | ConcreteValue>
 ): BabelNodeBlockStatement {
   let statements = context.serializeGenerator(generator, valuesToProcess);
   if (statements.length === 1 && statements[0].type === "BlockStatement") return (statements[0]: any);

--- a/test/serializer/optimized-functions/ArrayFrom2.js
+++ b/test/serializer/optimized-functions/ArrayFrom2.js
@@ -1,0 +1,25 @@
+function fn(arg) {
+  if (!arg.condition) {
+    return null;
+  }
+
+  var fooArr = Array.from(arg.foo);
+  return arg.calculate(function() {
+    var x = fooArr;
+
+    return function () {
+      return x;
+    }
+  });
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  var x = fn({condition: false});
+  var y = fn({condition: true, foo: 10, calculate(f) {return f}});
+  var z = y();
+  var y2 = fn({condition: true, foo: [1, 2, 3], calculate(f) {return f}});
+  var z2 = y();
+  return JSON.stringify(z, z2);
+}


### PR DESCRIPTION
Release notes: none

This is a follow up to the changes in https://github.com/facebook/prepack/pull/1926. This PR correctly fixes the derived values for waiting and ensures that the unknown array objects have their dependencies properly resolved. This fixes part of the issue in https://github.com/facebook/prepack/issues/1962, but it brought about another issue that this PR doesn't aim to solve – dependencies on an abstract function call's unbound/bound bindings.