### PR TITLE
Link to Prepack introduction from website

### DIFF
--- a/website/getting-started.html
+++ b/website/getting-started.html
@@ -45,6 +45,18 @@
     <div class="content">
       <div class="section">
         <div class="content-container">
+          <h2>What Does Prepack Do?</h2>
+
+          <p class="align-left">You can learn the basics of what Prepack does and how it works from <a href="https://gist.github.com/gaearon/d85dccba72b809f56a9553972e5c33c4">this overview</a>.</p>
+
+          <p class="align-left">It's not complete, but it can serve as a high-level overview while avoiding the computer science jargon.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="content">
+      <div class="section">
+        <div class="content-container">
           <h2>Prepack CLI</h2>
 
           <h3>Installation</h3>


### PR DESCRIPTION
I haven't written the next parts yet but I figured let's put a link on the website so this doesn't get lost.
I think even the details there are useful enough for users and new contributors.

<img width="1513" alt="screen shot 2018-06-21 at 3 57 52 pm" src="https://user-images.githubusercontent.com/810438/41727325-f9ba32da-756b-11e8-94f0-c83b71df859b.png">

I put it at the top of Getting Started because IMO you'll want to read this (or at least see it) before trying to run Prepack.

I initially planned to put it in the docs themselves but only today realized there's no build process. I don't want to convert the guide to HTML so I'd rather keep it as a gist (and update it if necessary) in the meantime.