### PR TITLE
Make ThrowCompletion constructor consistent with other completions

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -34,9 +34,10 @@ export class NormalCompletion extends Completion {}
 export class AbruptCompletion extends Completion {}
 
 export class ThrowCompletion extends AbruptCompletion {
-  constructor(realm: Realm, value: Value, location: ?BabelNodeSourceLocation, nativeStack?: ?string) {
+  constructor(value: Value, location: ?BabelNodeSourceLocation, nativeStack?: ?string) {
     super(value, location);
     this.nativeStack = nativeStack || new Error().stack;
+    let realm = value.$Realm;
     if (realm.isInPureScope() && realm.reportSideEffectCallback !== undefined) {
       realm.reportSideEffectCallback("EXCEPTION_THROWN", undefined, location);
     }

--- a/src/evaluators/ThrowStatement.js
+++ b/src/evaluators/ThrowStatement.js
@@ -24,5 +24,5 @@ export default function(
 ): Value {
   let exprRef = env.evaluate(ast.argument, strictCode);
   let exprValue = Environment.GetValue(realm, exprRef);
-  throw new ThrowCompletion(realm, exprValue, ast.loc);
+  throw new ThrowCompletion(exprValue, ast.loc);
 }

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -630,7 +630,7 @@ export class JoinImplementation {
     if (result1 instanceof ThrowCompletion && result2 instanceof ThrowCompletion) {
       let val = this.joinValues(realm, result1.value, result2.value, getAbstractValue);
       invariant(val instanceof Value);
-      return new ThrowCompletion(realm, val, result1.location);
+      return new ThrowCompletion(val, result1.location);
     }
     if (result1 instanceof AbruptCompletion && result2 instanceof AbruptCompletion) {
       return new JoinedAbruptCompletions(realm, joinCondition, result1, e1, result2, e2);

--- a/src/partial-evaluators/ThrowStatement.js
+++ b/src/partial-evaluators/ThrowStatement.js
@@ -24,7 +24,7 @@ export default function(
 ): [Completion | Value, BabelNode, Array<BabelNodeStatement>] {
   let [argValue, argAst, io] = env.partiallyEvaluateCompletionDeref(ast.argument, strictCode);
   if (argValue instanceof Value) {
-    let c = new ThrowCompletion(realm, argValue, ast.loc);
+    let c = new ThrowCompletion(argValue, ast.loc);
     let s = t.throwStatement((argAst: any)); // will be an expression because argValue is a Value
     return [c, s, io];
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1601,7 +1601,7 @@ export class Realm {
     if (typeof message === "string") message = new StringValue(this, message);
     invariant(message instanceof StringValue);
     this.nextContextLocation = this.currentLocation;
-    return new ThrowCompletion(this, Construct(this, type, [message]), this.currentLocation);
+    return new ThrowCompletion(Construct(this, type, [message]), this.currentLocation);
   }
 
   appendGenerator(generator: Generator, leadingComment: string = ""): void {

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -67,7 +67,7 @@ export default function(
         loc: e.loc,
         stackDecorated: false,
       };
-      throw new ThrowCompletion(realm, error, e.loc);
+      throw new ThrowCompletion(error, e.loc);
     } else {
       throw e;
     }


### PR DESCRIPTION
Release note: Made ThrowCompletion constructor consistent with other completions

extractAndJoinCompletionsOfType assumes that all completions can be constructed by supplying only a value as parameter. ThrowCompletion needs to conform to this expectation.

This is a refactor towards some bug fixes where this matters. Test coverage will come with those fixes.