### PR TITLE
Make more files flow strict

### DIFF
--- a/src/benchmarker.js
+++ b/src/benchmarker.js
@@ -14,6 +14,7 @@ import Serializer from "./serializer/index.js";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
 import invariant from "./invariant.js";
+import { isUndefinedOrNull } from "./utils.js";
 
 let chalk = require("chalk");
 let jsdom = require("jsdom");
@@ -170,8 +171,8 @@ function dump(
   let code = serialized.code;
   let total = Date.now() - start;
 
-  if (code.length >= 1000 || typeof outputFilename !== "undefined") {
-    let filename = typeof outputFilename !== "undefined" ? outputFilename : name + "-processed.js";
+  if (code.length >= 1000 || !isUndefinedOrNull(outputFilename)) {
+    let filename = typeof outputFilename === "string" ? outputFilename : name + "-processed.js";
     console.log(`Prepacked source code written to ${filename}.`);
     fs.writeFileSync(filename, code);
   }
@@ -186,7 +187,7 @@ function dump(
     beforeStats
   );
 
-  if (code.length <= 1000 && typeof outputFilename === "undefined") {
+  if (code.length <= 1000 && isUndefinedOrNull(outputFilename)) {
     console.log("+++++++++++++++++ Prepacked source code");
     console.log(code);
     console.log("=================");

--- a/src/benchmarker.js
+++ b/src/benchmarker.js
@@ -14,7 +14,6 @@ import Serializer from "./serializer/index.js";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
 import invariant from "./invariant.js";
-import { isUndefinedOrNull } from "./utils.js";
 
 let chalk = require("chalk");
 let jsdom = require("jsdom");
@@ -171,7 +170,7 @@ function dump(
   let code = serialized.code;
   let total = Date.now() - start;
 
-  if (code.length >= 1000 || !isUndefinedOrNull(outputFilename)) {
+  if (code.length >= 1000 || typeof outputFilename !== "undefined") {
     let filename = typeof outputFilename === "string" ? outputFilename : name + "-processed.js";
     console.log(`Prepacked source code written to ${filename}.`);
     fs.writeFileSync(filename, code);
@@ -187,7 +186,7 @@ function dump(
     beforeStats
   );
 
-  if (code.length <= 1000 && isUndefinedOrNull(outputFilename)) {
+  if (code.length <= 1000 && typeof outputFilename === "undefined") {
     console.log("+++++++++++++++++ Prepacked source code");
     console.log(code);
     console.log("=================");

--- a/src/benchmarker.js
+++ b/src/benchmarker.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Compatibility } from "./options.js";
 import Serializer from "./serializer/index.js";
@@ -21,13 +21,27 @@ let zlib = require("zlib");
 let fs = require("fs");
 let vm = require("vm");
 
+type Sandbox = {
+  setTimeout: (func: () => mixed, timeout?: number, ...args?: Array<mixed>) => TimeoutID,
+  setInterval: (func: () => mixed, timeout?: number, ...args?: Array<mixed>) => IntervalID,
+  console: {
+    error: (msg: string | {}) => void,
+    log: (msg: string | {}) => void,
+  },
+  window?: {},
+  document?: {},
+  navigator?: {},
+  location?: {},
+};
+
 function getTime() {
   let stamp = process.hrtime();
   return (stamp[0] * 1e9 + stamp[1]) / 1e6;
 }
 
-function exec(code: string, compatibility: Compatibility) {
-  let sandbox: any = {
+function exec(_code: string, compatibility: Compatibility) {
+  let code = _code;
+  let sandbox: Sandbox = {
     setTimeout: setTimeout,
     setInterval: setInterval,
     console: {
@@ -156,8 +170,8 @@ function dump(
   let code = serialized.code;
   let total = Date.now() - start;
 
-  if (code.length >= 1000 || outputFilename) {
-    let filename = outputFilename || name + "-processed.js";
+  if (code.length >= 1000 || typeof outputFilename !== "undefined") {
+    let filename = typeof outputFilename !== "undefined" ? outputFilename : name + "-processed.js";
     console.log(`Prepacked source code written to ${filename}.`);
     fs.writeFileSync(filename, code);
   }
@@ -172,7 +186,7 @@ function dump(
     beforeStats
   );
 
-  if (code.length <= 1000 && !outputFilename) {
+  if (code.length <= 1000 && typeof outputFilename === "undefined") {
     console.log("+++++++++++++++++ Prepacked source code");
     console.log(code);
     console.log("=================");

--- a/src/benchmarker.js
+++ b/src/benchmarker.js
@@ -170,8 +170,9 @@ function dump(
   let code = serialized.code;
   let total = Date.now() - start;
 
-  if (code.length >= 1000 || typeof outputFilename !== "undefined") {
-    let filename = typeof outputFilename === "string" ? outputFilename : name + "-processed.js";
+  const isValidOutputFilename = outputFilename !== undefined && outputFilename !== "";
+  if (code.length >= 1000 || isValidOutputFilename) {
+    let filename = outputFilename !== undefined ? outputFilename : name + "-processed.js";
     console.log(`Prepacked source code written to ${filename}.`);
     fs.writeFileSync(filename, code);
   }
@@ -186,7 +187,7 @@ function dump(
     beforeStats
   );
 
-  if (code.length <= 1000 && typeof outputFilename === "undefined") {
+  if (code.length <= 1000 && !isValidOutputFilename) {
     console.log("+++++++++++++++++ Prepacked source code");
     console.log(code);
     console.log("=================");

--- a/src/construct_realm.js
+++ b/src/construct_realm.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Realm } from "./realm.js";
 import initializeSingletons from "./initialize-singletons.js";

--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { DebugSession, InitializedEvent, OutputEvent, TerminatedEvent, StoppedEvent } from "vscode-debugadapter";
 import * as DebugProtocol from "vscode-debugprotocol";

--- a/src/debugger/common/channel/MessageMarshaller.js
+++ b/src/debugger/common/channel/MessageMarshaller.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 import { DebugMessage } from "./DebugMessage.js";
 import type {
   Breakpoint,

--- a/src/debugger/mock-ui/debugger-cli.js
+++ b/src/debugger/mock-ui/debugger-cli.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { UISession } from "./UISession.js";
 import type { DebuggerCLIArguments } from "./UISession.js";

--- a/src/debugger/server/BreakpointManager.js
+++ b/src/debugger/server/BreakpointManager.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { PerFileBreakpointMap } from "./PerFileBreakpointMap.js";
 import { Breakpoint } from "./Breakpoint.js";

--- a/src/debugger/server/Debugger.js
+++ b/src/debugger/server/Debugger.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { BreakpointManager } from "./BreakpointManager.js";
 import type { BabelNode, BabelNodeSourceLocation } from "babel-types";

--- a/src/debugger/server/Stepper.js
+++ b/src/debugger/server/Stepper.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 import type { SourceData } from "./../common/types.js";
 import { IsStatement } from "./../../methods/is.js";
 import { BabelNode } from "babel-types";

--- a/src/debugger/server/SteppingManager.js
+++ b/src/debugger/server/SteppingManager.js
@@ -12,7 +12,6 @@
 import { BabelNode } from "babel-types";
 import invariant from "./../common/invariant.js";
 import { Stepper, StepIntoStepper, StepOverStepper } from "./Stepper.js";
-import { isUndefinedOrNull } from "./../../utils.js";
 import type { Realm } from "./../../realm.js";
 import type { StoppableObject } from "./StopEventManager.js";
 
@@ -21,7 +20,7 @@ export class SteppingManager {
     this._realm = realm;
     this._steppers = [];
     this._keepOldSteppers = false;
-    if (!isUndefinedOrNull(keepOldSteppers)) this._keepOldSteppers = true;
+    if (typeof keepOldSteppers !== "undefined") this._keepOldSteppers = true;
   }
   _realm: Realm;
   _keepOldSteppers: boolean;

--- a/src/debugger/server/SteppingManager.js
+++ b/src/debugger/server/SteppingManager.js
@@ -12,6 +12,7 @@
 import { BabelNode } from "babel-types";
 import invariant from "./../common/invariant.js";
 import { Stepper, StepIntoStepper, StepOverStepper } from "./Stepper.js";
+import { isUndefinedOrNull } from "./../../utils.js";
 import type { Realm } from "./../../realm.js";
 import type { StoppableObject } from "./StopEventManager.js";
 
@@ -20,7 +21,7 @@ export class SteppingManager {
     this._realm = realm;
     this._steppers = [];
     this._keepOldSteppers = false;
-    if (typeof keepOldSteppers !== "undefined") this._keepOldSteppers = true;
+    if (!isUndefinedOrNull(keepOldSteppers)) this._keepOldSteppers = true;
   }
   _realm: Realm;
   _keepOldSteppers: boolean;

--- a/src/debugger/server/SteppingManager.js
+++ b/src/debugger/server/SteppingManager.js
@@ -20,7 +20,7 @@ export class SteppingManager {
     this._realm = realm;
     this._steppers = [];
     this._keepOldSteppers = false;
-    if (typeof keepOldSteppers !== "undefined") this._keepOldSteppers = true;
+    if (keepOldSteppers === true) this._keepOldSteppers = true;
   }
   _realm: Realm;
   _keepOldSteppers: boolean;

--- a/src/debugger/server/SteppingManager.js
+++ b/src/debugger/server/SteppingManager.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { BabelNode } from "babel-types";
 import invariant from "./../common/invariant.js";
@@ -20,7 +20,7 @@ export class SteppingManager {
     this._realm = realm;
     this._steppers = [];
     this._keepOldSteppers = false;
-    if (keepOldSteppers) this._keepOldSteppers = true;
+    if (typeof keepOldSteppers !== "undefined") this._keepOldSteppers = true;
   }
   _realm: Realm;
   _keepOldSteppers: boolean;

--- a/src/debugger/server/StopEventManager.js
+++ b/src/debugger/server/StopEventManager.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import invariant from "./../common/invariant.js";
 import { Breakpoint } from "./Breakpoint.js";

--- a/src/debugger/server/VariableManager.js
+++ b/src/debugger/server/VariableManager.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Variable, EvaluateResult } from "./../common/types.js";
 import { ReferenceMap } from "./ReferenceMap.js";

--- a/src/debugger/server/channel/DebugChannel.js
+++ b/src/debugger/server/channel/DebugChannel.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 import invariant from "./../../common/invariant.js";
 import { FileIOWrapper } from "./../../common/channel/FileIOWrapper.js";
 import { DebugMessage } from "./../../common/channel/DebugMessage.js";

--- a/src/domains/TypesDomain.js
+++ b/src/domains/TypesDomain.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import invariant from "../invariant.js";
 import type { BabelBinaryOperator, BabelNodeLogicalOperator, BabelUnaryOperator } from "babel-types";

--- a/src/domains/ValuesDomain.js
+++ b/src/domains/ValuesDomain.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelBinaryOperator, BabelNodeLogicalOperator, BabelUnaryOperator } from "babel-types";
 import { AbruptCompletion } from "../completions.js";
@@ -44,7 +44,8 @@ import { Utils } from "../singletons.js";
    one value, one of which will by the EmptyValue.  */
 
 export default class ValuesDomain {
-  constructor(values: void | Set<ConcreteValue> | ConcreteValue) {
+  constructor(_values: void | Set<ConcreteValue> | ConcreteValue) {
+    let values = _values;
     if (values instanceof ConcreteValue) {
       let valueSet = new Set();
       valueSet.add(values);
@@ -455,9 +456,11 @@ export default class ValuesDomain {
     return false;
   }
 
-  static joinValues(realm: Realm, v1: void | Value, v2: void | Value): ValuesDomain {
-    if (v1 === undefined) v1 = realm.intrinsics.undefined;
-    if (v2 === undefined) v2 = realm.intrinsics.undefined;
+  static joinValues(
+    realm: Realm,
+    v1: Value = realm.intrinsics.undefined,
+    v2: Value = realm.intrinsics.undefined
+  ): ValuesDomain {
     if (v1 instanceof AbstractValue) return v1.values.joinWith(v2);
     if (v2 instanceof AbstractValue) return v2.values.joinWith(v1);
     let union = new Set();
@@ -481,9 +484,11 @@ export default class ValuesDomain {
     return new ValuesDomain(union);
   }
 
-  static meetValues(realm: Realm, v1: void | Value, v2: void | Value): ValuesDomain {
-    if (v1 === undefined) v1 = realm.intrinsics.undefined;
-    if (v2 === undefined) v2 = realm.intrinsics.undefined;
+  static meetValues(
+    realm: Realm,
+    v1: Value = realm.intrinsics.undefined,
+    v2: Value = realm.intrinsics.undefined
+  ): ValuesDomain {
     if (v1 instanceof AbstractValue) return v1.values.meetWith(v2);
     if (v2 instanceof AbstractValue) return v2.values.meetWith(v1);
     let intersection = new Set();

--- a/src/domains/index.js
+++ b/src/domains/index.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default as TypesDomain } from "./TypesDomain.js";
 export { default as ValuesDomain } from "./ValuesDomain.js";

--- a/src/environment.js
+++ b/src/environment.js
@@ -287,7 +287,7 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
     if (binding.strict === true) S = true;
 
     // 4. If the binding for N in envRec has not yet been initialized, throw a ReferenceError exception.
-    if (binding.initialized === false) {
+    if (binding.initialized !== true) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, `${N} has not yet been initialized`);
     } else if (binding.mutable) {
       // 5. Else if the binding for N in envRec is a mutable binding, change its bound value to V.

--- a/src/environment.js
+++ b/src/environment.js
@@ -67,7 +67,7 @@ export function havocBinding(binding: Binding) {
     if (value !== undefined) {
       let realmGenerator = realm.generator;
       if (realmGenerator !== undefined) realmGenerator.emitBindingAssignment(binding, value);
-      if (!binding.mutable) binding.leakedImmutableValue = value;
+      if (binding.mutable !== true) binding.leakedImmutableValue = value;
       binding.value = realm.intrinsics.undefined;
     }
   }
@@ -242,7 +242,7 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
     let binding = envRec.bindings[N];
 
     // 2. Assert: envRec must have an uninitialized binding for N.
-    invariant(binding && !binding.initialized, `shouldn't have the binding ${N}`);
+    invariant(binding && binding.initialized !== true, `shouldn't have the binding ${N}`);
 
     // 3. Set the bound value for N in envRec to V.
     if (!skipRecord) this.realm.recordModifiedBinding(binding, V).value = V;
@@ -256,7 +256,8 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
   }
 
   // ECMA262 8.1.1.1.5
-  SetMutableBinding(N: string, V: Value, S: boolean): Value {
+  SetMutableBinding(N: string, V: Value, _S: boolean): Value {
+    let S = _S;
     // We can mutate frozen bindings because of captured bindings.
     let realm = this.realm;
 
@@ -283,10 +284,10 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
     }
 
     // 3. If the binding for N in envRec is a strict binding, let S be true.
-    if (binding.strict) S = true;
+    if (binding.strict === true) S = true;
 
     // 4. If the binding for N in envRec has not yet been initialized, throw a ReferenceError exception.
-    if (!binding.initialized) {
+    if (binding.initialized === false) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.ReferenceError, `${N} has not yet been initialized`);
     } else if (binding.mutable) {
       // 5. Else if the binding for N in envRec is a mutable binding, change its bound value to V.

--- a/src/evaluators/ArrayExpression.js
+++ b/src/evaluators/ArrayExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/ArrowFunctionExpression.js
+++ b/src/evaluators/ArrowFunctionExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/AwaitExpression.js
+++ b/src/evaluators/AwaitExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";

--- a/src/evaluators/BlockStatement.js
+++ b/src/evaluators/BlockStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeBlockStatement } from "babel-types";
 import type { Realm } from "../realm.js";

--- a/src/evaluators/BooleanLiteral.js
+++ b/src/evaluators/BooleanLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/BreakStatement.js
+++ b/src/evaluators/BreakStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/ClassExpression.js
+++ b/src/evaluators/ClassExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/ConditionalExpression.js
+++ b/src/evaluators/ConditionalExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { LexicalEnvironment } from "../environment.js";
 import { AbstractValue, ConcreteValue, Value } from "../values/index.js";

--- a/src/evaluators/ContinueStatement.js
+++ b/src/evaluators/ContinueStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/Directive.js
+++ b/src/evaluators/Directive.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/DirectiveLiteral.js
+++ b/src/evaluators/DirectiveLiteral.js
@@ -7,6 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default } from "./StringLiteral";

--- a/src/evaluators/DoExpression.js
+++ b/src/evaluators/DoExpression.js
@@ -7,6 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default } from "./BlockStatement.js";

--- a/src/evaluators/EmptyStatement.js
+++ b/src/evaluators/EmptyStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/ExpressionStatement.js
+++ b/src/evaluators/ExpressionStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/File.js
+++ b/src/evaluators/File.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/FunctionDeclaration.js
+++ b/src/evaluators/FunctionDeclaration.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/FunctionExpression.js
+++ b/src/evaluators/FunctionExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/Identifier.js
+++ b/src/evaluators/Identifier.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/IfStatement.js
+++ b/src/evaluators/IfStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { AbruptCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { Effects } from "../realm.js";

--- a/src/evaluators/MemberExpression.js
+++ b/src/evaluators/MemberExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/MetaProperty.js
+++ b/src/evaluators/MetaProperty.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/NullLiteral.js
+++ b/src/evaluators/NullLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/NumericLiteral.js
+++ b/src/evaluators/NumericLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/RegExpLiteral.js
+++ b/src/evaluators/RegExpLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/ReturnStatement.js
+++ b/src/evaluators/ReturnStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/SequenceExpression.js
+++ b/src/evaluators/SequenceExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/StringLiteral.js
+++ b/src/evaluators/StringLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/SuperCall.js
+++ b/src/evaluators/SuperCall.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeExpression, BabelNodeSpreadElement } from "babel-types";
 import type { Realm } from "../realm.js";

--- a/src/evaluators/SuperProperty.js
+++ b/src/evaluators/SuperProperty.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/TaggedTemplateExpression.js
+++ b/src/evaluators/TaggedTemplateExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/TemplateLiteral.js
+++ b/src/evaluators/TemplateLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/ThisExpression.js
+++ b/src/evaluators/ThisExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/ThrowStatement.js
+++ b/src/evaluators/ThrowStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -115,7 +115,7 @@ export default function(
 
       // 4. Let value be ? GetValue(rhs).
       let value = Environment.GetValue(realm, rhs);
-      if (declar.id && typeof declar.id.name !== "undefined") value.__originalName = bindingId;
+      if (declar.id && declar.id.name !== undefined) value.__originalName = bindingId;
 
       // 5. If IsAnonymousFunctionDefinition(Initializer) is true, then
       if (IsAnonymousFunctionDefinition(realm, Initializer)) {

--- a/src/evaluators/VariableDeclaration.js
+++ b/src/evaluators/VariableDeclaration.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
@@ -115,7 +115,7 @@ export default function(
 
       // 4. Let value be ? GetValue(rhs).
       let value = Environment.GetValue(realm, rhs);
-      if (declar.id && declar.id.name) value.__originalName = bindingId;
+      if (declar.id && typeof declar.id.name !== "undefined") value.__originalName = bindingId;
 
       // 5. If IsAnonymousFunctionDefinition(Initializer) is true, then
       if (IsAnonymousFunctionDefinition(realm, Initializer)) {

--- a/src/evaluators/WithStatement.js
+++ b/src/evaluators/WithStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { LexicalEnvironment, ObjectEnvironmentRecord } from "../environment.js";

--- a/src/evaluators/YieldExpression.js
+++ b/src/evaluators/YieldExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/evaluators/index.js
+++ b/src/evaluators/index.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default as ArrayExpression } from "./ArrayExpression.js";
 export { default as ArrowFunctionExpression } from "./ArrowFunctionExpression.js";

--- a/src/globals.js
+++ b/src/globals.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "./realm.js";
 import initializePrepackGlobals from "./intrinsics/prepack/global.js";

--- a/src/intrinsics/common/console.js
+++ b/src/intrinsics/common/console.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/dom/document.js
+++ b/src/intrinsics/dom/document.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, AbstractObjectValue } from "../../values/index.js";

--- a/src/intrinsics/dom/global.js
+++ b/src/intrinsics/dom/global.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 

--- a/src/intrinsics/ecma262/ArrayBuffer.js
+++ b/src/intrinsics/ecma262/ArrayBuffer.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
@@ -36,7 +36,8 @@ export default function(realm: Realm): NativeFunctionValue {
   );
 
   // ECMA262 24.1.3.1
-  func.defineNativeMethod("isView", 1, (context, [arg]) => {
+  func.defineNativeMethod("isView", 1, (context, [_arg]) => {
+    let arg = _arg;
     // 1. If Type(arg) is not Object, return false.
     if (!arg.mightBeObject()) return realm.intrinsics.false;
 

--- a/src/intrinsics/ecma262/ArrayBufferPrototype.js
+++ b/src/intrinsics/ecma262/ArrayBufferPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, NumberValue, UndefinedValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/ArrayIteratorPrototype.js
+++ b/src/intrinsics/ecma262/ArrayIteratorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { Create, To } from "../../singletons.js";

--- a/src/intrinsics/ecma262/ArrayProto_toString.js
+++ b/src/intrinsics/ecma262/ArrayProto_toString.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/ArrayProto_values.js
+++ b/src/intrinsics/ecma262/ArrayProto_values.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Boolean.js
+++ b/src/intrinsics/ecma262/Boolean.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, BooleanValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/BooleanPrototype.js
+++ b/src/intrinsics/ecma262/BooleanPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, AbstractValue, BooleanValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/DataView.js
+++ b/src/intrinsics/ecma262/DataView.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { IsDetachedBuffer } from "../../methods/index.js";
@@ -22,7 +22,8 @@ export default function(realm: Realm): NativeFunctionValue {
     "DataView",
     "DataView",
     3,
-    (context, [buffer, byteOffset, byteLength], argCount, NewTarget) => {
+    (context, [_buffer, byteOffset, byteLength], argCount, NewTarget) => {
+      let buffer = _buffer;
       // 1. If NewTarget is undefined, throw a TypeError exception.
       if (!NewTarget) {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);

--- a/src/intrinsics/ecma262/DataViewPrototype.js
+++ b/src/intrinsics/ecma262/DataViewPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, NumberValue } from "../../values/index.js";
@@ -119,7 +119,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.5
-  obj.defineNativeMethod("getFloat32", 1, (context, [byteOffset, littleEndian]) => {
+  obj.defineNativeMethod("getFloat32", 1, (context, [byteOffset, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -131,7 +132,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.6
-  obj.defineNativeMethod("getFloat64", 1, (context, [byteOffset, littleEndian]) => {
+  obj.defineNativeMethod("getFloat64", 1, (context, [byteOffset, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -152,7 +154,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.8
-  obj.defineNativeMethod("getInt16", 1, (context, [byteOffset, littleEndian]) => {
+  obj.defineNativeMethod("getInt16", 1, (context, [byteOffset, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -164,7 +167,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.9
-  obj.defineNativeMethod("getInt32", 1, (context, [byteOffset, littleEndian]) => {
+  obj.defineNativeMethod("getInt32", 1, (context, [byteOffset, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -185,7 +189,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.11
-  obj.defineNativeMethod("getUint16", 1, (context, [byteOffset, littleEndian]) => {
+  obj.defineNativeMethod("getUint16", 1, (context, [byteOffset, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -197,7 +202,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.12
-  obj.defineNativeMethod("getUint32", 1, (context, [byteOffset, littleEndian]) => {
+  obj.defineNativeMethod("getUint32", 1, (context, [byteOffset, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -209,7 +215,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.13
-  obj.defineNativeMethod("setFloat32", 2, (context, [byteOffset, value, littleEndian]) => {
+  obj.defineNativeMethod("setFloat32", 2, (context, [byteOffset, value, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -221,7 +228,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.14
-  obj.defineNativeMethod("setFloat64", 2, (context, [byteOffset, value, littleEndian]) => {
+  obj.defineNativeMethod("setFloat64", 2, (context, [byteOffset, value, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -242,7 +250,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.16
-  obj.defineNativeMethod("setInt16", 2, (context, [byteOffset, value, littleEndian]) => {
+  obj.defineNativeMethod("setInt16", 2, (context, [byteOffset, value, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -254,7 +263,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.17
-  obj.defineNativeMethod("setInt32", 2, (context, [byteOffset, value, littleEndian]) => {
+  obj.defineNativeMethod("setInt32", 2, (context, [byteOffset, value, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -275,7 +285,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.19
-  obj.defineNativeMethod("setUint16", 2, (context, [byteOffset, value, littleEndian]) => {
+  obj.defineNativeMethod("setUint16", 2, (context, [byteOffset, value, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 
@@ -287,7 +298,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 24.2.4.20
-  obj.defineNativeMethod("setUint32", 2, (context, [byteOffset, value, littleEndian]) => {
+  obj.defineNativeMethod("setUint32", 2, (context, [byteOffset, value, _littleEndian]) => {
+    let littleEndian = _littleEndian;
     // 1. Let v be the this value.
     let v = context;
 

--- a/src/intrinsics/ecma262/Date.js
+++ b/src/intrinsics/ecma262/Date.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NativeFunctionValue, NumberValue, StringValue, ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/DatePrototype.js
+++ b/src/intrinsics/ecma262/DatePrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { FatalError } from "../../errors.js";
@@ -338,7 +338,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 20.3.4.23
-  obj.defineNativeMethod("setMilliseconds", 1, (context, [ms]) => {
+  obj.defineNativeMethod("setMilliseconds", 1, (context, [_ms]) => {
+    let ms = _ms;
     // 1. Let t be LocalTime(? thisTimeValue(this value)).
     let t = LocalTime(realm, thisTimeValue(realm, context).throwIfNotConcreteNumber().value);
     invariant(context instanceof ObjectValue);
@@ -759,7 +760,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   obj.defineNativeMethod(
     realm.intrinsics.SymbolToPrimitive,
     1,
-    (context, [hint]) => {
+    (context, [_hint]) => {
+      let hint = _hint;
       // 1. Let O be the this value.
       let O = context.throwIfNotConcrete();
 

--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { LexicalEnvironment } from "../../environment.js";

--- a/src/intrinsics/ecma262/ErrorPrototype.js
+++ b/src/intrinsics/ecma262/ErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, UndefinedValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/EvalError.js
+++ b/src/intrinsics/ecma262/EvalError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/EvalErrorPrototype.js
+++ b/src/intrinsics/ecma262/EvalErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Float32Array.js
+++ b/src/intrinsics/ecma262/Float32Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Float32ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Float32ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Float64Array.js
+++ b/src/intrinsics/ecma262/Float64Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Float64ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Float64ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Function.js
+++ b/src/intrinsics/ecma262/Function.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
@@ -15,7 +15,8 @@ import { Create } from "../../singletons.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 19.2.1
-  let func = new NativeFunctionValue(realm, "Function", "Function", 1, (context, args, argCount, NewTarget) => {
+  let func = new NativeFunctionValue(realm, "Function", "Function", 1, (context, _args, argCount, NewTarget) => {
+    let args = _args;
     // 1. Let C be the active function object.
     let C = func;
 

--- a/src/intrinsics/ecma262/FunctionPrototype.js
+++ b/src/intrinsics/ecma262/FunctionPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { Functions, Properties } from "../../singletons.js";
@@ -164,8 +164,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   );
 
   // ECMA262 19.2.3.5
-  obj.defineNativeMethod("toString", 0, context => {
-    context = context.throwIfNotConcrete();
+  obj.defineNativeMethod("toString", 0, _context => {
+    let context = _context.throwIfNotConcrete();
     if (context instanceof NativeFunctionValue) {
       let name = context.name;
       if (name instanceof AbstractValue) {

--- a/src/intrinsics/ecma262/Generator.js
+++ b/src/intrinsics/ecma262/Generator.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/GeneratorFunction.js
+++ b/src/intrinsics/ecma262/GeneratorFunction.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
@@ -20,7 +20,8 @@ export default function(realm: Realm): NativeFunctionValue {
     "GeneratorFunction",
     "GeneratorFunction",
     1,
-    (context, args, argCount, NewTarget) => {
+    (context, _args, argCount, NewTarget) => {
+      let args = _args;
       // 1. Let C be the active function object.
       let C = func;
 

--- a/src/intrinsics/ecma262/GeneratorPrototype.js
+++ b/src/intrinsics/ecma262/GeneratorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ReturnCompletion } from "../../completions.js";

--- a/src/intrinsics/ecma262/Int16Array.js
+++ b/src/intrinsics/ecma262/Int16Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Int16ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Int16ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Int32Array.js
+++ b/src/intrinsics/ecma262/Int32Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Int32ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Int32ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Int8Array.js
+++ b/src/intrinsics/ecma262/Int8Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Int8ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Int8ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/IteratorPrototype.js
+++ b/src/intrinsics/ecma262/IteratorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import {
@@ -379,9 +379,9 @@ export default function(realm: Realm): ObjectValue {
   obj.defineNativeProperty(realm.intrinsics.SymbolToStringTag, new StringValue(realm, "JSON"), { writable: false });
 
   // ECMA262 24.3.2
-  obj.defineNativeMethod("stringify", 3, (context, [value, replacer, space]) => {
-    replacer = replacer.throwIfNotConcrete();
-    space = space.throwIfNotConcrete();
+  obj.defineNativeMethod("stringify", 3, (context, [value, _replacer, _space]) => {
+    let replacer = _replacer.throwIfNotConcrete();
+    let space = _space.throwIfNotConcrete();
 
     // 1. Let stack be a new empty List.
     let stack = [];

--- a/src/intrinsics/ecma262/Map.js
+++ b/src/intrinsics/ecma262/Map.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import {
@@ -32,7 +32,8 @@ import { Create } from "../../singletons.js";
 import invariant from "../../invariant.js";
 
 export default function(realm: Realm): NativeFunctionValue {
-  let func = new NativeFunctionValue(realm, "Map", "Map", 0, (context, [iterable], argCount, NewTarget) => {
+  let func = new NativeFunctionValue(realm, "Map", "Map", 0, (context, [_iterable], argCount, NewTarget) => {
+    let iterable = _iterable;
     // 1. If NewTarget is undefined, throw a TypeError exception.
     if (!NewTarget) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);

--- a/src/intrinsics/ecma262/MapIteratorPrototype.js
+++ b/src/intrinsics/ecma262/MapIteratorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { StringValue, NumberValue, ObjectValue, UndefinedValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Number.js
+++ b/src/intrinsics/ecma262/Number.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, NumberValue } from "../../values/index.js";
@@ -44,7 +44,8 @@ export default function(realm: Realm): NativeFunctionValue {
 
   // ECMA262 20.1.2.2
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
-    func.defineNativeMethod("isFinite", 1, (context, [number]) => {
+    func.defineNativeMethod("isFinite", 1, (context, [_number]) => {
+      let number = _number;
       // 1. If Type(number) is not Number, return false.
       if (!number.mightBeNumber()) return realm.intrinsics.false;
 
@@ -59,7 +60,8 @@ export default function(realm: Realm): NativeFunctionValue {
 
   // ECMA262 20.1.2.3
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
-    func.defineNativeMethod("isInteger", 1, (context, [number]) => {
+    func.defineNativeMethod("isInteger", 1, (context, [_number]) => {
+      let number = _number;
       // 1. If Type(number) is not Number, return false.
       if (!number.mightBeNumber()) return realm.intrinsics.false;
 
@@ -80,7 +82,8 @@ export default function(realm: Realm): NativeFunctionValue {
 
   // ECMA262 20.1.2.4
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
-    func.defineNativeMethod("isNaN", 1, (context, [number]) => {
+    func.defineNativeMethod("isNaN", 1, (context, [_number]) => {
+      let number = _number;
       // 1. If Type(number) is not Number, return false.
       if (!number.mightBeNumber()) return realm.intrinsics.false;
 
@@ -94,7 +97,8 @@ export default function(realm: Realm): NativeFunctionValue {
 
   // ECMA262 20.1.2.5
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
-    func.defineNativeMethod("isSafeInteger", 1, (context, [number]) => {
+    func.defineNativeMethod("isSafeInteger", 1, (context, [_number]) => {
+      let number = _number;
       // 1. If Type(number) is not Number, return false.
       if (!number.mightBeNumber()) return realm.intrinsics.false;
 

--- a/src/intrinsics/ecma262/NumberPrototype.js
+++ b/src/intrinsics/ecma262/NumberPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import {
@@ -27,7 +27,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   obj.$NumberData = realm.intrinsics.zero;
 
   // ECMA262 20.1.3.2
-  obj.defineNativeMethod("toExponential", 1, (context, [fractionDigits]) => {
+  obj.defineNativeMethod("toExponential", 1, (context, [_fractionDigits]) => {
+    let fractionDigits = _fractionDigits;
     // 1. Let x be ? thisNumberValue(this value).
     let x = To.thisNumberValue(realm, context).value;
 

--- a/src/intrinsics/ecma262/ObjectProto_toString.js
+++ b/src/intrinsics/ecma262/ObjectProto_toString.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, UndefinedValue, StringValue, NullValue } from "../../values/index.js";
@@ -39,28 +39,28 @@ export default function(realm: Realm): NativeFunctionValue {
 
       // 5. If isArray is true, let builtinTag be "Array".
       if (isArray) builtinTag = "Array";
-      else if (O.$StringData)
+      else if (typeof O.$StringData !== "undefined")
         // 6. Else, if O is an exotic String object, let builtinTag be "String".
         builtinTag = "String";
-      else if (O.$ParameterMap)
+      else if (typeof O.$ParameterMap !== "undefined")
         // 7. Else, if O has an [[ParameterMap]] internal slot, let builtinTag be "Arguments".
         builtinTag = "Arguments";
-      else if (O.$Call)
+      else if (typeof O.$Call !== "undefined")
         // 8. Else, if O has a [[Call]] internal method, let builtinTag be "Function".
         builtinTag = "Function";
-      else if (O.$ErrorData)
+      else if (typeof O.$ErrorData !== "undefined")
         // 9. Else, if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
         builtinTag = "Error";
-      else if (O.$BooleanData)
+      else if (typeof O.$BooleanData !== "undefined")
         // 10. Else, if O has a [[BooleanData]] internal slot, let builtinTag be "Boolean".
         builtinTag = "Boolean";
-      else if (O.$NumberData)
+      else if (typeof O.$NumberData !== "undefined")
         // 11. Else, if O has a [[NumberData]] internal slot, let builtinTag be "Number".
         builtinTag = "Number";
-      else if (O.$DateValue)
+      else if (typeof O.$DateValue !== "undefined")
         // 12. Else, if O has a [[DateValue]] internal slot, let builtinTag be "Date".
         builtinTag = "Date";
-      else if (O.$RegExpMatcher)
+      else if (typeof O.$RegExpMatcher !== "undefined")
         // 13. Else, if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
         builtinTag = "RegExp";
       else {

--- a/src/intrinsics/ecma262/ObjectProto_toString.js
+++ b/src/intrinsics/ecma262/ObjectProto_toString.js
@@ -39,28 +39,28 @@ export default function(realm: Realm): NativeFunctionValue {
 
       // 5. If isArray is true, let builtinTag be "Array".
       if (isArray) builtinTag = "Array";
-      else if (typeof O.$StringData !== "undefined")
+      else if (O.$StringData !== undefined)
         // 6. Else, if O is an exotic String object, let builtinTag be "String".
         builtinTag = "String";
-      else if (typeof O.$ParameterMap !== "undefined")
+      else if (O.$ParameterMap !== undefined)
         // 7. Else, if O has an [[ParameterMap]] internal slot, let builtinTag be "Arguments".
         builtinTag = "Arguments";
-      else if (typeof O.$Call !== "undefined")
+      else if (O.$Call !== undefined)
         // 8. Else, if O has a [[Call]] internal method, let builtinTag be "Function".
         builtinTag = "Function";
-      else if (typeof O.$ErrorData !== "undefined")
+      else if (O.$ErrorData !== undefined)
         // 9. Else, if O has an [[ErrorData]] internal slot, let builtinTag be "Error".
         builtinTag = "Error";
-      else if (typeof O.$BooleanData !== "undefined")
+      else if (O.$BooleanData !== undefined)
         // 10. Else, if O has a [[BooleanData]] internal slot, let builtinTag be "Boolean".
         builtinTag = "Boolean";
-      else if (typeof O.$NumberData !== "undefined")
+      else if (O.$NumberData !== undefined)
         // 11. Else, if O has a [[NumberData]] internal slot, let builtinTag be "Number".
         builtinTag = "Number";
-      else if (typeof O.$DateValue !== "undefined")
+      else if (O.$DateValue !== undefined)
         // 12. Else, if O has a [[DateValue]] internal slot, let builtinTag be "Date".
         builtinTag = "Date";
-      else if (typeof O.$RegExpMatcher !== "undefined")
+      else if (O.$RegExpMatcher !== undefined)
         // 13. Else, if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
         builtinTag = "RegExp";
       else {

--- a/src/intrinsics/ecma262/Promise.js
+++ b/src/intrinsics/ecma262/Promise.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, FunctionValue, NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/PromisePrototype.js
+++ b/src/intrinsics/ecma262/PromisePrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { StringValue, ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Proxy.js
+++ b/src/intrinsics/ecma262/Proxy.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ProxyValue, NullValue, NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/RangeError.js
+++ b/src/intrinsics/ecma262/RangeError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/RangeErrorPrototype.js
+++ b/src/intrinsics/ecma262/RangeErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/ReferenceError.js
+++ b/src/intrinsics/ecma262/ReferenceError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/ReferenceErrorPrototype.js
+++ b/src/intrinsics/ecma262/ReferenceErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Reflect.js
+++ b/src/intrinsics/ecma262/Reflect.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { BooleanValue, ObjectValue, NullValue } from "../../values/index.js";
@@ -34,7 +34,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.2
-  obj.defineNativeMethod("construct", 2, (context, [target, argumentsList, newTarget]) => {
+  obj.defineNativeMethod("construct", 2, (context, [target, argumentsList, _newTarget]) => {
+    let newTarget = _newTarget;
     // 1. If IsConstructor(target) is false, throw a TypeError exception.
     if (!IsConstructor(realm, target)) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
@@ -56,8 +57,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.3
-  obj.defineNativeMethod("defineProperty", 3, (context, [target, propertyKey, attributes]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("defineProperty", 3, (context, [_target, propertyKey, attributes]) => {
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -75,8 +76,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.4
-  obj.defineNativeMethod("deleteProperty", 2, (context, [target, propertyKey]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("deleteProperty", 2, (context, [_target, propertyKey]) => {
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -91,8 +92,9 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.5
-  obj.defineNativeMethod("get", 2, (context, [target, propertyKey, receiver]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("get", 2, (context, [_target, propertyKey, _receiver]) => {
+    let receiver = _receiver;
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -113,8 +115,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.6
-  obj.defineNativeMethod("getOwnPropertyDescriptor", 2, (context, [target, propertyKey]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("getOwnPropertyDescriptor", 2, (context, [_target, propertyKey]) => {
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -132,8 +134,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.7
-  obj.defineNativeMethod("getPrototypeOf", 1, (context, [target]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("getPrototypeOf", 1, (context, [_target]) => {
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -160,8 +162,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.9
-  obj.defineNativeMethod("isExtensible", 1, (context, [target]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("isExtensible", 1, (context, [_target]) => {
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -173,8 +175,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.10
-  obj.defineNativeMethod("ownKeys", 1, (context, [target]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("ownKeys", 1, (context, [_target]) => {
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -189,8 +191,8 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.11
-  obj.defineNativeMethod("preventExtensions", 1, (context, [target]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("preventExtensions", 1, (context, [_target]) => {
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -202,8 +204,9 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.12
-  obj.defineNativeMethod("set", 3, (context, [target, propertyKey, V, receiver]) => {
-    target = target.throwIfNotConcrete();
+  obj.defineNativeMethod("set", 3, (context, [_target, propertyKey, V, _receiver]) => {
+    let receiver = _receiver;
+    let target = _target.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {
@@ -224,9 +227,9 @@ export default function(realm: Realm): ObjectValue {
   });
 
   // ECMA262 26.1.13
-  obj.defineNativeMethod("setPrototypeOf", 2, (context, [target, proto]) => {
-    target = target.throwIfNotConcrete();
-    proto = proto.throwIfNotConcrete();
+  obj.defineNativeMethod("setPrototypeOf", 2, (context, [_target, _proto]) => {
+    let target = _target.throwIfNotConcrete();
+    let proto = _proto.throwIfNotConcrete();
 
     // 1. If Type(target) is not Object, throw a TypeError exception.
     if (!(target instanceof ObjectValue)) {

--- a/src/intrinsics/ecma262/RegExp.js
+++ b/src/intrinsics/ecma262/RegExp.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { StringValue, NativeFunctionValue, UndefinedValue, ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/RegExpPrototype.js
+++ b/src/intrinsics/ecma262/RegExpPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import invariant from "../../invariant.js";
@@ -237,7 +237,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 21.2.5.8
-  obj.defineNativeMethod(realm.intrinsics.SymbolReplace, 2, (context, [string, replaceValue]) => {
+  obj.defineNativeMethod(realm.intrinsics.SymbolReplace, 2, (context, [string, _replaceValue]) => {
+    let replaceValue = _replaceValue;
     // 1. Let rx be the this value.
     let rx = context.throwIfNotConcrete();
 

--- a/src/intrinsics/ecma262/Set.js
+++ b/src/intrinsics/ecma262/Set.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, NullValue, UndefinedValue } from "../../values/index.js";
@@ -28,7 +28,8 @@ import { CompilerDiagnostic } from "../../errors.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 23.2.1.1
-  let func = new NativeFunctionValue(realm, "Set", "Set", 0, (context, [iterable], argCount, NewTarget) => {
+  let func = new NativeFunctionValue(realm, "Set", "Set", 0, (context, [_iterable], argCount, NewTarget) => {
+    let iterable = _iterable;
     // 1. If NewTarget is undefined, throw a TypeError exception.
     if (!NewTarget) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);

--- a/src/intrinsics/ecma262/SetIteratorPrototype.js
+++ b/src/intrinsics/ecma262/SetIteratorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { StringValue, ObjectValue, UndefinedValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/String.js
+++ b/src/intrinsics/ecma262/String.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue, NumberValue, StringValue, SymbolValue } from "../../values/index.js";
@@ -127,7 +127,8 @@ export default function(realm: Realm): NativeFunctionValue {
 
   // ECMA262 21.1.2.4
   if (!realm.isCompatibleWith(realm.MOBILE_JSC_VERSION) && !realm.isCompatibleWith("mobile"))
-    func.defineNativeMethod("raw", 1, (context, [template, ...substitutions], argCount) => {
+    func.defineNativeMethod("raw", 1, (context, [template, ..._substitutions], argCount) => {
+      let substitutions = _substitutions;
       // 1. Let substitutions be a List consisting of all of the arguments passed to this function, starting with the second argument. If fewer than two arguments were passed, the List is empty.
       substitutions = argCount < 2 ? [] : substitutions;
 

--- a/src/intrinsics/ecma262/StringIteratorPrototype.js
+++ b/src/intrinsics/ecma262/StringIteratorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { Create } from "../../singletons.js";

--- a/src/intrinsics/ecma262/Symbol.js
+++ b/src/intrinsics/ecma262/Symbol.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NativeFunctionValue, StringValue, SymbolValue, UndefinedValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/SymbolPrototype.js
+++ b/src/intrinsics/ecma262/SymbolPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue, SymbolValue, AbstractValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/SyntaxError.js
+++ b/src/intrinsics/ecma262/SyntaxError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/SyntaxErrorPrototype.js
+++ b/src/intrinsics/ecma262/SyntaxErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/ThrowTypeError.js
+++ b/src/intrinsics/ecma262/ThrowTypeError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/TypeError.js
+++ b/src/intrinsics/ecma262/TypeError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/TypeErrorPrototype.js
+++ b/src/intrinsics/ecma262/TypeErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/TypedArray.js
+++ b/src/intrinsics/ecma262/TypedArray.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ElementType, TypedArrayKind } from "../../types.js";

--- a/src/intrinsics/ecma262/TypedArrayProto_values.js
+++ b/src/intrinsics/ecma262/TypedArrayProto_values.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ElementType } from "../../types.js";
@@ -641,7 +641,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
   });
 
   // ECMA262 22.2.3.15
-  obj.defineNativeMethod("join", 1, (context, [separator]) => {
+  obj.defineNativeMethod("join", 1, (context, [_separator]) => {
+    let separator = _separator;
     // 1. Let O be ? ToObject(this value).
     let O = To.ToObject(realm, context);
 

--- a/src/intrinsics/ecma262/URIError.js
+++ b/src/intrinsics/ecma262/URIError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/URIErrorPrototype.js
+++ b/src/intrinsics/ecma262/URIErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint16Array.js
+++ b/src/intrinsics/ecma262/Uint16Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint16ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Uint16ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint32Array.js
+++ b/src/intrinsics/ecma262/Uint32Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint32ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Uint32ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint8Array.js
+++ b/src/intrinsics/ecma262/Uint8Array.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint8ArrayPrototype.js
+++ b/src/intrinsics/ecma262/Uint8ArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint8ClampedArray.js
+++ b/src/intrinsics/ecma262/Uint8ClampedArray.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/Uint8ClampedArrayPrototype.js
+++ b/src/intrinsics/ecma262/Uint8ClampedArrayPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/decodeURI.js
+++ b/src/intrinsics/ecma262/decodeURI.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
@@ -17,7 +17,8 @@ import { To } from "../../singletons.js";
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.6.2
   let name = "decodeURI";
-  return new NativeFunctionValue(realm, name, name, 1, (context, [encodedURI], argCount, NewTarget) => {
+  return new NativeFunctionValue(realm, name, name, 1, (context, [_encodedURI], argCount, NewTarget) => {
+    let encodedURI = _encodedURI;
     if (NewTarget) throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, `${name} is not a constructor`);
 
     encodedURI = encodedURI.throwIfNotConcrete();

--- a/src/intrinsics/ecma262/decodeURIComponent.js
+++ b/src/intrinsics/ecma262/decodeURIComponent.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
@@ -17,7 +17,8 @@ import { StringValue } from "../../values/index.js";
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.6.3
   let name = "decodeURIComponent";
-  return new NativeFunctionValue(realm, name, name, 1, (context, [encodedURIComponent], argCount, NewTarget) => {
+  return new NativeFunctionValue(realm, name, name, 1, (context, [_encodedURIComponent], argCount, NewTarget) => {
+    let encodedURIComponent = _encodedURIComponent;
     if (NewTarget) throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, `${name} is not a constructor`);
 
     encodedURIComponent = encodedURIComponent.throwIfNotConcrete();

--- a/src/intrinsics/ecma262/encodeURI.js
+++ b/src/intrinsics/ecma262/encodeURI.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
@@ -17,7 +17,8 @@ import { StringValue } from "../../values/index.js";
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.6.4
   let name = "encodeURI";
-  return new NativeFunctionValue(realm, name, name, 1, (context, [uri], argCount, NewTarget) => {
+  return new NativeFunctionValue(realm, name, name, 1, (context, [_uri], argCount, NewTarget) => {
+    let uri = _uri;
     if (NewTarget) throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, `${name} is not a constructor`);
 
     uri = uri.throwIfNotConcrete();

--- a/src/intrinsics/ecma262/encodeURIComponent.js
+++ b/src/intrinsics/ecma262/encodeURIComponent.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
@@ -17,7 +17,8 @@ import { StringValue } from "../../values/index.js";
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 18.2.6.5
   let name = "encodeURIComponent";
-  return new NativeFunctionValue(realm, name, name, 1, (context, [uriComponent], argCount, NewTarget) => {
+  return new NativeFunctionValue(realm, name, name, 1, (context, [_uriComponent], argCount, NewTarget) => {
+    let uriComponent = _uriComponent;
     if (NewTarget) throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, `${name} is not a constructor`);
 
     uriComponent = uriComponent.throwIfNotConcrete();

--- a/src/intrinsics/ecma262/eval.js
+++ b/src/intrinsics/ecma262/eval.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/global.js
+++ b/src/intrinsics/ecma262/global.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import invariant from "../../invariant.js";

--- a/src/intrinsics/ecma262/isFinite.js
+++ b/src/intrinsics/ecma262/isFinite.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/isNaN.js
+++ b/src/intrinsics/ecma262/isNaN.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/parseFloat.js
+++ b/src/intrinsics/ecma262/parseFloat.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/ecma262/parseInt.js
+++ b/src/intrinsics/ecma262/parseInt.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, NativeFunctionValue, StringValue, ObjectValue } from "../../values/index.js";

--- a/src/intrinsics/index.js
+++ b/src/intrinsics/index.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Intrinsics } from "../types.js";
 import type { Realm } from "../realm.js";

--- a/src/intrinsics/prepack/__IntrospectionError.js
+++ b/src/intrinsics/prepack/__IntrospectionError.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import type { NativeFunctionValue } from "../../values/index.js";

--- a/src/intrinsics/prepack/__IntrospectionErrorPrototype.js
+++ b/src/intrinsics/prepack/__IntrospectionErrorPrototype.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import { ObjectValue, StringValue } from "../../values/index.js";

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -33,13 +33,20 @@ import { valueIsKnownReactAbstraction } from "../../react/utils.js";
 import { CompilerDiagnostic, FatalError } from "../../errors.js";
 
 export function createAbstractFunction(realm: Realm, ...additionalValues: Array<ConcreteValue>): NativeFunctionValue {
-  return new NativeFunctionValue(realm, "global.__abstract", "__abstract", 0, (context, [typeNameOrTemplate, name]) => {
-    if (name instanceof StringValue) name = name.value;
-    if (name !== undefined && typeof name !== "string") {
-      throw new TypeError("intrinsic name argument is not a string");
+  return new NativeFunctionValue(
+    realm,
+    "global.__abstract",
+    "__abstract",
+    0,
+    (context, [typeNameOrTemplate, _name]) => {
+      let name = _name;
+      if (name instanceof StringValue) name = name.value;
+      if (name !== undefined && typeof name !== "string") {
+        throw new TypeError("intrinsic name argument is not a string");
+      }
+      return createAbstract(realm, typeNameOrTemplate, name, ...additionalValues);
     }
-    return createAbstract(realm, typeNameOrTemplate, name, ...additionalValues);
-  });
+  );
 }
 
 export default function(realm: Realm): void {

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 import {
@@ -89,8 +89,8 @@ export function createAbstract(
     );
     if (locString !== undefined) break;
   }
-  if (!name) {
-    let locVal = new StringValue(realm, locString || "(unknown location)");
+  if (typeof name === "undefined") {
+    let locVal = new StringValue(realm, typeof locString === "string" ? locString : "(unknown location)");
     let kind = AbstractValue.makeKind("abstractCounted", (realm.objectCount++).toString()); // need not be an object, but must be unique
     result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
   } else {
@@ -110,7 +110,7 @@ export function createAbstract(
   if (template && !(template instanceof FunctionValue)) {
     // why exclude functions?
     template.makePartial();
-    if (name) realm.rebuildNestedProperties(result, name);
+    if (typeof name === "string") realm.rebuildNestedProperties(result, name);
   }
   if (functionResultType) {
     invariant(result instanceof AbstractObjectValue);

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -89,8 +89,8 @@ export function createAbstract(
     );
     if (locString !== undefined) break;
   }
-  if (typeof name === "undefined") {
-    let locVal = new StringValue(realm, typeof locString === "string" ? locString : "(unknown location)");
+  if (name === undefined) {
+    let locVal = new StringValue(realm, locString !== undefined ? locString : "(unknown location)");
     let kind = AbstractValue.makeKind("abstractCounted", (realm.objectCount++).toString()); // need not be an object, but must be unique
     result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
   } else {
@@ -110,7 +110,7 @@ export function createAbstract(
   if (template && !(template instanceof FunctionValue)) {
     // why exclude functions?
     template.makePartial();
-    if (typeof name === "string") realm.rebuildNestedProperties(result, name);
+    if (name !== undefined) realm.rebuildNestedProperties(result, name);
   }
   if (functionResultType) {
     invariant(result instanceof AbstractObjectValue);

--- a/src/intrinsics/react-native/global.js
+++ b/src/intrinsics/react-native/global.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
 

--- a/src/methods/arraybuffer.js
+++ b/src/methods/arraybuffer.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { DataBlock, ElementType } from "../types.js";
@@ -49,11 +49,14 @@ export function CreateByteDataBlock(realm: Realm, size: number): DataBlock {
 export function CopyDataBlockBytes(
   realm: Realm,
   toBlock: DataBlock,
-  toIndex: number,
+  _toIndex: number,
   fromBlock: DataBlock,
-  fromIndex: number,
-  count: number
+  _fromIndex: number,
+  _count: number
 ): EmptyValue {
+  let toIndex = _toIndex;
+  let fromIndex = _fromIndex;
+  let count = _count;
   // 1. Assert: fromBlock and toBlock are distinct Data Block values.
   invariant(toBlock instanceof Uint8Array && fromBlock instanceof Uint8Array && toBlock !== fromBlock);
 
@@ -133,12 +136,12 @@ export function DetachArrayBuffer(realm: Realm, arrayBuffer: ObjectValue): NullV
 // ECMA262 24.2.1.1
 export function GetViewValue(
   realm: Realm,
-  view: Value,
+  _view: Value,
   requestIndex: Value,
   isLittleEndian: Value,
   type: ElementType
 ): NumberValue {
-  view = view.throwIfNotConcrete();
+  let view = _view.throwIfNotConcrete();
 
   // 1. If Type(view) is not Object, throw a TypeError exception.
   if (!(view instanceof ObjectValue)) {
@@ -200,8 +203,9 @@ export function GetValueFromBuffer(
   arrayBuffer: ObjectValue,
   byteIndex: number,
   type: ElementType,
-  isLittleEndian?: boolean
+  _isLittleEndian?: boolean
 ): NumberValue {
+  let isLittleEndian = _isLittleEndian;
   // 1. Assert: IsDetachedBuffer(arrayBuffer) is false.
   invariant(IsDetachedBuffer(realm, arrayBuffer) === false);
 
@@ -275,13 +279,13 @@ export function GetValueFromBuffer(
 // ECMA262 24.2.1.2
 export function SetViewValue(
   realm: Realm,
-  view: Value,
+  _view: Value,
   requestIndex: Value,
   isLittleEndian: Value,
   type: ElementType,
   value: Value
 ): UndefinedValue {
-  view = view.throwIfNotConcrete();
+  let view = _view.throwIfNotConcrete();
 
   // 1. If Type(view) is not Object, throw a TypeError exception.
   if (!(view instanceof ObjectValue)) {
@@ -345,8 +349,9 @@ export function CloneArrayBuffer(
   realm: Realm,
   srcBuffer: ObjectValue,
   srcByteOffset: number,
-  cloneConstructor?: ObjectValue
+  _cloneConstructor?: ObjectValue
 ): ObjectValue {
+  let cloneConstructor = _cloneConstructor;
   // 1. Assert: Type(srcBuffer) is Object and it has an [[ArrayBufferData]] internal slot.
   invariant(srcBuffer instanceof ObjectValue && srcBuffer.$ArrayBufferData);
 
@@ -359,10 +364,10 @@ export function CloneArrayBuffer(
     if (IsDetachedBuffer(realm, srcBuffer) === true) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "IsDetachedBuffer(srcBuffer) is true");
     }
+  } else {
+    // 3. Else, Assert: IsConstructor(cloneConstructor) is true.
+    invariant(IsConstructor(realm, cloneConstructor) === true, "IsConstructor(cloneConstructor) is true");
   }
-
-  // 3. Else, Assert: IsConstructor(cloneConstructor) is true.
-  invariant(IsConstructor(realm, cloneConstructor) === true, "IsConstructor(cloneConstructor) is true");
 
   // 4. Let srcLength be the value of srcBuffer's [[ArrayBufferByteLength]] internal slot.
   let srcLength = srcBuffer.$ArrayBufferByteLength;
@@ -379,7 +384,7 @@ export function CloneArrayBuffer(
   invariant(srcBlock);
 
   // 8. Let targetBuffer be ? AllocateArrayBuffer(cloneConstructor, srcLength).
-  let targetBuffer = AllocateArrayBuffer(realm, cloneConstructor, srcLength);
+  let targetBuffer = AllocateArrayBuffer(realm, (cloneConstructor: ObjectValue), srcLength);
 
   // 9. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
   if (IsDetachedBuffer(realm, srcBuffer) === true) {
@@ -404,8 +409,9 @@ export function SetValueInBuffer(
   byteIndex: number,
   type: ElementType,
   value: number,
-  isLittleEndian?: boolean
+  _isLittleEndian?: boolean
 ): UndefinedValue {
+  let isLittleEndian = _isLittleEndian;
   // 1. Assert: IsDetachedBuffer(arrayBuffer) is false.
   invariant(IsDetachedBuffer(realm, arrayBuffer) === false);
 

--- a/src/methods/construct.js
+++ b/src/methods/construct.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import {
@@ -30,9 +30,11 @@ import type { BabelNodeClassMethod } from "babel-types";
 export function MakeConstructor(
   realm: Realm,
   F: ECMAScriptSourceFunctionValue,
-  writablePrototype?: boolean,
-  prototype?: ObjectValue
+  _writablePrototype?: boolean,
+  _prototype?: ObjectValue
 ): UndefinedValue {
+  let writablePrototype = _writablePrototype;
+  let prototype = _prototype;
   // 1. Assert: F is an ECMAScript function object.
   invariant(F instanceof ECMAScriptSourceFunctionValue, "expected function value");
 
@@ -78,9 +80,11 @@ export function MakeConstructor(
 export function Construct(
   realm: Realm,
   F: ObjectValue,
-  argumentsList?: Array<Value>,
-  newTarget?: ObjectValue
+  _argumentsList?: Array<Value>,
+  _newTarget?: ObjectValue
 ): ObjectValue {
+  let argumentsList = _argumentsList;
+  let newTarget = _newTarget;
   // If newTarget was not passed, let newTarget be F.
   if (!newTarget) newTarget = F;
 

--- a/src/methods/date.js
+++ b/src/methods/date.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { NumberValue, Value, ObjectValue } from "../values/index.js";
 import type { Realm } from "../realm.js";
@@ -165,11 +165,12 @@ export function LocalTime(realm: Realm, t: number): number {
 }
 
 // ECMA262 20.3.1.10
-export function UTC(realm: Realm, t: number | Value): NumberValue {
+export function UTC(realm: Realm, _t: number | Value): NumberValue {
+  let t = _t;
   if (t instanceof Value) t = t.throwIfNotConcreteNumber().value;
 
   // 1. Return t - LocalTZA - DaylightSavingTA(t - LocalTZA).
-  return new NumberValue(realm, t - LocalTZA - DaylightSavingTA(realm, t - LocalTZA));
+  return new NumberValue(realm, (t: number) - LocalTZA - DaylightSavingTA(realm, (t: number) - LocalTZA));
 }
 
 // ECMA262 20.3.1.11
@@ -276,18 +277,19 @@ export function MakeDate(realm: Realm, day: number, time: number): number {
 }
 
 // ECMA262 20.3.1.15
-export function TimeClip(realm: Realm, time: number | Value): NumberValue {
+export function TimeClip(realm: Realm, _time: number | Value): NumberValue {
+  let time = _time;
   if (time instanceof Value) time = time.throwIfNotConcreteNumber().value;
   // 1. If time is not finite, return NaN.
   if (!isFinite(time)) return realm.intrinsics.NaN;
 
   // 2. If abs(time) > 8.64 × 10^15, return NaN.
-  if (Math.abs(time) > 8640000000000000) {
+  if (Math.abs((time: number)) > 8640000000000000) {
     return realm.intrinsics.NaN;
   }
 
   // 3. Let clippedTime be ToInteger(time).
-  let clippedTime = To.ToInteger(realm, new NumberValue(realm, time));
+  let clippedTime = To.ToInteger(realm, new NumberValue(realm, (time: number)));
 
   // 4. If clippedTime is -0, let clippedTime be +0.
   if (Object.is(clippedTime, -0)) clippedTime = +0;

--- a/src/methods/descriptor.js
+++ b/src/methods/descriptor.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Descriptor } from "../types.js";
 

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import invariant from "../invariant.js";
 import type { Realm } from "../realm.js";
@@ -92,11 +92,12 @@ export function DestructuringAssignmentEvaluation(
 // ECMA262 12.15.5.3
 export function IteratorDestructuringAssignmentEvaluation(
   realm: Realm,
-  elements: $ReadOnlyArray<BabelNodeLVal | null>,
+  _elements: $ReadOnlyArray<BabelNodeLVal | null>,
   iteratorRecord: { $Iterator: ObjectValue, $Done: boolean },
   strictCode: boolean,
   env: LexicalEnvironment
 ) {
+  let elements = _elements;
   // Check if the last element is a rest element. If so then we want to save the
   // element and handle it separately after we iterate through the other
   // formals. This also enforces that a rest element may only ever be in the

--- a/src/methods/generator.js
+++ b/src/methods/generator.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { AbruptCompletion } from "../completions.js";

--- a/src/methods/has.js
+++ b/src/methods/has.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export * from "./abstract.js";
 export * from "./call.js";

--- a/src/methods/integrity.js
+++ b/src/methods/integrity.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { ObjectValue } from "../values/index.js";

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -213,7 +213,7 @@ export function IsRegExp(realm: Realm, _argument: Value): boolean {
   if (isRegExp !== undefined) return To.ToBooleanPartial(realm, isRegExp) === true;
 
   // 4. If argument has a [[RegExpMatcher]] internal slot, return true.
-  if (typeof argument.$RegExpMatcher !== "undefined") return true;
+  if (argument.$RegExpMatcher !== undefined) return true;
 
   // 5. Return false.
   return false;
@@ -329,7 +329,7 @@ export function IsPromise(realm: Realm, _x: Value): boolean {
 
   // 2. If x does not have a [[PromiseState]] internal slot, return false.
   x = x.throwIfNotConcreteObject();
-  if (typeof x.$PromiseState === "undefined") return false;
+  if (x.$PromiseState === undefined) return false;
 
   // 3. Return true.
   return true;

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -34,7 +34,8 @@ import type { BabelNodeExpression, BabelNodeCallExpression, BabelNodeLVal, Babel
 import { BabelNode } from "babel-types";
 
 // ECMA262 22.1.3.1.1
-export function IsConcatSpreadable(realm: Realm, O: Value): boolean {
+export function IsConcatSpreadable(realm: Realm, _O: Value): boolean {
+  let O = _O;
   // 1. If Type(O) is not Object, return false.
   if (!O.mightBeObject()) return false;
   O = O.throwIfNotObject();
@@ -101,7 +102,8 @@ export function IsExtensible(realm: Realm, O: ObjectValue | AbstractObjectValue)
 }
 
 // ECMA262 7.2.3
-export function IsCallable(realm: Realm, func: Value): boolean {
+export function IsCallable(realm: Realm, _func: Value): boolean {
+  let func = _func;
   // 1. If Type(argument) is not Object, return false.
   if (!func.mightBeObject()) return false;
   if (HasCompatibleType(func, FunctionValue)) return true;
@@ -116,7 +118,8 @@ export function IsCallable(realm: Realm, func: Value): boolean {
 }
 
 // ECMA262 7.2.4
-export function IsConstructor(realm: Realm, argument: Value): boolean {
+export function IsConstructor(realm: Realm, _argument: Value): boolean {
+  let argument = _argument;
   // 1. If Type(argument) is not Object, return false.
   if (!argument.mightBeObject()) return false;
 
@@ -197,7 +200,8 @@ export function IsInTailPosition(realm: Realm, node: BabelNodeCallExpression): b
 }
 
 // ECMA262 7.2.8
-export function IsRegExp(realm: Realm, argument: Value): boolean {
+export function IsRegExp(realm: Realm, _argument: Value): boolean {
+  let argument = _argument;
   // 1. If Type(argument) is not Object, return false.
   if (!argument.mightBeObject()) return false;
   argument = argument.throwIfNotObject();
@@ -209,7 +213,7 @@ export function IsRegExp(realm: Realm, argument: Value): boolean {
   if (isRegExp !== undefined) return To.ToBooleanPartial(realm, isRegExp) === true;
 
   // 4. If argument has a [[RegExpMatcher]] internal slot, return true.
-  if (argument.$RegExpMatcher) return true;
+  if (typeof argument.$RegExpMatcher !== "undefined") return true;
 
   // 5. Return false.
   return false;
@@ -318,13 +322,14 @@ export function IsArrayIndex(realm: Realm, P: PropertyKeyValue): boolean {
 }
 
 // ECMA262 25.4.1.6
-export function IsPromise(realm: Realm, x: Value): boolean {
+export function IsPromise(realm: Realm, _x: Value): boolean {
+  let x = _x;
   // 1. If Type(x) is not Object, return false.
   if (!x.mightBeObject()) return false;
 
   // 2. If x does not have a [[PromiseState]] internal slot, return false.
   x = x.throwIfNotConcreteObject();
-  if (!x.$PromiseState) return false;
+  if (typeof x.$PromiseState === "undefined") return false;
 
   // 3. Return true.
   return true;
@@ -342,7 +347,8 @@ export function IsDetachedBuffer(realm: Realm, arrayBuffer: ObjectValue): boolea
   return false;
 }
 
-export function IsIntrospectionError(realm: Realm, value: Value): boolean {
+export function IsIntrospectionError(realm: Realm, _value: Value): boolean {
+  let value = _value;
   if (!value.mightBeObject()) return false;
   value = value.throwIfNotConcreteObject();
   return value.$GetPrototypeOf() === realm.intrinsics.__IntrospectionErrorPrototype;

--- a/src/methods/iterator.js
+++ b/src/methods/iterator.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { CallableObjectValue } from "../types.js";
@@ -20,7 +20,8 @@ import { SameValue } from "./abstract.js";
 import { Create, To } from "../singletons.js";
 
 // ECMA262 7.4.1
-export function GetIterator(realm: Realm, obj: Value = realm.intrinsics.undefined, method?: Value): ObjectValue {
+export function GetIterator(realm: Realm, obj: Value = realm.intrinsics.undefined, _method?: Value): ObjectValue {
+  let method = _method;
   // 1. If method was not passed, then
   if (!method) {
     // a. Let method be ? GetMethod(obj, @@iterator).
@@ -28,7 +29,7 @@ export function GetIterator(realm: Realm, obj: Value = realm.intrinsics.undefine
   }
 
   // 2. Let iterator be ? Call(method, obj).
-  let iterator = Call(realm, method, obj);
+  let iterator = Call(realm, (method: Value), obj);
 
   // 3. If Type(iterator) is not Object, throw a TypeError exception.
   if (!(iterator instanceof ObjectValue)) {

--- a/src/methods/json.js
+++ b/src/methods/json.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { Value, ObjectValue, NumberValue, UndefinedValue, StringValue } from "../values/index.js";

--- a/src/methods/proxy.js
+++ b/src/methods/proxy.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { ProxyValue, NullValue, ObjectValue, Value, UndefinedValue } from "../values/index.js";
@@ -100,8 +100,9 @@ export function ProxyConstruct(
 }
 
 // ECMA262 9.5.14
-export function ProxyCreate(realm: Realm, target: Value, handler: Value): ProxyValue {
-  target = target.throwIfNotConcrete();
+export function ProxyCreate(realm: Realm, _target: Value, _handler: Value): ProxyValue {
+  let handler = _handler;
+  let target = _target.throwIfNotConcrete();
 
   // 1. If Type(target) is not Object, throw a TypeError exception.
   if (!(target instanceof ObjectValue)) {

--- a/src/partial-evaluators/ArrowFunctionExpression.js
+++ b/src/partial-evaluators/ArrowFunctionExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeArrowFunctionExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/AwaitExpression.js
+++ b/src/partial-evaluators/AwaitExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeAwaitExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/BlockStatement.js
+++ b/src/partial-evaluators/BlockStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeBlockStatement, BabelNodeStatement } from "babel-types";
 import type { Realm } from "../realm.js";

--- a/src/partial-evaluators/BooleanLiteral.js
+++ b/src/partial-evaluators/BooleanLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeBooleanLiteral, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/BreakStatement.js
+++ b/src/partial-evaluators/BreakStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeBreakStatement, BabelNodeStatement } from "babel-types";
 import type { Realm } from "../realm.js";

--- a/src/partial-evaluators/ClassDeclaration.js
+++ b/src/partial-evaluators/ClassDeclaration.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeClassDeclaration, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ClassExpression.js
+++ b/src/partial-evaluators/ClassExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeClassExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ConditionalExpression.js
+++ b/src/partial-evaluators/ConditionalExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeConditionalExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ContinueStatement.js
+++ b/src/partial-evaluators/ContinueStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeContinueStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/Directive.js
+++ b/src/partial-evaluators/Directive.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeDirective, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/DirectiveLiteral.js
+++ b/src/partial-evaluators/DirectiveLiteral.js
@@ -7,6 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default } from "./StringLiteral";

--- a/src/partial-evaluators/DoExpression.js
+++ b/src/partial-evaluators/DoExpression.js
@@ -7,6 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default } from "./BlockStatement.js";

--- a/src/partial-evaluators/DoWhileStatement.js
+++ b/src/partial-evaluators/DoWhileStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeDoWhileStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/EmptyStatement.js
+++ b/src/partial-evaluators/EmptyStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeEmptyStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ForInStatement.js
+++ b/src/partial-evaluators/ForInStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeForInStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ForOfStatement.js
+++ b/src/partial-evaluators/ForOfStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeForOfStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ForStatement.js
+++ b/src/partial-evaluators/ForStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeForStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/FunctionDeclaration.js
+++ b/src/partial-evaluators/FunctionDeclaration.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeFunctionDeclaration, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/FunctionExpression.js
+++ b/src/partial-evaluators/FunctionExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeFunctionExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/Identifier.js
+++ b/src/partial-evaluators/Identifier.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeIdentifier, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment, Reference } from "../environment.js";

--- a/src/partial-evaluators/LabeledStatement.js
+++ b/src/partial-evaluators/LabeledStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeLabeledStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/LogicalExpression.js
+++ b/src/partial-evaluators/LogicalExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeLogicalExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/MemberExpression.js
+++ b/src/partial-evaluators/MemberExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeMemberExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment, Reference } from "../environment.js";

--- a/src/partial-evaluators/MetaProperty.js
+++ b/src/partial-evaluators/MetaProperty.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeMetaProperty, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/NewExpression.js
+++ b/src/partial-evaluators/NewExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeNewExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/NullLiteral.js
+++ b/src/partial-evaluators/NullLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeNullLiteral, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/NumericLiteral.js
+++ b/src/partial-evaluators/NumericLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeNumericLiteral, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ObjectExpression.js
+++ b/src/partial-evaluators/ObjectExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeObjectExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/RegExpLiteral.js
+++ b/src/partial-evaluators/RegExpLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeRegExpLiteral, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ReturnStatement.js
+++ b/src/partial-evaluators/ReturnStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeReturnStatement, BabelNodeStatement } from "babel-types";
 import type { Realm } from "../realm.js";

--- a/src/partial-evaluators/SequenceExpression.js
+++ b/src/partial-evaluators/SequenceExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeSequenceExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/StringLiteral.js
+++ b/src/partial-evaluators/StringLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeStringLiteral, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/SwitchStatement.js
+++ b/src/partial-evaluators/SwitchStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeSwitchStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/TaggedTemplateExpression.js
+++ b/src/partial-evaluators/TaggedTemplateExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeTaggedTemplateExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/TemplateLiteral.js
+++ b/src/partial-evaluators/TemplateLiteral.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeTemplateLiteral, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/ThisExpression.js
+++ b/src/partial-evaluators/ThisExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeThisExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/TryStatement.js
+++ b/src/partial-evaluators/TryStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeTryStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/UnaryExpression.js
+++ b/src/partial-evaluators/UnaryExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeUnaryExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/UpdateExpression.js
+++ b/src/partial-evaluators/UpdateExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeUpdateExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/VariableDeclaration.js
+++ b/src/partial-evaluators/VariableDeclaration.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeVariableDeclaration, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/WhileStatement.js
+++ b/src/partial-evaluators/WhileStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeWhileStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/WithStatement.js
+++ b/src/partial-evaluators/WithStatement.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeWithStatement, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/YieldExpression.js
+++ b/src/partial-evaluators/YieldExpression.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { BabelNodeYieldExpression, BabelNodeStatement } from "babel-types";
 import type { LexicalEnvironment } from "../environment.js";

--- a/src/partial-evaluators/index.js
+++ b/src/partial-evaluators/index.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default as ArrayExpression } from "./ArrayExpression.js";
 export { default as ArrowFunctionExpression } from "./ArrowFunctionExpression.js";

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -30,6 +30,7 @@ import invariant from "./invariant";
 import zipFactory from "node-zip";
 import path from "path";
 import JSONTokenizer from "./utils/JSONTokenizer.js";
+import { isUndefinedOrNull } from "./utils.js";
 
 // Prepack helper
 declare var __residual: any;
@@ -344,7 +345,7 @@ fi
     },
     flags
   );
-  if (typeof heapGraphFilePath !== "undefined") resolvedOptions.heapGraphFormat = "DotLanguage";
+  if (!isUndefinedOrNull(heapGraphFilePath)) resolvedOptions.heapGraphFormat = "DotLanguage";
   if (
     typeof lazyObjectsRuntime === "string" &&
     (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -344,11 +344,8 @@ fi
     },
     flags
   );
-  if (typeof heapGraphFilePath !== "undefined") resolvedOptions.heapGraphFormat = "DotLanguage";
-  if (
-    typeof lazyObjectsRuntime === "string" &&
-    (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)
-  ) {
+  if (heapGraphFilePath !== undefined) resolvedOptions.heapGraphFormat = "DotLanguage";
+  if (lazyObjectsRuntime !== undefined && (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)) {
     console.error("lazy objects feature is incompatible with delayInitializations and inlineExpressions options");
     process.exit(1);
   }
@@ -484,7 +481,7 @@ fi
     if (outputSourceMap) {
       fs.writeFileSync(outputSourceMap, serialized.map ? JSON.stringify(serialized.map) : "");
     }
-    if (typeof heapGraphFilePath === "string") {
+    if (heapGraphFilePath !== undefined) {
       invariant(serialized.heapGraph);
       fs.writeFileSync(heapGraphFilePath, serialized.heapGraph);
     }

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -344,8 +344,11 @@ fi
     },
     flags
   );
-  if (heapGraphFilePath) resolvedOptions.heapGraphFormat = "DotLanguage";
-  if (lazyObjectsRuntime && (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)) {
+  if (typeof heapGraphFilePath !== "undefined") resolvedOptions.heapGraphFormat = "DotLanguage";
+  if (
+    typeof lazyObjectsRuntime === "string" &&
+    (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)
+  ) {
     console.error("lazy objects feature is incompatible with delayInitializations and inlineExpressions options");
     process.exit(1);
   }
@@ -481,7 +484,7 @@ fi
     if (outputSourceMap) {
       fs.writeFileSync(outputSourceMap, serialized.map ? JSON.stringify(serialized.map) : "");
     }
-    if (heapGraphFilePath) {
+    if (typeof heapGraphFilePath === "string") {
       invariant(serialized.heapGraph);
       fs.writeFileSync(heapGraphFilePath, serialized.heapGraph);
     }

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -30,7 +30,6 @@ import invariant from "./invariant";
 import zipFactory from "node-zip";
 import path from "path";
 import JSONTokenizer from "./utils/JSONTokenizer.js";
-import { isUndefinedOrNull } from "./utils.js";
 
 // Prepack helper
 declare var __residual: any;
@@ -345,7 +344,7 @@ fi
     },
     flags
   );
-  if (!isUndefinedOrNull(heapGraphFilePath)) resolvedOptions.heapGraphFormat = "DotLanguage";
+  if (typeof heapGraphFilePath !== "undefined") resolvedOptions.heapGraphFormat = "DotLanguage";
   if (
     typeof lazyObjectsRuntime === "string" &&
     (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -19,6 +19,7 @@ import { getDebuggerOptions } from "./prepack-options";
 import { prepackNodeCLI, prepackNodeCLISync } from "./prepack-node-environment.js";
 import { prepackSources } from "./prepack-standalone.js";
 import { type SourceMap } from "./types.js";
+import { isUndefinedOrNull } from "./utils.js";
 import { DebugChannel } from "./debugger/server/channel/DebugChannel.js";
 import { FileIOWrapper } from "./debugger/common/channel/FileIOWrapper.js";
 import { type SerializedResult } from "./serializer/types.js";
@@ -31,7 +32,7 @@ export * from "./prepack-standalone";
 
 function createStatistics(options: PrepackOptions) {
   let gc = global.gc; // eslint-disable-line no-undef
-  return typeof options.profile !== "undefined"
+  return !isUndefinedOrNull(options.profile)
     ? new SerializerStatistics(
         () => Date.now(),
         () => {

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -19,7 +19,6 @@ import { getDebuggerOptions } from "./prepack-options";
 import { prepackNodeCLI, prepackNodeCLISync } from "./prepack-node-environment.js";
 import { prepackSources } from "./prepack-standalone.js";
 import { type SourceMap } from "./types.js";
-import { isUndefinedOrNull } from "./utils.js";
 import { DebugChannel } from "./debugger/server/channel/DebugChannel.js";
 import { FileIOWrapper } from "./debugger/common/channel/FileIOWrapper.js";
 import { type SerializedResult } from "./serializer/types.js";
@@ -32,7 +31,7 @@ export * from "./prepack-standalone";
 
 function createStatistics(options: PrepackOptions) {
   let gc = global.gc; // eslint-disable-line no-undef
-  return !isUndefinedOrNull(options.profile)
+  return typeof options.profile !== "undefined"
     ? new SerializerStatistics(
         () => Date.now(),
         () => {

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -31,7 +31,7 @@ export * from "./prepack-standalone";
 
 function createStatistics(options: PrepackOptions) {
   let gc = global.gc; // eslint-disable-line no-undef
-  return typeof options.profile !== "undefined"
+  return options.profile !== undefined
     ? new SerializerStatistics(
         () => Date.now(),
         () => {
@@ -91,7 +91,7 @@ export function prepackFile(
     return;
   }
   let sourceMapFilename =
-    typeof options.inputSourceMapFilename === "string" ? options.inputSourceMapFilename : filename + ".map";
+    options.inputSourceMapFilename !== undefined ? options.inputSourceMapFilename : filename + ".map";
   fs.readFile(filename, "utf8", function(fileErr, code) {
     if (fileErr) {
       if (fileErrorHandler) fileErrorHandler(fileErr);
@@ -130,17 +130,16 @@ export function prepackFileSync(filenames: Array<string>, options: PrepackOption
     let code = fs.readFileSync(filename, "utf8");
     let sourceMap = "";
     let sourceMapFilename =
-      typeof options.inputSourceMapFilename === "string" ? options.inputSourceMapFilename : filename + ".map";
+      options.inputSourceMapFilename !== undefined ? options.inputSourceMapFilename : filename + ".map";
     try {
       sourceMap = fs.readFileSync(sourceMapFilename, "utf8");
     } catch (_e) {
-      if (typeof options.inputSourceMapFilename === "string")
-        console.warn(`No sourcemap found at ${sourceMapFilename}.`);
+      if (options.inputSourceMapFilename !== undefined) console.warn(`No sourcemap found at ${sourceMapFilename}.`);
     }
     return { filePath: filename, fileContents: code, sourceMapContents: sourceMap };
   });
   let debugChannel;
-  if (typeof options.debugInFilePath === "string" && typeof options.debugOutFilePath === "string") {
+  if (options.debugInFilePath !== undefined && options.debugOutFilePath !== undefined) {
     let debugOptions = getDebuggerOptions(options);
     let ioWrapper = new FileIOWrapper(false, debugOptions.inFilePath, debugOptions.outFilePath);
     debugChannel = new DebugChannel(ioWrapper);

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -97,9 +97,11 @@ export function prepackFile(
       if (fileErrorHandler) fileErrorHandler(fileErr);
       return;
     }
-    fs.readFile(sourceMapFilename, "utf8", function(mapErr, sourceMap = "") {
+    fs.readFile(sourceMapFilename, "utf8", function(mapErr, _sourceMap) {
+      let sourceMap = _sourceMap;
       if (mapErr) {
         console.warn(`No sourcemap found at ${sourceMapFilename}.`);
+        sourceMap = "";
       }
       let serialized;
       try {

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -31,7 +31,7 @@ export * from "./prepack-standalone";
 
 function createStatistics(options: PrepackOptions) {
   let gc = global.gc; // eslint-disable-line no-undef
-  return options.profile
+  return typeof options.profile !== "undefined"
     ? new SerializerStatistics(
         () => Date.now(),
         () => {
@@ -52,11 +52,10 @@ export function prepackStdin(
   process.stdin.setEncoding("utf8");
   process.stdin.resume();
   process.stdin.on("data", function(code) {
-    fs.readFile(sourceMapFilename, "utf8", function(mapErr, sourceMap) {
+    fs.readFile(sourceMapFilename, "utf8", function(mapErr, sourceMap = "") {
       if (mapErr) {
         //if no sourcemap was provided we silently ignore
         if (sourceMapFilename !== "") console.warn(`No sourcemap found at ${sourceMapFilename}.`);
-        sourceMap = "";
       }
       let filename = "no-filename-specified";
       let serialized;
@@ -98,10 +97,9 @@ export function prepackFile(
       if (fileErrorHandler) fileErrorHandler(fileErr);
       return;
     }
-    fs.readFile(sourceMapFilename, "utf8", function(mapErr, sourceMap) {
+    fs.readFile(sourceMapFilename, "utf8", function(mapErr, sourceMap = "") {
       if (mapErr) {
         console.warn(`No sourcemap found at ${sourceMapFilename}.`);
-        sourceMap = "";
       }
       let serialized;
       try {

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -91,7 +91,8 @@ export function prepackFile(
     prepackNodeCLI(filename, options, callback);
     return;
   }
-  let sourceMapFilename = options.inputSourceMapFilename || filename + ".map";
+  let sourceMapFilename =
+    typeof options.inputSourceMapFilename === "string" ? options.inputSourceMapFilename : filename + ".map";
   fs.readFile(filename, "utf8", function(fileErr, code) {
     if (fileErr) {
       if (fileErrorHandler) fileErrorHandler(fileErr);
@@ -130,16 +131,18 @@ export function prepackFileSync(filenames: Array<string>, options: PrepackOption
   const sourceFiles = filenames.map(filename => {
     let code = fs.readFileSync(filename, "utf8");
     let sourceMap = "";
-    let sourceMapFilename = options.inputSourceMapFilename || filename + ".map";
+    let sourceMapFilename =
+      typeof options.inputSourceMapFilename === "string" ? options.inputSourceMapFilename : filename + ".map";
     try {
       sourceMap = fs.readFileSync(sourceMapFilename, "utf8");
     } catch (_e) {
-      if (options.inputSourceMapFilename) console.warn(`No sourcemap found at ${sourceMapFilename}.`);
+      if (typeof options.inputSourceMapFilename === "string")
+        console.warn(`No sourcemap found at ${sourceMapFilename}.`);
     }
     return { filePath: filename, fileContents: code, sourceMapContents: sourceMap };
   });
   let debugChannel;
-  if (options.debugInFilePath && options.debugOutFilePath) {
+  if (typeof options.debugInFilePath === "string" && typeof options.debugOutFilePath === "string") {
     let debugOptions = getDebuggerOptions(options);
     let ioWrapper = new FileIOWrapper(false, debugOptions.inFilePath, debugOptions.outFilePath);
     debugChannel = new DebugChannel(ioWrapper);

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { ErrorHandler } from "./errors.js";
 import type {

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -31,6 +31,7 @@ import { Modules } from "./utils/modules.js";
 import { Logger } from "./utils/logger.js";
 import { Generator } from "./utils/generator.js";
 import { AbstractObjectValue, AbstractValue, ObjectValue } from "./values/index.js";
+import { isUndefinedOrNull } from "./utils";
 
 export function prepackSources(
   sources: Array<SourceFile>,
@@ -61,7 +62,7 @@ export function prepackSources(
     invariant(options.check);
     checkResidualFunctions(modules, options.check[0], options.check[1]);
     return { code: "", map: undefined };
-  } else if (options.serialize || !options.residual) {
+  } else if (options.serialize === true || options.residual === false || isUndefinedOrNull(options.residual)) {
     let serializer = new Serializer(realm, getSerializerOptions(options));
     let serialized = serializer.init(sources, options.sourceMaps);
 

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -31,7 +31,6 @@ import { Modules } from "./utils/modules.js";
 import { Logger } from "./utils/logger.js";
 import { Generator } from "./utils/generator.js";
 import { AbstractObjectValue, AbstractValue, ObjectValue } from "./values/index.js";
-import { isUndefinedOrNull } from "./utils";
 
 export function prepackSources(
   sources: Array<SourceFile>,
@@ -62,7 +61,7 @@ export function prepackSources(
     invariant(options.check);
     checkResidualFunctions(modules, options.check[0], options.check[1]);
     return { code: "", map: undefined };
-  } else if (options.serialize === true || options.residual === false || isUndefinedOrNull(options.residual)) {
+  } else if (options.serialize === true || options.residual === false || typeof options.residual === "undefined") {
     let serializer = new Serializer(realm, getSerializerOptions(options));
     let serialized = serializer.init(sources, options.sourceMaps);
 

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -61,7 +61,7 @@ export function prepackSources(
     invariant(options.check);
     checkResidualFunctions(modules, options.check[0], options.check[1]);
     return { code: "", map: undefined };
-  } else if (options.serialize === true || options.residual === false || typeof options.residual === "undefined") {
+  } else if (options.serialize === true || options.residual !== true) {
     let serializer = new Serializer(realm, getSerializerOptions(options));
     let serialized = serializer.init(sources, options.sourceMaps);
 

--- a/src/react/branching.js
+++ b/src/react/branching.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Realm } from "../realm.js";
 import {

--- a/src/react/errors.js
+++ b/src/react/errors.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { type ReactEvaluatedNode } from "../serializer/types.js";
 import { FatalError } from "../errors.js";

--- a/src/react/experimental-server-rendering/dom-config.js
+++ b/src/react/experimental-server-rendering/dom-config.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 // Warning: This code is experimental and might not fully work. There is no guarantee
-// that is up-to-date with the curent react-dom/server logic and there may also be
+// that it is up-to-date with the current react-dom/server logic and there may also be
 // security holes in the string escaping because of this.
 
 import type { Realm } from "../../realm.js";

--- a/src/react/experimental-server-rendering/rendering.js
+++ b/src/react/experimental-server-rendering/rendering.js
@@ -137,18 +137,18 @@ function createMarkupForProperty(
     } else if (value instanceof StringValue || value instanceof NumberValue) {
       return attributeName + "=" + quoteAttributeValueForBrowser(value.value + "");
     } else if (value instanceof AbstractValue) {
-      return [attributeName + "=", renderValueWithHelper(realm, value, htmlEscapeHelper)];
+      return ([attributeName + "=", renderValueWithHelper(realm, value, htmlEscapeHelper)]: Array<ReactNode>);
     }
   } else if (value instanceof StringValue || value instanceof NumberValue) {
     return name + "=" + quoteAttributeValueForBrowser(value.value + "");
   } else if (value instanceof AbstractValue) {
-    return [name + '="', renderValueWithHelper(realm, value, htmlEscapeHelper), '"'];
+    return ([name + '="', renderValueWithHelper(realm, value, htmlEscapeHelper), '"']: Array<ReactNode>);
   }
   invariant(false, "TODO");
 }
 
 function createMarkupForStyles(realm: Realm, styles: Value): Value {
-  let serialized = [];
+  let serialized = ([]: Array<ReactNode>);
   let delimiter = "";
 
   if (styles instanceof ObjectValue && !styles.isPartialObject()) {

--- a/src/react/experimental-server-rendering/rendering.js
+++ b/src/react/experimental-server-rendering/rendering.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 // Warning: This code is experimental and might not fully work. There is no guarantee
-// that is up-to-date with the curent react-dom/server logic and there may also be
+// that it is up-to-date with the current react-dom/server logic and there may also be
 // security holes in the string escaping because of this.
 
 import type { Realm } from "../../realm.js";

--- a/src/react/experimental-server-rendering/utils.js
+++ b/src/react/experimental-server-rendering/utils.js
@@ -128,9 +128,9 @@ export function normalizeNode(realm: Realm, reactNode: ReactNode): ReactNode {
           }
         }
       } else if (newReactNode === undefined) {
-        newReactNode = [element];
+        newReactNode = ([element]: Array<ReactNode>);
       } else if (typeof newReactNode === "string") {
-        newReactNode = [newReactNode, element];
+        newReactNode = ([newReactNode, element]: Array<ReactNode>);
       } else {
         newReactNode.push(element);
       }

--- a/src/react/optimizing.js
+++ b/src/react/optimizing.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { type Effects, Realm } from "../realm.js";
 import { AbstractValue, ECMAScriptSourceFunctionValue, BoundFunctionValue, ObjectValue } from "../values/index.js";
@@ -34,12 +34,13 @@ import { Logger } from "../utils/logger.js";
 function applyWriteEffectsForOptimizedComponent(
   realm: Realm,
   componentType: ECMAScriptSourceFunctionValue,
-  effects: Effects,
+  _effects: Effects,
   componentTreeState: ComponentTreeState,
   evaluatedNode: ReactEvaluatedNode,
   writeEffects: WriteEffects,
   environmentRecordIdAfterGlobalCode: number
 ): void {
+  let effects = _effects;
   let additionalFunctionEffects = createAdditionalEffects(
     realm,
     effects,

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -321,7 +321,7 @@ export function convertSimpleClassComponentToFunctionalComponent(
         },
       },
       undefined,
-      (undefined: any),
+      {},
       undefined
     );
     traverse.clearCache();

--- a/src/realm.js
+++ b/src/realm.js
@@ -219,7 +219,7 @@ export class Realm {
     }
 
     this.start = Date.now();
-    this.compatibility = opts.compatibility || "browser";
+    this.compatibility = typeof opts.compatibility !== "undefined" ? opts.compatibility : "browser";
     this.maxStackDepth = opts.maxStackDepth || 225;
     this.invariantLevel = opts.invariantLevel || 0;
     this.invariantMode = opts.invariantMode || "throw";
@@ -710,19 +710,17 @@ export class Realm {
     strictCode: boolean,
     env: LexicalEnvironment,
     state?: any,
-    generatorName?: string
+    generatorName?: string = "evaluateNodeForEffects"
   ): Effects {
-    return this.evaluateForEffects(
-      () => env.evaluateCompletionDeref(ast, strictCode),
-      state,
-      generatorName || "evaluateNodeForEffects"
-    );
+    return this.evaluateForEffects(() => env.evaluateCompletionDeref(ast, strictCode), state, generatorName);
   }
 
-  evaluateForEffectsInGlobalEnv(func: () => Value, state?: any, generatorName?: string): Effects {
-    return this.wrapInGlobalEnv(() =>
-      this.evaluateForEffects(func, state, generatorName || "evaluateForEffectsInGlobalEnv")
-    );
+  evaluateForEffectsInGlobalEnv(
+    func: () => Value,
+    state?: any,
+    generatorName?: string = "evaluateForEffectsInGlobalEnv"
+  ): Effects {
+    return this.wrapInGlobalEnv(() => this.evaluateForEffects(func, state, generatorName));
   }
 
   // NB: does not apply generators because there's no way to cleanly revert them.
@@ -1261,9 +1259,8 @@ export class Realm {
     this.createdObjects = new Set();
   }
 
-  getCapturedEffects(completion: PossiblyNormalCompletion, v?: Value): void | Effects {
+  getCapturedEffects(completion: PossiblyNormalCompletion, v?: Value = this.intrinsics.undefined): void | Effects {
     if (completion.savedEffects === undefined) return undefined;
-    if (v === undefined) v = this.intrinsics.undefined;
     invariant(this.generator !== undefined);
     invariant(this.modifiedBindings !== undefined);
     invariant(this.modifiedProperties !== undefined);

--- a/src/realm.js
+++ b/src/realm.js
@@ -198,7 +198,7 @@ export class Realm {
   constructor(opts: RealmOptions, statistics: RealmStatistics) {
     this.statistics = statistics;
     this.isReadOnly = false;
-    this.useAbstractInterpretation = !!opts.serialize || !!opts.residual || !!opts.check;
+    this.useAbstractInterpretation = opts.serialize === true || opts.residual === true || Array.isArray(opts.check);
     this.ignoreLeakLogic = false;
     this.isInPureTryStatement = false;
     if (opts.mathRandomSeed !== undefined) {
@@ -207,12 +207,12 @@ export class Realm {
     this.strictlyMonotonicDateNow = !!opts.strictlyMonotonicDateNow;
 
     // 0 = disabled
-    this.abstractValueImpliesMax = opts.abstractValueImpliesMax || 0;
+    this.abstractValueImpliesMax = typeof opts.abstractValueImpliesMax === "number" ? opts.abstractValueImpliesMax : 0;
     this.abstractValueImpliesCounter = 0;
     this.inSimplificationPath = false;
 
     this.timeout = opts.timeout;
-    if (this.timeout) {
+    if (typeof this.timeout === "number") {
       // We'll call Date.now for every this.timeoutCounterThreshold'th AST node.
       // The threshold is there to reduce the cost of the surprisingly expensive Date.now call.
       this.timeoutCounter = this.timeoutCounterThreshold = 1024;
@@ -455,7 +455,7 @@ export class Realm {
 
   testTimeout() {
     let timeout = this.timeout;
-    if (timeout && !--this.timeoutCounter) {
+    if (typeof timeout === "number" && !--this.timeoutCounter) {
       this.timeoutCounter = this.timeoutCounterThreshold;
       let total = Date.now() - this.start;
       if (total > timeout) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -207,19 +207,19 @@ export class Realm {
     this.strictlyMonotonicDateNow = !!opts.strictlyMonotonicDateNow;
 
     // 0 = disabled
-    this.abstractValueImpliesMax = typeof opts.abstractValueImpliesMax === "number" ? opts.abstractValueImpliesMax : 0;
+    this.abstractValueImpliesMax = opts.abstractValueImpliesMax !== undefined ? opts.abstractValueImpliesMax : 0;
     this.abstractValueImpliesCounter = 0;
     this.inSimplificationPath = false;
 
     this.timeout = opts.timeout;
-    if (typeof this.timeout === "number") {
+    if (this.timeout !== undefined) {
       // We'll call Date.now for every this.timeoutCounterThreshold'th AST node.
       // The threshold is there to reduce the cost of the surprisingly expensive Date.now call.
       this.timeoutCounter = this.timeoutCounterThreshold = 1024;
     }
 
     this.start = Date.now();
-    this.compatibility = typeof opts.compatibility !== "undefined" ? opts.compatibility : "browser";
+    this.compatibility = opts.compatibility !== undefined ? opts.compatibility : "browser";
     this.maxStackDepth = opts.maxStackDepth || 225;
     this.invariantLevel = opts.invariantLevel || 0;
     this.invariantMode = opts.invariantMode || "throw";
@@ -455,7 +455,7 @@ export class Realm {
 
   testTimeout() {
     let timeout = this.timeout;
-    if (typeof timeout === "number" && !--this.timeoutCounter) {
+    if (timeout !== undefined && !--this.timeoutCounter) {
       this.timeoutCounter = this.timeoutCounterThreshold;
       let total = Date.now() - this.start;
       if (total > timeout) {

--- a/src/serializer/GeneratorDAG.js
+++ b/src/serializer/GeneratorDAG.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import invariant from "../invariant.js";
 import { FunctionValue, ObjectValue } from "../values/index.js";

--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Realm } from "../realm.js";
 import { AbstractValue, ConcreteValue, FunctionValue, Value, ObjectValue } from "../values/index.js";

--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { FunctionValue, Value } from "../values/index.js";
 import * as t from "babel-types";

--- a/src/serializer/ResidualHeapGraphGenerator.js
+++ b/src/serializer/ResidualHeapGraphGenerator.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Logger } from "../utils/logger.js";
 import type { Modules } from "../utils/modules.js";

--- a/src/serializer/ResidualHeapRefCounter.js
+++ b/src/serializer/ResidualHeapRefCounter.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Logger } from "../utils/logger.js";
 import type { Modules } from "../utils/modules.js";

--- a/src/serializer/ResidualHeapValueIdentifiers.js
+++ b/src/serializer/ResidualHeapValueIdentifiers.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Value } from "../values/index.js";
 import type { BabelNodeIdentifier } from "babel-types";

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Realm } from "../realm.js";
 import { AbstractValue, ObjectValue, SymbolValue, Value } from "../values/index.js";

--- a/src/serializer/factorify.js
+++ b/src/serializer/factorify.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import * as t from "babel-types";
 import type { BabelNodeStatement, BabelNodeObjectExpression, BabelNodeLVal } from "babel-types";
@@ -204,12 +204,12 @@ export function factorifyObjects(body: Array<BabelNodeStatement>, factoryNameGen
       let highestPairCount;
       for (let pairArgs in sharedPairs) {
         let pair = sharedPairs[pairArgs];
-        if (!highestPairArgs || pair.length > highestPairCount) {
+        if (typeof highestPairArgs === "undefined" || pair.length > highestPairCount) {
           highestPairCount = pair.length;
           highestPairArgs = pairArgs;
         }
       }
-      if (!highestPairArgs) continue;
+      if (typeof highestPairArgs === "undefined") continue;
 
       //
       let declarsSub = sharedPairs[highestPairArgs].concat(declar);

--- a/src/serializer/factorify.js
+++ b/src/serializer/factorify.js
@@ -204,12 +204,12 @@ export function factorifyObjects(body: Array<BabelNodeStatement>, factoryNameGen
       let highestPairCount;
       for (let pairArgs in sharedPairs) {
         let pair = sharedPairs[pairArgs];
-        if (typeof highestPairArgs === "undefined" || pair.length > highestPairCount) {
+        if (highestPairArgs === undefined || pair.length > highestPairCount) {
           highestPairCount = pair.length;
           highestPairArgs = pairArgs;
         }
       }
-      if (typeof highestPairArgs === "undefined") continue;
+      if (highestPairArgs === undefined) continue;
 
       //
       let declarsSub = sharedPairs[highestPairArgs].concat(declar);

--- a/src/serializer/index.js
+++ b/src/serializer/index.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Serializer } from "./serializer.js";
 export default Serializer;

--- a/src/serializer/statistics.js
+++ b/src/serializer/statistics.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { RealmStatistics, PerformanceTracker } from "../statistics.js";
 

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { DeclarativeEnvironmentRecord, type Binding } from "../environment.js";
 import { ConcreteValue, Value, ObjectValue, AbstractValue } from "../values/index.js";
@@ -46,7 +46,7 @@ export type AdditionalFunctionEffects = {
   parentAdditionalFunction: FunctionValue | void,
   effects: Effects,
   generator: Generator,
-  transforms: Array<Function>,
+  transforms: Array<(body: Array<BabelNodeStatement>) => void>,
   additionalRoots: Set<ObjectValue>,
 };
 

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -48,9 +48,9 @@ export function commonAncestorOf<T>(node1: void | T, node2: void | T, getParent:
     let p2 = n2 && getParent(n2);
     if (p1 === node2) return node2;
     if (p2 === node1) return node1;
-    if (typeof p1 !== "undefined") count1++;
-    if (typeof p2 !== "undefined") count2++;
-    if (typeof p1 === "undefined" && typeof p2 === "undefined") break;
+    if (p1 !== undefined) count1++;
+    if (p2 !== undefined) count2++;
+    if (p1 === undefined && p2 === undefined) break;
     n1 = p1;
     n2 = p2;
   }

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -124,7 +124,7 @@ export function getObjectPrototypeMetadata(
   if (obj.$IsClassPrototype) {
     skipPrototype = true;
   }
-  if (proto && proto.$IsClassPrototype === true) {
+  if (proto && proto.$IsClassPrototype) {
     invariant(proto instanceof ObjectValue);
     // we now need to check if the prototpe has a constructor
     let _constructor = proto.properties.get("constructor");

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -50,7 +50,7 @@ export function commonAncestorOf<T>(node1: void | T, node2: void | T, getParent:
     if (p2 === node1) return node1;
     if (p1 === true) count1++;
     if (p2 === true) count2++;
-    if (p1 === false && p2 === false) break;
+    if (p1 !== true && p2 !== true) break;
     n1 = p1;
     n2 = p2;
   }

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -48,9 +48,9 @@ export function commonAncestorOf<T>(node1: void | T, node2: void | T, getParent:
     let p2 = n2 && getParent(n2);
     if (p1 === node2) return node2;
     if (p2 === node1) return node1;
-    if (p1) count1++;
-    if (p2) count2++;
-    if (!p1 && !p2) break;
+    if (p1 === true) count1++;
+    if (p2 === true) count2++;
+    if (p1 === false && p2 === false) break;
     n1 = p1;
     n2 = p2;
   }
@@ -124,7 +124,7 @@ export function getObjectPrototypeMetadata(
   if (obj.$IsClassPrototype) {
     skipPrototype = true;
   }
-  if (proto && proto.$IsClassPrototype) {
+  if (proto && proto.$IsClassPrototype === true) {
     invariant(proto instanceof ObjectValue);
     // we now need to check if the prototpe has a constructor
     let _constructor = proto.properties.get("constructor");

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -48,9 +48,9 @@ export function commonAncestorOf<T>(node1: void | T, node2: void | T, getParent:
     let p2 = n2 && getParent(n2);
     if (p1 === node2) return node2;
     if (p2 === node1) return node1;
-    if (p1 === true) count1++;
-    if (p2 === true) count2++;
-    if (p1 !== true && p2 !== true) break;
+    if (typeof p1 !== "undefined") count1++;
+    if (typeof p2 !== "undefined") count2++;
+    if (typeof p1 === "undefined" && typeof p2 === "undefined") break;
     n1 = p1;
     n2 = p2;
   }

--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Realm } from "../realm.js";
 import * as t from "babel-types";

--- a/src/types.js
+++ b/src/types.js
@@ -1052,4 +1052,5 @@ export type UtilsType = {|
   typeToString: (typeof Value) => void | string,
   getTypeFromName: string => void | typeof Value,
   describeValue: Value => string,
+  isUndefinedOrNull: (void | Value) => boolean,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -1052,5 +1052,4 @@ export type UtilsType = {|
   typeToString: (typeof Value) => void | string,
   getTypeFromName: string => void | typeof Value,
   describeValue: Value => string,
-  isUndefinedOrNull: (void | Value) => boolean,
 |};

--- a/src/utils.js
+++ b/src/utils.js
@@ -106,7 +106,3 @@ export function describeValue(value: Value): string {
   if (value.__originalName !== undefined) title += `, original name: ${value.__originalName}`;
   return suffix ? `${title}\n${suffix}` : title;
 }
-
-export function isUndefinedOrNull(value: void | mixed): boolean {
-  return typeof value === "undefined" || value === null;
-}

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import {
   AbstractValue,

--- a/src/utils.js
+++ b/src/utils.js
@@ -106,3 +106,7 @@ export function describeValue(value: Value): string {
   if (value.__originalName !== undefined) title += `, original name: ${value.__originalName}`;
   return suffix ? `${title}\n${suffix}` : title;
 }
+
+export function isUndefinedOrNull(value: void | mixed): boolean {
+  return typeof value === "undefined" || value === null;
+}

--- a/src/utils/HeapInspector.js
+++ b/src/utils/HeapInspector.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { Realm } from "../realm.js";
 import type { Descriptor } from "../types.js";

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { FatalError } from "../errors.js";
 import { Realm } from "../realm.js";

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import invariant from "../invariant.js";
 import type { SourceType } from "../types.js";

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { AbstractValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
 import { InfeasiblePathError } from "../errors.js";

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -291,7 +291,8 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   // ECMA262 9.1.5
-  $GetOwnProperty(P: PropertyKeyValue): Descriptor | void {
+  $GetOwnProperty(_P: PropertyKeyValue): Descriptor | void {
+    let P = _P;
     if (P instanceof StringValue) P = P.value;
 
     if (this.values.isTop()) {
@@ -397,7 +398,8 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   // ECMA262 9.1.6
-  $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor): boolean {
+  $DefineOwnProperty(_P: PropertyKeyValue, Desc: Descriptor): boolean {
+    let P = _P;
     if (P instanceof StringValue) P = P.value;
     if (this.values.isTop()) {
       AbstractValue.reportIntrospectionError(this, P);
@@ -450,7 +452,8 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   // ECMA262 9.1.7
-  $HasProperty(P: PropertyKeyValue): boolean {
+  $HasProperty(_P: PropertyKeyValue): boolean {
+    let P = _P;
     if (P instanceof StringValue) P = P.value;
     if (this.values.isTop()) {
       let error = new CompilerDiagnostic(
@@ -487,7 +490,8 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   // ECMA262 9.1.8
-  $Get(P: PropertyKeyValue, Receiver: Value): Value {
+  $Get(_P: PropertyKeyValue, Receiver: Value): Value {
+    let P = _P;
     if (P instanceof StringValue) P = P.value;
 
     if (this.values.isTop()) {
@@ -690,7 +694,8 @@ export default class AbstractObjectValue extends AbstractValue {
     }
   }
 
-  $SetPartial(P: AbstractValue | PropertyKeyValue, V: Value, Receiver: Value): boolean {
+  $SetPartial(_P: AbstractValue | PropertyKeyValue, V: Value, Receiver: Value): boolean {
+    let P = _P;
     if (this.values.isTop()) {
       if (this.$Realm.isInPureScope()) {
         // If we're in a pure scope, we can havoc the key and the instance,
@@ -775,7 +780,8 @@ export default class AbstractObjectValue extends AbstractValue {
   }
 
   // ECMA262 9.1.10
-  $Delete(P: PropertyKeyValue): boolean {
+  $Delete(_P: PropertyKeyValue): boolean {
+    let P = _P;
     if (P instanceof StringValue) P = P.value;
     if (this.values.isTop()) {
       AbstractValue.reportIntrospectionError(this, P);

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -76,7 +76,7 @@ export default class AbstractObjectValue extends AbstractValue {
     }
     for (let element of this.values.getElements()) {
       invariant(element instanceof ObjectValue);
-      element.temoralAlias = temporalValue;
+      element.temporalAlias = temporalValue;
     }
   }
 

--- a/src/values/ArgumentsExotic.js
+++ b/src/values/ArgumentsExotic.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor, ObjectKind } from "../types.js";

--- a/src/values/BooleanValue.js
+++ b/src/values/BooleanValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { PrimitiveValue, Value } from "./index.js";
 import type { Realm } from "../realm.js";

--- a/src/values/BoundFunctionValue.js
+++ b/src/values/BoundFunctionValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { Value, FunctionValue, ObjectValue } from "./index.js";

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import {

--- a/src/values/ECMAScriptFunctionValue.js
+++ b/src/values/ECMAScriptFunctionValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { ObjectValue } from "./index.js";

--- a/src/values/EmptyValue.js
+++ b/src/values/EmptyValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { UndefinedValue, Value } from "./index.js";
 

--- a/src/values/IntegerIndexedExotic.js
+++ b/src/values/IntegerIndexedExotic.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";

--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Value } from "./index.js";
 import type { Realm } from "../realm.js";
@@ -71,7 +71,7 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
       enumerable: false,
     });
 
-    if (name) {
+    if (typeof name !== "undefined") {
       if (name instanceof SymbolValue) {
         this.name = name.$Description ? `[${name.$Description.throwIfNotConcreteString().value}]` : "[native]";
       } else {

--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -71,7 +71,7 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
       enumerable: false,
     });
 
-    if (name !== undefined) {
+    if (name !== undefined && name !== "") {
       if (name instanceof SymbolValue) {
         this.name = name.$Description ? `[${name.$Description.throwIfNotConcreteString().value}]` : "[native]";
       } else {

--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -71,7 +71,7 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
       enumerable: false,
     });
 
-    if (typeof name !== "undefined") {
+    if (name !== undefined) {
       if (name instanceof SymbolValue) {
         this.name = name.$Description ? `[${name.$Description.throwIfNotConcreteString().value}]` : "[native]";
       } else {

--- a/src/values/NullValue.js
+++ b/src/values/NullValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { PrimitiveValue, Value } from "./index.js";
 

--- a/src/values/NumberValue.js
+++ b/src/values/NumberValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { PrimitiveValue, Value } from "./index.js";
 import type { Realm } from "../realm.js";

--- a/src/values/PrimitiveValue.js
+++ b/src/values/PrimitiveValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import { ConcreteValue } from "./index.js";

--- a/src/values/StringExotic.js
+++ b/src/values/StringExotic.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";

--- a/src/values/StringValue.js
+++ b/src/values/StringValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { hashString } from "../methods/index.js";
 import { PrimitiveValue, Value } from "../values/index.js";

--- a/src/values/SymbolValue.js
+++ b/src/values/SymbolValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { PrimitiveValue, Value } from "./index.js";
 import type { Realm } from "../realm.js";
@@ -27,7 +27,7 @@ export default class SymbolValue extends PrimitiveValue {
   }
 
   getHash(): number {
-    if (!this.hashValue) {
+    if (typeof this.hashValue !== "number") {
       this.hashValue = ++this.$Realm.symbolCount;
     }
     return this.hashValue;

--- a/src/values/SymbolValue.js
+++ b/src/values/SymbolValue.js
@@ -27,7 +27,7 @@ export default class SymbolValue extends PrimitiveValue {
   }
 
   getHash(): number {
-    if (typeof this.hashValue !== "number") {
+    if (this.hashValue === undefined) {
       this.hashValue = ++this.$Realm.symbolCount;
     }
     return this.hashValue;

--- a/src/values/UndefinedValue.js
+++ b/src/values/UndefinedValue.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 import { EmptyValue, PrimitiveValue, Value } from "./index.js";
 

--- a/src/values/index.js
+++ b/src/values/index.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* @flow */
+/* @flow strict-local */
 
 export { default as Value } from "./Value.js";
 export { default as ConcreteValue } from "./ConcreteValue.js";


### PR DESCRIPTION
Release Notes: none

I made more files flow strict, to move forward on https://github.com/facebook/prepack/issues/1941.
I'm using `/* @flow strict-local */` to avoid the problem with importing non-strict files for now.

I created a small utility to check for an undefined type or null value, but am wondering if it is a bit pointless. Would like some feedback on that. Thanks!