### PR TITLE
Add no-use-before-define to debug-fb-www script

### DIFF
--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -117,7 +117,10 @@ function lintCompiledSource(source) {
       commonjs: true,
       browser: true,
     },
-    rules: { "no-undef": "error", "no-use-before-define": ["error", { variables: false, functions: false }] },
+    rules: {
+      "no-undef": "error",
+      "no-use-before-define": ["error", { variables: false, functions: false }],
+    },
     parserOptions: {
       ecmaVersion: 6,
       ecmaFeatures: {

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -117,7 +117,7 @@ function lintCompiledSource(source) {
       commonjs: true,
       browser: true,
     },
-    rules: { "no-undef": "error" },
+    rules: { "no-undef": "error", "no-use-before-define": ["error", { variables: false, functions: false }] },
     parserOptions: {
       ecmaVersion: 6,
       ecmaFeatures: {


### PR DESCRIPTION
Release notes: none

This adds the `no-use-before-define` rule to `debug-fb-www` script. `variables` and `functions` are set to false, which allows them to be skipped if defined in a parent scope or if the function is in the same scope (as it gets hoisted), see: https://github.com/eslint/eslint/pull/7948/files. With our current internal bundle and latest master, this brings about a new error that wasn't previously emitted: `'_$Fg' was used before it was defined. (5525:15)`.  Fixes https://github.com/facebook/prepack/issues/1982