### PR TITLE
Call React createDefaultPropsHelper creates function on init

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -3152,6 +3152,43 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads #13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App2",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -7463,6 +7500,43 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads #13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App2",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
 exports[`Test React with JSX input, create-element output Functional component folding Simple with multiple JSX spreads 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,
@@ -11771,6 +11845,43 @@ ReactStatistics {
   "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Simple with multiple JSX spreads #13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App2",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
 }
 `;
 
@@ -16097,6 +16208,43 @@ ReactStatistics {
   "inlinedComponents": 1,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Simple with multiple JSX spreads #13 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Button",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App2",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
 }
 `;
 

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -499,6 +499,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "simple-with-jsx-spread12.js");
       });
 
+      it("Simple with multiple JSX spreads #13", async () => {
+        await runTest(directory, "simple-with-jsx-spread13.js");
+      });
+
       it("Simple with Object.assign", async () => {
         await runTest(directory, "simple-assign.js");
       });

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -23,7 +23,10 @@ import { createDefaultPropsHelper } from "../../react/utils.js";
 export default function(realm: Realm): void {
   let global = realm.$GlobalObject;
 
-  createDefaultPropsHelper(realm);
+  if (realm.react.enabled) {
+    // Create it eagerly so it's created outside effect branches
+    realm.react.defaultPropsHelper = createDefaultPropsHelper(realm);
+  }
 
   // module.exports support
   let moduleValue = AbstractValue.createAbstractObject(realm, "module");

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -18,9 +18,12 @@ import { createFbMocks } from "./fb-mocks.js";
 import { FatalError } from "../../errors";
 import { Get } from "../../methods/index.js";
 import invariant from "../../invariant";
+import { createDefaultPropsHelper } from "../../react/utils.js";
 
 export default function(realm: Realm): void {
   let global = realm.$GlobalObject;
+
+  createDefaultPropsHelper(realm);
 
   // module.exports support
   let moduleValue = AbstractValue.createAbstractObject(realm, "module");

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -170,10 +170,12 @@ function createPropsObject(
           );
           Properties.Set(realm, props, "children", conditionalChildren, true);
         }
+        let defaultPropsHelper = realm.react.defaultPropsHelper;
+        invariant(defaultPropsHelper !== undefined);
         let temporalTo = AbstractValue.createTemporalFromBuildFunction(
           realm,
           ObjectValue,
-          [realm.react.defaultPropsHelper, props.getSnapshot(), defaultProps],
+          [defaultPropsHelper, props.getSnapshot(), defaultProps],
           ([methodNode, ..._args]) => {
             return t.callExpression(methodNode, ((_args: any): Array<any>));
           },

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -17,7 +17,6 @@ import invariant from "../invariant.js";
 import { Get } from "../methods/index.js";
 import {
   applyObjectAssignConfigsForReactElement,
-  createDefaultPropsHelper,
   createInternalReactElement,
   flagPropsWithNoPartialKeyOrRef,
   getProperty,
@@ -174,7 +173,7 @@ function createPropsObject(
         let temporalTo = AbstractValue.createTemporalFromBuildFunction(
           realm,
           ObjectValue,
-          [createDefaultPropsHelper(realm), props.getSnapshot(), defaultProps],
+          [realm.react.defaultPropsHelper, props.getSnapshot(), defaultProps],
           ([methodNode, ..._args]) => {
             return t.callExpression(methodNode, ((_args: any): Array<any>));
           },

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -881,9 +881,6 @@ export function doNotOptimizeComponent(realm: Realm, componentType: Value): bool
 }
 
 export function createDefaultPropsHelper(realm: Realm): ECMAScriptSourceFunctionValue {
-  if (realm.react.defaultPropsHelper !== undefined) {
-    return realm.react.defaultPropsHelper;
-  }
   let defaultPropsHelper = `
     function defaultPropsHelper(props, defaultProps) {
       for (var propName in defaultProps) {
@@ -901,7 +898,6 @@ export function createDefaultPropsHelper(realm: Realm): ECMAScriptSourceFunction
   ((body: any): FunctionBodyAstNode).uniqueOrderedTag = realm.functionBodyUniqueTagSeed++;
   helper.$ECMAScriptCode = body;
   helper.$FormalParameters = escapeHelperAst.params;
-  realm.react.defaultPropsHelper = helper;
   return helper;
 }
 

--- a/test/react/functional-components/simple-with-jsx-spread13.js
+++ b/test/react/functional-components/simple-with-jsx-spread13.js
@@ -1,0 +1,33 @@
+var React = require('react');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function Button(props) {
+  return <span>{props.name}{props.text}</span>
+}
+
+Button.defaultProps = {
+	name: "Dominic",
+};
+
+function App(props) {
+  return <Button {...props} />
+}
+
+function App2(_props) {
+  return <Button {..._props} />
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root text={"Hello world"} />);
+  return [['simple render with jsx spread 12', renderer.toJSON()]];
+};
+
+App.App2 = App2;
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+  __optimizeReactComponentTree(App2);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

This fixes an issue where `createDefaultPropsHelper` gets created in a branch of effects, and is cached on the `realm`. Instead `createDefaultPropsHelper` should get created during the init phase, so the function is accessible throughout the entire lifecycle of the realm.