### PR TITLE
Avoid redundant conversions to object

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -493,12 +493,14 @@ export default class AbstractObjectValue extends AbstractValue {
 
     if (this.values.isTop()) {
       let generateAbstractGet = () => {
+        let ob = this;
+        if (this.kind === "explicit conversion to object") ob = this.args[0];
         let type = Value;
         if (P === "length" && Value.isTypeCompatibleWith(this.getType(), ArrayValue)) type = NumberValue;
         return AbstractValue.createTemporalFromBuildFunction(
           this.$Realm,
           type,
-          [this],
+          [ob],
           ([o]) => {
             invariant(typeof P === "string");
             return t.isValidIdentifier(P)

--- a/test/serializer/additional-functions/NestedThrowEffects.js
+++ b/test/serializer/additional-functions/NestedThrowEffects.js
@@ -1,3 +1,4 @@
+// does not contain:.fakeB;
 (function() {
   function URI() {}
 

--- a/test/serializer/additional-functions/ToObject.js
+++ b/test/serializer/additional-functions/ToObject.js
@@ -1,3 +1,4 @@
+// does not contain:(props).x
 (function() {
   function URIBase(uri) {
     if (uri instanceof URIBase) {


### PR DESCRIPTION
Release note: none

When debugging another issue, I noticed that member expressions do explicit conversions of abstract base objects to object and that call expressions obtain a temporal value for the function but then go ahead without it, leaving a useless assignment in the timeline.
