### PR TITLE
Refactor of createElement props/config to fix bugs + use snapshotting

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -2983,6 +2983,151 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #7 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #8 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #9 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #10 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #11 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -3059,16 +3204,23 @@ exports[`Test React with JSX input, JSX output Functional component folding Unsa
 
 exports[`Test React with JSX input, JSX output Functional component folding defaultProps 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 1,
+  "componentsEvaluated": 2,
   "evaluatedRootNodes": Array [
     Object {
-      "children": Array [],
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 0,
+  "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -7118,6 +7270,151 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #7 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #8 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #9 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #10 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #11 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -7194,16 +7491,23 @@ exports[`Test React with JSX input, create-element output Functional component f
 
 exports[`Test React with JSX input, create-element output Functional component folding defaultProps 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 1,
+  "componentsEvaluated": 2,
   "evaluatedRootNodes": Array [
     Object {
-      "children": Array [],
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 0,
+  "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -11253,6 +11557,151 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #7 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #8 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #9 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #10 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #11 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -11344,16 +11793,23 @@ ReactStatistics {
 
 exports[`Test React with create-element input, JSX output Functional component folding defaultProps 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 1,
+  "componentsEvaluated": 2,
   "evaluatedRootNodes": Array [
     Object {
-      "children": Array [],
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 0,
+  "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -15403,6 +15859,151 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #7 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #8 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #9 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #10 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #11 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Child2",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -15494,16 +16095,23 @@ ReactStatistics {
 
 exports[`Test React with create-element input, create-element output Functional component folding defaultProps 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 1,
+  "componentsEvaluated": 2,
   "evaluatedRootNodes": Array [
     Object {
-      "children": Array [],
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 0,
+  "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3128,6 +3128,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -7415,6 +7439,30 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -11697,6 +11745,30 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -15999,6 +16071,30 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 3,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #12 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -74,7 +74,7 @@ let prepackOptions = {
   reactEnabled: true,
   reactOutput: "jsx",
   reactVerbose: true,
-  reactOptimizeNestedFunctions: true,
+  reactOptimizeNestedFunctions: false,
   inlineExpressions: true,
   invariantLevel: 0,
   abstractValueImpliesMax: 1000,

--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -74,7 +74,7 @@ let prepackOptions = {
   reactEnabled: true,
   reactOutput: "jsx",
   reactVerbose: true,
-  reactOptimizeNestedFunctions: false,
+  reactOptimizeNestedFunctions: true,
   inlineExpressions: true,
   invariantLevel: 0,
   abstractValueImpliesMax: 1000,

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -495,6 +495,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-with-jsx-spread11.js");
       });
 
+      it("Simple with multiple JSX spreads #12", async () => {
+        await runTest(directory, "simple-with-jsx-spread12.js");
+      });
+
       it("Simple with Object.assign", async () => {
         await runTest(directory, "simple-assign.js");
       });

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -475,6 +475,26 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-with-jsx-spread6.js");
       });
 
+      it("Simple with multiple JSX spreads #7", async () => {
+        await runTest(directory, "simple-with-jsx-spread7.js");
+      });
+
+      it("Simple with multiple JSX spreads #8", async () => {
+        await runTest(directory, "simple-with-jsx-spread8.js");
+      });
+
+      it("Simple with multiple JSX spreads #9", async () => {
+        await runTest(directory, "simple-with-jsx-spread9.js");
+      });
+
+      it("Simple with multiple JSX spreads #10", async () => {
+        await runTest(directory, "simple-with-jsx-spread10.js");
+      });
+
+      it("Simple with multiple JSX spreads #11", async () => {
+        await runTest(directory, "simple-with-jsx-spread11.js");
+      });
+
       it("Simple with Object.assign", async () => {
         await runTest(directory, "simple-assign.js");
       });

--- a/src/evaluators/JSXElement.js
+++ b/src/evaluators/JSXElement.js
@@ -264,7 +264,11 @@ function evaluateJSXAttributes(
   if (abstractSpreadCount > 0) {
     // if we only have a single spread config, then use that,
     // i.e. <div {...something} />  -->  React.createElement("div", something)
-    if (abstractSpreadCount === 1 && astAttributes.length === 1) {
+    if (
+      abstractSpreadCount === 1 &&
+      astAttributes.length === 1 &&
+      (spreadValue instanceof ObjectValue || spreadValue instanceof AbstractObjectValue)
+    ) {
       return spreadValue;
     }
     // we create an abstract Object.assign() to deal with the fact that we don't what

--- a/src/evaluators/JSXElement.js
+++ b/src/evaluators/JSXElement.js
@@ -25,7 +25,6 @@ import type {
 import {
   AbstractObjectValue,
   ArrayValue,
-  ECMAScriptFunctionValue,
   StringValue,
   Value,
   NumberValue,
@@ -33,13 +32,15 @@ import {
   AbstractValue,
 } from "../values/index.js";
 import { convertJSXExpressionToIdentifier } from "../react/jsx.js";
-import * as t from "babel-types";
 import { Get } from "../methods/index.js";
 import { Create, Environment, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import { createReactElement } from "../react/elements.js";
-import { flagPropsWithNoPartialKeyOrRef, hasNoPartialKeyOrRef } from "../react/utils.js";
-import { FatalError } from "../errors.js";
+import {
+  applyObjectAssignConfigsFoReactElement,
+  flagPropsWithNoPartialKeyOrRef,
+  hasNoPartialKeyOrRef,
+} from "../react/utils.js";
 
 // taken from Babel
 function cleanJSXElementLiteralChild(child: string): null | string {
@@ -261,6 +262,11 @@ function evaluateJSXAttributes(
   }
 
   if (abstractSpreadCount > 0) {
+    // if we only have a single spread config, then use that,
+    // i.e. <div {...something} />  -->  React.createElement("div", something)
+    // if (abstractSpreadCount === 1 && astAttributes.length === 1) {
+    //   return spreadValue;
+    // }
     // we create an abstract Object.assign() to deal with the fact that we don't what
     // the props are because they contain abstract spread attributes that we can't
     // evaluate ahead of time
@@ -269,39 +275,10 @@ function evaluateJSXAttributes(
 
     // create a new config object that will be the target of the Object.assign
     config = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
-    // ensure the config partial
-    config.makePartial();
 
-    // get the global Object.assign
-    let globalObj = Get(realm, realm.$GlobalObject, "Object");
-    invariant(globalObj instanceof ObjectValue);
-    let objAssign = Get(realm, globalObj, "assign");
-    invariant(objAssign instanceof ECMAScriptFunctionValue);
-    let objectAssignCall = objAssign.$Call;
-    invariant(objectAssignCall !== undefined);
-
-    try {
-      objectAssignCall(realm.intrinsics.undefined, [config, ...abstractPropsArgs]);
-      if (safeAbstractSpreadCount === abstractSpreadCount) {
-        flagPropsWithNoPartialKeyOrRef(realm, config);
-      }
-    } catch (e) {
-      if (realm.isInPureScope() && e instanceof FatalError) {
-        let flagProps = hasNoPartialKeyOrRef(realm, config);
-
-        config = AbstractValue.createTemporalFromBuildFunction(
-          realm,
-          ObjectValue,
-          [objAssign, config, ...abstractPropsArgs],
-          ([methodNode, ..._args]) => {
-            return t.callExpression(methodNode, ((_args: any): Array<any>));
-          }
-        );
-        invariant(config instanceof AbstractObjectValue);
-        if (flagProps) {
-          flagPropsWithNoPartialKeyOrRef(realm, config);
-        }
-      }
+    applyObjectAssignConfigsFoReactElement(realm, config, abstractPropsArgs);
+    if (safeAbstractSpreadCount === abstractSpreadCount) {
+      flagPropsWithNoPartialKeyOrRef(realm, config);
     }
   }
   invariant(config instanceof ObjectValue || config instanceof AbstractObjectValue);

--- a/src/evaluators/JSXElement.js
+++ b/src/evaluators/JSXElement.js
@@ -37,7 +37,7 @@ import { Create, Environment, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import { createReactElement } from "../react/elements.js";
 import {
-  applyObjectAssignConfigsFoReactElement,
+  applyObjectAssignConfigsForReactElement,
   flagPropsWithNoPartialKeyOrRef,
   hasNoPartialKeyOrRef,
 } from "../react/utils.js";
@@ -264,9 +264,9 @@ function evaluateJSXAttributes(
   if (abstractSpreadCount > 0) {
     // if we only have a single spread config, then use that,
     // i.e. <div {...something} />  -->  React.createElement("div", something)
-    // if (abstractSpreadCount === 1 && astAttributes.length === 1) {
-    //   return spreadValue;
-    // }
+    if (abstractSpreadCount === 1 && astAttributes.length === 1) {
+      return spreadValue;
+    }
     // we create an abstract Object.assign() to deal with the fact that we don't what
     // the props are because they contain abstract spread attributes that we can't
     // evaluate ahead of time
@@ -276,7 +276,7 @@ function evaluateJSXAttributes(
     // create a new config object that will be the target of the Object.assign
     config = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
 
-    applyObjectAssignConfigsFoReactElement(realm, config, abstractPropsArgs);
+    applyObjectAssignConfigsForReactElement(realm, config, abstractPropsArgs);
     if (safeAbstractSpreadCount === abstractSpreadCount) {
       flagPropsWithNoPartialKeyOrRef(realm, config);
     }

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -12,11 +12,11 @@
 import type { Realm } from "../realm.js";
 import { ValuesDomain } from "../domains/index.js";
 import { AbstractValue, AbstractObjectValue, ArrayValue, NumberValue, ObjectValue, Value } from "../values/index.js";
-import { Create, Properties, To } from "../singletons.js";
+import { Create, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 import { Get } from "../methods/index.js";
 import {
-  applyObjectAssignConfigsFoReactElement,
+  applyObjectAssignConfigsForReactElement,
   createDefaultPropsHelper,
   createInternalReactElement,
   flagPropsWithNoPartialKeyOrRef,
@@ -91,7 +91,7 @@ function createPropsObject(
     // create a new props object that will be the target of the Object.assign
     props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
 
-    applyObjectAssignConfigsFoReactElement(realm, props, args);
+    applyObjectAssignConfigsForReactElement(realm, props, args);
 
     if (children !== undefined) {
       Properties.Set(realm, props, "children", children, true);

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -57,12 +57,32 @@ function createPropsObject(
 
   let possibleKey = Get(realm, config, "key");
   if (possibleKey !== realm.intrinsics.null && possibleKey !== realm.intrinsics.undefined) {
-    key = computeBinary(realm, "+", realm.intrinsics.emptyString, possibleKey);
+    // if the config has been marked as having no partial key or ref and the possible key
+    // is abstract, yet the config doesn't have a key property, then the key can remain null
+    let keyNotNeeded =
+      hasNoPartialKeyOrRef(realm, config) &&
+      possibleKey instanceof AbstractValue &&
+      config instanceof ObjectValue &&
+      !config.properties.has("key");
+
+    if (!keyNotNeeded) {
+      key = computeBinary(realm, "+", realm.intrinsics.emptyString, possibleKey);
+    }
   }
 
   let possibleRef = Get(realm, config, "ref");
   if (possibleRef !== realm.intrinsics.null && possibleRef !== realm.intrinsics.undefined) {
-    ref = possibleRef;
+    // if the config has been marked as having no partial key or ref and the possible ref
+    // is abstract, yet the config doesn't have a ref property, then the ref can remain null
+    let refNotNeeded =
+      hasNoPartialKeyOrRef(realm, config) &&
+      possibleRef instanceof AbstractValue &&
+      config instanceof ObjectValue &&
+      !config.properties.has("ref");
+
+    if (!refNotNeeded) {
+      ref = possibleRef;
+    }
   }
 
   const setProp = (name: string, value: Value): void => {

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -10,19 +10,13 @@
 /* @flow */
 
 import type { Realm } from "../realm.js";
-import {
-  AbstractValue,
-  AbstractObjectValue,
-  ArrayValue,
-  ECMAScriptFunctionValue,
-  NumberValue,
-  ObjectValue,
-  Value,
-} from "../values/index.js";
-import { Create, Properties } from "../singletons.js";
+import { ValuesDomain } from "../domains/index.js";
+import { AbstractValue, AbstractObjectValue, ArrayValue, NumberValue, ObjectValue, Value } from "../values/index.js";
+import { Create, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import { Get } from "../methods/index.js";
 import {
+  applyObjectAssignConfigsFoReactElement,
   createDefaultPropsHelper,
   createInternalReactElement,
   flagPropsWithNoPartialKeyOrRef,
@@ -38,7 +32,7 @@ function createPropsObject(
   type: Value,
   config: ObjectValue | AbstractObjectValue,
   children: void | Value
-): { key: Value, ref: Value, props: ObjectValue | AbstractObjectValue } {
+): { key: Value, ref: Value, props: ObjectValue } {
   let defaultProps =
     type instanceof ObjectValue || type instanceof AbstractObjectValue
       ? Get(realm, type, "defaultProps")
@@ -97,48 +91,80 @@ function createPropsObject(
     // create a new props object that will be the target of the Object.assign
     props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
 
-    // get the global Object.assign
-    let globalObj = Get(realm, realm.$GlobalObject, "Object");
-    invariant(globalObj instanceof ObjectValue);
-    let objAssign = Get(realm, globalObj, "assign");
-    invariant(objAssign instanceof ECMAScriptFunctionValue);
-    let objectAssignCall = objAssign.$Call;
-    invariant(objectAssignCall !== undefined);
+    applyObjectAssignConfigsFoReactElement(realm, props, args);
 
-    // TODO: maybe we can optimize the serialized output more here?
-    // do we really need to create an object just for { children }
     if (children !== undefined) {
-      let childrenObject = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
-      Properties.Set(realm, childrenObject, "children", children, true);
-      args.push(childrenObject);
-    }
-
-    try {
-      objectAssignCall(realm.intrinsics.undefined, [props, ...args]);
-    } catch (e) {
-      if (realm.isInPureScope() && e instanceof FatalError) {
-        // TODO: maybe we can use temporalAlias and/or snapshots to improve this?
-        props = AbstractValue.createTemporalFromBuildFunction(
-          realm,
-          ObjectValue,
-          [objAssign, props, ...args],
-          ([methodNode, ..._args]) => {
-            return t.callExpression(methodNode, ((_args: any): Array<any>));
-          }
-        );
-      }
+      Properties.Set(realm, props, "children", children, true);
     }
 
     // handle default props on a partial/abstract config
     if (defaultProps !== realm.intrinsics.undefined) {
-      props = AbstractValue.createTemporalFromBuildFunction(
-        realm,
-        ObjectValue,
-        [createDefaultPropsHelper(realm), props, defaultProps],
-        ([methodNode, ..._args]) => {
-          return t.callExpression(methodNode, ((_args: any): Array<any>));
+      let defaultPropsEvaluated = 0;
+
+      // first see if we can apply all the defaultProps without needing the helper
+      if (defaultProps instanceof ObjectValue && !defaultProps.isPartialObject()) {
+        for (let [propName, binding] of defaultProps.properties) {
+          if (binding.descriptor !== undefined && binding.descriptor.value !== realm.intrinsics.undefined) {
+            // see if we have this on our props object
+            let propBinding = props.properties.get(propName);
+            // if the binding exists and value is abstract, it might be undefined
+            // so in that case we need the helper, otherwise we can continue
+            if (propBinding !== undefined && !(propBinding.descriptor.value instanceof AbstractValue)) {
+              defaultPropsEvaluated++;
+              // if the value we have is undefined, we can apply the defaultProp
+              if (propBinding.descriptor.value === realm.intrinsics.undefined) {
+                Properties.Set(realm, props, propName, Get(realm, defaultProps, propName), true);
+              }
+            }
+          }
         }
-      );
+      }
+      // if defaultPropsEvauated === the amount of properties defaultProps has, then we've successfully
+      // ensured all the defaultProps have already been dealt with, so we don't need the helper
+      if (
+        !(defaultProps instanceof ObjectValue) ||
+        (defaultProps.isPartialObject() || defaultPropsEvaluated !== defaultProps.properties.size)
+      ) {
+        props.makePartial();
+        props.makeSimple();
+        // if the props has any properties that are "undefined", we need to make them abstract
+        // as the helper function applies defaultProps on values that are undefined or do not
+        // exist
+        for (let [propName, binding] of props.properties) {
+          if (binding.descriptor !== undefined && binding.descriptor.value === realm.intrinsics.undefined) {
+            Properties.Set(realm, props, propName, AbstractValue.createFromType(realm, Value), true);
+          }
+        }
+        // if we have children and they are abstract, they might be undefined at runtime
+        if (children !== undefined && children instanceof AbstractValue) {
+          // children === undefined ? defaultProps.children : children;
+          let condition = AbstractValue.createFromBinaryOp(realm, "===", children, realm.intrinsics.undefined);
+          let conditionalChildren = AbstractValue.createFromConditionalOp(
+            realm,
+            condition,
+            Get(realm, defaultProps, "children"),
+            children
+          );
+          Properties.Set(realm, props, "children", conditionalChildren, true);
+        }
+        let temporalTo = AbstractValue.createTemporalFromBuildFunction(
+          realm,
+          ObjectValue,
+          [createDefaultPropsHelper(realm), props.getSnapshot(), defaultProps],
+          ([methodNode, ..._args]) => {
+            return t.callExpression(methodNode, ((_args: any): Array<any>));
+          },
+          { skipInvariant: true }
+        );
+        invariant(temporalTo instanceof AbstractObjectValue);
+        if (props instanceof AbstractObjectValue) {
+          temporalTo.values = props.values;
+        } else {
+          invariant(props instanceof ObjectValue);
+          temporalTo.values = new ValuesDomain(props);
+        }
+        props.temporalAlias = temporalTo;
+      }
     }
   } else {
     applyProperties();
@@ -159,16 +185,11 @@ function createPropsObject(
       invariant(false, "TODO: we need to eventually support this");
     }
   }
-  invariant(props instanceof ObjectValue || props instanceof AbstractObjectValue);
+  invariant(props instanceof ObjectValue);
   // We know the props has no keys because if it did it would have thrown above
   // so we can remove them the props we create.
   flagPropsWithNoPartialKeyOrRef(realm, props);
-  // If the object is an object or abstract object value that has a backing object
-  // value for a template, we can make them final. We can't make abstract values
-  // final though – but that's okay. They also can't be havoced.
-  if (props instanceof ObjectValue || (props instanceof AbstractObjectValue && !props.values.isTop())) {
-    props.makeFinal();
-  }
+  props.makeFinal();
   return { key, props, ref };
 }
 

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -109,10 +109,13 @@ function createPropsObject(
             let propBinding = props.properties.get(propName);
             // if the binding exists and value is abstract, it might be undefined
             // so in that case we need the helper, otherwise we can continue
-            if (propBinding !== undefined && !(propBinding.descriptor.value instanceof AbstractValue)) {
+            if (
+              propBinding !== undefined &&
+              !(propBinding.descriptor && propBinding.descriptor.value instanceof AbstractValue)
+            ) {
               defaultPropsEvaluated++;
               // if the value we have is undefined, we can apply the defaultProp
-              if (propBinding.descriptor.value === realm.intrinsics.undefined) {
+              if (propBinding.descriptor && propBinding.descriptor.value === realm.intrinsics.undefined) {
                 Properties.Set(realm, props, propName, Get(realm, defaultProps, propName), true);
               }
             }
@@ -139,6 +142,7 @@ function createPropsObject(
         if (children !== undefined && children instanceof AbstractValue) {
           // children === undefined ? defaultProps.children : children;
           let condition = AbstractValue.createFromBinaryOp(realm, "===", children, realm.intrinsics.undefined);
+          invariant(defaultProps instanceof AbstractObjectValue || defaultProps instanceof ObjectValue);
           let conditionalChildren = AbstractValue.createFromConditionalOp(
             realm,
             condition,
@@ -297,6 +301,7 @@ export function traverseReactElement(
 
   const handleChildren = () => {
     // handle children
+    invariant(propsValue instanceof ObjectValue);
     if (propsValue.properties.has("children")) {
       let childrenValue = getProperty(realm, propsValue, "children");
       if (childrenValue !== realm.intrinsics.undefined && childrenValue !== realm.intrinsics.null) {

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -142,7 +142,7 @@ function createPropsObject(
           }
         }
       }
-      // if defaultPropsEvauated === the amount of properties defaultProps has, then we've successfully
+      // if defaultPropsEvaluated === the amount of properties defaultProps has, then we've successfully
       // ensured all the defaultProps have already been dealt with, so we don't need the helper
       if (
         !(defaultProps instanceof ObjectValue) ||

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -28,11 +28,11 @@ import {
 } from "../values/index.js";
 import { ReactStatistics, type ReactEvaluatedNode } from "../serializer/types.js";
 import {
+  cloneProps,
   createInternalReactElement,
   createReactEvaluatedNode,
   doNotOptimizeComponent,
   evaluateWithNestedParentEffects,
-  flagPropsWithNoPartialKeyOrRef,
   flattenChildren,
   getComponentName,
   getComponentTypeFromRootValue,
@@ -1019,24 +1019,8 @@ export class Reconciler {
           resolvedChildren = flattenChildren(this.realm, resolvedChildren);
         }
         if (resolvedChildren !== childrenValue) {
-          let newProps = new ObjectValue(this.realm, this.realm.intrinsics.ObjectPrototype);
+          let newProps = cloneProps(this.realm, propsValue, false, resolvedChildren);
 
-          for (let [key, binding] of propsValue.properties) {
-            if (binding && binding.descriptor && binding.descriptor.enumerable && key !== "children") {
-              Properties.Set(this.realm, newProps, key, getProperty(this.realm, propsValue, key), true);
-            }
-          }
-          Properties.Set(this.realm, newProps, "children", resolvedChildren, true);
-          if (propsValue.isSimpleObject()) {
-            newProps.makeSimple();
-          }
-          if (propsValue.isPartialObject()) {
-            newProps.makePartial();
-          }
-          if (this.realm.react.propsWithNoPartialKeyOrRef.has(propsValue)) {
-            flagPropsWithNoPartialKeyOrRef(this.realm, newProps);
-          }
-          newProps.makeFinal();
           return createInternalReactElement(this.realm, typeValue, keyValue, refValue, newProps);
         }
       }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -965,7 +965,7 @@ export function cloneProps(
   return clonedProps;
 }
 
-export function applyObjectAssignConfigsFoReactElement(realm: Realm, to: ObjectValue, sources: Array<Value>): void {
+export function applyObjectAssignConfigsForReactElement(realm: Realm, to: ObjectValue, sources: Array<Value>): void {
   // get the global Object.assign
   let globalObj = Get(realm, realm.$GlobalObject, "Object");
   invariant(globalObj instanceof ObjectValue);
@@ -986,16 +986,18 @@ export function applyObjectAssignConfigsFoReactElement(realm: Realm, to: ObjectV
       );
     } catch (error) {
       if (error instanceof FatalError) {
+        // if the built-in Object.assign failed, we need to recover
         realm.suppressDiagnostics = savedSuppressDiagnostics;
         let delayedSources = [];
 
         for (let obj of sources) {
+          // ignore null or undefined
           if (obj === realm.intrinsics.null || obj === realm.intrinsics.undefined) {
             continue;
           }
           let source = To.ToObject(realm, obj);
+          // the object is simple and partial so we can safely copy over properties
           if (source instanceof ObjectValue && !source.isPartialObject()) {
-            // the object is simple and partial so we can safely copy over properties
             for (let [propName, binding] of source.properties) {
               if (binding.descriptor !== undefined) {
                 Properties.Set(realm, to, propName, Get(realm, source, propName), true);
@@ -1003,6 +1005,9 @@ export function applyObjectAssignConfigsFoReactElement(realm: Realm, to: ObjectV
             }
             delayedSources.push(source.getSnapshot());
           } else {
+            // if we are dealing with an abstract object or one that is partial, then
+            // we don't try and copy its properties over as there's no guarantee they are
+            // safe to copy
             if (source instanceof AbstractObjectValue && source.kind === "explicit conversion to object") {
               // Make it implicit again since it is getting delayed into an Object.assign call.
               delayedSources.push(source.args[0]);
@@ -1016,7 +1021,7 @@ export function applyObjectAssignConfigsFoReactElement(realm: Realm, to: ObjectV
             }
           }
         }
-
+        // prepare our temporal Object.assign fallback
         to.makePartial();
         to.makeSimple();
         let temporalTo = AbstractValue.createTemporalFromBuildFunction(

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -10,6 +10,7 @@
 /* @flow */
 
 import { Realm, Effects } from "../realm.js";
+import { ValuesDomain } from "../domains/index.js";
 import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
 import type { BabelNode, BabelNodeJSXIdentifier } from "babel-types";
 import { parseExpression } from "babylon";
@@ -19,6 +20,7 @@ import {
   ArrayValue,
   BooleanValue,
   BoundFunctionValue,
+  ECMAScriptFunctionValue,
   ECMAScriptSourceFunctionValue,
   FunctionValue,
   NumberValue,
@@ -835,42 +837,13 @@ export function sanitizeReactElementForFirstRenderOnly(realm: Realm, reactElemen
   let keyValue = getProperty(realm, reactElement, "key");
   let propsValue = getProperty(realm, reactElement, "props");
 
-  const sanitizeHostProps = (): ObjectValue | AbstractObjectValue => {
-    // if the props object is abstract, then we just return the value
-    if (propsValue instanceof ObjectValue) {
-      let newProps = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
-      for (let [propName, binding] of propsValue.properties) {
-        if (binding && binding.descriptor && binding.descriptor.enumerable) {
-          // check for onSomething prop event handlers, i.e. onClick
-          if (!isEventProp(propName)) {
-            Properties.Set(realm, newProps, propName, Get(realm, propsValue, propName), true);
-          }
-        }
-      }
-      if (propsValue.isPartialObject()) {
-        newProps.makePartial();
-      }
-      if (propsValue.isSimpleObject()) {
-        newProps.makeSimple();
-      }
-      if (realm.react.propsWithNoPartialKeyOrRef.has(propsValue)) {
-        flagPropsWithNoPartialKeyOrRef(realm, newProps);
-      }
-      newProps.makeFinal();
-      return newProps;
-    }
-    // otherwise, return the original props
-    invariant(propsValue instanceof ObjectValue || propsValue instanceof AbstractObjectValue);
-    return propsValue;
-  };
-
   invariant(propsValue instanceof ObjectValue || propsValue instanceof AbstractObjectValue);
   return createInternalReactElement(
     realm,
     typeValue,
     keyValue,
     realm.intrinsics.null,
-    typeValue instanceof StringValue ? sanitizeHostProps() : propsValue
+    typeValue instanceof StringValue ? cloneProps(realm, propsValue, true) : propsValue
   );
 }
 
@@ -956,4 +929,135 @@ export function createInternalReactElement(
   Create.CreateDataPropertyOrThrow(realm, obj, "_owner", realm.intrinsics.null);
   obj.makeFinal();
   return obj;
+}
+
+export function cloneProps(
+  realm: Realm,
+  props: ObjectValue,
+  excludeEventProps: boolean,
+  newChildren?: Value
+): ObjectValue {
+  let clonedProps = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
+
+  for (let [propName, binding] of props.properties) {
+    if (binding && binding.descriptor && binding.descriptor.enumerable) {
+      if (newChildren !== undefined && propName === "children") {
+        Properties.Set(realm, clonedProps, propName, newChildren, true);
+      } else if (!excludeEventProps || !isEventProp(propName)) {
+        Properties.Set(realm, clonedProps, propName, getProperty(realm, props, propName), true);
+      }
+    }
+  }
+
+  if (props.isPartialObject()) {
+    clonedProps.makePartial();
+  }
+  if (props.isSimpleObject()) {
+    clonedProps.makeSimple();
+  }
+  if (realm.react.propsWithNoPartialKeyOrRef.has(props)) {
+    flagPropsWithNoPartialKeyOrRef(realm, clonedProps);
+  }
+  if (props.temporalAlias !== undefined) {
+    clonedProps.temporalAlias = props.temporalAlias;
+  }
+  clonedProps.makeFinal();
+  return clonedProps;
+}
+
+export function applyObjectAssignConfigsFoReactElement(realm: Realm, to: ObjectValue, sources: Array<Value>): void {
+  // get the global Object.assign
+  let globalObj = Get(realm, realm.$GlobalObject, "Object");
+  invariant(globalObj instanceof ObjectValue);
+  let objAssign = Get(realm, globalObj, "assign");
+  invariant(objAssign instanceof ECMAScriptFunctionValue);
+  let objectAssignCall = objAssign.$Call;
+  invariant(objectAssignCall !== undefined);
+
+  const tryToApplyObjectAssign = () => {
+    let effects;
+    let savedSuppressDiagnostics = realm.suppressDiagnostics;
+    try {
+      realm.suppressDiagnostics = true;
+      effects = realm.evaluateForEffects(
+        () => objectAssignCall(realm.intrinsics.undefined, [to, ...sources]),
+        undefined,
+        "tryToApplyObjectAssign"
+      );
+    } catch (error) {
+      if (error instanceof FatalError) {
+        realm.suppressDiagnostics = savedSuppressDiagnostics;
+        let delayedSources = [];
+
+        for (let obj of sources) {
+          let source = To.ToObject(realm, obj);
+          if (source.isSimpleObject() && !source.isPartialObject()) {
+            // the object is simple and partial so we can safely copy over properties
+            for (let [propName, binding] of source.properties) {
+              if (binding.descriptor !== undefined) {
+                Properties.Set(realm, to, propName, Get(realm, source, propName), true);
+              }
+            }
+            delayedSources.push(source.getSnapshot());
+          } else {
+            if (source instanceof AbstractObjectValue && source.kind === "explicit conversion to object") {
+              // Make it implicit again since it is getting delayed into an Object.assign call.
+              delayedSources.push(source.args[0]);
+            } else {
+              delayedSources.push(source.getSnapshot());
+            }
+            // if to has properties, we better remove them because after the temporal call to Object.assign we don't know their values anymore
+            if (to.hasStringOrSymbolProperties()) {
+              // preserve them in a snapshot and add the snapshot to the sources
+              delayedSources.push(to.getSnapshot({ removeProperties: true }));
+            }
+          }
+        }
+
+        to.makePartial();
+        to.makeSimple();
+        let temporalTo = AbstractValue.createTemporalFromBuildFunction(
+          realm,
+          ObjectValue,
+          [objAssign, to, ...delayedSources],
+          ([methodNode, ..._args]) => {
+            return t.callExpression(methodNode, ((_args: any): Array<any>));
+          },
+          { skipInvariant: true }
+        );
+        invariant(temporalTo instanceof AbstractObjectValue);
+        if (to instanceof AbstractObjectValue) {
+          temporalTo.values = to.values;
+        } else {
+          invariant(to instanceof ObjectValue);
+          temporalTo.values = new ValuesDomain(to);
+        }
+        to.temporalAlias = temporalTo;
+        return;
+      } else {
+        throw error;
+      }
+    } finally {
+      realm.suppressDiagnostics = savedSuppressDiagnostics;
+    }
+    // Note that the effects of (non joining) abrupt branches are not included
+    // in effects, but are tracked separately inside completion.
+    realm.applyEffects(effects);
+    let completion = effects.result;
+    if (completion instanceof PossiblyNormalCompletion) {
+      // in this case one of the branches may complete abruptly, which means that
+      // not all control flow branches join into one flow at this point.
+      // Consequently we have to continue tracking changes until the point where
+      // all the branches come together into one.
+      completion = realm.composeWithSavedCompletion(completion);
+    }
+    // return or throw completion
+    if (completion instanceof AbruptCompletion) throw completion;
+  };
+
+  if (realm.isInPureScope()) {
+    tryToApplyObjectAssign();
+  } else {
+    objectAssignCall(realm.intrinsics.undefined, [to, ...sources]);
+  }
 }

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -14,7 +14,7 @@ import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { canHoistReactElement } from "../react/hoisting.js";
 import * as t from "babel-types";
 import type { BabelNode, BabelNodeExpression } from "babel-types";
-import { AbstractValue, ObjectValue, SymbolValue, Value } from "../values/index.js";
+import { AbstractObjectValue, AbstractValue, ObjectValue, SymbolValue, Value } from "../values/index.js";
 import { convertExpressionToJSXIdentifier, convertKeyValueToJSXAttribute } from "../react/jsx.js";
 import { Logger } from "../utils/logger.js";
 import invariant from "../invariant.js";
@@ -284,10 +284,10 @@ export class ResidualReactElementSerializer {
         let reactElementSpread = this._createReactElementAttribute();
         this._serializeNowOrAfterWaitingForDependencies(propsValue, reactElement, () => {
           let expr;
-          if (propsValue.temporalAlias === undefined) {
-            expr = this.residualHeapSerializer.serializeValue(propsValue);
-          } else {
+          if (propsValue.temporalAlias instanceof AbstractObjectValue) {
             expr = this.residualHeapSerializer.serializeValue(propsValue.temporalAlias);
+          } else {
+            expr = this.residualHeapSerializer.serializeValue(propsValue);
           }
           reactElementSpread.expr = expr;
           reactElementSpread.type = "SPREAD";

--- a/src/serializer/ResidualReactElementSerializer.js
+++ b/src/serializer/ResidualReactElementSerializer.js
@@ -283,7 +283,12 @@ export class ResidualReactElementSerializer {
       visitAbstractOrPartialProps: (propsValue: AbstractValue | ObjectValue) => {
         let reactElementSpread = this._createReactElementAttribute();
         this._serializeNowOrAfterWaitingForDependencies(propsValue, reactElement, () => {
-          let expr = this.residualHeapSerializer.serializeValue(propsValue);
+          let expr;
+          if (propsValue.temporalAlias === undefined) {
+            expr = this.residualHeapSerializer.serializeValue(propsValue);
+          } else {
+            expr = this.residualHeapSerializer.serializeValue(propsValue.temporalAlias);
+          }
           reactElementSpread.expr = expr;
           reactElementSpread.type = "SPREAD";
         });

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -52,7 +52,11 @@ export class ResidualReactElementVisitor {
         this.residualHeapVisitor.visitValue(refValue);
       },
       visitAbstractOrPartialProps: (propsValue: AbstractValue | ObjectValue) => {
-        this.residualHeapVisitor.visitValue(propsValue);
+        if (propsValue.temporalAlias === undefined) {
+          this.residualHeapVisitor.visitValue(propsValue);
+        } else {
+          this.residualHeapVisitor.visitValue(propsValue.temporalAlias);
+        }
       },
       visitConcreteProps: (propsValue: ObjectValue) => {
         for (let [propName, binding] of propsValue.properties) {

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -10,7 +10,7 @@
 /* @flow strict-local */
 
 import { Realm } from "../realm.js";
-import { AbstractValue, ObjectValue, SymbolValue, Value } from "../values/index.js";
+import { AbstractObjectValue, AbstractValue, ObjectValue, SymbolValue, Value } from "../values/index.js";
 import { ResidualHeapVisitor } from "./ResidualHeapVisitor.js";
 import { determineIfReactElementCanBeHoisted } from "../react/hoisting.js";
 import { traverseReactElement } from "../react/elements.js";
@@ -52,10 +52,10 @@ export class ResidualReactElementVisitor {
         this.residualHeapVisitor.visitValue(refValue);
       },
       visitAbstractOrPartialProps: (propsValue: AbstractValue | ObjectValue) => {
-        if (propsValue.temporalAlias === undefined) {
-          this.residualHeapVisitor.visitValue(propsValue);
-        } else {
+        if (propsValue.temporalAlias instanceof AbstractObjectValue) {
           this.residualHeapVisitor.visitValue(propsValue.temporalAlias);
+        } else {
+          this.residualHeapVisitor.visitValue(propsValue);
         }
       },
       visitConcreteProps: (propsValue: ObjectValue) => {

--- a/test/react/functional-components/simple-with-jsx-spread10.js
+++ b/test/react/functional-components/simple-with-jsx-spread10.js
@@ -25,7 +25,7 @@ function App(props) {
 
 App.getTrials = function(renderer, Root) {
   renderer.update(<Root item1="foo" item2="bar" />);
-  return [['simple render with jsx spread 7', renderer.toJSON()]];
+  return [['simple render with jsx spread 10', renderer.toJSON()]];
 };
 
 if (this.__optimizeReactComponentTree) {

--- a/test/react/functional-components/simple-with-jsx-spread10.js
+++ b/test/react/functional-components/simple-with-jsx-spread10.js
@@ -1,0 +1,35 @@
+var React = require('react');
+this['React'] = React;
+
+function Child2(props) {
+  return <span>{props.text}</span>
+}
+
+function Child(props) {
+  return (
+    <div {...props}>
+      <Child2 text={props.item1} />
+      <Child2 text={props.item2} />
+    </div>
+  );
+}
+
+Child.defaultProps = {
+  className: "foobar",
+  children: null,
+};
+
+function App(props) {
+  return <Child {...props} />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root item1="foo" item2="bar" />);
+  return [['simple render with jsx spread 7', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread11.js
+++ b/test/react/functional-components/simple-with-jsx-spread11.js
@@ -29,7 +29,7 @@ function App(props) {
 
 App.getTrials = function(renderer, Root) {
   renderer.update(<Root item1="foo" item2="bar" />);
-  return [['simple render with jsx spread 7', renderer.toJSON()]];
+  return [['simple render with jsx spread 11', renderer.toJSON()]];
 };
 
 if (this.__optimizeReactComponentTree) {

--- a/test/react/functional-components/simple-with-jsx-spread11.js
+++ b/test/react/functional-components/simple-with-jsx-spread11.js
@@ -1,0 +1,39 @@
+var React = require('react');
+this['React'] = React;
+
+function Child2(props) {
+  return <span>{props.text}</span>
+}
+
+function Child(props) {
+  var newProps = Object.assign({}, props, {
+    className: "foobar2",
+    children: "should not display"
+  });
+  return (
+    <div {...newProps}>
+      <Child2 text={props.item1} />
+      <Child2 text={props.item2} />
+    </div>
+  );
+}
+
+Child.defaultProps = {
+  className: "foobar",
+  children: null,
+};
+
+function App(props) {
+  return <Child {...props} />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root item1="foo" item2="bar" />);
+  return [['simple render with jsx spread 7', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread12.js
+++ b/test/react/functional-components/simple-with-jsx-spread12.js
@@ -1,0 +1,26 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Button(props) {
+  return <span>{props.name}{props.text}</span>
+}
+
+Button.defaultProps = {
+	name: "Dominic",
+};
+
+function App(props) {
+  return <Button {...props} name={undefined} />
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root text={"Hello world"} />);
+  return [['simple render with jsx spread 12', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/simple-with-jsx-spread7.js
+++ b/test/react/functional-components/simple-with-jsx-spread7.js
@@ -2,27 +2,19 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-function Child(props) {
-  return <span>{props.children}</span>;
-}
-
-Child.defaultProps = {
-  children: "default text"
-};
-
 function App(props) {
-  return <Child {...props.foo}>{props.bar}</Child>
+  return <div {...props.foo}>{props.bar}</div>
 }
 
 
 App.getTrials = function(renderer, Root) {
   let results = [];
   renderer.update(<Root foo={{children: undefined}} bar={undefined} />);
-  results.push(['defaultProps', renderer.toJSON()]);
+  results.push(['jsx spread', renderer.toJSON()]);
   renderer.update(<Root foo={{children: "prop children text"}} bar={undefined} />);
-  results.push(['defaultProps', renderer.toJSON()]);
+  results.push(['jsx spread', renderer.toJSON()]);
   renderer.update(<Root foo={{children: undefined}} bar={"children prop text"} />);
-  results.push(['defaultProps', renderer.toJSON()]);
+  results.push(['jsx spread', renderer.toJSON()]);
   return results;
 };
 

--- a/test/react/functional-components/simple-with-jsx-spread8.js
+++ b/test/react/functional-components/simple-with-jsx-spread8.js
@@ -2,27 +2,23 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-function Child(props) {
-  return <span>{props.children}</span>;
-}
-
-Child.defaultProps = {
-  children: "default text"
-};
-
 function App(props) {
-  return <Child {...props.foo}>{props.bar}</Child>
+  var data = {
+    a: 1,
+    b: 2,
+  };
+  return <div {...props.foo} {...data}>{props.bar}</div>
 }
 
 
 App.getTrials = function(renderer, Root) {
   let results = [];
   renderer.update(<Root foo={{children: undefined}} bar={undefined} />);
-  results.push(['defaultProps', renderer.toJSON()]);
+  results.push(['jsx spread', renderer.toJSON()]);
   renderer.update(<Root foo={{children: "prop children text"}} bar={undefined} />);
-  results.push(['defaultProps', renderer.toJSON()]);
+  results.push(['jsx spread', renderer.toJSON()]);
   renderer.update(<Root foo={{children: undefined}} bar={"children prop text"} />);
-  results.push(['defaultProps', renderer.toJSON()]);
+  results.push(['jsx spread', renderer.toJSON()]);
   return results;
 };
 

--- a/test/react/functional-components/simple-with-jsx-spread9.js
+++ b/test/react/functional-components/simple-with-jsx-spread9.js
@@ -20,7 +20,7 @@ function App(props) {
 
 App.getTrials = function(renderer, Root) {
   renderer.update(<Root item1="foo" item2="bar" />);
-  return [['simple render with jsx spread 7', renderer.toJSON()]];
+  return [['simple render with jsx spread 9', renderer.toJSON()]];
 };
 
 if (this.__optimizeReactComponentTree) {

--- a/test/react/functional-components/simple-with-jsx-spread9.js
+++ b/test/react/functional-components/simple-with-jsx-spread9.js
@@ -1,0 +1,30 @@
+var React = require('react');
+this['React'] = React;
+
+function Child2(props) {
+  return <span>{props.text}</span>
+}
+
+function Child(props) {
+  return (
+    <div {...props}>
+      <Child2 text={props.item1} />
+      <Child2 text={props.item2} />
+    </div>
+  );
+}
+
+function App(props) {
+  return <Child {...props} />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root item1="foo" item2="bar" />);
+  return [['simple render with jsx spread 7', renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: fixes a range of spread bugs with ReactElements

This is a very important PR for React reconciliation, it fixes many undiscovered bugs and adds a huge amount of test coverage that was previously missing.

Whilst testing quite complex cases of JSX spreads in combination with defaultProps on our internal bundle I noticed that there were some bugs appearing, but because the branches where these bugs were appearing were not used on firstRender, it meant we got away with it on our internal tests.

We now use snapshotting and properly evaluateForEffects when recovering from `Object.assign` with ReactElement creation of config/props. We also properly use the `temporalAlias` to ensure we reference the correct object.