### PR TITLE
Fixing binding value after havocing

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -70,6 +70,11 @@ export function havocBinding(binding: Binding) {
   let value = binding.value;
   if (!binding.hasLeaked && !(value instanceof ObjectValue && value.isFinalObject())) {
     realm.recordModifiedBinding(binding).hasLeaked = true;
+    if (value !== undefined) {
+      let realmGenerator = realm.generator;
+      if (realmGenerator !== undefined) realmGenerator.emitBindingAssignment(binding, value);
+      binding.value = realm.intrinsics.undefined;
+    }
   }
 }
 

--- a/test/serializer/optimized-functions/HavocBindings4.js
+++ b/test/serializer/optimized-functions/HavocBindings4.js
@@ -1,0 +1,19 @@
+(function () {
+    function f(c, g) {
+        let x = 23;
+        let y;
+        if (c) {
+            x = Date.now();
+            function h() { y = x; x++; }
+            g(h);
+            return x - y;
+        } else {
+            x = Date.now();
+            function h() { y = x; x++; }
+            g(h);
+            return x - y;
+        }
+    }
+    global.__optimize && __optimize(f);
+    global.inspect = function() { return f(true, g => g()); }
+})();

--- a/test/serializer/optimized-functions/HavocBindings5.js
+++ b/test/serializer/optimized-functions/HavocBindings5.js
@@ -1,0 +1,30 @@
+function foo(a, b, c) {
+    if (!a) {
+        return null;
+    }
+    var b = Object.assign({}, c);
+
+    return a.callFunc(function() {
+            return b.foo;
+        });
+}
+
+inspect = function() {
+    return JSON.stringify(
+                          foo({
+                                  a: {
+                                      callFunc(x) {
+                                          return x() 
+                                      },
+                                  },
+                                  b: {
+                                      foo() {
+                                          return 'works!';
+                                      },
+                                  },
+                                  c: {},
+                              })
+                          );
+}
+
+this.__optimize && __optimize(foo);


### PR DESCRIPTION
Release notes: Fixing havocing of bindings.

This fixes #1973 and it fixes #2003.

When havocing a binding,
the binding's value at that point in time would remain in the binding,
and participate in the whole value merging process,
which was meant to compute final values and caused issues.

To fix this, an explicit assignment is now emitted at binding havocing time with the current binding value, and afterwards, the current binding value, which is irrelevant from then on, is set to undefined.

This effectively fixes the issue for bindings, but the whole way binding havocing works is a bit inefficient (after havocing, Prepack effectively stops tracking that binding); even worse, similar problems that we observed here for bindings should exist for object properties as well; and the generated code looks a bit awful. I'll follow up creating separate issues for those, but they are out of scope for this change.

Adding regression tests.