### PR TITLE
Fix composePossiblyNormalCompletions to leave abrupt branches alone

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -164,7 +164,7 @@ export class JoinImplementation {
           c.value,
           pnc.joinCondition,
           pnc.consequent,
-          !priorEffects ? pnc.consequentEffects : realm.composeEffects(priorEffects, pnc.consequentEffects),
+          pnc.consequentEffects,
           c,
           !priorEffects ? newAlternateEffects : realm.composeEffects(priorEffects, newAlternateEffects),
           savedPathConditions,
@@ -172,21 +172,15 @@ export class JoinImplementation {
         );
       }
       invariant(pnc.alternate instanceof PossiblyNormalCompletion);
-      let new_alternate = this.composePossiblyNormalCompletions(realm, pnc.alternate, c);
+      let na = this.composePossiblyNormalCompletions(realm, pnc.alternate, c, priorEffects);
       let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.alternateEffects;
-      let newAlternateEffects = new Effects(
-        new_alternate,
-        generator,
-        modifiedBindings,
-        modifiedProperties,
-        createdObjects
-      );
+      let newAlternateEffects = new Effects(na, generator, modifiedBindings, modifiedProperties, createdObjects);
       return new PossiblyNormalCompletion(
-        new_alternate.value,
+        c.value,
         pnc.joinCondition,
         pnc.consequent,
         pnc.consequentEffects,
-        new_alternate,
+        na,
         newAlternateEffects,
         savedPathConditions,
         pnc.savedEffects
@@ -200,7 +194,7 @@ export class JoinImplementation {
           c.value,
           pnc.joinCondition,
           c,
-          newConsequentEffects,
+          !priorEffects ? newConsequentEffects : realm.composeEffects(priorEffects, newConsequentEffects),
           pnc.alternate,
           pnc.alternateEffects,
           savedPathConditions,
@@ -208,19 +202,13 @@ export class JoinImplementation {
         );
       }
       invariant(pnc.consequent instanceof PossiblyNormalCompletion);
-      let new_consequent = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
+      let nc = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
       let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.consequentEffects;
-      let newConsequentEffects = new Effects(
-        new_consequent,
-        generator,
-        modifiedBindings,
-        modifiedProperties,
-        createdObjects
-      );
+      let newConsequentEffects = new Effects(nc, generator, modifiedBindings, modifiedProperties, createdObjects);
       return new PossiblyNormalCompletion(
-        new_consequent.value,
+        c.value,
         pnc.joinCondition,
-        new_consequent,
+        nc,
         newConsequentEffects,
         pnc.alternate,
         pnc.alternateEffects,

--- a/src/realm.js
+++ b/src/realm.js
@@ -967,30 +967,9 @@ export class Realm {
       completion = joinedEffects.result;
       this.applyEffects(joinedEffects, "evaluateWithAbstractConditional");
     } else {
-      let {
-        result: result1,
-        generator: generator1,
-        modifiedBindings: modifiedBindings1,
-        modifiedProperties: modifiedProperties1,
-        createdObjects: createdObjects1,
-      } = effects1;
-
-      let {
-        result: result2,
-        generator: generator2,
-        modifiedBindings: modifiedBindings2,
-        modifiedProperties: modifiedProperties2,
-        createdObjects: createdObjects2,
-      } = effects2;
-
       // Join the effects, creating an abstract view of what happened, regardless
       // of the actual value of condValue.
-      joinedEffects = Join.joinEffects(
-        this,
-        condValue,
-        new Effects(result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1),
-        new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2)
-      );
+      joinedEffects = Join.joinEffects(this, condValue, effects1, effects2);
       completion = joinedEffects.result;
       if (completion instanceof JoinedAbruptCompletions) {
         // Note that the effects are tracked separately inside completion and will be applied later.
@@ -1216,11 +1195,6 @@ export class Realm {
       this.captureEffects(completion);
     } else {
       let savedCompletion = this.savedCompletion;
-      invariant(savedCompletion.savedEffects !== undefined);
-      invariant(this.generator !== undefined);
-      savedCompletion.savedEffects.generator.appendGenerator(this.generator, "composeWithSavedCompletion");
-      this.generator = new Generator(this, "composeWithSavedCompletion");
-      invariant(this.savedCompletion !== undefined);
       let e = this.getCapturedEffects(savedCompletion);
       invariant(e !== undefined);
       this.stopEffectCaptureAndUndoEffects(savedCompletion);


### PR DESCRIPTION
Release note: none

This pull out the parts of PR #1995 that seem obviously correct and that do not break anything.