### PR TITLE
Special case havocing on React instance

### DIFF
--- a/src/react/components.js
+++ b/src/react/components.js
@@ -123,6 +123,7 @@ export function createSimpleClassInstance(
   invariant(componentPrototype instanceof ObjectValue);
   // create an instance object and disable serialization as we don't want to output the internals we set below
   let instance = new ObjectValue(realm, componentPrototype, "this", true);
+  realm.react.reactInstances.add(instance);
   let allowedPropertyAccess = new Set(["props", "context"]);
   for (let [name] of componentPrototype.properties) {
     if (lifecycleMethods.has(name)) {
@@ -192,6 +193,7 @@ export function createClassInstanceForFirstRenderOnly(
   evaluatedNode: ReactEvaluatedNode
 ): ObjectValue {
   let instance = getValueFromFunctionCall(realm, componentType, realm.intrinsics.undefined, [props, context], true);
+  realm.react.reactInstances.add(instance);
   let objectAssign = Get(realm, realm.intrinsics.Object, "assign");
   invariant(objectAssign instanceof ECMAScriptFunctionValue);
   let objectAssignCall = objectAssign.$Call;
@@ -253,6 +255,7 @@ export function createClassInstance(
   invariant(componentPrototype instanceof ObjectValue);
   // create an instance object and disable serialization as we don't want to output the internals we set below
   let instance = new ObjectValue(realm, componentPrototype, "this", true);
+  realm.react.reactInstances.add(instance);
   deeplyApplyInstancePrototypeProperties(realm, instance, componentPrototype, classMetadata);
 
   // assign refs
@@ -302,6 +305,10 @@ export function evaluateClassConstructor(
     instanceProperties,
     instanceSymbols,
   };
+}
+
+export function havocReactInstance(realm: Realm, instance: ObjectValue): void {
+  // TODO: maybe we should havoc some thing
 }
 
 export function applyGetDerivedStateFromProps(

--- a/src/realm.js
+++ b/src/realm.js
@@ -261,6 +261,7 @@ export class Realm {
       noopFunction: undefined,
       output: opts.reactOutput || "create-element",
       reactElements: new WeakSet(),
+      reactInstances: new WeakSet(),
       symbols: new Map(),
       verbose: opts.reactVerbose || false,
     };
@@ -348,6 +349,7 @@ export class Realm {
     noopFunction: void | ECMAScriptSourceFunctionValue,
     output?: ReactOutputTypes,
     reactElements: WeakSet<ObjectValue>,
+    reactInstances: WeakSet<ObjectValue>,
     symbols: Map<ReactSymbolTypes, SymbolValue>,
     verbose: boolean,
   };


### PR DESCRIPTION
Release notes: none

This PR puts in a special case that stops class instances from being havoced after they've been created. This is not a long term fix, but in order to get things working internally, we need this otherwise React class instances break down quickly. Once we have applied the big changes needed in https://github.com/facebook/prepack/issues/1973, we can remove this.