### PR TITLE
Store consequentEffects and alternateEffects in consequent and alternate

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -96,6 +96,8 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
   consequent: AbruptCompletion;
   alternate: AbruptCompletion;
 
+  // For convenience, this.consequent.effects should always be defined, but accessing it directly requires
+  // verifying that with an invariant.
   get consequentEffects(): Effects {
     invariant(this.consequent.effects);
     return this.consequent.effects;
@@ -215,6 +217,8 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   // The path conditions that applied at the time of the oldest fork that caused this completion to arise.
   savedPathConditions: Array<AbstractValue>;
 
+  // For convenience, this.consequent.effects should always be defined, but accessing it directly requires
+  // verifying that with an invariant.
   get consequentEffects(): Effects {
     invariant(this.consequent.effects);
     return this.consequent.effects;

--- a/src/completions.js
+++ b/src/completions.js
@@ -101,22 +101,22 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
 
   joinCondition: AbstractValue;
   _consequent: AbruptCompletion;
-  updateConsequentKeepingCurrentEffects(newConsequent) {
+  updateConsequentKeepingCurrentEffects(newConsequent: AbruptCompletion) {
     let effects = this.consequentEffects;
     newConsequent.effects = effects;
     newConsequent.effects.result = newConsequent;
     this.consequent = newConsequent;
     return newConsequent;
   }
-  updateAlternateKeepingCurrentEffects(newAlternate) {
+  updateAlternateKeepingCurrentEffects(newAlternate: AbruptCompletion) {
     let effects = this.alternateEffects;
     newAlternate.effects = effects;
     newAlternate.effects.result = newAlternate;
     this.alternate = newAlternate;
     return newAlternate;
   }
-  get consequent() { return this._consequent; }
-  set consequent(newConsequent) {
+  get consequent(): AbruptCompletion { return this._consequent; }
+  set consequent(newConsequent: AbruptCompletion) {
     //invariant(newConsequent instanceof AbruptCompletion);
     invariant(newConsequent);
     invariant(newConsequent.effects);
@@ -129,30 +129,17 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
     return this.consequent.effects;
   }
 
-  /*set consequentEffects(newEffects: Effects): Effects {
-    invariant(newEffects);
-    this.consequent.effects = newEffects;
-    return this.consequent.effects;
-  }*/
   _alternate: AbruptCompletion;
-  get alternate() { return this._alternate; }
-  set alternate(newConsequent) {
-    //invariant(newConsequent instanceof AbruptCompletion);
+  get alternate(): AbruptCompletion { return this._alternate; }
+  set alternate(newConsequent: AbruptCompletion) {
     invariant(newConsequent.effects);
     this._alternate = newConsequent;
     return newConsequent;
   }
-  //alternateEffects: Effects;
   get alternateEffects(): Effects {
     invariant(this.alternate.effects);
     return this.alternate.effects;
   }
-
-  /*set alternateEffects(newEffects: Effects): Effects {
-    invariant(newEffects);
-    this.alternate.effects = newEffects;
-    return this.alternate.effects;
-  }*/
 
   toDisplayString(): string {
     let superString = super.toDisplayString().slice(0, -1);
@@ -240,60 +227,41 @@ export class PossiblyNormalCompletion extends NormalCompletion {
 
   joinCondition: AbstractValue;
   _consequent: Completion;
-  get consequent() { return this._consequent; }
-  set consequent(newConsequent) {
-    //invariant(newConsequent instanceof AbruptCompletion);
+  get consequent(): Completion { return this._consequent; }
+  set consequent(newConsequent: Completion) {
     invariant(newConsequent);
     invariant(newConsequent.effects);
     this._consequent = newConsequent;
     return newConsequent;
   }
-  //consequentEffects: Effects;
   get consequentEffects(): Effects {
     invariant(this.consequent.effects);
     return this.consequent.effects;
   }
-
-  /*set consequentEffects(newEffects: Effects): Effects {
-    invariant(newEffects);
-    this.consequent.effects = newEffects;
-    return this.consequent.effects;
-  }*/
   _alternate: Completion;
-  get alternate() { return this._alternate; }
-  set alternate(newConsequent) {
-    //invariant(newConsequent instanceof AbruptCompletion);
+  get alternate(): Completion { return this._alternate; }
+  set alternate(newConsequent: Completion) {
     invariant(newConsequent.effects);
     this._alternate = newConsequent;
     return newConsequent;
   }
-  //alternateEffects: Effects;
   get alternateEffects(): Effects {
     invariant(this.alternate.effects);
     return this.alternate.effects;
   }
 
-  /*set alternateEffects(newEffects: Effects): Effects {
-    invariant(newEffects);
-    this.alternate.effects = newEffects;
-    return this.alternate.effects;
-  }*/
-  /*consequent: Completion;
-  consequentEffects: Effects;
-  alternate: Completion;
-  alternateEffects: Effects;*/
   savedEffects: void | Effects;
   // The path conditions that applied at the time of the oldest fork that caused this completion to arise.
   savedPathConditions: Array<AbstractValue>;
 
-  updateConsequentKeepingCurrentEffects(newConsequent) {
+  updateConsequentKeepingCurrentEffects(newConsequent: Completion) {
     let effects = this.consequentEffects;
     newConsequent.effects = effects;
     newConsequent.effects.result = newConsequent;
     this.consequent = newConsequent;
     return newConsequent;
   }
-  updateAlternateKeepingCurrentEffects(newAlternate) {
+  updateAlternateKeepingCurrentEffects(newAlternate: Completion) {
     let effects = this.alternateEffects;
     newAlternate.effects = effects;
     newAlternate.effects.result = newAlternate;

--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -112,7 +112,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         },
         "composeNestedThrowEffectsWithHandler/1"
       );
-      c.consequentEffects.result = c.consequent = new AbruptCompletion(realm.intrinsics.empty);
+      c.updateConsequentKeepingCurrentEffects(new AbruptCompletion(realm.intrinsics.empty));
     }
     priorEffects.pop();
     let alternate = c.alternate;
@@ -129,7 +129,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         },
         "composeNestedThrowEffectsWithHandler/2"
       );
-      c.alternateEffects.result = c.alternate = new AbruptCompletion(realm.intrinsics.empty);
+      c.updateAlternateKeepingCurrentEffects(new AbruptCompletion(realm.intrinsics.empty));
     }
     priorEffects.pop();
     return Join.joinForkOrChoose(realm, c.joinCondition, consequentEffects, alternateEffects);

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -375,7 +375,7 @@ export class JoinImplementation {
     } else {
       if (pnc.consequent instanceof SimpleNormalCompletion) {
         nc.value = AbstractValue.createFromConditionalOp(realm, joinCondition, v, pnc.consequent.value);
-        pnc.updateConsequentKeepingCurrentEffects(nc)
+        pnc.updateConsequentKeepingCurrentEffects(nc);
       } else {
         invariant(pnc.consequent instanceof PossiblyNormalCompletion);
         this.updatePossiblyNormalCompletionWithInverseConditionalSimpleNormalCompletion(
@@ -440,9 +440,9 @@ export class JoinImplementation {
     if (ce.result instanceof CompletionType) {
       // Erase completions of type CompletionType and prepare for transformation of c to a possibly normal completion
       if (c.consequent instanceof CompletionType) {
-        c.updateConsequentKeepingCurrentEffects(convertToPNC
-          ? new SimpleNormalCompletion(realm.intrinsics.empty)
-          : dummyCompletion);
+        c.updateConsequentKeepingCurrentEffects(
+          convertToPNC ? new SimpleNormalCompletion(realm.intrinsics.empty) : dummyCompletion
+        );
         convertToPNC = false;
       } else if (convertToPNC && c.consequent instanceof ForkedAbruptCompletion) {
         c.updateConsequentKeepingCurrentEffects((c.consequent.transferChildrenToPossiblyNormalCompletion(): any));
@@ -460,9 +460,9 @@ export class JoinImplementation {
     if (ae.result instanceof CompletionType) {
       // Erase completions of type CompletionType and prepare for transformation of c to a possibly normal completion
       if (c.alternate instanceof CompletionType) {
-        c.updateAlternateKeepingCurrentEffects(convertToPNC
-          ? new SimpleNormalCompletion(realm.intrinsics.empty)
-          : dummyCompletion);
+        c.updateAlternateKeepingCurrentEffects(
+          convertToPNC ? new SimpleNormalCompletion(realm.intrinsics.empty) : dummyCompletion
+        );
       } else if (convertToPNC && c.alternate instanceof ForkedAbruptCompletion) {
         c.updateAlternateKeepingCurrentEffects((c.alternate.transferChildrenToPossiblyNormalCompletion(): any));
       }

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -464,7 +464,7 @@ export class JoinImplementation {
           ? new SimpleNormalCompletion(realm.intrinsics.empty)
           : dummyCompletion);
       } else if (convertToPNC && c.alternate instanceof ForkedAbruptCompletion) {
-        c.updateAlternateKeepingCurrentEffects(c.alternate.transferChildrenToPossiblyNormalCompletion(): any);
+        c.updateAlternateKeepingCurrentEffects((c.alternate.transferChildrenToPossiblyNormalCompletion(): any));
       }
     } else {
       ae.result = new CompletionType(realm.intrinsics.empty);

--- a/src/realm.js
+++ b/src/realm.js
@@ -1178,12 +1178,12 @@ export class Realm {
 
   updateAbruptCompletions(priorEffects: Effects, c: PossiblyNormalCompletion) {
     if (c.consequent instanceof AbruptCompletion) {
-      c.consequentEffects = this.composeEffects(priorEffects, c.consequentEffects);
+      c.consequent.effects = this.composeEffects(priorEffects, c.consequentEffects);
       let alternate = c.alternate;
       if (alternate instanceof PossiblyNormalCompletion) this.updateAbruptCompletions(priorEffects, alternate);
     } else {
       invariant(c.alternate instanceof AbruptCompletion);
-      c.alternateEffects = this.composeEffects(priorEffects, c.alternateEffects);
+      c.alternate.effects = this.composeEffects(priorEffects, c.alternateEffects);
       let consequent = c.consequent;
       if (consequent instanceof PossiblyNormalCompletion) this.updateAbruptCompletions(priorEffects, consequent);
     }


### PR DESCRIPTION
Release Notes: None

Follow up on #2110, this PR makes progress towards unifying PossiblyNormalCompletion and ForkedAbruptCompletion as well as unifying completion and effects.

Introduces `updateConsequentKeepingCurrentEffects` for a common pattern of updating one of the completions for a PNC/FAC and fixing up the effects.