### PR TITLE
Fix test runner and don't swallow invariant failures

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -492,7 +492,7 @@ function runTest(name, code, options: PrepackOptions, args) {
                 console.error(newCode);
               }
             }
-            if (markersIssue || matchesIssue) return () => Promise.reject();
+            if (markersIssue || matchesIssue) return () => Promise.reject({ type: "MARKER" });
             let codeToRun = addedCode + newCode;
             if (!execSpec && options.lazyObjectsRuntime !== undefined) {
               codeToRun = augmentCodeWithLazyObjectSupport(codeToRun, args.lazyObjectsRuntime);
@@ -581,6 +581,8 @@ function runTest(name, code, options: PrepackOptions, args) {
             return Promise.resolve(false);
           } else if (type === "RETURN") {
             return value;
+          } else if (type === "MARKER") {
+            return undefined;
           } else {
             console.error(err);
             console.error(err.stack);
@@ -689,7 +691,6 @@ function run(args) {
           flagPermutations.push([false, true, undefined, true]);
         }
         if (args.fast) flagPermutations = [[false, false, undefined, isSimpleClosureTest]];
-        let lastFailed = failed;
         return () =>
           SerialPromises(
             flagPermutations
@@ -707,17 +708,14 @@ function run(args) {
                 return () =>
                   runTest(test.name, test.file, options, args).then(testResult => {
                     if (testResult) {
-                      // console.log("passed", test.name, testResult);
                       passed++;
                     } else {
-                      // console.log("failed", test.name, testResult);
                       failed++;
+                      failedTests.push(test);
                     }
                   });
               })
-          ).then(function() {
-            if (failed !== lastFailed) failedTests.push(test);
-          });
+          );
       })
   ).then(function() {
     failedTests.sort((x, y) => y.file.length - x.file.length);

--- a/src/errors.js
+++ b/src/errors.js
@@ -53,4 +53,11 @@ export class InfeasiblePathError extends Error {
   }
 }
 
+// This error is thrown when a false invariant is encountered. This error should never be swallowed.
+export class InvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
 export type ErrorHandler = (error: CompilerDiagnostic) => ErrorHandlerResult;

--- a/src/invariant.js
+++ b/src/invariant.js
@@ -9,11 +9,13 @@
 
 /* @flow strict */
 
+import { InvariantError } from "./errors.js";
+
 export default function invariant(condition: boolean, format: string = ""): void {
   if (condition) return;
   const message = `${format}
 This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.`;
-  let error = new Error(message);
+  let error = new InvariantError(message);
   error.name = "Invariant Violation";
   throw error;
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -820,6 +820,7 @@ export class Realm {
         try {
           c = f();
           if (c instanceof Reference) c = Environment.GetValue(this, c);
+          else if (c instanceof SimpleNormalCompletion) c = c.value;
         } catch (e) {
           if (e instanceof AbruptCompletion) c = e;
           else throw e;
@@ -974,7 +975,8 @@ export class Realm {
         effects1 = Widen.widenEffects(this, effects1, effects2);
       }
     } catch (e) {
-      return undefined;
+      if (e instanceof FatalError) return undefined;
+      throw e;
     }
   }
 


### PR DESCRIPTION
Release note: Fix test runner and don't swallow invariant failures

The recent changes to make the serializer test runner deal with promises, caused it to list every test that follows a failing test as also failing.

I've also noticed that invariant failures can get swallowed. And as a result of that some test cases that should have failed with false invariants showed up as passing.

Those failures were recently introduced by PR #2134. It boils down to a single line fix, which is also included with this.