### PR TITLE
Follow up fixes for 2138

### DIFF
--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -24,7 +24,7 @@ import {
 } from "../../values/index.js";
 import { Environment } from "../../singletons.js";
 import { createReactHintObject, getReactSymbol, isReactElement } from "../../react/utils.js";
-import { cloneElement, createReactElement } from "../../react/elements.js";
+import { cloneReactElement, createReactElement } from "../../react/elements.js";
 import { Properties, Create, To } from "../../singletons.js";
 import { renderToString } from "../../react/experimental-server-rendering/rendering.js";
 import * as t from "babel-types";
@@ -473,7 +473,7 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
           children.makeFinal();
         }
       }
-      return cloneElement(realm, element, config, children);
+      return cloneReactElement(realm, element, config, children);
     }
   );
 

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -292,13 +292,14 @@ function splitReactElementsByConditionalConfig(
   );
 }
 
-export function cloneElement(
+export function cloneReactElement(
   realm: Realm,
   reactElement: ObjectValue,
   config: ObjectValue | AbstractObjectValue | NullValue,
   children: void | Value
 ): ObjectValue {
   let props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
+  realm.react.reactProps.has(props);
 
   const setProp = (name: string, value: Value): void => {
     if (name !== "__self" && name !== "__source" && name !== "key" && name !== "ref") {

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -20,7 +20,7 @@ import {
   ObjectValue,
   Value,
 } from "../values/index.js";
-import { Create, Properties } from "../singletons.js";
+import { Create } from "../singletons.js";
 import invariant from "../invariant.js";
 import { Get } from "../methods/index.js";
 import {
@@ -47,6 +47,9 @@ function createPropsObject(
       : realm.intrinsics.undefined;
 
   let props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
+  props.makeFinal();
+  realm.react.reactProps.add(props);
+
   let key = realm.intrinsics.null;
   let ref = realm.intrinsics.null;
 
@@ -96,7 +99,7 @@ function createPropsObject(
   const setProp = (name: string, value: Value): void => {
     if (name !== "__self" && name !== "__source" && name !== "key" && name !== "ref") {
       invariant(props instanceof ObjectValue || props instanceof AbstractObjectValue);
-      Properties.Set(realm, props, name, value, true);
+      hardModifyReactObjectPropertyBinding(realm, props, name, value);
     }
   };
 
@@ -118,6 +121,7 @@ function createPropsObject(
     args.push(config);
     // create a new props object that will be the target of the Object.assign
     props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
+    realm.react.reactProps.add(props);
 
     applyObjectAssignConfigsForReactElement(realm, props, args);
     props.makeFinal();
@@ -231,7 +235,6 @@ function createPropsObject(
   // We know the props has no keys because if it did it would have thrown above
   // so we can remove them the props we create.
   flagPropsWithNoPartialKeyOrRef(realm, props);
-  props.makeFinal();
   return { key, props, ref };
 }
 
@@ -389,7 +392,6 @@ export function createReactElement(
     return splitReactElementsByConditionalConfig(realm, condValue, consequentVal, alternateVal, type, children);
   }
   let { key, props, ref } = createPropsObject(realm, type, config, children);
-  realm.react.reactProps.add(props);
   return createInternalReactElement(realm, type, key, ref, props);
 }
 

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -299,7 +299,7 @@ export function cloneReactElement(
   children: void | Value
 ): ObjectValue {
   let props = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
-  realm.react.reactProps.has(props);
+  realm.react.reactProps.add(props);
 
   const setProp = (name: string, value: Value): void => {
     if (name !== "__self" && name !== "__source" && name !== "key" && name !== "ref") {

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -98,7 +98,7 @@ function createPropsObject(
 
   const setProp = (name: string, value: Value): void => {
     if (name !== "__self" && name !== "__source" && name !== "key" && name !== "ref") {
-      invariant(props instanceof ObjectValue || props instanceof AbstractObjectValue);
+      invariant(props instanceof ObjectValue);
       hardModifyReactObjectPropertyBinding(realm, props, name, value);
     }
   };

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -215,7 +215,7 @@ export function addKeyToReactElement(realm: Realm, reactElement: ObjectValue): O
   if (currentKeyValue !== realm.intrinsics.null) {
     newKeyValue = computeBinary(realm, "+", currentKeyValue, newKeyValue);
   }
-  invariant(propsValue instanceof ObjectValue || propsValue instanceof AbstractObjectValue);
+  invariant(propsValue instanceof ObjectValue);
   return createInternalReactElement(realm, typeValue, newKeyValue, refValue, propsValue);
 }
 // we create a unique key for each JSXElement to prevent collisions
@@ -910,16 +910,13 @@ export function createInternalReactElement(
   type: Value,
   key: Value,
   ref: Value,
-  props: ObjectValue | AbstractObjectValue
+  props: ObjectValue
 ): ObjectValue {
   let obj = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
 
-  // sanity checks
+  // Sanity check the type is not conditional
   if (type instanceof AbstractValue && type.kind === "conditional") {
     invariant(false, "createInternalReactElement should never encounter a conditional type");
-  }
-  if (props instanceof AbstractObjectValue && props.kind === "conditional") {
-    invariant(false, "createInternalReactElement should never encounter a conditional props");
   }
   Create.CreateDataPropertyOrThrow(realm, obj, "$$typeof", getReactSymbol("react.element", realm));
   Create.CreateDataPropertyOrThrow(realm, obj, "type", type);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -934,7 +934,7 @@ export function createInternalReactElement(
   // Sanity check to ensure no bugs have crept in
   invariant(
     realm.react.reactProps.has(props) && props.mightBeFinalObject(),
-    "React props object are not correctly setup"
+    "React props object is not correctly setup"
   );
   return obj;
 }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -934,6 +934,11 @@ export function createInternalReactElement(
   let firstRenderOnly = createdDuringReconcilation ? activeReconciler.componentTreeConfig.firstRenderOnly : false;
 
   realm.react.reactElements.set(obj, { createdDuringReconcilation, firstRenderOnly });
+  // Sanity check to ensure no bugs have crept in
+  invariant(
+    realm.react.reactProps.has(props) && props.mightBeFinalObject(),
+    "React props object as not correctly setup"
+  );
   return obj;
 }
 

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -934,7 +934,7 @@ export function createInternalReactElement(
   // Sanity check to ensure no bugs have crept in
   invariant(
     realm.react.reactProps.has(props) && props.mightBeFinalObject(),
-    "React props object as not correctly setup"
+    "React props object are not correctly setup"
   );
   return obj;
 }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -561,6 +561,14 @@ export default class ObjectValue extends ConcreteValue {
       invariant(!this.isPartialObject());
       let template = new ObjectValue(this.$Realm, this.$Realm.intrinsics.ObjectPrototype);
       this.copyKeys(this.$OwnPropertyKeys(), this, template);
+      let realm = this.$Realm;
+      // The snapshot is an immutable object snapshot
+      template.makeFinal();
+      // The original object might be a React props object, thus
+      // if it is, we need to ensure we mark it with the same rules
+      if (realm.react.enabled && realm.react.reactProps.has(this)) {
+        realm.react.reactProps.add(template);
+      }
       let result = AbstractValue.createTemporalFromBuildFunction(this.$Realm, ObjectValue, [template], ([x]) => x, {
         skipInvariant: true,
         isPure: true,


### PR DESCRIPTION
Release notes: none

This PR contains some fixes and small tidy ups that would have been in #2138. There was a bug to do with the React props equivalence system and snapshots that was found when https://github.com/facebook/prepack/pull/2137 was merged (along with the fix I commented to on that PR). This PR unblocks https://github.com/facebook/prepack/pull/2137 to land as it should now pass our internal bundle test.