### PR TITLE
Provide a basic recovery mechanism for `for` and `while` loops

### DIFF
--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -39,6 +39,7 @@ type BailOutWrapperInfo = {
   usesThis: boolean,
   usesReturn: boolean,
   usesGotoToLabel: boolean,
+  usesThrow: boolean,
 };
 
 // ECMA262 13.7.4.9
@@ -297,6 +298,9 @@ let BailOutWrapperClosureRefVisitor = {
   ReturnStatement(path: BabelTraversePath, state: BailOutWrapperInfo) {
     state.usesReturn = true;
   },
+  ThrowStatement(path: BabelTraversePath, state: BailOutWrapperInfo) {
+    state.usesThrow = true;
+  },
 };
 
 function generateRuntimeForStatement(
@@ -312,12 +316,13 @@ function generateRuntimeForStatement(
   wrapperFunction.$ECMAScriptCode = body;
   wrapperFunction.$FormalParameters = [];
   wrapperFunction.$Environment = env;
-  // We need to scan to AST looking for "this", "return", labels and "arguments"
+  // We need to scan to AST looking for "this", "return", "throw", labels and "arguments"
   let functionInfo = {
     usesArguments: false,
     usesThis: false,
     usesReturn: false,
     usesGotoToLabel: false,
+    usesThrow: false,
   };
 
   traverse(

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -353,6 +353,10 @@ function generateRuntimeForStatement(
     args.push(thisVal);
   }
 
+  // We havoc the wrapping function value, which in turn invokes the havocing
+  // logic which is transitive. The havocing logic should recursively visit
+  // all bindings/objects in the loop and its body and mark the associated
+  // bindings/objects that do havoc appropiately.
   Havoc.value(realm, wrapperFunction);
 
   let wrapperValue = AbstractValue.createTemporalFromBuildFunction(

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -332,7 +332,7 @@ function generateRuntimeForStatement(
     // We do not have support for these yet
     let diagnostic = new CompilerDiagnostic(
       `"failed to recover from a for/while loop bail-out due to unsupported logic in loop body`,
-      realm.currentLocaiton,
+      realm.currentLocation,
       "PP0035",
       "FatalError"
     );

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -338,7 +338,7 @@ function generateRuntimeForStatement(
     let diagnostic = new CompilerDiagnostic(
       `failed to recover from a for/while loop bail-out due to unsupported logic in loop body`,
       realm.currentLocation,
-      "PP0035",
+      "PP0037",
       "FatalError"
     );
     realm.handleError(diagnostic);

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -330,8 +330,14 @@ function generateRuntimeForStatement(
 
   if (functionInfo.usesReturn || functionInfo.usesArguments || functionInfo.usesGotoToLabel) {
     // We do not have support for these yet
-    // TODO: issue number upon creation of issue
-    throw new FatalError("TODO: #? handle more loop bail out cases");
+    let diagnostic = new CompilerDiagnostic(
+      `"failed to recover from a for/while loop bail-out due to unsupported logic in loop body`,
+      realm.currentLocaiton,
+      "PP0035",
+      "FatalError"
+    );
+    realm.handleError(diagnostic);
+    throw new FatalError();
   }
   let args = [wrapperFunction];
 

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -20,6 +20,7 @@ import {
   ForkedAbruptCompletion,
   PossiblyNormalCompletion,
   ReturnCompletion,
+  SimpleNormalCompletion,
   ThrowCompletion,
 } from "../completions.js";
 import traverse from "babel-traverse";
@@ -465,6 +466,7 @@ function tryToEvaluateForStatementOrLeaveAsAbstract(
   }
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
+  if (completion instanceof SimpleNormalCompletion) completion = completion.value;
   invariant(completion instanceof Value);
   return completion;
 }

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -333,7 +333,7 @@ function generateRuntimeForStatement(
   );
   traverse.clearCache();
 
-  if (functionInfo.usesReturn || functionInfo.usesArguments || functionInfo.usesGotoToLabel) {
+  if (functionInfo.usesReturn || functionInfo.usesThrow || functionInfo.usesArguments || functionInfo.usesGotoToLabel) {
     // We do not have support for these yet
     let diagnostic = new CompilerDiagnostic(
       `"failed to recover from a for/while loop bail-out due to unsupported logic in loop body`,

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -336,7 +336,7 @@ function generateRuntimeForStatement(
   if (functionInfo.usesReturn || functionInfo.usesThrow || functionInfo.usesArguments || functionInfo.usesGotoToLabel) {
     // We do not have support for these yet
     let diagnostic = new CompilerDiagnostic(
-      `"failed to recover from a for/while loop bail-out due to unsupported logic in loop body`,
+      `failed to recover from a for/while loop bail-out due to unsupported logic in loop body`,
       realm.currentLocation,
       "PP0035",
       "FatalError"

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -337,10 +337,9 @@ function generateRuntimeForStatement(
 
   if (functionInfo.usesThis) {
     let thisRef = env.evaluate(t.thisExpression(), strictCode);
-    if (thisRef instanceof Value) {
-      Havoc.value(realm, thisRef);
-      args.push(thisRef);
-    }
+    let thisVal = Environment.GetValue(realm, thisRef);
+    Havoc.value(realm, thisVal);
+    args.push(thisVal);
   }
 
   Havoc.value(realm, wrapperFunction);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -1099,11 +1099,10 @@ export function applyObjectAssignConfigsForReactElement(realm: Realm, to: Object
       // Consequently we have to continue tracking changes until the point where
       // all the branches come together into one.
       completion = realm.composeWithSavedCompletion(completion);
-    } else if (completion instanceof SimpleNormalCompletion) {
-      completion = completion.value;
     }
     // return or throw completion
     if (completion instanceof AbruptCompletion) throw completion;
+    if (completion instanceof SimpleNormalCompletion) completion = completion.value;
   };
 
   if (realm.isInPureScope()) {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -11,7 +11,7 @@
 
 import { Realm, Effects } from "../realm.js";
 import { ValuesDomain } from "../domains/index.js";
-import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
+import { AbruptCompletion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
 import type { BabelNode, BabelNodeJSXIdentifier, BabelNodeExpression } from "babel-types";
 import { parseExpression } from "babylon";
 import {
@@ -843,6 +843,7 @@ export function getValueFromFunctionCall(
   }
   // return or throw completion
   if (completion instanceof AbruptCompletion) throw completion;
+  if (completion instanceof SimpleNormalCompletion) completion = completion.value;
   invariant(completion instanceof Value);
   return completion;
 }
@@ -1098,6 +1099,8 @@ export function applyObjectAssignConfigsForReactElement(realm: Realm, to: Object
       // Consequently we have to continue tracking changes until the point where
       // all the branches come together into one.
       completion = realm.composeWithSavedCompletion(completion);
+    } else if (completion instanceof SimpleNormalCompletion) {
+      completion = completion.value;
     }
     // return or throw completion
     if (completion instanceof AbruptCompletion) throw completion;

--- a/test/serializer/optimized-functions/LoopBailout.js
+++ b/test/serializer/optimized-functions/LoopBailout.js
@@ -1,0 +1,18 @@
+function fn(props, splitPoint) {
+  var text = props.text || "";
+
+  text = text.replace(/\s*$/, "");
+
+  if (splitPoint !== null) {
+    while (text[splitPoint - 1] === "\n") {
+      splitPoint--;
+    }
+  }
+  return splitPoint;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn({text: "foo\nfoo"}, 5);
+};

--- a/test/serializer/optimized-functions/LoopBailout10.js
+++ b/test/serializer/optimized-functions/LoopBailout10.js
@@ -3,8 +3,9 @@ function fn(x, counter) {
   for (; i !== x;) {
     counter.x++;
     i++;
+    var val1 = counter.x, val2 = val1 + 1;
   }
-  return counter.x;
+  return val2;
 }
 
 global.__optimize && __optimize(fn);

--- a/test/serializer/optimized-functions/LoopBailout11.js
+++ b/test/serializer/optimized-functions/LoopBailout11.js
@@ -1,10 +1,12 @@
 function fn(x, counter) {
   var i = 0;
+  var val2 = undefined;
   for (; i !== x;) {
     counter.x++;
     i++;
+    val2 = i;
   }
-  return counter.x;
+  return val2;
 }
 
 global.__optimize && __optimize(fn);

--- a/test/serializer/optimized-functions/LoopBailout12.js
+++ b/test/serializer/optimized-functions/LoopBailout12.js
@@ -1,14 +1,17 @@
 function fn(x, counter) {
   var i = 0;
+  var val2 = undefined;
   for (; i !== x;) {
+    var foo = {};
     counter.x++;
     i++;
+    foo.x = x;
   }
-  return counter.x;
+  return foo;
 }
 
 global.__optimize && __optimize(fn);
 
 inspect = function() {
-  return fn(100, {x: 2});
+  return fn(100, {x: 2}).x;
 };

--- a/test/serializer/optimized-functions/LoopBailout13.js
+++ b/test/serializer/optimized-functions/LoopBailout13.js
@@ -1,14 +1,17 @@
 function fn(x, counter) {
   var i = 0;
+  var val2 = undefined;
   for (; i !== x;) {
+    var foo = {};
     counter.x++;
     i++;
+    foo.counter = counter;
   }
-  return counter.x;
+  return foo;
 }
 
 global.__optimize && __optimize(fn);
 
 inspect = function() {
-  return fn(100, {x: 2});
+  return fn(100, {x: 2}).counter.x;
 };

--- a/test/serializer/optimized-functions/LoopBailout14.js
+++ b/test/serializer/optimized-functions/LoopBailout14.js
@@ -1,10 +1,13 @@
 function fn(x, counter) {
   var i = 0;
+  var val2 = undefined;
   for (; i !== x;) {
+    var foo = {};
     counter.x++;
     i++;
+    foo.counter = counter;
   }
-  return counter.x;
+  return foo.counter.x + 10;
 }
 
 global.__optimize && __optimize(fn);

--- a/test/serializer/optimized-functions/LoopBailout15.js
+++ b/test/serializer/optimized-functions/LoopBailout15.js
@@ -1,0 +1,18 @@
+function fn(secondaryPattern, replaceWith, wholeNumber) {
+  var replaced;
+  while (
+    (replaced = wholeNumber.replace(
+      secondaryPattern,
+      replaceWith
+    )) != wholeNumber
+  ) {
+    wholeNumber = replaced;
+  }
+  return wholeNumber;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn("1", "2", "121341");
+};

--- a/test/serializer/optimized-functions/LoopBailout16.js
+++ b/test/serializer/optimized-functions/LoopBailout16.js
@@ -1,0 +1,16 @@
+function fn(x, total, val) {
+  var replaced;
+  let wholeNumber = val.toString();
+  if (x === true) {
+    for (var i = 0; i < total; i++) {
+      wholeNumber++;
+    }
+  }
+  return wholeNumber;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn(false, 10, 5);
+};

--- a/test/serializer/optimized-functions/LoopBailout17.js
+++ b/test/serializer/optimized-functions/LoopBailout17.js
@@ -1,0 +1,111 @@
+(function() {
+
+  global._DateFormatConfig = {
+    formats: {
+      'l, F j, Y': 'l, F j, Y',
+    },
+  }
+
+  var DateFormatConfig = global.__abstract ?  __abstract({}, "(global._DateFormatConfig)") : global._DateFormatConfig;
+  global.__makeSimple && __makeSimple(DateFormatConfig);
+
+  var MONTH_NAMES = void 0;
+  var WEEKDAY_NAMES = void 0;
+
+  var DateStrings = {
+    getWeekdayName: function getWeekdayName(weekday) {
+      if (!WEEKDAY_NAMES) {
+        WEEKDAY_NAMES = [
+          "Sunday",
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday"
+        ];
+      }
+
+      return WEEKDAY_NAMES[weekday];
+    },
+    _initializeMonthNames: function _initializeMonthNames() {
+      MONTH_NAMES = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December"
+      ];
+    },
+
+    getMonthName: function getMonthName(month) {
+      if (!MONTH_NAMES) {
+        DateStrings._initializeMonthNames();
+      }
+
+      return MONTH_NAMES[month - 1];
+    },
+  };
+
+  function formatDate(date, format, options) {
+    options = options || {};
+
+    if (typeof date === "string") {
+      date = parseInt(date, 10);
+    }
+    if (typeof date === "number") {
+      date = new Date(date * 1000);
+    }
+    var localizedFormat = DateFormatConfig.formats[format];
+    var prefix = "getUTC";
+    var dateDay = date[prefix + "Date"]();
+    var dateDayOfWeek = date[prefix + "Day"]();
+    var dateMonth = date[prefix + "Month"]();
+    var dateYear = date[prefix + "FullYear"]();
+
+    var output = "";
+    for (var i = 0; i < localizedFormat.length; i++) {
+      var character = localizedFormat.charAt(i);
+
+      switch (character) {
+        case "j":
+          output += dateDay;
+          break;
+        case "l":
+          output += DateStrings.getWeekdayName(dateDayOfWeek);
+          break;
+        case "F":
+        case "f":
+          output += DateStrings.getMonthName(dateMonth + 1);
+          break;
+        case "Y":
+          output += dateYear;
+          break;
+        default:
+          output += character;
+      }
+    }
+
+    return output;
+  }
+
+  function fn(a, b) {
+    return formatDate(a, "l, F j, Y");
+  }
+
+  global.fn = fn;
+
+  global.__optimize && __optimize(fn);
+
+  global.inspect = function() {
+    return JSON.stringify(global.fn("1529579851072"));
+  }
+
+})();

--- a/test/serializer/optimized-functions/LoopBailout2.js
+++ b/test/serializer/optimized-functions/LoopBailout2.js
@@ -1,0 +1,14 @@
+function fn(x, oldItems) {
+  var items = [];
+  for (let i = 0; i < x; i++) {
+    var oldItem = oldItems[i];
+    items.push(oldItem + 2);
+  }
+  return items;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify(fn(5, [1,2,3,4,5]));
+};

--- a/test/serializer/optimized-functions/LoopBailout3.js
+++ b/test/serializer/optimized-functions/LoopBailout3.js
@@ -1,0 +1,16 @@
+function Model(x, oldItems) {
+  this.oldItems = oldItems;
+  var items = [];
+  for (let i = 0; i < x; i++) {
+    var oldItem = this.oldItems[i];
+    items.push(oldItem + 2);
+  }
+  this.items = items;
+}
+
+global.__optimize && __optimize(Model);
+
+inspect = function() {
+  var model = new Model(5, [1,2,3,4,5]);
+  return JSON.stringify(model.items);
+};

--- a/test/serializer/optimized-functions/LoopBailout4.js
+++ b/test/serializer/optimized-functions/LoopBailout4.js
@@ -1,0 +1,15 @@
+function Model(x, oldItems) {
+
+  this.items = [];
+  for (let i = 0; i < x; i++) {
+    var oldItem = oldItems[i];
+    this.items.push(oldItem + 2);
+  }
+}
+
+global.__optimize && __optimize(Model);
+
+inspect = function() {
+  var model = new Model(5, [1,2,3,4,5]);
+  return JSON.stringify(model.items);
+};

--- a/test/serializer/optimized-functions/LoopBailout5.js
+++ b/test/serializer/optimized-functions/LoopBailout5.js
@@ -1,0 +1,16 @@
+function Model(x, oldItems) {
+  this.items = [];
+  for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < x; i++) {
+      var oldItem = oldItems[i];
+      this.items.push(oldItem + 2);
+    }
+  }
+}
+
+global.__optimize && __optimize(Model);
+
+inspect = function() {
+  var model = new Model(5, [1,2,3,4,5]);
+  return JSON.stringify(model.items);
+};

--- a/test/serializer/optimized-functions/LoopBailout6.js
+++ b/test/serializer/optimized-functions/LoopBailout6.js
@@ -1,0 +1,16 @@
+function fn(x, oldItems) {
+  var items = [];
+  var i = 0;
+  while (i < x) {
+    var oldItem = oldItems[i];
+    items.push(oldItem + 2);
+    i++;
+  }
+  return items;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify(fn(5, [1,2,3,4,5]));
+};

--- a/test/serializer/optimized-functions/LoopBailout7.js
+++ b/test/serializer/optimized-functions/LoopBailout7.js
@@ -1,0 +1,15 @@
+function fn(x, oldItems) {
+  var items = [];
+  for (; i !== x;) {
+    var oldItem = oldItems[i];
+    items.push(oldItem + 2);
+    i++;
+  }
+  return items;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify(fn(5, [1,2,3,4,5]));
+};

--- a/test/serializer/optimized-functions/LoopBailout8.js
+++ b/test/serializer/optimized-functions/LoopBailout8.js
@@ -1,0 +1,14 @@
+function fn(x, counter) {
+  var i = 0;
+  for (; i !== x;) {
+    counter.x++;
+    i++;
+  }
+  return counter.x;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn(100, {counter: 2});
+};

--- a/test/serializer/optimized-functions/LoopBailout9.js
+++ b/test/serializer/optimized-functions/LoopBailout9.js
@@ -3,8 +3,9 @@ function fn(x, counter) {
   for (; i !== x;) {
     counter.x++;
     i++;
+    var val = counter.x
   }
-  return counter.x;
+  return val;
 }
 
 global.__optimize && __optimize(fn);


### PR DESCRIPTION
Release notes: standard for loops and while loops have a recovery mechanism in pure scope

This PR provides a bail-out recovery mechanism in pure scope for FatalErrors thrown and caught from for/while loops. Until now, if a FatalError occurs from trying to evaluate abstract for/while loops, we'd have to recover at a higher point in the callstack, which wasn't always possible (the loop may be at the root of a function/component).

The ideal long-term strategy is to properly model out the different cases for loops, but this is a complex and time-consuming process. This PR adds a recovery mechanism that serializes out the original for loop, but within a newly created wrapper function containing the loop logic and a function call to that newly created function wrapper. This allows us to still run the same code at runtime, where we were unable to evaluate and optimize it at build time.

For now, this PR only adds recovery support for standard `for` and `while` loops (as they go through the same code path). We already have some basic evaluation for `do while` loops, but trying to adapt that code to work with the failing test case (https://github.com/facebook/prepack/issues/2055) didn't work for me – we have so many strange problems to deal with first before we can properly handle that issue.

In cases where the loop uses `this`, the context is found and correctly called with the wrapper function. In cases of usage of `return`, `arguments` and labelled `break/continue` we bail out again as this is not currently supported in the scope of this PR (can be added in a follow up PR, but I wanted to keep the scope of this PR limited).

For example, take this failing case on master:

```js
function fn(props, splitPoint) {
  var text = props.text || "";

  text = text.replace(/\s*$/, "");

  if (splitPoint !== null) {
    while (text[splitPoint - 1] === "\n") {
      splitPoint--;
    }
  }
  return splitPoint;
}
```

This serializes out to:

```js
  var _0 = function (props, splitPoint) {
    var __scope_0 = new Array(1);

    var __get_scope_binding_0 = function (__selector) {
      var __captured;

      switch (__selector) {
        case 0:
          __captured = [_G, _E];
          break;
      }

      __scope_0[__selector] = __captured;
      return __captured;
    };

    var _C = function () {
      var __captured__scope_1 = __scope_0[0] || __get_scope_binding_0(0);

      for (; __captured__scope_1[1][__captured__scope_1[0] - 1] === "\n";) {
        __captured__scope_1[0]--;
      }
    };

    var _$0 = props.text;

    var _$2 = (_$0 || "").replace(/\s*$/, "");

    var _6 = splitPoint !== null;

    var _G = _6 ? void 0 : splitPoint;

    var _E = _6 ? void 0 : _$2;

    if (_6) {
      (__scope_0[0] || __get_scope_binding_0(0))[0] = splitPoint;
      (__scope_0[0] || __get_scope_binding_0(0))[1] = _$2;

      var _$5 = _C();
    }

    var _$6 = (__scope_0[0] || __get_scope_binding_0(0))[0];

    return _$6;
  };
```

Furthermore, an idea that might be a good follow up PR would be to break the wrapper function into two functions, depending on some heuristics. If we can detect that the loop body does not have any unsupported side-effects like writing to variables that are havoced etc, we can then tell Prepack to optimize the inner function wrapper for the loop body. That way, at least some parts of the loop get optimized (the outer bindings will be havoced before this point, so it should work okay). I think I suggested this in person with @hermanventer and @sebmarkbage in Seattle as a potential way to optimize complex loops that we can't compute the fixed point for right now.

Fixes #2055