### PR TITLE
Ensure react lazy initializer is in the top generator body

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -504,4 +504,17 @@ export class Emitter {
     invariant(!this._finalized);
     return new BodyReference(this._body, this._body.entries.length);
   }
+  emitLazyReactElementInitializer(statement: BabelNodeStatement): void {
+    let currentBody = this._body;
+    let topBody = currentBody;
+
+    // find the top parent body
+    while (topBody.parentBody !== undefined) {
+      topBody = topBody.parentBody;
+    }
+    // temproarily set the body to be the top parent body
+    this._body = topBody;
+    this.emit(statement);
+    this._body = currentBody;
+  }
 }

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -504,17 +504,4 @@ export class Emitter {
     invariant(!this._finalized);
     return new BodyReference(this._body, this._body.entries.length);
   }
-  emitLazyReactElementInitializer(statement: BabelNodeStatement): void {
-    let currentBody = this._body;
-    let topBody = currentBody;
-
-    // find the top parent body
-    while (topBody.parentBody !== undefined) {
-      topBody = topBody.parentBody;
-    }
-    // temproarily set the body to be the top parent body
-    this._body = topBody;
-    this.emit(statement);
-    this._body = currentBody;
-  }
 }

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -96,7 +96,7 @@ export class ResidualReactElementSerializer {
           t.callExpression(funcId, originalCreateElementIdentifier ? [originalCreateElementIdentifier] : [])
         )
       );
-      this.residualHeapSerializer.emitter.emit(statement);
+      this.residualHeapSerializer.emitter.emitLazyReactElementInitializer(statement);
     }
     // we then push the reactElement and its id into our list of elements to process after
     // the current additional function has serialzied


### PR DESCRIPTION
Release notes: none

We need to ensure we emit the ReactElement lazy initializer is in the top generator body (the function body) of the React component render. If we emit it in a nested generator body, it may not get called in the right place after we've nested many components. This also renames a bunch of functions to optimized functions rather than additional functions.

I've got an issue tracking the progress on a follow up PR to add regression tests for this PR: https://github.com/facebook/prepack/issues/2027