### PR TITLE
Add a name generator for __get_scope_binding_ functions

### DIFF
--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -41,23 +41,23 @@ export class Referentializer {
     realm: Realm,
     options: SerializerOptions,
     scopeNameGenerator: NameGenerator,
-    referentializedNameGenerator: NameGenerator
+    scopeBindingNameGenerator: NameGenerator
   ) {
     this._options = options;
     this.scopeNameGenerator = scopeNameGenerator;
+    this.scopeBindingNameGenerator = scopeBindingNameGenerator;
 
     this.referentializationState = new Map();
-    this._referentializedNameGenerator = referentializedNameGenerator;
     this.realm = realm;
   }
 
   _options: SerializerOptions;
   scopeNameGenerator: NameGenerator;
+  scopeBindingNameGenerator: NameGenerator;
   realm: Realm;
 
   _newCapturedScopeInstanceIdx: number;
   referentializationState: Map<ReferentializationScope, ReferentializationState>;
-  _referentializedNameGenerator: NameGenerator;
 
   getStatistics(): SerializerStatistics {
     invariant(this.realm.statistics instanceof SerializerStatistics, "serialization requires SerializerStatistics");
@@ -68,7 +68,7 @@ export class Referentializer {
     return {
       capturedScopeInstanceIdx: 0,
       capturedScopesArray: t.identifier(this.scopeNameGenerator.generate("main")),
-      capturedScopeAccessFunctionId: t.identifier(this.scopeNameGenerator.generate("get_scope_binding")),
+      capturedScopeAccessFunctionId: t.identifier(this.scopeBindingNameGenerator.generate("get_scope_binding")),
       serializedScopes: new Map(),
     };
   }

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -149,7 +149,7 @@ export class Serializer {
           this.realm,
           this.options,
           preludeGenerator.createNameGenerator("__scope_"),
-          preludeGenerator.createNameGenerator("$")
+          preludeGenerator.createNameGenerator("__get_scope_binding_")
         );
         if (this.realm.react.verbose) {
           this.logger.logInformation(`Visiting evaluated nodes...`);


### PR DESCRIPTION
Release Note: none

This uses a separate name generator for scope access functions. 

This addresses #1084 and here is a sample output:
```javascript
(function () {
  var __scope_0 = new Array(2);

  var __get_scope_binding_0 = function (__selector) {
    var __captured;

    switch (__selector) {
      case 0:
        __captured = [5];
        break;

      case 1:
        __captured = [3];
        break;

      default:
        throw new Error("Unknown scope selector");
    }

    __scope_0[__selector] = __captured;
    return __captured;
  };

  var _2 = function () {
    var __scope_3 = new Array(1);

    var __get_scope_binding_1 = function (__selector) {
      var __captured;

      switch (__selector) {
        case 0:
          __captured = [3];
          break;

        default:
          throw new Error("Unknown scope selector");
      }

      __scope_3[__selector] = __captured;
      return __captured;
    };

    var _3 = function () {
      var __captured__scope_1 = __scope_0[0] || __get_scope_binding_0(0);

      var __captured__scope_4 = __scope_3[0] || __get_scope_binding_1(0);

      --__captured__scope_1[0];
      return ++__captured__scope_4[0];
    };

    return _3;
  };

  var _0 = function () {
    return g();
  };

  var _1 = function () {
    var __captured__scope_1 = __scope_0[0] || __get_scope_binding_0(0);

    var __captured__scope_2 = __scope_0[1] || __get_scope_binding_0(1);

    --__captured__scope_1[0];
    return ++__captured__scope_2[0];
  };

  f = _2;
  g = _1;
  inspect = _0;
})();
```