### PR TITLE
Record current values in the bindings map

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -683,7 +683,23 @@ export class JoinImplementation {
         liv1 === undefined && liv2 === undefined ? undefined : this.joinValues(realm, liv1, liv2, getAbstractValue);
       invariant(value instanceof Value);
       invariant(leakedImmutableValue === undefined || leakedImmutableValue instanceof Value);
-      return { leakedImmutableValue, hasLeaked, value };
+      let previousLeakedImmutableValue, previousHasLeaked, previousValue;
+      if (b1 !== undefined) {
+        previousLeakedImmutableValue = b1.previousLeakedImmutableValue;
+        previousHasLeaked = b1.previousHasLeaked;
+        previousValue = b1.previousValue;
+        invariant(
+          b2 === undefined ||
+            (previousLeakedImmutableValue === b2.previousLeakedImmutableValue &&
+              previousHasLeaked === b2.previousHasLeaked &&
+              previousValue === b2.previousValue)
+        );
+      } else if (b2 !== undefined) {
+        previousLeakedImmutableValue = b2.previousLeakedImmutableValue;
+        previousHasLeaked = b2.previousHasLeaked;
+        previousValue = b2.previousValue;
+      }
+      return { leakedImmutableValue, hasLeaked, value, previousLeakedImmutableValue, previousHasLeaked, previousValue };
     };
     return this.joinMaps(m1, m2, join);
   }

--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -138,9 +138,6 @@ export class WidenImplementation {
 
   widenBindings(realm: Realm, m1: Bindings, m2: Bindings): Bindings {
     let widen = (b: Binding, b1: void | BindingEntry, b2: void | BindingEntry) => {
-      let l1 = b1 === undefined ? b.hasLeaked : b1.hasLeaked;
-      let l2 = b2 === undefined ? b.hasLeaked : b2.hasLeaked;
-      let hasLeaked = l1 || l2; // If either has leaked, then this binding has leaked.
       let v1 = b1 === undefined || b1.value === undefined ? b.value : b1.value;
       invariant(b2 !== undefined); // Local variables are not going to get deleted as a result of widening
       let v2 = b2.value;
@@ -168,8 +165,17 @@ export class WidenImplementation {
         result._buildNode = args => t.identifier(phiName);
       }
       invariant(result instanceof Value);
-      // TODO: deal with leakedImmutableValue
-      return { leakedImmutableValue: undefined, hasLeaked, value: result };
+      let previousLeakedImmutableValue = b2.previousLeakedImmutableValue;
+      let previousHasLeaked = b2.previousHasLeaked;
+      let previousValue = b2.previousValue;
+      return {
+        leakedImmutableValue: previousLeakedImmutableValue,
+        hasLeaked: previousHasLeaked,
+        value: result,
+        previousLeakedImmutableValue,
+        previousHasLeaked,
+        previousValue,
+      };
     };
     return this.widenMaps(m1, m2, widen);
   }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -629,7 +629,7 @@ export function evaluateWithNestedParentEffects(realm: Realm, nestedEffects: Arr
     }
   } finally {
     if (modifiedBindings && modifiedProperties) {
-      realm.restoreBindings(modifiedBindings);
+      realm.undoBindings(modifiedBindings);
       realm.restoreProperties(modifiedProperties);
     }
   }


### PR DESCRIPTION
Release note: none

Effects objects are currently stateful: If you apply the effects it becomes an undo map and if you undo the effects, it becomes a redo map.

In most situations this is just fine since apply and undo are usually nicely paired. In some situations, however, we end up applying or undoing the same effects object twice in a row. This causes issues that are extremely hard to debug. I've tried to purge the code base of all such cases, but they just keep coming up. In essence, I am trying to maintain a very subtle invariant that is quite hard to check and I am failing.

I now give up on this invariant and am making Effects into an object that is immutable except when being constructed incrementally. This is the first step towards that.
