### PR TITLE
Fixed a DebugAdapter error check bug

### DIFF
--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -349,7 +349,7 @@ class PrepackDebugSession extends DebugSession {
     // All responses that involve the Adapter Channel should only be invoked
     // after the channel has been created. If this ordering is perturbed,
     // there was likely a change in the protocol implementation by Nuclide.
-    if (this._adapterChannel !== undefined) {
+    if (this._adapterChannel === undefined) {
       throw Error(`Adapter Channel in Debugger is being used before it has been created. Caused by ${callingRequest}.`);
     }
   }


### PR DESCRIPTION
Release notes: Reversed an !== undefined check so the check behaves as intended

Test Plan: Testing _requires_ that the `lib` versions of the adapter files replace the existing files in the Nuclide repo. I believe that a mental lapse while testing the former PR lead to my neglecting to update the adapter files and thus caused this issue to not be caught. 