### PR TITLE
Add __doNotRender flag to React reconcilation

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -934,6 +934,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding __reactCompilerDoNotOptimize 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding 16.3 refs 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -4617,6 +4634,23 @@ ReactStatistics {
       "children": Array [],
       "message": "",
       "name": "MyComponent",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding __reactCompilerDoNotOptimize 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
       "status": "ROOT",
     },
   ],
@@ -8318,6 +8352,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding __reactCompilerDoNotOptimize 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding 16.3 refs 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,
@@ -11966,6 +12017,23 @@ ReactStatistics {
       "children": Array [],
       "message": "",
       "name": "MyComponent",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding __reactCompilerDoNotOptimize 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
       "status": "ROOT",
     },
   ],

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -344,6 +344,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-15.js");
       });
 
+      it.only("__reactCompilerDoNotOptimize", async () => {
+        await runTest(directory, "do-not-optimize.js");
+      });
+
       it("Mutations - not-safe 1", async () => {
         await expectReconcilerFatalError(async () => {
           await runTest(directory, "not-safe.js");

--- a/src/react/errors.js
+++ b/src/react/errors.js
@@ -40,6 +40,8 @@ export class NewComponentTreeBranch extends Error {
   evaluatedNode: ReactEvaluatedNode;
 }
 
+export class DoNotOptimize extends Error {}
+
 // Used when an entire React component tree has failed to optimize
 // this means there is a programming bug in the application that is
 // being Prepacked

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -750,7 +750,7 @@ export class Reconciler {
     evaluatedNode: ReactEvaluatedNode
   ) {
     if (doNotOptimizeComponent(this.realm, componentType)) {
-      throw new DoNotOptimize("__doNotOptimize flag detected");
+      throw new DoNotOptimize("__reactCompilerDoNotOptimize flag detected");
     }
     this.statistics.componentsEvaluated++;
     if (valueIsKnownReactAbstraction(this.realm, componentType)) {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -29,6 +29,7 @@ import {
 import { ReactStatistics, type ReactSerializerState, type ReactEvaluatedNode } from "../serializer/types.js";
 import {
   createReactEvaluatedNode,
+  doNotOptimizeComponent,
   evaluateWithNestedParentEffects,
   flattenChildren,
   mapArrayValue,
@@ -62,6 +63,7 @@ import {
   applyGetDerivedStateFromProps,
 } from "./components.js";
 import {
+  DoNotOptimize,
   ExpectedBailOut,
   NewComponentTreeBranch,
   ReconcilerFatalError,
@@ -747,6 +749,9 @@ export class Reconciler {
     branchState: BranchState | null,
     evaluatedNode: ReactEvaluatedNode
   ) {
+    if (doNotOptimizeComponent(this.realm, componentType)) {
+      throw new DoNotOptimize("__doNotOptimize flag detected");
+    }
     this.statistics.componentsEvaluated++;
     if (valueIsKnownReactAbstraction(this.realm, componentType)) {
       invariant(componentType instanceof AbstractValue);
@@ -1266,7 +1271,7 @@ export class Reconciler {
       throw error;
     } else if (error instanceof ReconcilerFatalError) {
       throw new ReconcilerFatalError(error.message, evaluatedRootNode);
-    } else if (error instanceof UnsupportedSideEffect) {
+    } else if (error instanceof UnsupportedSideEffect || error instanceof DoNotOptimize) {
       throw new ReconcilerFatalError(
         `Failed to render React component root "${evaluatedRootNode.name}" due to ${error.message}`,
         evaluatedRootNode
@@ -1317,6 +1322,8 @@ export class Reconciler {
         `Failed to render React component "${evaluatedNode.name}" due to ${error.message}`,
         evaluatedNode
       );
+    } else if (error instanceof DoNotOptimize) {
+      return reactElement;
     } else if (error instanceof Completion) {
       let value = error.value;
       invariant(value instanceof ObjectValue);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -15,17 +15,17 @@ import type { BabelNode, BabelNodeJSXIdentifier } from "babel-types";
 import {
   AbstractObjectValue,
   AbstractValue,
-  Value,
+  ArrayValue,
+  BooleanValue,
+  BoundFunctionValue,
+  ECMAScriptSourceFunctionValue,
+  FunctionValue,
   NumberValue,
   ObjectValue,
-  SymbolValue,
-  FunctionValue,
   StringValue,
-  ArrayValue,
-  ECMAScriptSourceFunctionValue,
-  BoundFunctionValue,
+  SymbolValue,
   UndefinedValue,
-  BooleanValue,
+  Value,
 } from "../values/index.js";
 import { Generator } from "../utils/generator.js";
 import type {
@@ -918,4 +918,14 @@ export function createNoopFunction(realm: Realm): ECMAScriptSourceFunctionValue 
   noOpFunc.$ECMAScriptCode = body;
   realm.react.noopFunction = noOpFunc;
   return noOpFunc;
+}
+
+export function doNotOptimizeComponent(realm: Realm, componentType: Value): boolean {
+  let doNotOptimize = Get(realm, componentType, "__doNotOptimize");
+
+  if (doNotOptimize instanceof BooleanValue) {
+    return doNotOptimize.value;
+  }
+
+  return false;
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -921,11 +921,12 @@ export function createNoopFunction(realm: Realm): ECMAScriptSourceFunctionValue 
 }
 
 export function doNotOptimizeComponent(realm: Realm, componentType: Value): boolean {
-  let doNotOptimize = Get(realm, componentType, "__reactCompilerDoNotOptimize");
+  if (componentType instanceof ObjectValue) {
+    let doNotOptimize = Get(realm, componentType, "__reactCompilerDoNotOptimize");
 
-  if (doNotOptimize instanceof BooleanValue) {
-    return doNotOptimize.value;
+    if (doNotOptimize instanceof BooleanValue) {
+      return doNotOptimize.value;
+    }
   }
-
   return false;
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -921,7 +921,7 @@ export function createNoopFunction(realm: Realm): ECMAScriptSourceFunctionValue 
 }
 
 export function doNotOptimizeComponent(realm: Realm, componentType: Value): boolean {
-  let doNotOptimize = Get(realm, componentType, "__doNotOptimize");
+  let doNotOptimize = Get(realm, componentType, "__reactCompilerDoNotOptimize");
 
   if (doNotOptimize instanceof BooleanValue) {
     return doNotOptimize.value;

--- a/test/react/functional-components/do-not-optimize.js
+++ b/test/react/functional-components/do-not-optimize.js
@@ -1,0 +1,27 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Child() {
+  return <div>{[1,2,3]}</div>
+}
+
+Child.__reactCompilerDoNotOptimize = true;
+
+function App() {
+  return <Child />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  var render = renderer.toJSON();
+  return [['hoely children #2', render.children.length]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App, {
+    firstRenderOnly: true,
+  });
+}
+
+module.exports = App;

--- a/test/react/functional-components/do-not-optimize.js
+++ b/test/react/functional-components/do-not-optimize.js
@@ -15,7 +15,7 @@ function App() {
 App.getTrials = function(renderer, Root) {
   renderer.update(<Root />);
   var render = renderer.toJSON();
-  return [['hoely children #2', render.children.length]];
+  return [['do not optimize', render.children.length]];
 };
 
 if (this.__optimizeReactComponentTree) {


### PR DESCRIPTION
Release notes: opt out of optimizing a React component in a tree with `__doNotRender`

This PR makes it possible to opt out of a single component in a React component tree by detecting a `__doNotRender` flag. For example:

```js
function MyComponent(props) {
   ...
}

MyComponent.__doNotRender = true;

class MyComponent extends React.Component {
  render() {
    ...
  }
}

MyComponent.__doNotRender = true;
```