### PR TITLE
Fixing invalid code generation for abstract member access (#2084)

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -1520,7 +1520,10 @@ export class Realm {
       propertyValue.intrinsicName = `${path}.${key}`;
       propertyValue.kind = "rebuiltProperty";
       propertyValue.args = [object];
-      propertyValue._buildNode = ([node]) => t.memberExpression(node, t.identifier(key));
+      propertyValue._buildNode = ([node]) =>
+        t.isValidIdentifier(key)
+          ? t.memberExpression(node, t.identifier(key), false)
+          : t.memberExpression(node, t.stringLiteral(key), true);
       this.rebuildNestedProperties(propertyValue, propertyValue.intrinsicName);
     }
   }

--- a/test/serializer/abstract/AbstractNumericProperty.js
+++ b/test/serializer/abstract/AbstractNumericProperty.js
@@ -1,0 +1,7 @@
+// add at runtime: global.z = { 0: "test string" };
+if (global.__assumeDataProperty)
+  __assumeDataProperty(this, "z", __abstract({
+    0: __abstract("string")
+  }));
+let check = z && typeof z[0] === "string" && z[0];
+inspect = function() { return check; }


### PR DESCRIPTION
There is a case when prepack emits non-computed member expressions in `rebuildObjectProperty` for properties which cannot be used this way. This PR is to fix #2084 .