### PR TITLE
If left and right in createFromConditionalOp are equal, do early return

### DIFF
--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -666,6 +666,9 @@ export default class AbstractValue extends Value {
     isCondition?: boolean,
     doNotSimplify?: boolean
   ): Value {
+    if (left === right) {
+      return left;
+    }
     if (!condition.mightNotBeTrue()) return left || realm.intrinsics.undefined;
     if (!condition.mightNotBeFalse()) return right || realm.intrinsics.undefined;
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -667,7 +667,7 @@ export default class AbstractValue extends Value {
     doNotSimplify?: boolean
   ): Value {
     if (left === right) {
-      return left;
+      return left || realm.intrinsics.undefined;
     }
     if (!condition.mightNotBeTrue()) return left || realm.intrinsics.undefined;
     if (!condition.mightNotBeFalse()) return right || realm.intrinsics.undefined;


### PR DESCRIPTION
Release notes: none

Do early return if both `left` and `right` values in `createFromConditionalOp` are equal. This improves performance quite a bit on some complex paths when running on our internal bundle.