### PR TITLE
Fixes nested `evaluatePure` calls and React nested optimized closure side-effect detection

### DIFF
--- a/scripts/test-react.js
+++ b/scripts/test-react.js
@@ -707,7 +707,9 @@ function runTestSuite(outputJsx, shouldTranspileSource) {
       });
 
       it("Class component as root with refs", async () => {
-        await runTest(directory, "class-root-with-refs.js");
+        await expectReconcilerFatalError(async () => {
+          await runTest(directory, "class-root-with-refs.js");
+        });
       });
 
       it("Class component as root with instance variables", async () => {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -283,10 +283,12 @@ export class Reconciler {
     try {
       this.realm.react.activeReconciler = this;
       let effects = this.realm.wrapInGlobalEnv(() =>
-        this.realm.evaluatePure(() =>
-          evaluateWithNestedParentEffects(this.realm, nestedEffects, () =>
-            this.realm.evaluateForEffects(resolveOptimizedClosure, /*state*/ null, `react nested optimized closure`)
-          )
+        this.realm.evaluatePure(
+          () =>
+            evaluateWithNestedParentEffects(this.realm, nestedEffects, () =>
+              this.realm.evaluateForEffects(resolveOptimizedClosure, /*state*/ null, `react nested optimized closure`)
+            ),
+          this._handleReportedSideEffect
         )
       );
       this._handleNestedOptimizedClosuresFromEffects(effects, evaluatedNode);

--- a/src/realm.js
+++ b/src/realm.js
@@ -683,19 +683,37 @@ export class Realm {
       value: void | Value
     ) => void
   ) {
-    let saved_createdObjectsTrackedForLeaks = this.createdObjectsTrackedForLeaks;
     let saved_reportSideEffectCallback = this.reportSideEffectCallback;
-    // Track all objects (including function closures) created during
-    // this call. This will be used to make the assumption that every
-    // *other* object is unchanged (pure). These objects are marked
-    // as leaked if they're passed to abstract functions.
-    this.createdObjectsTrackedForLeaks = new Set();
-    this.reportSideEffectCallback = reportSideEffectFunc;
+    let shouldClearCreatedObjectsTrackedForLeaks = false;
+    // Only create a tracked objects set if we haven't already got one
+    // otherwise, we'll end up creating a new set for nested evalautePure
+    // calls.
+    if (this.createdObjectsTrackedForLeaks === undefined) {
+      // Track all objects (including function closures) created during
+      // this call. This will be used to make the assumption that every
+      // *other* object is unchanged (pure). These objects are marked
+      // as leaked if they're passed to abstract functions.
+      this.createdObjectsTrackedForLeaks = new Set();
+      // Ensure we set this flag so we clear the set once finished with
+      // this root evalutePure call
+      shouldClearCreatedObjectsTrackedForLeaks = true;
+    }
+    this.reportSideEffectCallback = (...args) => {
+      if (reportSideEffectFunc !== undefined) {
+        reportSideEffectFunc(...args);
+      }
+      // Ensure we call any previously nested side-effect callbacks
+      if (saved_reportSideEffectCallback !== undefined) {
+        saved_reportSideEffectCallback(...args);
+      }
+    };
     try {
       return f();
     } finally {
-      this.createdObjectsTrackedForLeaks = saved_createdObjectsTrackedForLeaks;
       this.reportSideEffectCallback = saved_reportSideEffectCallback;
+      if (shouldClearCreatedObjectsTrackedForLeaks) {
+        this.createdObjectsTrackedForLeaks = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
Release notes: none

Fixes nested `evaluatePure` calls, where before they would collide and overwrite one another. Also ensure React reconciler uses side-effect detection on nested optimized closures. This fixes a React test which should have been failing before, but wasn't.