### PR TITLE
setState within componentWillMount uses internal property update

### DIFF
--- a/src/react/components.js
+++ b/src/react/components.js
@@ -224,8 +224,8 @@ export function createClassInstanceForFirstRenderOnly(
     }
     if (stateToUpdate instanceof ObjectValue) {
       let newState = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
-      newState.makeFinal();
       objectAssignCall(realm.intrinsics.undefined, [newState, prevState]);
+      newState.makeFinal();
 
       for (let [key, binding] of stateToUpdate.properties) {
         if (binding && binding.descriptor && binding.descriptor.enumerable) {

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -23,7 +23,13 @@ import {
 } from "../values/index.js";
 import * as t from "babel-types";
 import type { BabelNodeIdentifier } from "babel-types";
-import { flagPropsWithNoPartialKeyOrRef, getProperty, getValueFromFunctionCall, valueIsClassComponent } from "./utils";
+import {
+  flagPropsWithNoPartialKeyOrRef,
+  getProperty,
+  getValueFromFunctionCall,
+  hardModifyReactObjectPropertyBinding,
+  valueIsClassComponent,
+} from "./utils";
 import { ExpectedBailOut, SimpleClassBailOut } from "./errors.js";
 import { Get, Construct } from "../methods/index.js";
 import { Properties } from "../singletons.js";
@@ -218,16 +224,16 @@ export function createClassInstanceForFirstRenderOnly(
     }
     if (stateToUpdate instanceof ObjectValue) {
       let newState = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
+      newState.makeFinal();
       objectAssignCall(realm.intrinsics.undefined, [newState, prevState]);
 
       for (let [key, binding] of stateToUpdate.properties) {
         if (binding && binding.descriptor && binding.descriptor.enumerable) {
           let value = getProperty(realm, stateToUpdate, key);
-          Properties.Set(realm, newState, key, value, true);
+          hardModifyReactObjectPropertyBinding(realm, newState, key, value);
         }
       }
 
-      newState.makeFinal();
       Properties.Set(realm, instance, "state", newState, true);
     }
     if (callback instanceof ECMAScriptSourceFunctionValue && callback.$Call) {


### PR DESCRIPTION
Release notes: none

As we're updating state on a final object, in this case `state`, ensure we use `hardModifyReactObjectPropertyBinding`. Unblocks https://github.com/facebook/prepack/pull/2137.