### PR TITLE
Better support `indexOf` and `reverse` on unknown arrays with numeric properties

### DIFF
--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -562,12 +562,12 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // we can return a temporal here as we know nothing of the array's properties.
     // This should be safe to do, as we never expose the internals of the array.
     if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O) && realm.isInPureScope()) {
-      return AbstractValue.createTemporalFromBuildFunction(
-        realm,
-        NumberValue,
-        [O, searchElement, fromIndex],
-        ([objNode, ..._args]) =>
-          t.callExpression(t.memberExpression(objNode, t.identifier("indexOf")), ((_args: any): Array<any>))
+      let args = [O, searchElement];
+      if (fromIndex) {
+        args.push(fromIndex);
+      }
+      return AbstractValue.createTemporalFromBuildFunction(realm, NumberValue, args, ([objNode, ..._args]) =>
+        t.callExpression(t.memberExpression(objNode, t.identifier("indexOf")), ((_args: any): Array<any>))
       );
     }
 
@@ -1059,7 +1059,6 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // we can return a temporal here as we know nothing of the array's properties.
     // This should be safe to do, as we never expose the internals of the array.
     if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O) && realm.isInPureScope()) {
-      debugger;
       return AbstractValue.createTemporalFromBuildFunction(realm, ArrayValue, [O], ([objNode, ..._args]) =>
         t.callExpression(t.memberExpression(objNode, t.identifier("reverse")), [])
       );

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -11,6 +11,7 @@
 
 import type { Realm } from "../../realm.js";
 import {
+  AbstractValue,
   ArrayValue,
   NullValue,
   NumberValue,
@@ -557,6 +558,19 @@ export default function(realm: Realm, obj: ObjectValue): void {
     // 1. Let O be ? ToObject(this value).
     let O = To.ToObject(realm, context);
 
+    // If we have an object that is an unknown array with numeric properties, then
+    // we can return a temporal here as we know nothing of the array's properties.
+    // This should be safe to do, as we never expose the internals of the array.
+    if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O) && realm.isInPureScope()) {
+      return AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        NumberValue,
+        [O, searchElement, fromIndex],
+        ([objNode, ..._args]) =>
+          t.callExpression(t.memberExpression(objNode, t.identifier("indexOf")), ((_args: any): Array<any>))
+      );
+    }
+
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));
 
@@ -1040,6 +1054,16 @@ export default function(realm: Realm, obj: ObjectValue): void {
   obj.defineNativeMethod("reverse", 0, context => {
     // 1. Let O be ? ToObject(this value).
     let O = To.ToObject(realm, context);
+
+    // If we have an object that is an unknown array with numeric properties, then
+    // we can return a temporal here as we know nothing of the array's properties.
+    // This should be safe to do, as we never expose the internals of the array.
+    if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O) && realm.isInPureScope()) {
+      debugger;
+      return AbstractValue.createTemporalFromBuildFunction(realm, ArrayValue, [O], ([objNode, ..._args]) =>
+        t.callExpression(t.memberExpression(objNode, t.identifier("reverse")), [])
+      );
+    }
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
     let len = To.ToLength(realm, Get(realm, O, "length"));

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -289,8 +289,14 @@ export function OrdinaryCallEvaluateBody(
 ): Reference | Value | AbruptCompletion {
   if (f instanceof NativeFunctionValue) {
     let env = realm.getRunningContext().lexicalEnvironment;
+    let context = env.environmentRecord.GetThisBinding();
+
+    if (context instanceof AbstractValue && context.kind === "conditional") {
+      // TODO: we should handle this case and split the calls up
+      // on the conditional, as it may yield better results
+    }
     try {
-      return f.callCallback(env.environmentRecord.GetThisBinding(), argumentsList, env.environmentRecord.$NewTarget);
+      return f.callCallback(context, argumentsList, env.environmentRecord.$NewTarget);
     } catch (err) {
       if (err instanceof AbruptCompletion) {
         return err;

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -291,7 +291,7 @@ export function OrdinaryCallEvaluateBody(
     let env = realm.getRunningContext().lexicalEnvironment;
     let context = env.environmentRecord.GetThisBinding();
 
-    if (context instanceof AbstractValue && context.kind === "conditional") {
+    if (context instanceof AbstractObjectValue && context.kind === "conditional") {
       // TODO: we should handle this case and split the calls up
       // on the conditional, as it may yield better results
     }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -557,10 +557,11 @@ export function GetFromArrayWithWidenedNumericProperty(realm: Realm, arr: ArrayV
   let type = Value;
 
   if (typeof P === "string") {
-    // these are safe methods to allow, as they return a new array
-    // so we use the ordinary get for these cases.
-    if (P === "map" || P === "slice" || P === "filter" || P === "concat") {
-      return OrdinaryGet(realm, arr, P, arr);
+    // these are safe methods to allow, as they either return a new array or are a method
+    // that doesn't mutate global state or affect that of the values passed in as arguments
+    if (P === "map" || P === "slice" || P === "filter" || P === "concat" || P === "indexOf" || P === "reverse") {
+      let proto = arr.$GetPrototypeOf();
+      return OrdinaryGet(realm, proto, P, arr);
     }
     if (P === "length") {
       type = NumberValue;

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -561,6 +561,7 @@ export function GetFromArrayWithWidenedNumericProperty(realm: Realm, arr: ArrayV
     // that doesn't mutate global state or affect that of the values passed in as arguments
     if (P === "map" || P === "slice" || P === "filter" || P === "concat" || P === "indexOf" || P === "reverse") {
       let proto = arr.$GetPrototypeOf();
+      invariant(proto instanceof ObjectValue);
       return OrdinaryGet(realm, proto, P, arr);
     }
     if (P === "length") {

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -397,6 +397,7 @@ class ObjectValueHavocingVisitor {
       // All intrinsic values exist from the beginning of time (except unknown arrays)...
       // ...except for a few that come into existance as templates for abstract objects.
       if (val instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(val)) {
+        debugger;
         if (this.mustVisit(val)) this.visitValueObject(val);
       } else {
         this.mustVisit(val);

--- a/test/serializer/optimized-functions/ArrayIndexOf.js
+++ b/test/serializer/optimized-functions/ArrayIndexOf.js
@@ -1,0 +1,27 @@
+function inner(props) {
+  var foo = Array.from(props.foo);
+  var bar = foo.filter(Boolean);
+  var idx = bar.indexOf(5);
+
+  return idx;
+}
+
+function fn(arg) {
+  if (!arg.condition) {
+    return null
+  }
+  return inner(arg)
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify([
+    fn({condition: false}),
+    fn({condition: true, foo: []}),
+    fn({condition: true, foo: [false]}),
+    fn({condition: true, foo: [true]}),
+    fn({condition: true, foo: [false, 5]}),
+    fn({condition: true, foo: [true, 5]}),
+  ])
+};

--- a/test/serializer/optimized-functions/ArrayReverse.js
+++ b/test/serializer/optimized-functions/ArrayReverse.js
@@ -1,0 +1,27 @@
+function inner(props) {
+  var foo = Array.from(props.foo);
+  var bar = foo.filter(Boolean);
+  bar.reverse();
+
+  return bar;
+}
+
+function fn(arg) {
+  if (!arg.condition) {
+    return null
+  }
+  return inner(arg)
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify([
+    fn({condition: false}),
+    fn({condition: true, foo: [1, 2, 3]}),
+    fn({condition: true, foo: [false, 1, 2]}),
+    fn({condition: true, foo: [true, 1, 2]}),
+    fn({condition: true, foo: [false, 5, 4]}),
+    fn({condition: true, foo: [true, 5, 8]}),
+  ])
+};


### PR DESCRIPTION
Release notes: support `indexOf` and `reverse` on unknown arrays with numeric properties

This PR aims to better support `indexOf` and `reverse` on unknown arrays with numeric properties. Previously, these two methods on the array would cause a FatalError in pure mode that would recover and havoc the array itself and the arguments. I don't believe this is necessary for these two methods in pure mode because they don't mutate the arguments passed. In pure mode we expect that calling `toString` on the arguments won't affect global scope, so these operations should be fine to be emitted as temporals with them being havoced.

I also added a TODO to an area I want to look at next week that I feel will unlock many more optimizations and inlining possibilities (with regards to handling conditional abstract objects as the context of the function call).