### PR TITLE
Pass previously evaluated effects to alternate callback in evaluateWithAbstractConditional

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -874,12 +874,15 @@ export class Reconciler {
           "_resolveAbstractConditionalValue consequent"
         );
       },
-      () => {
-        return this.realm.evaluateForEffects(
-          () => this._resolveDeeply(componentType, alternateVal, context, "NEW_BRANCH", newBranchState, evaluatedNode),
-          null,
-          "_resolveAbstractConditionalValue consequent"
-        );
+      effects => {
+        return this.realm.withEffectsAppliedInGlobalEnv(() => {
+          return this.realm.evaluateForEffects(
+            () =>
+              this._resolveDeeply(componentType, alternateVal, context, "NEW_BRANCH", newBranchState, evaluatedNode),
+            null,
+            "_resolveAbstractConditionalValue consequent"
+          );
+        }, effects);
       }
     );
     if (this.reactSerializerState !== undefined) {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -875,14 +875,19 @@ export class Reconciler {
         );
       },
       effects => {
-        return this.realm.withEffectsAppliedInGlobalEnv(() => {
+        const handleAlternateVal = () => {
           return this.realm.evaluateForEffects(
             () =>
               this._resolveDeeply(componentType, alternateVal, context, "NEW_BRANCH", newBranchState, evaluatedNode),
             null,
             "_resolveAbstractConditionalValue consequent"
           );
-        }, effects);
+        };
+        if (effects) {
+          return this.realm.withEffectsAppliedInGlobalEnv(handleAlternateVal, effects);
+        } else {
+          return handleAlternateVal();
+        }
       }
     );
     if (this.reactSerializerState !== undefined) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -942,7 +942,7 @@ export class Realm {
   evaluateWithAbstractConditional(
     condValue: AbstractValue,
     consequentEffectsFunc: () => Effects,
-    alternateEffectsFunc: () => Effects
+    alternateEffectsFunc: (effects?: Effects) => Effects
   ): Value {
     // Evaluate consequent and alternate in sandboxes and get their effects.
     let effects1;

--- a/src/realm.js
+++ b/src/realm.js
@@ -954,7 +954,7 @@ export class Realm {
 
     let effects2;
     try {
-      effects2 = Path.withInverseCondition(condValue, alternateEffectsFunc);
+      effects2 = Path.withInverseCondition(condValue, () => alternateEffectsFunc(effects1));
     } catch (e) {
       if (!(e instanceof InfeasiblePathError)) throw e;
     }


### PR DESCRIPTION
Release notes: none

This fixes an invariant occurring during React reconciliation using our internal bundle. React takes a previously evaluated conditional and tries to re-evaluate it, resolving the ReactElements from both paths. The issue is that there may be a ReactElement that is shared between both `consequent` and `alternate` stages of re-evaluation and thus it needs to have its affects applied in both stages. We have the bindings for the ReactElement in the `consequent` effects, so if we re-apply them before we find the `alternate` effects, we can access the object properly. I couldn't get a repro as this was a very deep problem with our internal bundle.