### PR TITLE
Simplify getCapturedEffects

### DIFF
--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -265,8 +265,7 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
     let res = Functions.incorporateSavedCompletion(realm, val);
     if (res instanceof PossiblyNormalCompletion) {
       // Get state to be joined in
-      let e = realm.getCapturedEffects(res);
-      invariant(e !== undefined);
+      let e = realm.getCapturedEffects();
       realm.stopEffectCaptureAndUndoEffects(res);
       // The global state is now at the point where the last fork occurred.
       if (res.containsCompletion(ThrowCompletion)) {

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -43,11 +43,10 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
       // Note: The handler may have introduced new forks
     } else if (blockRes instanceof ForkedAbruptCompletion || blockRes instanceof PossiblyNormalCompletion) {
       if (blockRes instanceof PossiblyNormalCompletion) {
-        // Nothing has been joined and we are going to keep it that way.
+        // The throw completions have not been joined and we are going to keep it that way.
         // The current state may have advanced since the time control forked into the various paths recorded in blockRes.
         // Update the normal path and restore the global state to what it was at the time of the fork.
-        let subsequentEffects = realm.getCapturedEffects(blockRes, blockRes.value);
-        invariant(subsequentEffects !== undefined);
+        let subsequentEffects = realm.getCapturedEffects(blockRes.value);
         realm.stopEffectCaptureAndUndoEffects(blockRes);
         Join.updatePossiblyNormalCompletionWithSubsequentEffects(realm, blockRes, subsequentEffects);
       }

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1136,8 +1136,7 @@ export class FunctionImplementation {
         Join.updatePossiblyNormalCompletionWithValue(realm, savedCompletion, c);
         return savedCompletion;
       } else {
-        let e = realm.getCapturedEffects(savedCompletion);
-        invariant(e !== undefined);
+        let e = realm.getCapturedEffects();
         realm.stopEffectCaptureAndUndoEffects(savedCompletion);
         return Join.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, savedCompletion, c, e);
       }

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -102,8 +102,7 @@ export class JoinImplementation {
     c2: AbruptCompletion,
     realm: Realm
   ): ForkedAbruptCompletion {
-    let e = realm.getCapturedEffects(c1);
-    invariant(e !== undefined);
+    let e = realm.getCapturedEffects();
     realm.stopEffectCaptureAndUndoEffects(c1);
     return this.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, c1, c2, e);
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -792,8 +792,7 @@ export class Realm {
         if (c instanceof PossiblyNormalCompletion) {
           // The current state may have advanced since the time control forked into the various paths recorded in c.
           // Update the normal path and restore the global state to what it was at the time of the fork.
-          let subsequentEffects = this.getCapturedEffects(c, c.value);
-          invariant(subsequentEffects !== undefined);
+          let subsequentEffects = this.getCapturedEffects(c.value);
           this.stopEffectCaptureAndUndoEffects(c);
           Join.updatePossiblyNormalCompletionWithSubsequentEffects(this, c, subsequentEffects);
           this.savedCompletion = undefined;
@@ -1196,8 +1195,7 @@ export class Realm {
       this.captureEffects(completion);
     } else {
       let savedCompletion = this.savedCompletion;
-      let e = this.getCapturedEffects(savedCompletion);
-      invariant(e !== undefined);
+      let e = this.getCapturedEffects();
       this.stopEffectCaptureAndUndoEffects(savedCompletion);
       savedCompletion = Join.composePossiblyNormalCompletions(this, savedCompletion, completion, e);
       this.applyEffects(e);
@@ -1259,8 +1257,7 @@ export class Realm {
     this.createdObjects = new Set();
   }
 
-  getCapturedEffects(completion: PossiblyNormalCompletion, v?: Value = this.intrinsics.undefined): void | Effects {
-    if (completion.savedEffects === undefined) return undefined;
+  getCapturedEffects(v?: Value = this.intrinsics.undefined): Effects {
     invariant(this.generator !== undefined);
     invariant(this.modifiedBindings !== undefined);
     invariant(this.modifiedProperties !== undefined);


### PR DESCRIPTION
Release note: none

Remove an unneeded option from getCapturedEffects and strengthen the return type.