### PR TITLE
Skip check on `elementTypes` in `CreateListFromArrayLike` if parameter is default

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3425,7 +3425,7 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with JSX input, JSX output fb-www mocks fb-www 15 1`] = `"Failed to render React component root \\"Inner\\" due to side-effects from mutating the binding \\"result\\""`;
+exports[`Test React with JSX input, JSX output fb-www mocks fb-www 15 1`] = `"Failed to render React component \\"Outer\\" due to side-effects from mutating the binding \\"result\\""`;
 
 exports[`Test React with JSX input, JSX output fb-www mocks fb-www 16 1`] = `"Failed to render React component root \\"ViewCount\\" due to side-effects from mutating a property "`;
 
@@ -7073,7 +7073,7 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with JSX input, create-element output fb-www mocks fb-www 15 1`] = `"Failed to render React component root \\"Inner\\" due to side-effects from mutating the binding \\"result\\""`;
+exports[`Test React with JSX input, create-element output fb-www mocks fb-www 15 1`] = `"Failed to render React component \\"Outer\\" due to side-effects from mutating the binding \\"result\\""`;
 
 exports[`Test React with JSX input, create-element output fb-www mocks fb-www 16 1`] = `"Failed to render React component root \\"ViewCount\\" due to side-effects from mutating a property "`;
 
@@ -10686,7 +10686,7 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with create-element input, JSX output fb-www mocks fb-www 15 1`] = `"Failed to render React component root \\"Inner\\" due to side-effects from mutating the binding \\"result\\""`;
+exports[`Test React with create-element input, JSX output fb-www mocks fb-www 15 1`] = `"Failed to render React component \\"Outer\\" due to side-effects from mutating the binding \\"result\\""`;
 
 exports[`Test React with create-element input, JSX output fb-www mocks fb-www 16 1`] = `"Failed to render React component root \\"ViewCount\\" due to side-effects from mutating a property "`;
 
@@ -14299,7 +14299,7 @@ ReactStatistics {
 }
 `;
 
-exports[`Test React with create-element input, create-element output fb-www mocks fb-www 15 1`] = `"Failed to render React component root \\"Inner\\" due to side-effects from mutating the binding \\"result\\""`;
+exports[`Test React with create-element input, create-element output fb-www mocks fb-www 15 1`] = `"Failed to render React component \\"Outer\\" due to side-effects from mutating the binding \\"result\\""`;
 
 exports[`Test React with create-element input, create-element output fb-www mocks fb-www 16 1`] = `"Failed to render React component root \\"ViewCount\\" due to side-effects from mutating a property "`;
 

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -39,7 +39,7 @@ import parse from "../utils/parse.js";
 import traverseFast from "../utils/traverse-fast.js";
 import type { BabelNodeIdentifier, BabelNodeLVal, BabelNodeFunctionDeclaration } from "babel-types";
 
-const defaultElementTypes = ["Undefined", "Null", "Boolean", "String", "Symbol", "Number", "Object"];
+const allElementTypes = ["Undefined", "Null", "Boolean", "String", "Symbol", "Number", "Object"];
 
 export class CreateImplementation {
   // ECMA262 9.4.3.3
@@ -703,7 +703,7 @@ export class CreateImplementation {
   // ECMA262 7.3.17
   CreateListFromArrayLike(realm: Realm, obj: Value, elementTypes?: Array<string>): Array<Value> {
     // 1. If elementTypes was not passed, let elementTypes be « Undefined, Null, Boolean, String, Symbol, Number, Object ».
-    elementTypes = elementTypes || defaultElementTypes;
+    elementTypes = elementTypes || allElementTypes;
 
     // 2. If Type(obj) is not Object, throw a TypeError exception.
     if (!(obj instanceof ObjectValue)) {

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -728,7 +728,7 @@ export class CreateImplementation {
       let next = Get(realm, obj, indexName);
 
       // c. If Type(next) is not an element of elementTypes, throw a TypeError exception.
-      if (elementTypes !== defaultElementTypes && elementTypes.indexOf(Type(realm, next)) < 0) {
+      if (elementTypes !== allElementTypes && elementTypes.indexOf(Type(realm, next)) < 0) {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "invalid element type");
       }
 

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -14,19 +14,19 @@ import type { EnvironmentRecord } from "../environment.js";
 import type { PropertyKeyValue, IterationKind } from "../types.js";
 import {
   AbstractObjectValue,
+  AbstractValue,
+  ArrayValue,
+  ArgumentsExotic,
+  BooleanValue,
+  FunctionValue,
   NativeFunctionValue,
   NullValue,
-  BooleanValue,
-  ArrayValue,
-  ObjectValue,
-  Value,
-  StringValue,
   NumberValue,
-  FunctionValue,
-  UndefinedValue,
+  ObjectValue,
   StringExotic,
-  ArgumentsExotic,
-  AbstractValue,
+  StringValue,
+  UndefinedValue,
+  Value,
 } from "../values/index.js";
 import { GetPrototypeFromConstructor } from "./get.js";
 import { IsConstructor, IsPropertyKey, IsArray } from "./is.js";

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -26,6 +26,7 @@ import {
   UndefinedValue,
   StringExotic,
   ArgumentsExotic,
+  AbstractValue,
 } from "../values/index.js";
 import { GetPrototypeFromConstructor } from "./get.js";
 import { IsConstructor, IsPropertyKey, IsArray } from "./is.js";
@@ -726,7 +727,7 @@ export class CreateImplementation {
       let next = Get(realm, obj, indexName);
 
       // c. If Type(next) is not an element of elementTypes, throw a TypeError exception.
-      if (elementTypes.indexOf(Type(realm, next)) < 0) {
+      if (elementTypes.indexOf(Type(realm, next)) < 0 || (realm.isInPureScope() && next instanceof AbstractValue)) {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "invalid element type");
       }
 

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -14,7 +14,6 @@ import type { EnvironmentRecord } from "../environment.js";
 import type { PropertyKeyValue, IterationKind } from "../types.js";
 import {
   AbstractObjectValue,
-  AbstractValue,
   ArrayValue,
   ArgumentsExotic,
   BooleanValue,
@@ -39,6 +38,8 @@ import invariant from "../invariant.js";
 import parse from "../utils/parse.js";
 import traverseFast from "../utils/traverse-fast.js";
 import type { BabelNodeIdentifier, BabelNodeLVal, BabelNodeFunctionDeclaration } from "babel-types";
+
+const defaultElementTypes = ["Undefined", "Null", "Boolean", "String", "Symbol", "Number", "Object"];
 
 export class CreateImplementation {
   // ECMA262 9.4.3.3
@@ -702,7 +703,7 @@ export class CreateImplementation {
   // ECMA262 7.3.17
   CreateListFromArrayLike(realm: Realm, obj: Value, elementTypes?: Array<string>): Array<Value> {
     // 1. If elementTypes was not passed, let elementTypes be « Undefined, Null, Boolean, String, Symbol, Number, Object ».
-    elementTypes = elementTypes || ["Undefined", "Null", "Boolean", "String", "Symbol", "Number", "Object"];
+    elementTypes = elementTypes || defaultElementTypes;
 
     // 2. If Type(obj) is not Object, throw a TypeError exception.
     if (!(obj instanceof ObjectValue)) {
@@ -727,7 +728,7 @@ export class CreateImplementation {
       let next = Get(realm, obj, indexName);
 
       // c. If Type(next) is not an element of elementTypes, throw a TypeError exception.
-      if (elementTypes.indexOf(Type(realm, next)) < 0 || (realm.isInPureScope() && next instanceof AbstractValue)) {
+      if (elementTypes !== defaultElementTypes && elementTypes.indexOf(Type(realm, next)) < 0) {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "invalid element type");
       }
 


### PR DESCRIPTION
Release notes: none

When we create an array with `CreateListFromArrayLike`, if the `elementTypes` parameter is left undefined, then skip the check that might throw an invariant if the passed in value is abstract.