### PR TITLE
Optimize ReactElement children with equivalence logic

### DIFF
--- a/scripts/__snapshots__/test-react.js.snap
+++ b/scripts/__snapshots__/test-react.js.snap
@@ -1938,6 +1938,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, JSX output Functional component folding Equivalence 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, JSX output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -6593,6 +6610,23 @@ ReactStatistics {
 }
 `;
 
+exports[`Test React with JSX input, create-element output Functional component folding Equivalence 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Test React with JSX input, create-element output Functional component folding Event handlers 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,
@@ -11243,6 +11277,23 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, JSX output Functional component folding Equivalence 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -15913,6 +15964,23 @@ ReactStatistics {
     },
   ],
   "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Test React with create-element input, create-element output Functional component folding Equivalence 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -547,6 +547,10 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
         await runTest(directory, "key-change.js");
       });
 
+      it("Equivalence", async () => {
+        await runTest(directory, "equivalence.js");
+      });
+
       it("Delete element prop key", async () => {
         await runTest(directory, "delete-element-prop-key.js");
       });

--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -548,7 +548,26 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
       });
 
       it("Equivalence", async () => {
-        await runTest(directory, "equivalence.js");
+        let createElement = React.createElement;
+        let count = 0;
+        // For this test we want to also check how React.createElement
+        // calls occur so we can validate that we are correctly using
+        // lazy branched elements. To do this, we override the createElement
+        // call and increment a counter for ever call.
+
+        // $FlowFixMe: intentional for this test
+        React.createElement = (type, config) => {
+          count++;
+          return createElement(type, config);
+        };
+        try {
+          await runTest(directory, "equivalence.js");
+        } finally {
+          // $FlowFixMe: intentional for this test
+          React.createElement = createElement;
+        }
+        // The non-compiled version has 20 calls, the compiled should have 8 calls
+        expect(count).toEqual(28);
       });
 
       it("Delete element prop key", async () => {

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -299,7 +299,7 @@ type ElementTraversalVisitor = {
   visitRef: (keyValue: Value) => void,
   visitAbstractOrPartialProps: (propsValue: AbstractValue | ObjectValue) => void,
   visitConcreteProps: (propsValue: ObjectValue) => void,
-  visitChildNode: (childValue: Value) => void,
+  visitChildNode: (childValue: Value) => void | Value,
 };
 
 export function traverseReactElement(

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -67,7 +67,7 @@ export class ResidualReactElementVisitor {
         }
       },
       visitChildNode: (childValue: Value) => {
-        this.residualHeapVisitor.visitValue(childValue);
+        return this.residualHeapVisitor.visitEquivalentValue(childValue);
       },
     });
 

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -387,6 +387,10 @@ export default class ObjectValue extends ConcreteValue {
     this._isFinal = this.$Realm.intrinsics.true;
   }
 
+  makeNotFinal(): void {
+    this._isFinal = this.$Realm.intrinsics.false;
+  }
+
   isPartialObject(): boolean {
     return this._isPartial.mightBeTrue();
   }

--- a/test/react/functional-components/equivalence.js
+++ b/test/react/functional-components/equivalence.js
@@ -1,0 +1,87 @@
+var React = require('React');
+// the JSX transform converts to React, so we need to add it back in
+this['React'] = React;
+
+function joinClasses(className) {
+  var newClassName = className || "";
+  for (
+    var _len = arguments.length,
+      classes = Array(_len > 1 ? _len - 1 : 0),
+      _key = 1;
+    _key < _len;
+    _key++
+  ) {
+    classes[_key - 1] = arguments[_key];
+  }
+  var argLength = classes.length;
+
+  for (var index = 0; index < argLength; index++) {
+    var nextClass = classes[index];
+    if (nextClass != null && nextClass !== "") {
+      newClassName =
+        (newClassName ? newClassName + " " : "") + nextClass;
+    }
+  }
+  return newClassName;
+}
+
+var csx = function csx(selector) {
+  return selector && selector.replace(/([^\\])\//g, "$1__");
+};
+
+var cx = function cx(classNames) {
+  if (typeof classNames == "object") {
+    return Object.keys(classNames)
+      .map(function(className) {
+        return classNames[className] ? className : "";
+      })
+      .map(csx)
+      .join(" ");
+  } else {
+    return Array.prototype.map.call(arguments, csx).join(" ");
+  }
+};
+
+function App(props) {
+  var classNames = cx(
+    "foo/root",
+    "foo/sutroColor"
+  );
+
+  return React.createElement(
+    "div",
+    { className: joinClasses(classNames) },
+    React.createElement(
+      "div",
+      { className: cx("foo/wrapper") },
+      React.createElement("span", {
+        className: cx("public/foo/dot")
+      }),
+
+      React.createElement("span", {
+        className: cx("public/foo/dot")
+      }),
+
+      React.createElement("span", {
+        className: cx("public/foo/dot")
+      })
+    ),
+    React.createElement("div", null, React.createElement("span")),
+    React.createElement("a", null, React.createElement("span")),
+  );
+}
+
+App.getTrials = function(renderer, Root) {
+  let results = [];
+  renderer.update(<Root x={true} a="1" />);
+  results.push(['ReactElement children equivalence', renderer.toJSON()]);
+  renderer.update(<Root x={false} a="1" />);
+  results.push(['ReactElement children equivalence update', renderer.toJSON()]);
+  return results;
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/functional-components/equivalence.js
+++ b/test/react/functional-components/equivalence.js
@@ -2,68 +2,25 @@ var React = require('React');
 // the JSX transform converts to React, so we need to add it back in
 this['React'] = React;
 
-function joinClasses(className) {
-  var newClassName = className || "";
-  for (
-    var _len = arguments.length,
-      classes = Array(_len > 1 ? _len - 1 : 0),
-      _key = 1;
-    _key < _len;
-    _key++
-  ) {
-    classes[_key - 1] = arguments[_key];
-  }
-  var argLength = classes.length;
-
-  for (var index = 0; index < argLength; index++) {
-    var nextClass = classes[index];
-    if (nextClass != null && nextClass !== "") {
-      newClassName =
-        (newClassName ? newClassName + " " : "") + nextClass;
-    }
-  }
-  return newClassName;
-}
-
-var csx = function csx(selector) {
-  return selector && selector.replace(/([^\\])\//g, "$1__");
-};
-
-var cx = function cx(classNames) {
-  if (typeof classNames == "object") {
-    return Object.keys(classNames)
-      .map(function(className) {
-        return classNames[className] ? className : "";
-      })
-      .map(csx)
-      .join(" ");
-  } else {
-    return Array.prototype.map.call(arguments, csx).join(" ");
-  }
-};
-
 function App(props) {
-  var classNames = cx(
-    "foo/root",
-    "foo/sutroColor"
-  );
 
   return React.createElement(
     "div",
-    { className: joinClasses(classNames) },
+    { className: "test" },
     React.createElement(
-      "div",
-      { className: cx("foo/wrapper") },
+      "div", {
+        className: "foo/wrapper",
+      },
       React.createElement("span", {
-        className: cx("public/foo/dot")
+        className: "public/foo/dot"
       }),
 
       React.createElement("span", {
-        className: cx("public/foo/dot")
+        className: "public/foo/dot"
       }),
 
       React.createElement("span", {
-        className: cx("public/foo/dot")
+        className: "public/foo/dot"
       })
     ),
     React.createElement("div", null, React.createElement("span")),


### PR DESCRIPTION
Release notes: improves ReactElement creation by re-using ReactElement nodes where possible

We already have a pretty good ReactElement equivalence system to re-use ReactElements. We weren't using it to its full power though. When we have nested ReactElements, we don't use the equivalence system at all, meaning we duplicate lots of ReactElements when we can re-use.

This is a nice performance optimization. I've added a test that should prevent regressions here too.