### PR TITLE
Upgrade ESlint to support ES2018

### DIFF
--- a/scripts/lint-config.js
+++ b/scripts/lint-config.js
@@ -21,7 +21,7 @@ module.exports = {
     "no-use-before-define": ["error", { variables: false, functions: false }],
   },
   parserOptions: {
-    ecmaVersion: 7,
+    ecmaVersion: 2018,
     ecmaFeatures: {
       jsx: true,
     },


### PR DESCRIPTION
Release notes: none

Make our linter use the latest `ecmaVersion`. https://eslint.org/docs/user-guide/configuring#deprecated