### PR TITLE
Do not mutate arrays or ReactElements during React reconciliation

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2229,6 +2229,40 @@ ReactStatistics {
 
 exports[`Test React with JSX input, JSX output Functional component folding Simple 13 1`] = `"Failed to render React component root \\"App\\" due to side-effects from throwing exception"`;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output Functional component folding Simple 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -5886,6 +5920,40 @@ ReactStatistics {
 `;
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 13 1`] = `"Failed to render React component root \\"App\\" due to side-effects from throwing exception"`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple children 1`] = `
 ReactStatistics {
@@ -9545,6 +9613,40 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding Simple 13 1`] = `"Failed to render React component root \\"App\\" due to side-effects from throwing exception"`;
 
+exports[`Test React with create-element input, JSX output Functional component folding Simple 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Simple 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -13167,6 +13269,40 @@ ReactStatistics {
 `;
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 13 1`] = `"Failed to render React component root \\"App\\" due to side-effects from throwing exception"`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple 14 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple 15 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple children 1`] = `
 ReactStatistics {

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -336,6 +336,14 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         });
       });
 
+      it("Simple 14", async () => {
+        await runTest(directory, "simple-14.js");
+      });
+
+      it("Simple 15", async () => {
+        await runTest(directory, "simple-15.js");
+      });
+
       it("Mutations - not-safe 1", async () => {
         await expectReconcilerFatalError(async () => {
           await runTest(directory, "not-safe.js");

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1061,6 +1061,12 @@ export class Reconciler {
             }
           }
           setProperty(newProps, "children", resolvedChildren);
+          if (propsValue.isSimpleObject()) {
+            newProps.makeSimple();
+          }
+          if (propsValue.isPartialObject()) {
+            newProps.makePartial();
+          }
           newProps.makeFinal();
           return createInternalReactElement(this.realm, typeValue, keyValue, refValue, newProps);
         }

--- a/test/react/functional-components/simple-14.js
+++ b/test/react/functional-components/simple-14.js
@@ -1,0 +1,23 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App(props) {
+  var items = new Array(10);
+  items[0] = "div"
+  return React.createElement("div", null, items);
+}
+
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['hoely children', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;

--- a/test/react/functional-components/simple-15.js
+++ b/test/react/functional-components/simple-15.js
@@ -1,0 +1,21 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App(props) {
+  return React.createElement("div", null, [,,,,,,"div"]);
+}
+
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [['hoely children #2', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This fixes an issue that we were experiencing, that turned out to be the correct fix after looking at https://github.com/facebook/prepack/pull/1997. We shouldn't mutate arrays in the reconciliation process, instead we should create new ones when we have new values. Also, we should ensure that we don't mutate ReactElements during reconciliation too, instead we should just create new ones. Mutating existing objects and values breaks down completely when we enter nested effects that need to re-evaluate the same original values, so this fixes a bunch of internal issues we were seeing on our internal FB bundle.