### PR TITLE
stop the prototype cycle check if an object uses non-ordinary prototype methods

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1415,13 +1415,16 @@ export class PropertiesImplementation {
         return false;
       } else {
         // c. Else,
-        // TODO #1017 i. If the [[GetPrototypeOf]] internal method of p is not the ordinary object internal method defined in 9.1.1, let done be true.
-
-        // ii. Else, let p be the value of p's [[Prototype]] internal slot.
-        p = p.$Prototype;
-        if (p instanceof AbstractObjectValue) {
-          AbstractValue.reportIntrospectionError(p);
-          throw new FatalError();
+        // If the [[GetPrototypeOf]] internal method of p is not the ordinary object internal method defined in 9.1.1, let done be true.
+        if (!p.usesOrdinaryObjectInternalPrototypeMethods()) {
+          done = true;
+        } else {
+          // ii. Else, let p be the value of p's [[Prototype]] internal slot.
+          p = p.$Prototype;
+          if (p instanceof AbstractObjectValue) {
+            AbstractValue.reportIntrospectionError(p);
+            throw new FatalError();
+          }
         }
       }
     }

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -348,7 +348,11 @@ export class Emitter {
       switch (kind) {
         case "Object":
           let proto = val.$Prototype;
-          if (proto instanceof ObjectValue) {
+          if (
+            proto instanceof ObjectValue &&
+            // if this is falsy, prototype chain might be cyclic
+            proto.usesOrdinaryObjectInternalPrototypeMethods()
+          ) {
             result = recurse(val.$Prototype);
             if (result !== undefined) return result;
           }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -215,6 +215,10 @@ export default class AbstractObjectValue extends AbstractValue {
     return this;
   }
 
+  usesOrdinaryObjectInternalPrototypeMethods(): boolean {
+    return true;
+  }
+
   // ECMA262 9.1.1
   $GetPrototypeOf(): ObjectValue | AbstractObjectValue | NullValue {
     let realm = this.$Realm;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -604,6 +604,13 @@ export default class ObjectValue extends ConcreteValue {
     return obj;
   }
 
+  // Whether [[{Get,Set}PrototypeOf]] delegate to Ordinary{Get,Set}PrototypeOf.
+  // E.g. ProxyValue overrides this to return false.
+  // See ECMA262 9.1.2.1 for an algorithm where this is relevant
+  usesOrdinaryObjectInternalPrototypeMethods(): boolean {
+    return true;
+  }
+
   // ECMA262 9.1.1
   $GetPrototypeOf(): ObjectValue | AbstractObjectValue | NullValue {
     return this.$Prototype;

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -54,6 +54,10 @@ export default class ProxyValue extends ObjectValue {
     return false;
   }
 
+  usesOrdinaryObjectInternalPrototypeMethods(): boolean {
+    return false;
+  }
+
   // ECMA262 9.5.1
   $GetPrototypeOf(): NullValue | AbstractObjectValue | ObjectValue {
     let realm = this.$Realm;

--- a/test/serializer/basic/NonOrdinarySetPrototypeOf.js
+++ b/test/serializer/basic/NonOrdinarySetPrototypeOf.js
@@ -1,0 +1,17 @@
+const root = {};
+const proxy = new Proxy(Object.create(root), {});
+const leaf = Object.create(proxy);
+
+// This should not detect a cycle,
+// because proxy does not use the
+// ordinary object definition for [[SetPrototypeOf]].
+// See also test262/test/annexB/built-ins/Object/prototype/__proto__/set-cycle-shadowed.js
+Object.setPrototypeOf(root, leaf);
+
+inspect = function() {
+  return (
+    Object.getPrototypeOf(root) === leaf &&
+    Object.getPrototypeOf(leaf) === proxy &&
+    Object.getPrototypeOf(proxy) === root
+  );
+};


### PR DESCRIPTION
Release Notes: stop the prototype cycle check if an object (e.g. proxy) uses non-ordinary prototype methods

Fixes #1017