### PR TITLE
Make it clearer that some completions are forks rather than joins.

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -63,7 +63,7 @@ export class ReturnCompletion extends AbruptCompletion {
   }
 }
 
-export class JoinedAbruptCompletions extends AbruptCompletion {
+export class ForkedAbruptCompletion extends AbruptCompletion {
   constructor(
     realm: Realm,
     joinCondition: AbstractValue,
@@ -89,10 +89,10 @@ export class JoinedAbruptCompletions extends AbruptCompletion {
   containsCompletion(CompletionType: typeof Completion): boolean {
     if (this.consequent instanceof CompletionType) return true;
     if (this.alternate instanceof CompletionType) return true;
-    if (this.consequent instanceof JoinedAbruptCompletions) {
+    if (this.consequent instanceof ForkedAbruptCompletion) {
       if (this.consequent.containsCompletion(CompletionType)) return true;
     }
-    if (this.alternate instanceof JoinedAbruptCompletions) {
+    if (this.alternate instanceof ForkedAbruptCompletion) {
       if (this.alternate.containsCompletion(CompletionType)) return true;
     }
     return false;
@@ -101,10 +101,10 @@ export class JoinedAbruptCompletions extends AbruptCompletion {
   containsBreakOrContinue(): boolean {
     if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;
     if (this.alternate instanceof BreakCompletion || this.alternate instanceof ContinueCompletion) return true;
-    if (this.consequent instanceof JoinedAbruptCompletions) {
+    if (this.consequent instanceof ForkedAbruptCompletion) {
       if (this.consequent.containsBreakOrContinue()) return true;
     }
-    if (this.alternate instanceof JoinedAbruptCompletions) {
+    if (this.alternate instanceof ForkedAbruptCompletion) {
       if (this.alternate.containsBreakOrContinue()) return true;
     }
     return false;
@@ -184,10 +184,10 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   containsCompletion(CompletionType: typeof Completion): boolean {
     if (this.consequent instanceof CompletionType) return true;
     if (this.alternate instanceof CompletionType) return true;
-    if (this.consequent instanceof JoinedAbruptCompletions || this.consequent instanceof PossiblyNormalCompletion) {
+    if (this.consequent instanceof ForkedAbruptCompletion || this.consequent instanceof PossiblyNormalCompletion) {
       if (this.consequent.containsCompletion(CompletionType)) return true;
     }
-    if (this.alternate instanceof JoinedAbruptCompletions || this.alternate instanceof PossiblyNormalCompletion) {
+    if (this.alternate instanceof ForkedAbruptCompletion || this.alternate instanceof PossiblyNormalCompletion) {
       if (this.alternate.containsCompletion(CompletionType)) return true;
     }
     return false;
@@ -196,10 +196,10 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   containsBreakOrContinue(): boolean {
     if (this.consequent instanceof BreakCompletion || this.consequent instanceof ContinueCompletion) return true;
     if (this.alternate instanceof BreakCompletion || this.alternate instanceof ContinueCompletion) return true;
-    if (this.consequent instanceof JoinedAbruptCompletions || this.consequent instanceof PossiblyNormalCompletion) {
+    if (this.consequent instanceof ForkedAbruptCompletion || this.consequent instanceof PossiblyNormalCompletion) {
       if (this.consequent.containsBreakOrContinue()) return true;
     }
-    if (this.alternate instanceof JoinedAbruptCompletions || this.alternate instanceof PossiblyNormalCompletion) {
+    if (this.alternate instanceof ForkedAbruptCompletion || this.alternate instanceof PossiblyNormalCompletion) {
       if (this.alternate.containsBreakOrContinue()) return true;
     }
     return false;

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -93,7 +93,7 @@ function callBothFunctionsAndJoinTheirEffects(
     "callBothFunctionsAndJoinTheirEffects/2"
   );
 
-  let joinedEffects = Join.joinEffects(
+  let joinedEffects = Join.joinForkOrChoose(
     realm,
     cond,
     new Effects(e1.result, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),

--- a/src/evaluators/DoWhileStatement.js
+++ b/src/evaluators/DoWhileStatement.js
@@ -16,7 +16,7 @@ import { Value } from "../values/index.js";
 import { EmptyValue } from "../values/index.js";
 import { UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue, TryToApplyEffectsOfJoiningBranches } from "./ForOfStatement.js";
-import { AbruptCompletion, BreakCompletion, JoinedAbruptCompletions } from "../completions.js";
+import { AbruptCompletion, BreakCompletion, ForkedAbruptCompletion } from "../completions.js";
 import { Environment, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeDoWhileStatement } from "babel-types";
@@ -40,7 +40,7 @@ export default function(
       let stmt = env.evaluateCompletion(body, strictCode);
       //todo: check if stmt is a PossiblyNormalCompletion and defer to fixpoint computation below
       invariant(stmt instanceof Value || stmt instanceof AbruptCompletion);
-      if (stmt instanceof JoinedAbruptCompletions) stmt = TryToApplyEffectsOfJoiningBranches(realm, stmt);
+      if (stmt instanceof ForkedAbruptCompletion) stmt = TryToApplyEffectsOfJoiningBranches(realm, stmt);
 
       // b. If LoopContinues(stmt, labelSet) is false, return Completion(UpdateEmpty(stmt, V)).
       if (LoopContinues(realm, stmt, labelSet) === false) {

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -17,7 +17,7 @@ import {
   BreakCompletion,
   Completion,
   ContinueCompletion,
-  JoinedAbruptCompletions,
+  ForkedAbruptCompletion,
   PossiblyNormalCompletion,
   ReturnCompletion,
   ThrowCompletion,
@@ -100,7 +100,7 @@ function ForBodyEvaluation(
     // b. Let result be the result of evaluating stmt.
     let result = env.evaluateCompletion(stmt, strictCode);
     invariant(result instanceof Value || result instanceof AbruptCompletion);
-    if (result instanceof JoinedAbruptCompletions) result = TryToApplyEffectsOfJoiningBranches(realm, result);
+    if (result instanceof ForkedAbruptCompletion) result = TryToApplyEffectsOfJoiningBranches(realm, result);
 
     // c. If LoopContinues(result, labelSet) is false, return Completion(UpdateEmpty(result, V)).
     if (!LoopContinues(realm, result, labelSet)) {
@@ -159,7 +159,7 @@ function ForBodyEvaluation(
       realm.handleError(diagnostic);
       throw new FatalError();
     }
-    if (c instanceof PossiblyNormalCompletion || c instanceof JoinedAbruptCompletions) {
+    if (c instanceof PossiblyNormalCompletion || c instanceof ForkedAbruptCompletion) {
       failIfContainsBreakOrContinueCompletionWithNonLocalTarget(c.consequent);
       failIfContainsBreakOrContinueCompletionWithNonLocalTarget(c.alternate);
     }
@@ -175,7 +175,7 @@ function ForBodyEvaluation(
       }
       return false;
     }
-    if (c instanceof PossiblyNormalCompletion || c instanceof JoinedAbruptCompletions)
+    if (c instanceof PossiblyNormalCompletion || c instanceof ForkedAbruptCompletion)
       return containsContinueCompletion(c.consequent) || containsContinueCompletion(c.alternate);
     return false;
   }
@@ -195,7 +195,7 @@ function ForBodyEvaluation(
     invariant(abruptCompletion instanceof AbruptCompletion);
 
     // If there is now a single completion, we don't need to join
-    if (!(abruptCompletion instanceof JoinedAbruptCompletions)) return abruptCompletion;
+    if (!(abruptCompletion instanceof ForkedAbruptCompletion)) return abruptCompletion;
     invariant(containsContinueCompletion(abruptCompletion));
 
     // Apply the joined effects of continue completions to the current state since these now join the normal path
@@ -236,7 +236,7 @@ function ForBodyEvaluation(
 
     // If there is now a single completion, we don't need to join
     if (abruptCompletion instanceof BreakCompletion) return (UpdateEmpty(realm, abruptCompletion, V): any).value;
-    if (!(abruptCompletion instanceof JoinedAbruptCompletions)) throw abruptCompletion;
+    if (!(abruptCompletion instanceof ForkedAbruptCompletion)) throw abruptCompletion;
 
     // If there are no breaks, we don't need to join
     if (!abruptCompletion.containsCompletion(BreakCompletion)) throw abruptCompletion;

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -89,14 +89,14 @@ export default function(
   // use lval as is for the join condition.
   let joinedEffects;
   if (ast.operator === "&&") {
-    joinedEffects = Join.joinEffects(
+    joinedEffects = Join.joinForkOrChoose(
       realm,
       lval,
       new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2),
       new Effects(lval, generator1, modifiedBindings1, modifiedProperties1, createdObjects1)
     );
   } else {
-    joinedEffects = Join.joinEffects(
+    joinedEffects = Join.joinForkOrChoose(
       realm,
       lval,
       new Effects(lval, generator1, modifiedBindings1, modifiedProperties1, createdObjects1),
@@ -119,7 +119,7 @@ export default function(
   if (completion instanceof AbruptCompletion) throw completion;
   invariant(completion instanceof Value); // references do not survive join
   if (lval instanceof Value && result2 instanceof Value) {
-    // joinEffects does the right thing for the side effects of the second expression but for the result the join
+    // joinForkOrChoose does the right thing for the side effects of the second expression but for the result the join
     // produces a conditional expressions of the form (a ? b : a) for a && b and (a ? a : b) for a || b
     // Rather than look for this pattern everywhere, we override this behavior and replace the completion with
     // the actual logical operator. This helps with simplification and reasoning when dealing with path conditions.

--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -11,7 +11,7 @@
 
 import {
   AbruptCompletion,
-  JoinedAbruptCompletions,
+  ForkedAbruptCompletion,
   PossiblyNormalCompletion,
   ReturnCompletion,
   ThrowCompletion,
@@ -240,7 +240,7 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
         // We are about the leave this program and this presents a join point where all control flows
         // converge into a single flow using the joined effects as the new state.
         res = Functions.incorporateSavedCompletion(realm, res);
-        if (res instanceof JoinedAbruptCompletions && res.containsCompletion(ThrowCompletion)) {
+        if (res instanceof ForkedAbruptCompletion && res.containsCompletion(ThrowCompletion)) {
           // The global state is now at the point where the first fork occurred.
           let joinedEffects = Join.joinNestedEffects(realm, res);
           realm.applyEffects(joinedEffects);
@@ -285,7 +285,7 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
       realm.applyEffects(effectsTree, "", false);
       // The global state is now at the point where the first fork occurred.
       res = effectsTree.result;
-      invariant(res instanceof JoinedAbruptCompletions);
+      invariant(res instanceof ForkedAbruptCompletion);
       let generator = realm.generator;
       invariant(generator !== undefined);
       if (res.containsCompletion(ThrowCompletion)) {

--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -171,7 +171,7 @@ function AbstractCaseBlockEvaluation(
 
       invariant(trueEffects !== undefined);
       invariant(falseEffects !== undefined);
-      let joinedEffects = Join.joinEffects(realm, selectionResult, trueEffects, falseEffects);
+      let joinedEffects = Join.joinForkOrChoose(realm, selectionResult, trueEffects, falseEffects);
       let completion = joinedEffects.result;
       if (completion instanceof PossiblyNormalCompletion) {
         // in this case one of the branches may complete abruptly, which means that
@@ -356,7 +356,7 @@ export default function(
           "specialized switch"
         );
         joinedEffects =
-          joinedEffects === undefined ? effects : Join.joinEffects(realm, condition, effects, joinedEffects);
+          joinedEffects === undefined ? effects : Join.joinForkOrChoose(realm, condition, effects, joinedEffects);
       }
       invariant(joinedEffects !== undefined);
       realm.applyEffects(joinedEffects, "joined specialized switch");

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -11,12 +11,7 @@
 
 import type { Effects, Realm } from "../realm.js";
 import { type LexicalEnvironment } from "../environment.js";
-import {
-  AbruptCompletion,
-  JoinedAbruptCompletions,
-  PossiblyNormalCompletion,
-  ThrowCompletion,
-} from "../completions.js";
+import { AbruptCompletion, ForkedAbruptCompletion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
 import { UpdateEmpty } from "../methods/index.js";
 import { Functions, Join } from "../singletons.js";
 import { Value } from "../values/index.js";
@@ -46,7 +41,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
     if (blockRes instanceof ThrowCompletion) {
       handlerRes = env.evaluateCompletionDeref(handler, strictCode, blockRes);
       // Note: The handler may have introduced new forks
-    } else if (blockRes instanceof JoinedAbruptCompletions || blockRes instanceof PossiblyNormalCompletion) {
+    } else if (blockRes instanceof ForkedAbruptCompletion || blockRes instanceof PossiblyNormalCompletion) {
       if (blockRes instanceof PossiblyNormalCompletion) {
         // Nothing has been joined and we are going to keep it that way.
         // The current state may have advanced since the time control forked into the various paths recorded in blockRes.
@@ -69,7 +64,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
   if (ast.finalizer) {
     // The start of the finalizer is a join point where all threads of control come together.
     // However, we choose to keep the threads unjoined and to apply the finalizer separately to each thread.
-    if (blockRes instanceof PossiblyNormalCompletion || blockRes instanceof JoinedAbruptCompletions) {
+    if (blockRes instanceof PossiblyNormalCompletion || blockRes instanceof ForkedAbruptCompletion) {
       // The current global state is a the point of the fork that led to blockRes
       // All subsequent effects are kept inside the branches of blockRes.
       let finalizerEffects = composeNestedEffectsWithFinalizer(blockRes);
@@ -92,15 +87,15 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
   // it is tricky to join the joined and composed result of the throw completions with the non exceptional completions.
   // Unfortunately, things are still complicated because the handler may turn abrupt completions into normal
   // completions and the other way around. When this happens the container has to change its type.
-  // We do this by call joinEffects to create a new container at every level of the recursion.
+  // We do this by call joinForkOrChoose to create a new container at every level of the recursion.
   function composeNestedThrowEffectsWithHandler(
-    c: PossiblyNormalCompletion | JoinedAbruptCompletions,
+    c: PossiblyNormalCompletion | ForkedAbruptCompletion,
     priorEffects: Array<Effects> = []
   ): Effects {
     let consequent = c.consequent;
     let consequentEffects = c.consequentEffects;
     priorEffects.push(consequentEffects);
-    if (consequent instanceof JoinedAbruptCompletions || consequent instanceof PossiblyNormalCompletion) {
+    if (consequent instanceof ForkedAbruptCompletion || consequent instanceof PossiblyNormalCompletion) {
       consequentEffects = composeNestedThrowEffectsWithHandler(consequent, priorEffects);
     } else if (consequent instanceof ThrowCompletion) {
       consequentEffects = realm.evaluateForEffectsWithPriorEffects(
@@ -117,7 +112,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
     let alternate = c.alternate;
     let alternateEffects = c.alternateEffects;
     priorEffects.push(alternateEffects);
-    if (alternate instanceof PossiblyNormalCompletion || alternate instanceof JoinedAbruptCompletions) {
+    if (alternate instanceof PossiblyNormalCompletion || alternate instanceof ForkedAbruptCompletion) {
       alternateEffects = composeNestedThrowEffectsWithHandler(alternate, priorEffects);
     } else if (alternate instanceof ThrowCompletion) {
       alternateEffects = realm.evaluateForEffectsWithPriorEffects(
@@ -131,21 +126,21 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       c.alternateEffects.result = c.alternate = new AbruptCompletion(realm.intrinsics.empty);
     }
     priorEffects.pop();
-    return Join.joinEffects(realm, c.joinCondition, consequentEffects, alternateEffects);
+    return Join.joinForkOrChoose(realm, c.joinCondition, consequentEffects, alternateEffects);
   }
 
   // The finalizer is not a join point, so update each path in the completion separately.
   // Things are complicated because the finalizer may turn normal completions into abrupt completions.
   // When this happens the container has to change its type.
-  // We do this by call joinEffects to create a new container at every level of the recursion.
+  // We do this by call joinForkOrChoose to create a new container at every level of the recursion.
   function composeNestedEffectsWithFinalizer(
-    c: PossiblyNormalCompletion | JoinedAbruptCompletions,
+    c: PossiblyNormalCompletion | ForkedAbruptCompletion,
     priorEffects: Array<Effects> = []
   ): Effects {
     let consequent = c.consequent;
     let consequentEffects = c.consequentEffects;
     priorEffects.push(consequentEffects);
-    if (consequent instanceof JoinedAbruptCompletions || consequent instanceof PossiblyNormalCompletion) {
+    if (consequent instanceof ForkedAbruptCompletion || consequent instanceof PossiblyNormalCompletion) {
       consequentEffects = composeNestedThrowEffectsWithHandler(consequent, priorEffects);
     } else {
       consequentEffects = realm.evaluateForEffectsWithPriorEffects(
@@ -162,7 +157,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
     let alternate = c.alternate;
     let alternateEffects = c.alternateEffects;
     priorEffects.push(alternateEffects);
-    if (alternate instanceof PossiblyNormalCompletion || alternate instanceof JoinedAbruptCompletions) {
+    if (alternate instanceof PossiblyNormalCompletion || alternate instanceof ForkedAbruptCompletion) {
       alternateEffects = composeNestedThrowEffectsWithHandler(alternate, priorEffects);
     } else {
       alternateEffects = realm.evaluateForEffectsWithPriorEffects(
@@ -176,6 +171,6 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       if (!(alternateEffects.result instanceof AbruptCompletion)) alternateEffects.result = alternate;
     }
     priorEffects.pop();
-    return Join.joinEffects(realm, c.joinCondition, consequentEffects, alternateEffects);
+    return Join.joinForkOrChoose(realm, c.joinCondition, consequentEffects, alternateEffects);
   }
 }

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -27,7 +27,7 @@ import {
 } from "../values/index.js";
 import { GetIterator, HasSomeCompatibleType, IsCallable, IsPropertyKey, IteratorStep, IteratorValue } from "./index.js";
 import { GeneratorStart } from "../methods/generator.js";
-import { ReturnCompletion, AbruptCompletion, ThrowCompletion, JoinedAbruptCompletions } from "../completions.js";
+import { ReturnCompletion, AbruptCompletion, ThrowCompletion, ForkedAbruptCompletion } from "../completions.js";
 import { GetTemplateObject, GetV, GetThisValue } from "../methods/get.js";
 import { Create, Environment, Functions, Join, Havoc, To, Widen } from "../singletons.js";
 import invariant from "../invariant.js";
@@ -411,7 +411,7 @@ export function OrdinaryCallEvaluateBody(
           invariant(abruptCompletion instanceof AbruptCompletion);
 
           // If there is single completion, we don't need to join
-          if (!(abruptCompletion instanceof JoinedAbruptCompletions)) return abruptCompletion;
+          if (!(abruptCompletion instanceof ForkedAbruptCompletion)) return abruptCompletion;
 
           // If none of the completions are return completions, there is no need to join either
           if (!abruptCompletion.containsCompletion(ReturnCompletion)) return abruptCompletion;

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -19,7 +19,7 @@ import {
   ReturnCompletion,
   AbruptCompletion,
   NormalCompletion,
-  JoinedAbruptCompletions,
+  ForkedAbruptCompletion,
 } from "../completions.js";
 import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord } from "../environment.js";
@@ -1122,7 +1122,7 @@ export class FunctionImplementation {
   }
 
   // If c is an abrupt completion and realm.savedCompletion is defined, the result is an instance of
-  // JoinedAbruptCompletions and the effects that have been captured since the PossiblyNormalCompletion instance
+  // ForkedAbruptCompletion and the effects that have been captured since the PossiblyNormalCompletion instance
   // in realm.savedCompletion has been created, becomes the effects of the branch that terminates in c.
   // If c is a normal completion, the result is realm.savedCompletion, with its value updated to c.
   // If c is undefined, the result is just realm.savedCompletion.
@@ -1147,7 +1147,7 @@ export class FunctionImplementation {
         realm.stopEffectCaptureAndUndoEffects(savedCompletion);
         let joined_effects = Join.joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, c, e);
         let jc = joined_effects.result;
-        invariant(jc instanceof JoinedAbruptCompletions);
+        invariant(jc instanceof ForkedAbruptCompletion);
         realm.applyEffects(joined_effects, "incorporateSavedCompletion", false);
         return jc;
       }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -163,7 +163,7 @@ export function OrdinaryGet(
   }
   // Join the effects, creating an abstract view of what happened, regardless
   // of the actual value of ownDesc.joinCondition.
-  let joinedEffects = Join.joinEffects(
+  let joinedEffects = Join.joinForkOrChoose(
     realm,
     joinCondition,
     new Effects(result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1),

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -321,7 +321,7 @@ export class PropertiesImplementation {
 
       // Join the effects, creating an abstract view of what happened, regardless
       // of the actual value of ownDesc.joinCondition.
-      let joinedEffects = Join.joinEffects(
+      let joinedEffects = Join.joinForkOrChoose(
         realm,
         joinCondition,
         new Effects(result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1),

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -114,7 +114,7 @@ function callBothFunctionsAndJoinTheirEffects(
     "callBothFunctionsAndJoinTheirEffects/2"
   );
 
-  let joinedEffects = Join.joinEffects(
+  let joinedEffects = Join.joinForkOrChoose(
     realm,
     cond,
     new Effects(e1.result, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -78,7 +78,7 @@ export default function(
   // of the actual value of exprValue.
   const ce = consequentEffects;
   const ae = alternateEffects;
-  let joinedEffects = Join.joinEffects(
+  let joinedEffects = Join.joinForkOrChoose(
     realm,
     exprValue,
     new Effects(ce.result, ce.generator, ce.modifiedBindings, ce.modifiedProperties, ce.createdObjects),

--- a/src/realm.js
+++ b/src/realm.js
@@ -55,7 +55,7 @@ import { cloneDescriptor, Construct } from "./methods/index.js";
 import {
   AbruptCompletion,
   Completion,
-  JoinedAbruptCompletions,
+  ForkedAbruptCompletion,
   PossiblyNormalCompletion,
   ThrowCompletion,
 } from "./completions.js";
@@ -497,7 +497,7 @@ export class Realm {
         this.clearBlockBindingsFromCompletion(completion.alternate, environmentRecord);
       if (completion.consequent instanceof Completion)
         this.clearBlockBindingsFromCompletion(completion.consequent, environmentRecord);
-    } else if (completion instanceof JoinedAbruptCompletions) {
+    } else if (completion instanceof ForkedAbruptCompletion) {
       this.clearBlockBindings(completion.alternateEffects.modifiedBindings, environmentRecord);
       this.clearBlockBindings(completion.consequentEffects.modifiedBindings, environmentRecord);
       if (completion.alternate instanceof Completion)
@@ -552,7 +552,7 @@ export class Realm {
         this.clearFunctionBindingsFromCompletion(completion.alternate, funcVal);
       if (completion.consequent instanceof Completion)
         this.clearFunctionBindingsFromCompletion(completion.consequent, funcVal);
-    } else if (completion instanceof JoinedAbruptCompletions) {
+    } else if (completion instanceof ForkedAbruptCompletion) {
       this.clearFunctionBindings(completion.alternateEffects.modifiedBindings, funcVal);
       this.clearFunctionBindings(completion.consequentEffects.modifiedBindings, funcVal);
       if (completion.alternate instanceof Completion)
@@ -972,9 +972,9 @@ export class Realm {
     } else {
       // Join the effects, creating an abstract view of what happened, regardless
       // of the actual value of condValue.
-      joinedEffects = Join.joinEffects(this, condValue, effects1, effects2);
+      joinedEffects = Join.joinForkOrChoose(this, condValue, effects1, effects2);
       completion = joinedEffects.result;
-      if (completion instanceof JoinedAbruptCompletions) {
+      if (completion instanceof ForkedAbruptCompletion) {
         // Note that the effects are tracked separately inside completion and will be applied later.
         throw completion;
       }

--- a/src/types.js
+++ b/src/types.js
@@ -31,7 +31,7 @@ import { Value } from "./values/index.js";
 import {
   AbruptCompletion,
   Completion,
-  JoinedAbruptCompletions,
+  ForkedAbruptCompletion,
   NormalCompletion,
   PossiblyNormalCompletion,
 } from "./completions.js";
@@ -512,7 +512,7 @@ export type FunctionType = {
   PerformEval(realm: Realm, x: Value, evalRealm: Realm, strictCaller: boolean, direct: boolean): Value,
 
   // If c is an abrupt completion and realm.savedCompletion is defined, the result is an instance of
-  // JoinedAbruptCompletions and the effects that have been captured since the PossiblyNormalCompletion instance
+  // ForkedAbruptCompletion and the effects that have been captured since the PossiblyNormalCompletion instance
   // in realm.savedCompletion has been created, becomes the effects of the branch that terminates in c.
   // If c is a normal completion, the result is realm.savedCompletion, with its value updated to c.
   // If c is undefined, the result is just realm.savedCompletion.
@@ -696,7 +696,7 @@ export type JoinType = {
     c1: PossiblyNormalCompletion,
     c2: AbruptCompletion,
     realm: Realm
-  ): JoinedAbruptCompletions,
+  ): ForkedAbruptCompletion,
 
   unbundleNormalCompletion(
     completionOrValue: Completion | Value | Reference
@@ -726,7 +726,7 @@ export type JoinType = {
 
   // Returns the joined effects of all of the paths in pnc.
   // The normal path in pnc is modified to become terminated by ac,
-  // so the overall completion will always be an instance of JoinedAbruptCompletions
+  // so the overall completion will always be an instance of ForkedAbruptCompletion
   joinPossiblyNormalCompletionWithAbruptCompletion(
     realm: Realm,
     // a forked path with a non abrupt (normal) component
@@ -761,12 +761,12 @@ export type JoinType = {
   unbundle(
     CompletionType: typeof Completion,
     realm: Realm,
-    c: JoinedAbruptCompletions
+    c: ForkedAbruptCompletion
   ): [Effects, PossiblyNormalCompletion],
 
   removeNormalEffects(realm: Realm, c: PossiblyNormalCompletion): Effects,
 
-  joinEffects(realm: Realm, joinCondition: Value, e1: Effects, e2: Effects): Effects,
+  joinForkOrChoose(realm: Realm, joinCondition: Value, e1: Effects, e2: Effects): Effects,
 
   joinNestedEffects(realm: Realm, c: Completion, precedingEffects?: Effects): Effects,
 


### PR DESCRIPTION
Release note: Rename refactor make it clearer that forks are not joins

Mechanical refactor to help with future documentation.

To come in a future PR: making sure forks are not joined except by means of extractAndJoinCompletionsOfType.