### PR TITLE
Update build command to explictly invoke yarn build

### DIFF
--- a/scripts/publish-gh-pages.sh
+++ b/scripts/publish-gh-pages.sh
@@ -18,7 +18,7 @@ DEST_CLONE_DIR="$TMP_DIR/gh-pages"
 SCRIPT_NAME=`basename "$0"`
 COMMIT_MESSAGE="Website published using $SCRIPT_NAME"
 
-BUILD_COMMAND="yarn install && mv prepack.min.js $SRC_DIR/js/"
+BUILD_COMMAND="yarn install && yarn build && mv prepack.min.js $SRC_DIR/js/"
 
 # Utils
 RED='\033[0;31m'


### PR DESCRIPTION
Release note: none

yarn install used to also invoke the build step. This changed a while ago, but this script was not updated accordingly. Apparently no-one noticed until now.