### PR TITLE
Add in invariant checks to ensure we fail early on impossible cases

### DIFF
--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -242,12 +242,6 @@ export function createInternalReactElement(
   if (type instanceof AbstractValue && type.kind === "conditional") {
     invariant(false, "createInternalReactElement should never encounter a conditional type");
   }
-  if (key instanceof AbstractValue && key.kind === "conditional") {
-    invariant(false, "createInternalReactElement should never encounter a conditional key");
-  }
-  if (ref instanceof AbstractValue && ref.kind === "conditional") {
-    invariant(false, "createInternalReactElement should never encounter a conditional ref");
-  }
   if (props instanceof AbstractObjectValue && props.kind === "conditional") {
     invariant(false, "createInternalReactElement should never encounter a conditional props");
   }

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -184,8 +184,8 @@ function splitReactElementsByConditionalType(
 function splitReactElementsByConditionalConfig(
   realm: Realm,
   condValue: AbstractValue,
-  consequentVal: Value,
-  alternateVal: Value,
+  consequentVal: ObjectValue | AbstractObjectValue,
+  alternateVal: ObjectValue | AbstractObjectValue,
   type: Value,
   children: void | Value
 ): Value {
@@ -221,6 +221,8 @@ export function createReactElement(
   } else if (config instanceof AbstractObjectValue && config.kind === "conditional") {
     let [condValue, consequentVal, alternateVal] = config.args;
     invariant(condValue instanceof AbstractValue);
+    invariant(consequentVal instanceof ObjectValue || consequentVal instanceof AbstractObjectValue);
+    invariant(alternateVal instanceof ObjectValue || alternateVal instanceof AbstractObjectValue);
     return splitReactElementsByConditionalConfig(realm, condValue, consequentVal, alternateVal, type, children);
   }
   let { key, props, ref } = createPropsObject(realm, type, config, children);
@@ -246,7 +248,7 @@ export function createInternalReactElement(
   if (ref instanceof AbstractValue && ref.kind === "conditional") {
     invariant(false, "createInternalReactElement should never encounter a conditional ref");
   }
-  if (props instanceof AbstractValue && props.kind === "conditional") {
+  if (props instanceof AbstractObjectValue && props.kind === "conditional") {
     invariant(false, "createInternalReactElement should never encounter a conditional props");
   }
   Create.CreateDataPropertyOrThrow(realm, obj, "$$typeof", getReactSymbol("react.element", realm));

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1140,6 +1140,15 @@ export class Reconciler {
     let propsValue = getProperty(this.realm, reactElement, "props");
     let refValue = getProperty(this.realm, reactElement, "ref");
 
+    invariant(
+      !(typeValue instanceof AbstractValue && typeValue.kind === "conditional"),
+      `the reconciler should never encounter a ReactElement "type" that is conditional abstract value`
+    );
+    invariant(
+      !(propsValue instanceof AbstractValue && propsValue.kind === "conditional"),
+      `the reconciler should never encounter a ReactElement "props" that is conditional abstract value`
+    );
+
     if (typeValue instanceof StringValue) {
       return this._resolveReactElementHostChildren(
         componentType,
@@ -1175,12 +1184,6 @@ export class Reconciler {
 
       switch (componentResolutionStrategy) {
         case "NORMAL": {
-          if (typeValue instanceof AbstractValue && typeValue.kind === "conditional") {
-            invariant(
-              false,
-              "We should never have a component type that is condition, it should be handled in the createReactElement logic"
-            );
-          }
           if (
             !(typeValue instanceof ECMAScriptSourceFunctionValue || valueIsKnownReactAbstraction(this.realm, typeValue))
           ) {


### PR DESCRIPTION
Release notes: none

After speaking to @NTillmann, there seems to be cases where impossible cases are occuring during the React reconcilation. This PR adds in invariants so we fail early (rather than emit bad output). `type` and `props` are both parts of the immutable ReactElement. The ReactElement is final as is the props object. There should never be a case where the properties of a ReactElement are conditional abstract values – this violates so many parts of the reconciliation process. 

There's only one codepath that we support for creating ReactElements, and that's via the function `createReactElement` in `react/elements.js`. The ReactElement is made final after this, so the properties of the ReactElement should never change, even to conditionals.