### PR TITLE
[No merge] Temp hack solution to fix 1973

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -65,10 +65,13 @@ function deriveGetBinding(realm: Realm, binding: Binding) {
   return realm.generator.deriveAbstract(types, values, [], (_, context) => context.serializeBinding(binding));
 }
 
-export function havocBinding(binding: Binding) {
+export function havocBinding(binding: Binding, havocCallback?: (value: Binding) => void) {
   let realm = binding.environment.realm;
   let value = binding.value;
-  if (!binding.hasLeaked && !(value instanceof ObjectValue && value.isFinalObject())) {
+  if (!binding.hasLeaked && !(value instanceof ObjectValue && value.isFinalObject)) {
+    if (havocCallback) {
+      havocCallback(binding);
+    }
     realm.recordModifiedBinding(binding).hasLeaked = true;
   }
 }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -129,6 +129,9 @@ class TemporalBuildNodeEntry extends GeneratorEntry {
   isPure: void | boolean;
 
   visit(callbacks: VisitEntryCallbacks, containingGenerator: Generator): boolean {
+    if (this.binding && !this.declared) {
+      this.args.push(this.binding.value);
+    }
     if (this.isPure && this.declared && callbacks.canSkip(this.declared)) {
       callbacks.recordDelayedEntry(containingGenerator, this);
       return false;

--- a/test/serializer/additional-functions/ArrayFrom.js
+++ b/test/serializer/additional-functions/ArrayFrom.js
@@ -1,0 +1,30 @@
+function foo(a, b, c) {
+  if (!a) {
+    return null;
+  }
+  var b = Object.assign({}, c);
+
+  return a.callFunc(function() {
+    return b.foo;
+  });
+}
+
+inspect = function() {
+  return JSON.stringify(
+    foo({
+      a: {
+        callFunc(x) {
+          return x() 
+        },
+      },
+      b: {
+        foo() {
+          return 'works!';
+        },
+      },
+      c: {},
+    })
+  );
+}
+
+this.__optimize && __optimize(foo)


### PR DESCRIPTION
Release note: this should not be released

This is a hacky attempt to fix #1973, but more to shine some clarity over a conceptual idea I had around how we need to access the correct value of bindings that exist in residual functions from within an additional function. Take a look at #1973 for more context.

The issue is that when we call a function that is abstract and pass in a function, we need to ensure that the bindings within that function are correctly serialized **before** the function call occurs. This PR shows that we can detect the havoced bindings and emit a temporal before the function call. The issue is that the binding value at the time of the havoc is different from the value that we'll get when we visit the residual function further on in the process (when we get the binding in havoced, the effects of the conditional are applied, they are not when the residual function is visited). So I hacked the visitor to detect this new type of generator entry so it adds the same value that will be visited in the residual function to the args.

Let me know if this helps @NTillmann.