### PR TITLE
Havoc all the bindings, deal with havoced bindings that get assigned to.

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -589,7 +589,7 @@ export class ResidualHeapVisitor {
         invariant(functionInfo);
         for (let innerName of functionInfo.unbound.keys()) {
           let environment = this.resolveBinding(val, innerName);
-          let residualBinding = this.getBinding(val, environment, innerName);
+          let residualBinding = this.getBinding(environment, innerName);
           this.visitBinding(val, residualBinding);
           residualFunctionBindings.set(innerName, residualBinding);
           if (functionInfo.modified.has(innerName)) residualBinding.modified = true;
@@ -680,7 +680,7 @@ export class ResidualHeapVisitor {
   }
 
   // Visits a binding, returns a ResidualFunctionBinding
-  getBinding(val: FunctionValue, environment: EnvironmentRecord, name: string): ResidualFunctionBinding {
+  getBinding(environment: EnvironmentRecord, name: string): ResidualFunctionBinding {
     if (environment === this.globalEnvironmentRecord.$DeclarativeRecord) environment = this.globalEnvironmentRecord;
 
     if (environment === this.globalEnvironmentRecord) {
@@ -1109,7 +1109,7 @@ export class ResidualHeapVisitor {
         invariant(additionalFunctionInfo);
         let { functionValue } = additionalFunctionInfo;
         invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
-        let residualBinding = this.getBinding(functionValue, modifiedBinding.environment, modifiedBinding.name);
+        let residualBinding = this.getBinding(modifiedBinding.environment, modifiedBinding.name);
         let funcInstance = additionalFunctionInfo.instance;
         invariant(funcInstance !== undefined);
         funcInstance.residualFunctionBindings.set(modifiedBinding.name, residualBinding);
@@ -1138,6 +1138,11 @@ export class ResidualHeapVisitor {
         // TODO nested optimized functions: revisit adding GLOBAL as outer optimized function
         residualBinding.potentialReferentializationScopes.add("GLOBAL");
         return [residualBinding, newValue];
+      },
+      visitBindingAssignment: (binding: Binding, value: Value) => {
+        let residualBinding = this.getBinding(binding.environment, binding.name);
+        residualBinding.modified = true;
+        return this.visitEquivalentValue(value);
       },
     };
     return callbacks;

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -12,7 +12,7 @@
 import { DeclarativeEnvironmentRecord, type Binding } from "../environment.js";
 import { ConcreteValue, Value, ObjectValue, AbstractValue } from "../values/index.js";
 import type { ECMAScriptSourceFunctionValue, FunctionValue } from "../values/index.js";
-import type { BabelNodeExpression, BabelNodeStatement } from "babel-types";
+import type { BabelNodeExpression, BabelNodeStatement, BabelNodeMemberExpression } from "babel-types";
 import { SameValue } from "../methods/abstract.js";
 import { Realm, type Effects } from "../realm.js";
 import invariant from "../invariant.js";
@@ -111,6 +111,7 @@ export type ResidualFunctionBinding = {
   declarativeEnvironmentRecord: null | DeclarativeEnvironmentRecord,
   // The serializedValue is only not yet present during the initialization of a binding that involves recursive dependencies.
   serializedValue?: void | BabelNodeExpression,
+  serializedUnscopedLocation?: void | BabelNodeIdentifier | BabelNodeMemberExpression,
   referentialized?: boolean,
   scope?: ScopeBinding,
   // Which additional functions a binding is accessed by. (Determines what initializer

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -300,7 +300,7 @@ class ObjectValueHavocingVisitor {
 
     let remainingHavocedBindings = getHavocedFunctionInfo(val);
 
-    let environment = val.$Environment.parent;
+    let environment = val.$Environment;
     while (environment) {
       let record = environment.environmentRecord;
       if (record instanceof ObjectEnvironmentRecord) {

--- a/test/serializer/optimized-functions/HavocBindings1.js
+++ b/test/serializer/optimized-functions/HavocBindings1.js
@@ -1,0 +1,10 @@
+(function () {
+    function f(g) {
+        let x = 23;
+        function f() { x = x + 42; }
+        g(f);
+        return x;
+    }
+    global.__optimize && __optimize(f);
+    global.inspect = function() { return f(g => g()); }
+})();

--- a/test/serializer/optimized-functions/HavocBindings2.js
+++ b/test/serializer/optimized-functions/HavocBindings2.js
@@ -1,0 +1,10 @@
+(function () {
+    function f(g) {
+        var x = 23;
+        function f() { x = x + 42; }
+        g(f);
+        return x;
+    }
+    global.__optimize && __optimize(f);
+    global.inspect = function() { return f(g => g()); }
+})();

--- a/test/serializer/optimized-functions/HavocBindings3.js
+++ b/test/serializer/optimized-functions/HavocBindings3.js
@@ -1,0 +1,13 @@
+(function () {
+    function f(g) {
+        let x = 23;
+        function f() { return x; }
+        let a = [];
+        a.push(g(f));
+        x = 42;
+        a.push(g(f));
+        return a;
+    }
+    global.__optimize && __optimize(f);
+    global.inspect = function() { return f(g => g()); }
+})();


### PR DESCRIPTION
Release notes: None

This fixes #2001: `let` bindings didn't get properly havoced,
and things could got generally wrong when dealing with havoced bindings that get assigned to.
This fixes those basic issues, strictly making things better.

However, havoced bindings in general remains a conceptually flawed feature
as described in #2007.

Adding a few regression tests.