### PR TITLE
Stack completion saved effects

### DIFF
--- a/test/serializer/abstract/Return9.js
+++ b/test/serializer/abstract/Return9.js
@@ -1,13 +1,15 @@
 let b = global.__abstract ? __abstract("boolean", "true") : true;
 function f() {}
 
+let y = 1;
 function g() {
 
   if (b) return "foo";
+  y = 2;
   f();
   return "bar";
 }
 
 var x = g();
 
-inspect = function() { return x; }
+inspect = function() { return [x, y].join(" "); }


### PR DESCRIPTION
Release note: none

When forking the normal branch of a PossiblyNormalCompletion into yet another PossiblyNormalCompletion, push the current effects onto a stack of effects, rather than just continuing to use the currently active effects. Not doing so, causes mismatched undo operations.

The modified test case would fail and print 2 for y, without this change.