### PR TITLE
Distribute conditionals in certain relational expressions

### DIFF
--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -119,7 +119,6 @@ function AbstractCaseBlockEvaluation(
 
     let selector = CaseSelectorEvaluation(test, strictCode, env, realm);
     let selectionResult = computeBinary(realm, "===", input, selector);
-    invariant(selectionResult instanceof AbstractValue);
 
     if (Path.implies(selectionResult)) {
       //  we have a winning result for the switch case, bubble it back up!

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -134,11 +134,14 @@ export function AbstractRelationalComparison(
   }
 
   if (px instanceof AbstractValue || py instanceof AbstractValue) {
+    let res;
     if (LeftFirst) {
-      return AbstractValue.createFromBinaryOp(realm, op, px, py);
+      res = AbstractValue.createFromBinaryOp(realm, op, px, py);
     } else {
-      return AbstractValue.createFromBinaryOp(realm, op, py, px);
+      res = AbstractValue.createFromBinaryOp(realm, op, py, px);
     }
+    invariant(res instanceof BooleanValue || res instanceof UndefinedValue || res instanceof AbstractValue);
+    return res;
   }
 
   // 3. If both px and py are Strings, then
@@ -255,7 +258,9 @@ export function AbstractEqualityComparison(
   if ((x instanceof StringValue || x instanceof NumberValue || x instanceof SymbolValue) && y instanceof ObjectValue) {
     const py = To.ToPrimitiveOrAbstract(realm, y);
     if (py instanceof AbstractValue) {
-      return AbstractValue.createFromBinaryOp(realm, "==", x, py);
+      let res = AbstractValue.createFromBinaryOp(realm, "==", x, py);
+      invariant(res instanceof BooleanValue || res instanceof AbstractValue);
+      return res;
     }
     return AbstractEqualityComparison(realm, x, py, op);
   }
@@ -264,7 +269,9 @@ export function AbstractEqualityComparison(
   if (x instanceof ObjectValue && (y instanceof StringValue || y instanceof NumberValue || y instanceof SymbolValue)) {
     const px = To.ToPrimitiveOrAbstract(realm, x);
     if (px instanceof AbstractValue) {
-      return AbstractValue.createFromBinaryOp(realm, "==", px, y);
+      let res = AbstractValue.createFromBinaryOp(realm, "==", px, y);
+      invariant(res instanceof BooleanValue || res instanceof AbstractValue);
+      return res;
     }
     return AbstractEqualityComparison(realm, px, y, op);
   }

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -691,19 +691,19 @@ export class FunctionImplementation {
   }
 
   // ECMA262 9.2.11
-  SetFunctionName(realm: Realm, F: ObjectValue, name: PropertyKeyValue | AbstractValue, prefix?: string): boolean {
+  SetFunctionName(realm: Realm, F: ObjectValue, _name: PropertyKeyValue | AbstractValue, prefix?: string): boolean {
     // 1. Assert: F is an extensible object that does not have a name own property.
     invariant(F.getExtensible(), "expected object to be extensible and not have a name property");
 
     // 2. Assert: Type(name) is either Symbol or String.
     invariant(
-      typeof name === "string" ||
-        name instanceof StringValue ||
-        name instanceof SymbolValue ||
-        name instanceof AbstractValue,
+      typeof _name === "string" ||
+        _name instanceof StringValue ||
+        _name instanceof SymbolValue ||
+        _name instanceof AbstractValue,
       "expected name to be a string or symbol"
     );
-    if (typeof name === "string") name = new StringValue(realm, name);
+    let name = typeof _name === "string" ? new StringValue(realm, _name) : _name;
 
     // 3. Assert: If prefix was passed, then Type(prefix) is String.
     invariant(prefix === undefined || typeof prefix === "string", "expected prefix to be a string if passed");

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -656,7 +656,11 @@ export class JoinImplementation {
     }
   }
 
-  joinEffects(realm: Realm, joinCondition: AbstractValue, e1: Effects, e2: Effects): Effects {
+  joinEffects(realm: Realm, joinCondition: Value, e1: Effects, e2: Effects): Effects {
+    if (!joinCondition.mightNotBeTrue()) return e1;
+    if (!joinCondition.mightNotBeFalse()) return e2;
+    invariant(joinCondition instanceof AbstractValue);
+
     let {
       result: result1,
       generator: generator1,
@@ -896,7 +900,7 @@ export class JoinImplementation {
     }
   }
 
-  joinValuesAsConditional(realm: Realm, condition: AbstractValue, v1: void | Value, v2: void | Value): Value {
+  joinValuesAsConditional(realm: Realm, condition: Value, v1: void | Value, v2: void | Value): Value {
     return AbstractValue.createFromConditionalOp(realm, condition, v1, v2);
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -355,12 +355,12 @@ export type DebugServerType = {
 };
 
 export type PathType = {
-  implies(condition: AbstractValue): boolean,
-  impliesNot(condition: AbstractValue): boolean,
-  withCondition<T>(condition: AbstractValue, evaluate: () => T): T,
-  withInverseCondition<T>(condition: AbstractValue, evaluate: () => T): T,
-  pushAndRefine(condition: AbstractValue): void,
-  pushInverseAndRefine(condition: AbstractValue): void,
+  implies(condition: Value): boolean,
+  impliesNot(condition: Value): boolean,
+  withCondition<T>(condition: Value, evaluate: () => T): T,
+  withInverseCondition<T>(condition: Value, evaluate: () => T): T,
+  pushAndRefine(condition: Value): void,
+  pushInverseAndRefine(condition: Value): void,
 };
 
 export type HavocType = {
@@ -767,7 +767,7 @@ export type JoinType = {
 
   removeNormalEffects(realm: Realm, c: PossiblyNormalCompletion): Effects,
 
-  joinEffects(realm: Realm, joinCondition: AbstractValue, e1: Effects, e2: Effects): Effects,
+  joinEffects(realm: Realm, joinCondition: Value, e1: Effects, e2: Effects): Effects,
 
   joinNestedEffects(realm: Realm, c: Completion, precedingEffects?: Effects): Effects,
 
@@ -802,7 +802,7 @@ export type JoinType = {
     getAbstractValue: (void | Value, void | Value) => Value
   ): Value | Array<Value> | Array<{ $Key: void | Value, $Value: void | Value }>,
 
-  joinValuesAsConditional(realm: Realm, condition: AbstractValue, v1: void | Value, v2: void | Value): Value,
+  joinValuesAsConditional(realm: Realm, condition: Value, v1: void | Value, v2: void | Value): Value,
 
   joinPropertyBindings(
     realm: Realm,

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -11,6 +11,7 @@
 
 import { AbstractValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
 import { InfeasiblePathError } from "../errors.js";
+import type { Realm } from "../realm.js";
 import invariant from "../invariant.js";
 
 export class PathImplementation {
@@ -182,7 +183,7 @@ function pushInversePathCondition(condition: Value) {
   }
 }
 
-function pushRefinedConditions(realm, unrefinedConditions: Array<AbstractValue>) {
+function pushRefinedConditions(realm: Realm, unrefinedConditions: Array<AbstractValue>) {
   let refinedConditions = unrefinedConditions.map(c => realm.simplifyAndRefineAbstractCondition(c));
   if (refinedConditions.some(c => !c.mightNotBeFalse())) throw new InfeasiblePathError();
   let pc = realm.pathConditions;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -847,7 +847,7 @@ export default class ObjectValue extends ConcreteValue {
     return AbstractValue.createFromConditionalOp(this.$Realm, cond, arg1, arg2, absVal.expressionLocation);
   }
 
-  specializeCond(absVal: AbstractValue, propName: Value): AbstractValue {
+  specializeCond(absVal: AbstractValue, propName: Value): Value {
     if (absVal.kind === "template for property name condition")
       return AbstractValue.createFromBinaryOp(this.$Realm, "===", absVal.args[0], propName);
     return absVal;

--- a/test/serializer/abstract/Distribute.js
+++ b/test/serializer/abstract/Distribute.js
@@ -1,0 +1,9 @@
+// does not contain:infeasible
+(function () {
+    let c = global.__abstract ? __abstract("boolean", "(true)") : true;
+    let left = c ? 0 : 10;
+    let right = c ? 5 : 15;
+    let infeasible = left > right;
+    if (infeasible) throw new Error("infeasible!");
+    inspect = function() { return infeasible; }
+})();


### PR DESCRIPTION
Release notes: More simplification rules

The existing simplifier would never go into relational expressions
and distribute conditional expressions. It does now.

With this change, `AbstractValue.createFromBinaryOp` joins many other
value factory functions that may return non-abstract values.

This caused various changes downstream in types, and dealing with concrete
instead of abstract values.

Adding regression test.