### PR TITLE
Fix issue #1841.

### DIFF
--- a/src/intrinsics/ecma262/ErrorPrototype.js
+++ b/src/intrinsics/ecma262/ErrorPrototype.js
@@ -10,17 +10,13 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { AbstractValue, ObjectValue, StringValue, UndefinedValue } from "../../values/index.js";
+import { ObjectValue, StringValue, UndefinedValue } from "../../values/index.js";
 import { Get } from "../../methods/index.js";
 import { To } from "../../singletons.js";
-import buildExpressionTemplate from "../../utils/builder.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
   return build("Error", realm, obj);
 }
-
-const tsTemplateSrc = "(A).toString()";
-const tsTemplate = buildExpressionTemplate(tsTemplateSrc);
 
 export function build(name: string, realm: Realm, obj: ObjectValue): void {
   // ECMA262 19.5.3.2
@@ -41,22 +37,18 @@ export function build(name: string, realm: Realm, obj: ObjectValue): void {
 
     // 3. Let name be ? Get(O, "name").
     let nameValue = Get(realm, O, "name");
-    if (nameValue instanceof AbstractValue) {
-      return AbstractValue.createFromTemplate(realm, tsTemplate, StringValue, [O], tsTemplateSrc);
-    }
 
     // 4. If name is undefined, let name be "Error"; otherwise let name be ? ToString(name).
     let nameString = nameValue instanceof UndefinedValue ? "Error" : To.ToStringPartial(realm, nameValue);
 
     // 5. Let msg be ? Get(O, "message").
     let msg = Get(realm, O, "message");
-    if (msg instanceof AbstractValue) {
-      return AbstractValue.createFromTemplate(realm, tsTemplate, StringValue, [O], tsTemplateSrc);
-    }
 
     // 6. If msg is undefined, let msg be the empty String; otherwise let msg be ? ToString(msg).
     msg = msg instanceof UndefinedValue ? "" : To.ToStringPartial(realm, msg);
 
+    // Note that in ES5, both name and msg are checked for emptiness in step 7,
+    // which however is later dropped in ES6.
     // 7. If name is the empty String, return msg.
     if (nameString === "") return new StringValue(realm, msg);
 

--- a/test/serializer/abstract/Error.js
+++ b/test/serializer/abstract/Error.js
@@ -1,4 +1,5 @@
 // does not contain:setPrototypeOf
+// throws introspection error
 let x = global.__abstract ? __abstract("string", "('abc')") : 'abc';
 let err1 = new Error(x);
 err1.name = x;

--- a/test/serializer/basic/ErrorPrototypeToString.js
+++ b/test/serializer/basic/ErrorPrototypeToString.js
@@ -1,0 +1,27 @@
+function a() {
+  let e = new Error("");
+  e.name = "";
+  return e.toString();
+}
+
+function b() {
+  let e = new Error("");
+  e.name = "b";
+  return e.toString();
+}
+
+function c() {
+  let e = new Error("c");
+  e.name = "";
+  return e.toString();
+}
+
+function d() {
+  let e = new Error("c");
+  e.name = "c";
+  return e.toString();
+}
+
+x = a() + ";" + b() + ";" + c() + ";" + d();
+inspect = function() { return x; }
+console.log(x);


### PR DESCRIPTION
When either name or msg of Error is abstract, we do not want to partially evaluate it because the checks on string emptiness can be overwhelming, and better done in the VM than in JS.
Added a test to check these cases.
(I messed up my previous pull request. Sending a new one here.)