### PR TITLE
Don't rotate effects trees

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -85,6 +85,18 @@ export class JoinedAbruptCompletions extends AbruptCompletion {
   alternate: AbruptCompletion;
   alternateEffects: Effects;
 
+  containsCompletion(CompletionType: typeof Completion): boolean {
+    if (this.consequent instanceof CompletionType) return true;
+    if (this.alternate instanceof CompletionType) return true;
+    if (this.consequent instanceof JoinedAbruptCompletions) {
+      if (this.consequent.containsCompletion(CompletionType)) return true;
+    }
+    if (this.alternate instanceof JoinedAbruptCompletions) {
+      if (this.alternate.containsCompletion(CompletionType)) return true;
+    }
+    return false;
+  }
+
   containsBreakOrContinue(): boolean {
     if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;
     if (this.alternate instanceof BreakCompletion || this.alternate instanceof ContinueCompletion) return true;
@@ -95,6 +107,18 @@ export class JoinedAbruptCompletions extends AbruptCompletion {
       if (this.alternate.containsBreakOrContinue()) return true;
     }
     return false;
+  }
+
+  transferChildrenToPossiblyNormalCompletion(): PossiblyNormalCompletion {
+    return new PossiblyNormalCompletion(
+      this.value.$Realm.intrinsics.empty,
+      this.joinCondition,
+      this.consequent,
+      this.consequentEffects,
+      this.alternate,
+      this.alternateEffects,
+      []
+    );
   }
 }
 
@@ -155,6 +179,18 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   savedEffects: void | Effects;
   // The path conditions that applied at the time of the oldest fork that caused this completion to arise.
   savedPathConditions: Array<AbstractValue>;
+
+  containsCompletion(CompletionType: typeof Completion): boolean {
+    if (this.consequent instanceof CompletionType) return true;
+    if (this.alternate instanceof CompletionType) return true;
+    if (this.consequent instanceof JoinedAbruptCompletions || this.consequent instanceof PossiblyNormalCompletion) {
+      if (this.consequent.containsCompletion(CompletionType)) return true;
+    }
+    if (this.alternate instanceof JoinedAbruptCompletions || this.alternate instanceof PossiblyNormalCompletion) {
+      if (this.alternate.containsCompletion(CompletionType)) return true;
+    }
+    return false;
+  }
 
   containsBreakOrContinue(): boolean {
     if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;

--- a/src/realm.js
+++ b/src/realm.js
@@ -954,6 +954,7 @@ export class Realm {
       joinedEffects = effects1 || effects2;
       invariant(joinedEffects !== undefined);
       completion = joinedEffects.result;
+      this.applyEffects(joinedEffects, "evaluateWithAbstractConditional");
     } else {
       let {
         result: result1,
@@ -990,9 +991,11 @@ export class Realm {
         // Consequently we have to continue tracking changes until the point where
         // all the branches come together into one.
         completion = this.composeWithSavedCompletion(completion);
+        this.applyEffects(joinedEffects, "evaluateWithAbstractConditional", false);
+      } else {
+        this.applyEffects(joinedEffects, "evaluateWithAbstractConditional");
       }
     }
-    this.applyEffects(joinedEffects, "evaluateWithAbstractConditional");
 
     // return or throw completion
     if (completion instanceof AbruptCompletion) throw completion;

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -18,8 +18,6 @@ import invariant from "../invariant.js";
 import { IsArray, IsArrayIndex } from "../methods/index.js";
 import { Logger } from "../utils/logger.js";
 import { Generator } from "../utils/generator.js";
-import { Join } from "../singletons.js";
-import { JoinedAbruptCompletions, PossiblyNormalCompletion } from "../completions.js";
 import type { AdditionalFunctionEffects } from "./types";
 
 /**
@@ -151,8 +149,6 @@ export function getObjectPrototypeMetadata(
   };
 }
 
-// NB: effects that are returned may be different than the effects passed in, so after this call, you may no longer
-// use the effects object you passed into this function.
 export function createAdditionalEffects(
   realm: Realm,
   effects: Effects,
@@ -161,11 +157,7 @@ export function createAdditionalEffects(
   environmentRecordIdAfterGlobalCode: number,
   parentAdditionalFunction: FunctionValue | void = undefined
 ): AdditionalFunctionEffects | null {
-  let result = effects.result;
   let generator = Generator.fromEffects(effects, realm, name, environmentRecordIdAfterGlobalCode);
-  if (result instanceof PossiblyNormalCompletion || result instanceof JoinedAbruptCompletions) {
-    effects = Join.joinNestedEffects(realm, result);
-  }
   let retValue: AdditionalFunctionEffects = {
     parentAdditionalFunction,
     effects,

--- a/src/types.js
+++ b/src/types.js
@@ -751,6 +751,13 @@ export type JoinType = {
     v: Value
   ): void,
 
+  extractAndJoinCompletionsOfType(
+    CompletionType: typeof AbruptCompletion,
+    realm: Realm,
+    c: AbruptCompletion,
+    convertToPNC?: boolean
+  ): Effects,
+
   joinEffectsAndPromoteNested(
     CompletionType: typeof Completion,
     realm: Realm,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -36,6 +36,7 @@ import * as t from "babel-types";
 import invariant from "../invariant.js";
 import {
   Completion,
+  AbruptCompletion,
   JoinedAbruptCompletions,
   ThrowCompletion,
   ReturnCompletion,
@@ -402,6 +403,8 @@ export class Generator {
       output.emitIfThenElse(result, realm);
     } else if (result instanceof ThrowCompletion) {
       output.emitThrow(result.value);
+    } else if (result instanceof AbruptCompletion) {
+      // no-op
     } else {
       invariant(false);
     }
@@ -1075,6 +1078,7 @@ export class Generator {
 
   joinGenerators(joinCondition: AbstractValue, generator1: Generator, generator2: Generator): void {
     invariant(generator1 !== this && generator2 !== this && generator1 !== generator2);
+    if (generator1.empty() && generator2.empty()) return;
     this._addEntry({
       args: [joinCondition],
       buildNode: function([cond], context, valuesToProcess) {

--- a/test/residual/call.js
+++ b/test/residual/call.js
@@ -1,3 +1,4 @@
+// skip
 let b = global.__abstract ? __abstract("boolean", "true") : true;
 
 let y = 1;

--- a/test/serializer/additional-functions/return-or-throw-modifybindings2.js
+++ b/test/serializer/additional-functions/return-or-throw-modifybindings2.js
@@ -31,6 +31,6 @@ else x = 11;
     } catch (e) {
       error = e.message;
     }
-    return 'prevfoo: ' + prevfoo + 'err: ' + error + ' ret ' + ret + ' foo ' + foo;
+    return 'prevfoo: ' + prevfoo + ' err: ' + error + ' ret ' + ret + ' foo ' + foo;
   }
 }());

--- a/test/serializer/optimized-functions/ObjectAssignProps.js
+++ b/test/serializer/optimized-functions/ObjectAssignProps.js
@@ -1,0 +1,24 @@
+function MaybeThrow(props) {
+  if (props.b === false) {
+    return "Good";
+  }
+  throw new Error("no");
+}
+
+function App(props) {
+  if (props.a === true) {
+    var newProps = {};
+
+    Object.assign(newProps, props, {
+      children: "div",
+    });
+    return MaybeThrow(newProps);
+  }
+  return "Bad";
+}
+
+inspect = function() {
+  return App({ a: true, b: false });
+}
+
+if (this.__optimize)  __optimize(App);


### PR DESCRIPTION
Release note: fix numerous problems with code ordering
Closes: #1914

We've been seeing an endless stream of bugs where code is either missing or in the wrong place. A lot of these were due to the complexity of joinEffectsAndPromoteNested and some more are due to a fundamental flaw in its algorithm: it rotates branches of the effects tree in order to group together all completions of a given type. That can cause generators to end up in the wrong place in the temporal sequence.

We also had a problem with generators being duplicated in the tree.

This pull request introduces a new algorithm for doing what joinEffectsAndPromoteNested does. This too is complicated and I spent days on debugging and fixing many subtle issues. So, for now, I'm only doing it for calls. More will come in later pull requests.

I am not super confident that I've found and addressed all subtle bugs. I think we can expect to run into quite a few more of those. I am, however, reasonably confident that we now have the right approach to dealing with abrupt control flow.

Please have a careful look, but let's get this landed as soon as possible because it is on the critical path.
