### PR TITLE
Fix inefficient loop in switch statements

### DIFF
--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -407,7 +407,7 @@ function evaluationHelper(
 
   // 5. Perform BlockDeclarationInstantiation(CaseBlock, blockEnv).
   let CaseBlock = [];
-  cases.forEach(c => Array.prototype.push.apply(CaseBlock, c.consequent));
+  cases.forEach(c => CaseBlock.push(...c.consequent));
   Environment.BlockDeclarationInstantiation(realm, strictCode, CaseBlock, blockEnv);
 
   // 6. Set the running execution context's LexicalEnvironment to blockEnv.

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -323,7 +323,7 @@ export class FunctionImplementation {
           break;
         case "SwitchStatement":
           for (let switchCase of ((ast: any): BabelNodeSwitchStatement).cases) {
-            Array.prototype.push.apply(statements, switchCase.consequent);
+            statements.push(...switchCase.consequent);
           }
           break;
         case "TryStatement":


### PR DESCRIPTION
Release Notes: None

Dan Caspi's change to internal test case created a giant switch statement, increasing evaluation time from 5.9s > 224s. This change brings it down to 6.2s by using `push` instead of `concat` in 2 places.