### PR TITLE
When havocing immutable bindings, keep around and later use the leaked value

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -73,6 +73,7 @@ export function havocBinding(binding: Binding) {
     if (value !== undefined) {
       let realmGenerator = realm.generator;
       if (realmGenerator !== undefined) realmGenerator.emitBindingAssignment(binding, value);
+      if (!binding.mutable) binding.leakedImmutableValue = value;
       binding.value = realm.intrinsics.undefined;
     }
   }
@@ -159,6 +160,7 @@ export type Binding = {
   // bindings that are assigned to inside loops with abstract termination conditions need temporal locations
   phiNode?: AbstractValue,
   hasLeaked: boolean,
+  leakedImmutableValue?: Value,
 };
 
 // ECMA262 8.1.1.1
@@ -334,7 +336,7 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
 
     // 4. Return the value currently bound to N in envRec.
     if (binding.hasLeaked) {
-      return deriveGetBinding(realm, binding);
+      return binding.leakedImmutableValue || deriveGetBinding(realm, binding);
     }
     invariant(binding.value);
     return binding.value;

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -737,10 +737,15 @@ export class JoinImplementation {
       let l2 = b2 === undefined ? b.hasLeaked : b2.hasLeaked;
       let v1 = b1 === undefined ? b.value : b1.value;
       let v2 = b2 === undefined ? b.value : b2.value;
+      let liv1 = b1 === undefined ? b.leakedImmutableValue : b1.leakedImmutableValue;
+      let liv2 = b2 === undefined ? b.leakedImmutableValue : b2.leakedImmutableValue;
       let hasLeaked = l1 || l2; // If either has leaked, then this binding has leaked.
       let value = this.joinValues(realm, v1, v2, getAbstractValue);
+      let leakedImmutableValue =
+        liv1 === undefined && liv2 === undefined ? undefined : this.joinValues(realm, liv1, liv2, getAbstractValue);
       invariant(value instanceof Value);
-      return { hasLeaked, value };
+      invariant(leakedImmutableValue === undefined || leakedImmutableValue instanceof Value);
+      return { leakedImmutableValue, hasLeaked, value };
     };
     return this.joinMaps(m1, m2, join);
   }

--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -168,7 +168,8 @@ export class WidenImplementation {
         result._buildNode = args => t.identifier(phiName);
       }
       invariant(result instanceof Value);
-      return { hasLeaked, value: result };
+      // TODO: deal with leakedImmutableValue
+      return { leakedImmutableValue: undefined, hasLeaked, value: result };
     };
     return this.widenMaps(m1, m2, widen);
   }
@@ -366,7 +367,8 @@ export class WidenImplementation {
         b1.value === undefined ||
         b2.value === undefined ||
         !this._containsValues(b1.value, b2.value) ||
-        b1.hasLeaked !== b2.hasLeaked
+        b1.hasLeaked !== b2.hasLeaked ||
+        b1.leakedImmutableValue !== b2.leakedImmutableValue
       ) {
         return false;
       }

--- a/test/serializer/optimized-functions/HavocBindings7.js
+++ b/test/serializer/optimized-functions/HavocBindings7.js
@@ -1,0 +1,11 @@
+// does contain:42
+(function () {
+    function f(g) {
+        const x = 23;
+        function f() { return x; }
+        g(f);
+        return x + 19;
+    }
+    global.__optimize && __optimize(f);
+    global.inspect = function() { return f(g => g()); }
+})();


### PR DESCRIPTION
Release notes: None

Adding regression test.
While this really just does something for const bindings that we probably don't care much about,
this is leading up to a similar change for final objects which is much more relevant.

(And eventually, the last known value of a havoced mutable binding and havoced non-final objects in between external calls should be handled in this way as well.)