### PR TITLE
Allow havocing of final objects

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1172,7 +1172,8 @@ export class PropertiesImplementation {
 
   // ECMA262 9.1.5.1
   OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue): Descriptor | void {
-    if (!realm.ignoreLeakLogic && O.isHavocedObject()) {
+    // if the object is havoced and final, then it's still safe to read the value from the object
+    if (!realm.ignoreLeakLogic && O.isHavocedObject() && !O.isFinalObject()) {
       invariant(realm.generator);
       let pname = realm.generator.getAsPropertyNameExpression(StringKey(P));
       let absVal = AbstractValue.createTemporalFromBuildFunction(realm, Value, [O._templateFor || O], ([node]) =>

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -157,7 +157,7 @@ class ObjectValueHavocingVisitor {
     // prototype
     this.visitObjectPrototype(obj);
 
-    if (TestIntegrityLevel(obj.$Realm, obj, "frozen") || obj.isFinalObject()) return;
+    if (TestIntegrityLevel(obj.$Realm, obj, "frozen")) return;
 
     // if this object wasn't already havoced, we need mark it as havoced
     // so that any mutation and property access get tracked after this.
@@ -424,7 +424,7 @@ class ObjectValueHavocingVisitor {
 
 function ensureFrozenValue(realm, value, loc) {
   // TODO: This should really check if it is recursively immutability.
-  if (value instanceof ObjectValue && !TestIntegrityLevel(realm, value, "frozen") && !value.isFinalObject()) {
+  if (value instanceof ObjectValue && !TestIntegrityLevel(realm, value, "frozen")) {
     let diag = new CompilerDiagnostic(
       "Unfrozen object leaked before end of global code",
       loc || realm.currentLocation,


### PR DESCRIPTION
Release note: final objects can be havoced

After looking at the changes of https://github.com/facebook/prepack/pull/2023, it occurred to me that we have wrongly made the assertion that "final" objects cannot be havoced. Currently, the only objects to be make final are all part of the React ecosystem, so: state, props and ReactElements. If these objects cannot havoc, then it means we do not emit their properties like we do when we havoc other objects (see https://github.com/facebook/prepack/pull/2023). If we don't emit their properties, then enter an abstract function call, then the conditional properties that have dependencies get emitted after the function call rather than before the function call.

So rather than exclude final objects from being havoced – where we miss out on all the benefits from emitting properties as they havoc, we allow final objects to get havoced, with one single change to make them unique. When we try and use `OrdinaryGetOwnProperty` on them, we don't emit a temporal and allow the property get to continue as per normal. Given the objects that are final are immutable, then this is a safe operation to allow through.

I've got an issue tracking the progress on a follow up PR to add regression tests for this PR: https://github.com/facebook/prepack/issues/2027