### PR TITLE
Do not join prematurely.

### DIFF
--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -9,13 +9,7 @@
 
 /* @flow */
 
-import {
-  AbruptCompletion,
-  ForkedAbruptCompletion,
-  PossiblyNormalCompletion,
-  ReturnCompletion,
-  ThrowCompletion,
-} from "../completions.js";
+import { AbruptCompletion, ForkedAbruptCompletion, PossiblyNormalCompletion, ThrowCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { Value, EmptyValue } from "../values/index.js";
@@ -270,29 +264,25 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
   if (val instanceof Value) {
     let res = Functions.incorporateSavedCompletion(realm, val);
     if (res instanceof PossiblyNormalCompletion) {
-      // There are still some conditional throws to emit and state still has to be joined in.
       // Get state to be joined in
       let e = realm.getCapturedEffects(res);
       invariant(e !== undefined);
-      let normalPathGenerator = e.generator;
       realm.stopEffectCaptureAndUndoEffects(res);
-      let effectsTree = Join.joinPossiblyNormalCompletionWithAbruptCompletion(
-        realm,
-        res,
-        new ReturnCompletion(realm.intrinsics.undefined),
-        e
-      );
-      realm.applyEffects(effectsTree, "", false);
-      // The global state is now at the point where the first fork occurred.
-      res = effectsTree.result;
-      invariant(res instanceof ForkedAbruptCompletion);
-      let generator = realm.generator;
-      invariant(generator !== undefined);
+      // The global state is now at the point where the last fork occurred.
       if (res.containsCompletion(ThrowCompletion)) {
-        generator.appendGenerator(effectsTree.generator, "");
-        generator.emitConditionalThrow(res.joinCondition, res.consequent, res.alternate);
+        // Join e with the remaining completions
+        let r = (e.result = new ThrowCompletion(realm.intrinsics.empty));
+        let fc = Join.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, res, r, e);
+        let allEffects = Join.extractAndJoinCompletionsOfType(ThrowCompletion, realm, fc);
+        realm.applyEffects(allEffects, "all code", true);
+        r = allEffects.result;
+        invariant(r instanceof ThrowCompletion);
+        let generator = realm.generator;
+        invariant(generator !== undefined);
+        generator.emitConditionalThrow(r.value);
+      } else {
+        realm.applyEffects(e, "all code", true);
       }
-      generator.appendGenerator(normalPathGenerator, "non exceptional post fork entries");
     }
   } else {
     // program was empty. Nothing to do.

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -14,13 +14,7 @@ import type { PropertyKeyValue, FunctionBodyAstNode } from "../types.js";
 import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { ECMAScriptFunctionValue } from "../values/index.js";
-import {
-  Completion,
-  ReturnCompletion,
-  AbruptCompletion,
-  NormalCompletion,
-  ForkedAbruptCompletion,
-} from "../completions.js";
+import { Completion, ReturnCompletion, AbruptCompletion, NormalCompletion } from "../completions.js";
 import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord } from "../environment.js";
 import {
@@ -1145,11 +1139,7 @@ export class FunctionImplementation {
         let e = realm.getCapturedEffects(savedCompletion);
         invariant(e !== undefined);
         realm.stopEffectCaptureAndUndoEffects(savedCompletion);
-        let joined_effects = Join.joinPossiblyNormalCompletionWithAbruptCompletion(realm, savedCompletion, c, e);
-        let jc = joined_effects.result;
-        invariant(jc instanceof ForkedAbruptCompletion);
-        realm.applyEffects(joined_effects, "incorporateSavedCompletion", false);
-        return jc;
+        return Join.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, savedCompletion, c, e);
       }
     }
     return c;

--- a/src/types.js
+++ b/src/types.js
@@ -724,10 +724,7 @@ export type JoinType = {
 
   updatePossiblyNormalCompletionWithValue(realm: Realm, pnc: PossiblyNormalCompletion, v: Value): void,
 
-  // Returns the joined effects of all of the paths in pnc.
-  // The normal path in pnc is modified to become terminated by ac,
-  // so the overall completion will always be an instance of ForkedAbruptCompletion
-  joinPossiblyNormalCompletionWithAbruptCompletion(
+  replacePossiblyNormalCompletionWithForkedAbruptCompletion(
     realm: Realm,
     // a forked path with a non abrupt (normal) component
     pnc: PossiblyNormalCompletion,
@@ -735,7 +732,7 @@ export type JoinType = {
     ac: AbruptCompletion,
     // effects collected after pnc was constructed
     e: Effects
-  ): Effects,
+  ): ForkedAbruptCompletion,
 
   joinPossiblyNormalCompletionWithValue(
     realm: Realm,


### PR DESCRIPTION
Release note: none

Quite a few of the outstanding issues arise because generators are either deleted or duplicated. After spending much time debugging such issues, I've realized that the code is not making a clear distinction between forking and joining and as a result we sometimes join when we should fork and this leads to problems.

I'm now systematically going through all the methods in Join and making sure they do the right thing in a less mysterious way. The subject of this pull request is method joinPossiblyNormalCompletionWithAbruptCompletion. The result of this method should be a just a fork because a join may not be required or desirable. The name is thus not helpful and so I've renamed it to replacePossiblyNormalCompletionWithForkedAbruptCompletion.

This broke some use cases that require the result to be joined. They had to be rewritten to use extractAndJoinCompletionsOfType to join just those parts of the fork that actually join at those code constructs.

While debugging the tests that inevitably broke while making these changes, a few other issues were uncovered that are also fixed in this PR. One of them involves specializing the result value of the abrupt completion that is being spliced into possibly normal completion (because a join is being composed into a fork).