### PR TITLE
Remove a hacky global for context tests

### DIFF
--- a/test/react/first-render-only/react-context3.js
+++ b/test/react/first-render-only/react-context3.js
@@ -1,18 +1,16 @@
 var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
-var { Provider, Consumer } = React.createContext(null);
-// this is done otherwise the test fails
-this['_Consumer'] = Consumer;
+var Ctx = React.createContext(null);
 
 function Child(props) {
   return (
     <div>
-      <_Consumer>
+      <Ctx.Consumer>
         {value => {
           return <span>{value}</span>
         }}
-      </_Consumer>
+      </Ctx.Consumer>
     </div>
   )
 }
@@ -21,11 +19,13 @@ function App(props) {
   return <div><Child /></div>;
 }
 
+App.Ctx = Ctx;
+
 App.getTrials = function(renderer, Root) {
   renderer.update((
-    <Provider value={5}>
+    <Root.Ctx.Provider value={5}>
       <Root />
-    </Provider>
+    </Root.Ctx.Provider>
   ));
   return [['render props context', renderer.toJSON()]];
 };

--- a/test/react/first-render-only/react-context4.js
+++ b/test/react/first-render-only/react-context4.js
@@ -2,30 +2,28 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-var { Provider, Consumer } = React.createContext(null);
-// this is done otherwise the test fails
-this['_Consumer'] = Consumer;
+var Ctx = React.createContext(null);
 
 function Child(props) {
   return (
     <div>
-      <Consumer>
+      <Ctx.Consumer>
         {value => {
           return <span>{value}</span>
         }}
-      </Consumer>
+      </Ctx.Consumer>
     </div>
   )
 }
 
 function App(props) {
   return (
-    <Provider value="a">
-      <Provider value="b">
+    <Ctx.Provider value="a">
+      <Ctx.Provider value="b">
         <Child />
-      </Provider>
+      </Ctx.Provider>
       <Child />
-    </Provider>
+    </Ctx.Provider>
   );
 }
 

--- a/test/react/first-render-only/react-context5.js
+++ b/test/react/first-render-only/react-context5.js
@@ -2,18 +2,16 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-var { Provider, Consumer } = React.createContext(null);
-// this is done otherwise the test fails
-this['_Consumer'] = Consumer;
+var Ctx = React.createContext(null);
 
 function Child(props) {
   return (
     <div>
-      <Consumer>
+      <Ctx.Consumer>
         {value => {
           return <span>{value}</span>
         }}
-      </Consumer>
+      </Ctx.Consumer>
     </div>
   )
 }
@@ -21,9 +19,9 @@ function Child(props) {
 function App(props) {
   return (
     <div>
-      <Provider value="b">
+      <Ctx.Provider value="b">
         <Child />
-      </Provider>
+      </Ctx.Provider>
       <Child />
     </div>
   );

--- a/test/react/render-props/react-context3.js
+++ b/test/react/render-props/react-context3.js
@@ -1,18 +1,16 @@
 var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
-var { Provider, Consumer } = React.createContext(null);
-// this is done otherwise the test fails
-this['_Consumer'] = Consumer;
+var Ctx = React.createContext(null);
 
 function Child(props) {
   return (
     <div>
-      <_Consumer>
+      <Ctx.Consumer>
         {value => {
           return <span>{value}</span>
         }}
-      </_Consumer>
+      </Ctx.Consumer>
     </div>
   )
 }
@@ -21,11 +19,13 @@ function App(props) {
   return <div><Child /></div>;
 }
 
+App.Ctx = Ctx;
+
 App.getTrials = function(renderer, Root) {
   renderer.update((
-    <Provider value={5}>
+    <Root.Ctx.Provider value={5}>
       <Root />
-    </Provider>
+    </Root.Ctx.Provider>
   ));
   return [['render props context', renderer.toJSON()]];
 };

--- a/test/react/render-props/react-context4.js
+++ b/test/react/render-props/react-context4.js
@@ -2,30 +2,28 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-var { Provider, Consumer } = React.createContext(null);
-// this is done otherwise the test fails
-this['_Consumer'] = Consumer;
+var Ctx = React.createContext(null);
 
 function Child(props) {
   return (
     <div>
-      <Consumer>
+      <Ctx.Consumer>
         {value => {
           return <span>{value}</span>
         }}
-      </Consumer>
+      </Ctx.Consumer>
     </div>
   )
 }
 
 function App(props) {
   return (
-    <Provider value="a">
-      <Provider value="b">
+    <Ctx.Provider value="a">
+      <Ctx.Provider value="b">
         <Child />
-      </Provider>
+      </Ctx.Provider>
       <Child />
-    </Provider>
+    </Ctx.Provider>
   );
 }
 

--- a/test/react/render-props/react-context5.js
+++ b/test/react/render-props/react-context5.js
@@ -2,18 +2,16 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-var { Provider, Consumer } = React.createContext(null);
-// this is done otherwise the test fails
-this['_Consumer'] = Consumer;
+var Ctx = React.createContext(null);
 
 function Child(props) {
   return (
     <div>
-      <Consumer>
+      <Ctx.Consumer>
         {value => {
           return <span>{value}</span>
         }}
-      </Consumer>
+      </Ctx.Consumer>
     </div>
   )
 }
@@ -21,9 +19,9 @@ function Child(props) {
 function App(props) {
   return (
     <div>
-      <Provider value="b">
+      <Ctx.Provider value="b">
         <Child />
-      </Provider>
+      </Ctx.Provider>
       <Child />
     </div>
   );


### PR DESCRIPTION
The code didn't work without it sometimes because conceptually all code outside of `getTrials` is an isolated "bundle". We can only access its internals through the `Root` reference. This fixes the tests to follow this constraint and removes the hack.