### PR TITLE
Ensure we wait for array length property if its abstract

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1198,7 +1198,7 @@ export class ResidualHeapSerializer {
       if (!(lenProperty instanceof AbstractValue) || lenProperty.kind !== "widened property") {
         let semaphore = this._acquireOneObjectSemaphore(val);
         this.emitter.emitNowOrAfterWaitingForDependencies(
-          [val],
+          [val, lenProperty],
           () => {
             this._assignProperty(
               () => t.memberExpression(this.getSerializeObjectIdentifier(val), t.identifier("length")),


### PR DESCRIPTION
Release notes: none

When testing https://github.com/facebook/prepack/pull/2023, this bug crept up in our internal bundle.  We should have always been waiting for the `lenProperty` as it can be a conditional abstract and thus delay the serialization of the length until its dependencies have been serialized.

I've got an issue tracking the progress on a follow up PR to add regression tests for this PR: https://github.com/facebook/prepack/issues/2027