### PR TITLE
Fix nit that crept through

### DIFF
--- a/test/serializer/abstract/Return10.js
+++ b/test/serializer/abstract/Return10.js
@@ -8,5 +8,3 @@
 	    return;
     }
 })()
-
-let inspect = () => logstream;


### PR DESCRIPTION
This line that refers to a missing variable slipped though a previous commit. 