### PR TITLE
Ensure name is handled better in _canIgnoreProperty

### DIFF
--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -156,7 +156,7 @@ export class ResidualHeapInspector {
           desc.value !== undefined &&
           !this.realm.isCompatibleWith(this.realm.MOBILE_JSC_VERSION) &&
           !this.realm.isCompatibleWith("mobile") &&
-          desc.writable === (val instanceof FunctionValue && !val.$Strict && targetDescriptor.writable) &&
+          desc.writable === true &&
           (desc.value instanceof AbstractValue ||
             (desc.value instanceof ConcreteValue &&
               val.__originalName &&

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -156,7 +156,7 @@ export class ResidualHeapInspector {
           desc.value !== undefined &&
           !this.realm.isCompatibleWith(this.realm.MOBILE_JSC_VERSION) &&
           !this.realm.isCompatibleWith("mobile") &&
-          desc.writable === (!val.$Strict && targetDescriptor.writable) &&
+          desc.writable === (val instanceof FunctionValue && !val.$Strict && targetDescriptor.writable) &&
           (desc.value instanceof AbstractValue ||
             (desc.value instanceof ConcreteValue &&
               val.__originalName &&

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -147,7 +147,13 @@ export class ResidualHeapInspector {
       }
 
       if (key === "name") {
-        if (desc.enumerable !== false || desc.writable !== false || desc.configurable !== true) return false;
+        if (
+          desc.enumerable !== false ||
+          desc.writable !== targetDescriptor.writable ||
+          desc.configurable !== targetDescriptor.configurable
+        ) {
+          return false;
+        }
         // TODO #474: Make sure that we retain original function names. Or set name property.
         // Or ensure that nothing references the name property.
         // NOTE: with some old runtimes notably JSC, function names are not configurable

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -156,6 +156,7 @@ export class ResidualHeapInspector {
           desc.value !== undefined &&
           !this.realm.isCompatibleWith(this.realm.MOBILE_JSC_VERSION) &&
           !this.realm.isCompatibleWith("mobile") &&
+          desc.writable === (!val.$Strict && targetDescriptor.writable) &&
           (desc.value instanceof AbstractValue ||
             (desc.value instanceof ConcreteValue &&
               val.__originalName &&

--- a/src/serializer/ResidualHeapInspector.js
+++ b/src/serializer/ResidualHeapInspector.js
@@ -147,6 +147,7 @@ export class ResidualHeapInspector {
       }
 
       if (key === "name") {
+        if (desc.enumerable !== false || desc.writable !== false || desc.configurable !== true) return false;
         // TODO #474: Make sure that we retain original function names. Or set name property.
         // Or ensure that nothing references the name property.
         // NOTE: with some old runtimes notably JSC, function names are not configurable
@@ -156,7 +157,6 @@ export class ResidualHeapInspector {
           desc.value !== undefined &&
           !this.realm.isCompatibleWith(this.realm.MOBILE_JSC_VERSION) &&
           !this.realm.isCompatibleWith("mobile") &&
-          desc.writable === true &&
           (desc.value instanceof AbstractValue ||
             (desc.value instanceof ConcreteValue &&
               val.__originalName &&


### PR DESCRIPTION
Release notes: none

When checking for `name ` in `_getIgnoredProperties` we should also check if the descriptor is writable in strict mode.