### PR TITLE
Trigger invariant upon the React reconciler detecting an object without its bindings

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1360,7 +1360,12 @@ export class Reconciler {
     ) {
       // terminal values
       return value;
-    } else if (value instanceof AbstractValue) {
+    }
+    invariant(
+      !(value instanceof ObjectValue) || value._isFinal !== undefined,
+      `An object value was detected during React reconcilation without its bindings properly applied`
+    );
+    if (value instanceof AbstractValue) {
       return this._resolveAbstractValue(componentType, value, context, branchStatus, branchState, evaluatedNode);
     }
     // TODO investigate what about other iterables type objects


### PR DESCRIPTION
Release notes: none

During React reconciliation, detect objects whose bindings have not been correctly applied with the right effects and trigger an invariant as this will result in broken output.