### PR TITLE
Tidy up simple tests and fix refuseSerialization bug

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2321,6 +2321,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple 17 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -6112,6 +6129,23 @@ ReactStatistics {
 `;
 
 exports[`Test React with JSX input, create-element output Functional component folding Simple 16 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple 17 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
   "evaluatedRootNodes": Array [
@@ -9935,6 +9969,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Simple 17 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Simple children 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -13741,6 +13792,23 @@ ReactStatistics {
 `;
 
 exports[`Test React with create-element input, create-element output Functional component folding Simple 16 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple 17 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
   "evaluatedRootNodes": Array [

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -364,6 +364,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-16.js");
       });
 
+      it("Simple 17", async () => {
+        await runTest(directory, "simple-17.js");
+      });
+
       it("__reactCompilerDoNotOptimize", async () => {
         await runTest(directory, "do-not-optimize.js");
       });

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -55,10 +55,6 @@ export class ResidualReactElementVisitor {
         this.residualHeapVisitor.visitValue(propsValue);
       },
       visitConcreteProps: (propsValue: ObjectValue) => {
-        // given that props is a concrete object, it should never be serialized
-        // as we'll be doing it directly with the ReactElementSerializer
-        // so we make the object as refusing serialization
-        propsValue.refuseSerialization = true;
         for (let [propName, binding] of propsValue.properties) {
           if (binding.descriptor !== undefined && propName !== "children") {
             let propValue = getProperty(this.realm, propsValue, propName);

--- a/test/react/functional-components/simple-13.js
+++ b/test/react/functional-components/simple-13.js
@@ -29,9 +29,7 @@ function Child(props) {
   return children();
 }
 
-__optimizeReactComponentTree(App, {
-  firstRenderOnly: true
-});
+__optimizeReactComponentTree(App);
 
 App.getTrials = function(renderer, Root) {
   // Just compile, don't run

--- a/test/react/functional-components/simple-14.js
+++ b/test/react/functional-components/simple-14.js
@@ -15,9 +15,7 @@ App.getTrials = function(renderer, Root) {
 };
 
 if (this.__optimizeReactComponentTree) {
-  __optimizeReactComponentTree(App, {
-    firstRenderOnly: true,
-  });
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-15.js
+++ b/test/react/functional-components/simple-15.js
@@ -13,9 +13,7 @@ App.getTrials = function(renderer, Root) {
 };
 
 if (this.__optimizeReactComponentTree) {
-  __optimizeReactComponentTree(App, {
-    firstRenderOnly: true,
-  });
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-16.js
+++ b/test/react/functional-components/simple-16.js
@@ -13,9 +13,7 @@ App.getTrials = function(renderer, Root) {
 };
 
 if (this.__optimizeReactComponentTree) {
-  __optimizeReactComponentTree(App, {
-    firstRenderOnly: true,
-  });
+  __optimizeReactComponentTree(App);
 }
 
 module.exports = App;

--- a/test/react/functional-components/simple-17.js
+++ b/test/react/functional-components/simple-17.js
@@ -1,0 +1,26 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App(props) {
+  var externalFunc = props.externalFunc;
+
+  var x = <span a="1" b="2" />;
+  externalFunc(x);
+  externalFunc(x.props);
+  return <div>{x}</div>
+}
+
+App.getTrials = function(renderer, Root) {
+  function externalFunc() {
+    // NO-OP
+  }
+  renderer.update(<Root externalFunc={externalFunc} />);
+  return [['with havoc functions', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release note: none

This PR remove `firstRenderOnly` from a bunch of tests that shouldn't have had it and adds a new test for a big with `props` being incorrectly marked for `refuseSerialization` – `props` can be serialialized without the ReactElement, and the test shows how this might happen.