### PR TITLE
Do not emit final property assignments when havocing

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -1939,6 +1939,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Havocing of ReactElements should not result in property assignments 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Key change 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,
@@ -6057,6 +6074,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output Functional component folding Havocing of ReactElements should not result in property assignments 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output Functional component folding Key change 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,
@@ -10171,6 +10205,23 @@ ReactStatistics {
   ],
   "inlinedComponents": 1,
   "optimizedNestedClosures": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Havocing of ReactElements should not result in property assignments 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
 `;
@@ -14304,6 +14355,23 @@ ReactStatistics {
   ],
   "inlinedComponents": 1,
   "optimizedNestedClosures": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Havocing of ReactElements should not result in property assignments 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
 `;

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -369,6 +369,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-17.js");
       });
 
+      it("Havocing of ReactElements should not result in property assignments", async () => {
+        await runTest(directory, "react-element-havoc.js");
+      });
+
       it("__reactCompilerDoNotOptimize", async () => {
         await runTest(directory, "do-not-optimize.js");
       });

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -40,6 +40,7 @@ import type { BabelNodeSourceLocation } from "babel-types";
 import invariant from "../invariant.js";
 import { HeapInspector } from "../utils/HeapInspector.js";
 import { Logger } from "../utils/logger.js";
+import { isReactElement } from "../react/utils.js";
 
 type HavocedFunctionInfo = {
   unboundReads: Set<string>,
@@ -210,13 +211,15 @@ class ObjectValueHavocingVisitor {
             } else {
               if (realmGenerator !== undefined) {
                 let targetDescriptor = this.getHeapInspector().getTargetIntegrityDescriptor(obj);
-                if (
-                  descriptor.writable !== targetDescriptor.writable ||
-                  descriptor.configurable !== targetDescriptor.configurable
-                ) {
-                  realmGenerator.emitDefineProperty(obj, name, descriptor);
-                } else {
-                  realmGenerator.emitPropertyAssignment(obj, name, value);
+                if (!isReactElement(obj)) {
+                  if (
+                    descriptor.writable !== targetDescriptor.writable ||
+                    descriptor.configurable !== targetDescriptor.configurable
+                  ) {
+                    realmGenerator.emitDefineProperty(obj, name, descriptor);
+                  } else {
+                    realmGenerator.emitPropertyAssignment(obj, name, value);
+                  }
                 }
               }
             }

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -211,7 +211,7 @@ class ObjectValueHavocingVisitor {
             } else {
               if (realmGenerator !== undefined) {
                 let targetDescriptor = this.getHeapInspector().getTargetIntegrityDescriptor(obj);
-                if (obj.mightNotBeFinalObject()) {
+                if (!isReactElement(obj)) {
                   if (
                     descriptor.writable !== targetDescriptor.writable ||
                     descriptor.configurable !== targetDescriptor.configurable

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -211,7 +211,7 @@ class ObjectValueHavocingVisitor {
             } else {
               if (realmGenerator !== undefined) {
                 let targetDescriptor = this.getHeapInspector().getTargetIntegrityDescriptor(obj);
-                if (!isReactElement(obj)) {
+                if (obj.mightNotBeFinalObject()) {
                   if (
                     descriptor.writable !== targetDescriptor.writable ||
                     descriptor.configurable !== targetDescriptor.configurable

--- a/test/react/functional-components/react-element-havoc.js
+++ b/test/react/functional-components/react-element-havoc.js
@@ -1,0 +1,24 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function App(props) {
+  "use strict";
+  var x = <div a={1} b={2} c={props.c} />
+  props.someAbstractFunction(x);
+  return x;
+}
+
+App.getTrials = function(renderer, Root) {
+  function someAbstractFunction() {
+    // NO-OP
+  }
+  renderer.update(<Root someAbstractFunction={someAbstractFunction} c={3} />);
+  return [['react element havoc', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/react-element-havoc.js
+++ b/test/react/functional-components/react-element-havoc.js
@@ -4,7 +4,8 @@ this['React'] = React;
 
 function App(props) {
   "use strict";
-  var x = <div a={1} b={2} c={props.c} />
+  var b = props.b !== null ? props.b.x !== null ? props.b.x : null : null;
+  var x = <div a={1} b={b} c={props.c} />
   props.someAbstractFunction(x);
   return x;
 }

--- a/test/react/functional-components/react-element-havoc.js
+++ b/test/react/functional-components/react-element-havoc.js
@@ -14,7 +14,7 @@ App.getTrials = function(renderer, Root) {
   function someAbstractFunction() {
     // NO-OP
   }
-  renderer.update(<Root someAbstractFunction={someAbstractFunction} c={3} />);
+  renderer.update(<Root someAbstractFunction={someAbstractFunction} b={null} c={3} />);
   return [['react element havoc', renderer.toJSON()]];
 };
 


### PR DESCRIPTION
Release notes: none

When in strict mode, emitting property assignments to a frozen object (ReactElement in this case) causes a runtime error. We shouldn't be emitting ReactElement properties when we havoc the object. Unfortunately, we can't do this to all final objects, because our internal snapshot test fails when doing this (because the final object has properties that are conditional and thus delayed, so we need all its bindings to be "flushed" at the point of havocing). As a more thorough future fix, we should probably add a separate codepath for serializing objects that are final (we delay the entire object being emitted until all its properties are ready, like the ReactElement serializer does).

Interestingly, the output contains an unused variable that should be removed @NTillmann?

```js
var _0 = function (props, context) {
    "use strict";

    var _J = props;
    var _$0 = _J.b;

    var _1 = _$0 !== null;

    if (_1) {
      var _$1 = _J.b;
      var _$2 = _$1.x;

      var _5 = _$2 !== null;

      if (_5) {
        var _$3 = _J.b;
        var _$4 = _$3.x;
      }
    }

    var _$5 = _J.c;
    var _$6 = _J.someAbstractFunction;

    var _A = _1 ? _5 ? _$4 : null : null;

    var _8 = {  // <-- why has this not been removed? can we not mark the entry as "pure"
      a: 1,
      b: _A,
      c: _$5
    };
    _8.a = 1;
    _8.b = _A;
    _8.c = _$5;

    var _F = <div a={1} b={_A} c={_$5} />;

    var _$7 = props.someAbstractFunction(_F);

    return _F;
  };
```