### PR TITLE
remove the undefined invariant violation

### DIFF
--- a/src/invariant.js
+++ b/src/invariant.js
@@ -9,7 +9,7 @@
 
 /* @flow strict */
 
-export default function invariant(condition: boolean, format: string): void {
+export default function invariant(condition: boolean, format: string = ""): void {
   if (condition) return;
   const message = `${format}
 This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.`;


### PR DESCRIPTION
Release Note: none

This is regarding #2072 

Instead of spitting back Invariant Violation: undefined in this case, it will give back the trace error.

Also the Invariant Violation: undefined is misleading. The undefined is coming from the invariant format parameter when format isn't supplied. The fix is to add an empty string to format so it won't show undefined.

Questions: would you want to separate that throw into a separate util method like invariant?