### PR TITLE
Batch effects applications in each fixed point visiting round.

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -708,16 +708,20 @@ export class ResidualHeapVisitor {
         environment,
         () => new Map()
       );
-      return getOrDefault(residualFunctionBindings, name, (): ResidualFunctionBinding => {
-        invariant(environment instanceof DeclarativeEnvironmentRecord);
-        return {
-          name,
-          value: undefined,
-          modified: false,
-          declarativeEnvironmentRecord: environment,
-          potentialReferentializationScopes: new Set(),
-        };
-      });
+      return getOrDefault(
+        residualFunctionBindings,
+        name,
+        (): ResidualFunctionBinding => {
+          invariant(environment instanceof DeclarativeEnvironmentRecord);
+          return {
+            name,
+            value: undefined,
+            modified: false,
+            declarativeEnvironmentRecord: environment,
+            potentialReferentializationScopes: new Set(),
+          };
+        }
+      );
       // Note that we don't yet visit the binding (and its value) here,
       // as that should be done by a call to visitBinding, in the right scope,
       // if the binding's incoming value is relevant.


### PR DESCRIPTION
Release notes: Speeding up visiting phase.

While there was already some batching in place, lumping together all actions associated with a particular final generator, the batching did not take into account the inherent tree structure of the generator effects. This is now being fixed.

Also added logging when in React verbose mode.

This change dramatically speeds up internal benchmarks.
However, the fixed point computation is still an intolerable bottleness.

Future changes can or should include some dependency tracking during the fixed point computation. Right now, each item is a block box, and it is not clear whether it needs to be re-run, so it is re-run.
(Created issue #2111 to track this opportunity.)

This speeds up an internal React benchmark from 261s to 193s.