### PR TITLE
Add ReactDOM.createPortal inlining

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3682,6 +3682,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output react-dom createPortal 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Foo",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "ReactDOM.createPortal",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output react-dom server rendering Hacker News app 1`] = `
 ReactStatistics {
   "componentsEvaluated": 0,
@@ -7374,6 +7412,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output react-dom createPortal 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Foo",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "ReactDOM.createPortal",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output react-dom server rendering Hacker News app 1`] = `
 ReactStatistics {
   "componentsEvaluated": 0,
@@ -11031,6 +11107,44 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output react-dom createPortal 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Foo",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "ReactDOM.createPortal",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output react-dom server rendering Hacker News app 1`] = `
 ReactStatistics {
   "componentsEvaluated": 0,
@@ -14683,6 +14797,44 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 6,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output react-dom createPortal 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "message": "",
+                  "name": "Foo",
+                  "status": "INLINED",
+                },
+              ],
+              "message": "",
+              "name": "ReactDOM.createPortal",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -890,6 +890,14 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "hacker-news.js", false, data);
       });
     });
+
+    describe("react-dom", () => {
+      let directory = "react-dom";
+
+      it.only("createPortal", async () => {
+        await runTest(directory, "create-portal.js", false);
+      });
+    });
   });
 }
 

--- a/test/react/react-dom/create-portal.js
+++ b/test/react/react-dom/create-portal.js
@@ -1,0 +1,34 @@
+var React = require('react');
+var ReactDOM = require('react-dom');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+var b = document.createElement("div");
+
+function Foo() {
+  return <span>Inlined</span>;
+}
+
+function Child(props) {
+  var x = ReactDOM.createPortal(<Foo />, b);
+  return <div>{x}</div>
+}
+
+function App(props) {
+  return <Child />;
+}
+
+App.getTrials = function(renderer, Root) {
+  var a = document.createElement("div");
+  ReactDOM.render(<Root />, a);
+  var results = [];
+  results.push(['render props A', a.innerHTML]);
+  results.push(['render props B', b.innerHTML]);
+  return results;
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: adds support for ReactDOM.createPortal inlining

Allows the React reconciler to inline components passed to ReactDOM.createPortal.