### PR TITLE
Tidy up React logic, pulled from #2096

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -19,7 +19,7 @@ let ReactDOMServer = require("react-dom/server");
 let PropTypes = require("prop-types");
 let ReactRelay = require("react-relay");
 let ReactTestRenderer = require("react-test-renderer");
-let { mergeAdacentJSONTextNodes } = require("../lib/utils/json.js");
+let { mergeAdjacentJSONTextNodes } = require("../lib/utils/json.js");
 /* eslint-disable no-undef */
 let { expect, describe, it } = global;
 
@@ -229,8 +229,8 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
       if (typeof valueA === "string" && typeof valueB === "string") {
         expect(valueA).toBe(valueB);
       } else {
-        expect(mergeAdacentJSONTextNodes(valueB, firstRenderOnly)).toEqual(
-          mergeAdacentJSONTextNodes(valueA, firstRenderOnly)
+        expect(mergeAdjacentJSONTextNodes(valueB, firstRenderOnly)).toEqual(
+          mergeAdjacentJSONTextNodes(valueA, firstRenderOnly)
         );
       }
       expect(nameB).toEqual(nameA);

--- a/src/intrinsics/fb-www/global.js
+++ b/src/intrinsics/fb-www/global.js
@@ -11,7 +11,8 @@
 
 import type { Realm } from "../../realm.js";
 import { AbstractValue, ArrayValue, NativeFunctionValue, StringValue, ObjectValue } from "../../values/index.js";
-import { createMockReact, createMockReactDOM, createMockReactDOMServer } from "./react-mocks.js";
+import { createMockReact } from "./react-mocks.js";
+import { createMockReactDOM, createMockReactDOMServer } from "./react-dom-mocks.js";
 import { createMockReactRelay } from "./relay-mocks.js";
 import { createAbstract } from "../prepack/utils.js";
 import { createFbMocks } from "./fb-mocks.js";

--- a/src/intrinsics/fb-www/react-dom-mocks.js
+++ b/src/intrinsics/fb-www/react-dom-mocks.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { Realm } from "../../realm.js";
+import { ObjectValue, AbstractObjectValue, AbstractValue, FunctionValue } from "../../values/index.js";
+import { createReactHintObject, isReactElement } from "../../react/utils.js";
+import * as t from "babel-types";
+import invariant from "../../invariant";
+import { updateIntrinsicNames, addMockFunctionToObject } from "./utils.js";
+import { renderToString } from "../../react/experimental-server-rendering/rendering.js";
+
+export function createMockReactDOM(realm: Realm, reactDomRequireName: string): ObjectValue {
+  let reactDomValue = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
+  reactDomValue.refuseSerialization = true;
+
+  updateIntrinsicNames(realm, reactDomValue, reactDomRequireName);
+
+  const genericTemporalFunc = (funcVal, args) => {
+    let reactDomMethod = AbstractValue.createTemporalFromBuildFunction(
+      realm,
+      FunctionValue,
+      [funcVal, ...args],
+      ([renderNode, ..._args]) => {
+        return t.callExpression(renderNode, ((_args: any): Array<any>));
+      },
+      { skipInvariant: true, isPure: true }
+    );
+    invariant(reactDomMethod instanceof AbstractObjectValue);
+    return reactDomMethod;
+  };
+
+  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "render", genericTemporalFunc);
+  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "hydrate", genericTemporalFunc);
+  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "findDOMNode", genericTemporalFunc);
+  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "unmountComponentAtNode", genericTemporalFunc);
+
+  const createPortalFunc = (funcVal, [reactPortalValue, domNodeValue]) => {
+    let reactDomMethod = AbstractValue.createTemporalFromBuildFunction(
+      realm,
+      ObjectValue,
+      [funcVal, reactPortalValue, domNodeValue],
+      ([renderNode, ..._args]) => {
+        return t.callExpression(renderNode, ((_args: any): Array<any>));
+      },
+      { skipInvariant: true, isPure: true }
+    );
+    invariant(reactDomMethod instanceof AbstractObjectValue);
+    realm.react.abstractHints.set(
+      reactDomMethod,
+      createReactHintObject(reactDomValue, "createPortal", [reactPortalValue, domNodeValue], realm.intrinsics.undefined)
+    );
+    return reactDomMethod;
+  };
+
+  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "createPortal", createPortalFunc);
+
+  reactDomValue.refuseSerialization = false;
+  reactDomValue.makeFinal();
+  return reactDomValue;
+}
+
+export function createMockReactDOMServer(realm: Realm, requireName: string): ObjectValue {
+  let reactDomServerValue = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
+  reactDomServerValue.refuseSerialization = true;
+
+  updateIntrinsicNames(realm, reactDomServerValue, requireName);
+
+  const genericTemporalFunc = (funcVal, args) => {
+    let reactDomMethod = AbstractValue.createTemporalFromBuildFunction(
+      realm,
+      FunctionValue,
+      [funcVal, ...args],
+      ([renderNode, ..._args]) => {
+        return t.callExpression(renderNode, ((_args: any): Array<any>));
+      },
+      { skipInvariant: true, isPure: true }
+    );
+    invariant(reactDomMethod instanceof AbstractObjectValue);
+    return reactDomMethod;
+  };
+
+  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToString", (funcVal, [input]) => {
+    if (input instanceof ObjectValue && isReactElement(input)) {
+      return renderToString(realm, input, false);
+    }
+    return genericTemporalFunc(funcVal, [input]);
+  });
+  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToStaticMarkup", (funcVal, [input]) => {
+    if (input instanceof ObjectValue && isReactElement(input)) {
+      return renderToString(realm, input, true);
+    }
+    return genericTemporalFunc(funcVal, [input]);
+  });
+  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToNodeStream", genericTemporalFunc);
+  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToStaticNodeStream", genericTemporalFunc);
+
+  reactDomServerValue.refuseSerialization = false;
+  reactDomServerValue.makeFinal();
+  return reactDomServerValue;
+}

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -23,10 +23,9 @@ import {
   Value,
 } from "../../values/index.js";
 import { Environment } from "../../singletons.js";
-import { createReactHintObject, getReactSymbol, isReactElement } from "../../react/utils.js";
+import { createReactHintObject, getReactSymbol } from "../../react/utils.js";
 import { cloneReactElement, createReactElement } from "../../react/elements.js";
 import { Properties, Create, To } from "../../singletons.js";
-import { renderToString } from "../../react/experimental-server-rendering/rendering.js";
 import * as t from "babel-types";
 import invariant from "../../invariant";
 import { updateIntrinsicNames, addMockFunctionToObject } from "./utils.js";
@@ -555,94 +554,4 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
   reactValue.refuseSerialization = false;
   reactValue.makeFinal();
   return reactValue;
-}
-
-export function createMockReactDOM(realm: Realm, reactDomRequireName: string): ObjectValue {
-  let reactDomValue = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
-  reactDomValue.refuseSerialization = true;
-
-  updateIntrinsicNames(realm, reactDomValue, reactDomRequireName);
-
-  const genericTemporalFunc = (funcVal, args) => {
-    let reactDomMethod = AbstractValue.createTemporalFromBuildFunction(
-      realm,
-      FunctionValue,
-      [funcVal, ...args],
-      ([renderNode, ..._args]) => {
-        return t.callExpression(renderNode, ((_args: any): Array<any>));
-      },
-      { skipInvariant: true, isPure: true }
-    );
-    invariant(reactDomMethod instanceof AbstractObjectValue);
-    return reactDomMethod;
-  };
-
-  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "render", genericTemporalFunc);
-  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "hydrate", genericTemporalFunc);
-  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "findDOMNode", genericTemporalFunc);
-  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "unmountComponentAtNode", genericTemporalFunc);
-
-  const createPortalFunc = (funcVal, [reactPortalValue, domNodeValue]) => {
-    let reactDomMethod = AbstractValue.createTemporalFromBuildFunction(
-      realm,
-      ObjectValue,
-      [funcVal, reactPortalValue, domNodeValue],
-      ([renderNode, ..._args]) => {
-        return t.callExpression(renderNode, ((_args: any): Array<any>));
-      },
-      { skipInvariant: true, isPure: true }
-    );
-    invariant(reactDomMethod instanceof AbstractObjectValue);
-    realm.react.abstractHints.set(
-      reactDomMethod,
-      createReactHintObject(reactDomValue, "createPortal", [reactPortalValue, domNodeValue], realm.intrinsics.undefined)
-    );
-    return reactDomMethod;
-  };
-
-  addMockFunctionToObject(realm, reactDomValue, reactDomRequireName, "createPortal", createPortalFunc);
-
-  reactDomValue.refuseSerialization = false;
-  reactDomValue.makeFinal();
-  return reactDomValue;
-}
-
-export function createMockReactDOMServer(realm: Realm, requireName: string): ObjectValue {
-  let reactDomServerValue = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
-  reactDomServerValue.refuseSerialization = true;
-
-  updateIntrinsicNames(realm, reactDomServerValue, requireName);
-
-  const genericTemporalFunc = (funcVal, args) => {
-    let reactDomMethod = AbstractValue.createTemporalFromBuildFunction(
-      realm,
-      FunctionValue,
-      [funcVal, ...args],
-      ([renderNode, ..._args]) => {
-        return t.callExpression(renderNode, ((_args: any): Array<any>));
-      },
-      { skipInvariant: true, isPure: true }
-    );
-    invariant(reactDomMethod instanceof AbstractObjectValue);
-    return reactDomMethod;
-  };
-
-  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToString", (funcVal, [input]) => {
-    if (input instanceof ObjectValue && isReactElement(input)) {
-      return renderToString(realm, input, false);
-    }
-    return genericTemporalFunc(funcVal, [input]);
-  });
-  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToStaticMarkup", (funcVal, [input]) => {
-    if (input instanceof ObjectValue && isReactElement(input)) {
-      return renderToString(realm, input, true);
-    }
-    return genericTemporalFunc(funcVal, [input]);
-  });
-  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToNodeStream", genericTemporalFunc);
-  addMockFunctionToObject(realm, reactDomServerValue, requireName, "renderToStaticNodeStream", genericTemporalFunc);
-
-  reactDomServerValue.refuseSerialization = false;
-  reactDomServerValue.makeFinal();
-  return reactDomServerValue;
 }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -12,7 +12,7 @@ type JSONValue = Array<JSONValue> | string | number | JSON;
 type JSON = { [key: string]: JSONValue };
 
 // this will mutate the original JSON object
-export function mergeAdacentJSONTextNodes(node: JSON, removeFunctions: boolean, visitedNodes?: Set<JSON>) {
+export function mergeAdjacentJSONTextNodes(node: JSON, removeFunctions: boolean, visitedNodes?: Set<JSON>) {
   if (visitedNodes === undefined) {
     visitedNodes = new Set();
   }
@@ -41,7 +41,7 @@ export function mergeAdacentJSONTextNodes(node: JSON, removeFunctions: boolean, 
           arr.push(concatString);
           concatString = null;
         }
-        arr.push(mergeAdacentJSONTextNodes(child, removeFunctions, visitedNodes));
+        arr.push(mergeAdjacentJSONTextNodes(child, removeFunctions, visitedNodes));
       }
     }
     if (concatString !== null) {
@@ -58,7 +58,7 @@ export function mergeAdacentJSONTextNodes(node: JSON, removeFunctions: boolean, 
           node[key] = "function";
         }
       } else if (typeof value === "object" && value !== null) {
-        node[key] = mergeAdacentJSONTextNodes(((value: any): JSON), removeFunctions, visitedNodes);
+        node[key] = mergeAdjacentJSONTextNodes(((value: any): JSON), removeFunctions, visitedNodes);
       }
     }
   }


### PR DESCRIPTION
Release notes: none

To make https://github.com/facebook/prepack/pull/2096 easier to review, this pulls out the tidy ups from that PR.

- fix typo on function name `mergeAdjacentJSONTextNodes`
- move ReactDOM mock logic into its own file