### PR TITLE
Fix bug with arrays with widened numeric properties

### DIFF
--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -16,6 +16,7 @@ import type { PropertyKeyValue, CallableObjectValue } from "../types.js";
 import {
   AbstractObjectValue,
   AbstractValue,
+  ArrayValue,
   BoundFunctionValue,
   EmptyValue,
   NullValue,
@@ -23,6 +24,7 @@ import {
   ObjectValue,
   ProxyValue,
   StringValue,
+  SymbolValue,
   UndefinedValue,
   Value,
 } from "../values/index.js";
@@ -40,6 +42,7 @@ import {
 import { Create, Environment, Join, Path, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeTemplateLiteral } from "babel-types";
+import * as t from "babel-types";
 
 // ECMA262 7.3.22
 export function GetFunctionRealm(realm: Realm, obj: ObjectValue): Realm {
@@ -548,4 +551,24 @@ export function GetTemplateObject(realm: Realm, templateLiteral: BabelNodeTempla
 
   // 15. Return template.
   return template;
+}
+
+export function GetFromArrayWithWidenedNumericProperty(realm: Realm, arr: ArrayValue, P: string | SymbolValue): Value {
+  let type = Value;
+
+  if (typeof P === "string") {
+    // these are safe methods to allow, as they return a new array
+    // so we use the ordinary get for these cases. Reduce can be
+    // unsafe, but we check for that in the prototype method
+    if (P === "map" || P === "slice" || P === "filter" || P === "concat") {
+      return OrdinaryGet(realm, arr, P, arr);
+    }
+    if (P === "length") {
+      type = NumberValue;
+    }
+  }
+  let prop = typeof P === "string" ? new StringValue(realm, P) : P;
+  return AbstractValue.createTemporalFromBuildFunction(realm, type, [arr, prop], ([o, p]) =>
+    t.memberExpression(o, p, true)
+  );
 }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -26,7 +26,12 @@ import {
 import { protoExpression } from "../utils/internalizer.js";
 import type { AbstractValueBuildNodeFunction } from "./AbstractValue.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
-import { IsDataDescriptor, cloneDescriptor, equalDescriptors } from "../methods/index.js";
+import {
+  GetFromArrayWithWidenedNumericProperty,
+  IsDataDescriptor,
+  cloneDescriptor,
+  equalDescriptors,
+} from "../methods/index.js";
 import { Havoc, Join, Widen } from "../singletons.js";
 import type { BabelNodeExpression } from "babel-types";
 import invariant from "../invariant.js";
@@ -528,6 +533,13 @@ export default class AbstractObjectValue extends AbstractValue {
     }
 
     let $GetHelper = ob => {
+      if (ob instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(ob) && typeof P === "string") {
+        return {
+          object: ob,
+          key: P,
+          value: GetFromArrayWithWidenedNumericProperty(this.$Realm, ob, P),
+        };
+      }
       let d = ob.$GetOwnProperty(P);
       if (d !== undefined) return d;
       let proto = ob.$GetPrototypeOf();
@@ -561,6 +573,9 @@ export default class AbstractObjectValue extends AbstractValue {
       }
       invariant(d1val instanceof Value);
       invariant(d2val instanceof Value);
+      if (d1val === d2val) {
+        return d1val;
+      }
       return Join.joinValuesAsConditional(this.$Realm, cond, d1val, d2val);
     } else {
       let result;

--- a/test/serializer/optimized-functions/ArrayFrom3.js
+++ b/test/serializer/optimized-functions/ArrayFrom3.js
@@ -1,0 +1,26 @@
+function fn(x, y) {
+  var edges = Array.from(x);
+  var items = edges
+    .map(function(a) {
+      return a;
+    })
+    .filter(Boolean);
+
+  var result = !y
+    ? []
+    : items.slice(
+        y.startIndex,
+        y.startIndex +
+          y.length
+      );
+
+  result.reverse();
+
+  return result;
+}
+
+this.__optimize && __optimize(fn);
+
+inspect = function() {
+ return JSON.stringify(fn([1, 2, 3], {startIndex: 0, length: 3}));
+}


### PR DESCRIPTION
Release notes: none

This PR fixes a bug where prototype methods on unknown arrays with widened numeric properties were incorrectly being used instead of following the route to filter which methods were safe or not. The functionality and logic for this was pulled out, into its own function so it can be re-used in places and tidied up.