### PR TITLE
Do not always give up when running Array.map over an abstract array.

### DIFF
--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -352,37 +352,12 @@ export default function(
     let elems = switchValue.values.getElements();
     let n = elems.size;
     if (n > 1 && n < 10) {
-      let joinedEffects;
-      for (let concreteSwitchValue of elems) {
-        let condition = AbstractValue.createFromBinaryOp(realm, "===", switchValue, concreteSwitchValue);
-        let effects = realm.evaluateForEffects(
-          () => {
-            return Path.withCondition(condition, () => {
-              return evaluationHelper(ast, concreteSwitchValue, strictCode, env, realm, labelSet);
-            });
-          },
-          undefined,
-          "specialized switch"
-        );
-        joinedEffects =
-          joinedEffects === undefined ? effects : Join.joinForkOrChoose(realm, condition, effects, joinedEffects);
-      }
-      invariant(joinedEffects !== undefined);
-      realm.applyEffects(joinedEffects, "joined specialized switch");
-      let { result } = joinedEffects;
-      if (result instanceof AbruptCompletion) throw result;
-      if (result instanceof PossiblyNormalCompletion) {
-        // in this case one of the branches may complete abruptly, which means that
-        // not all control flow branches join into one flow at this point.
-        // Consequently we have to continue tracking changes until the point where
-        // all the branches come together into one.
-        result = realm.composeWithSavedCompletion(result);
-      }
-      if (result instanceof SimpleNormalCompletion) {
-        result = result.value;
-      }
-      invariant(result instanceof Value); // since evaluationHelper returns a value in non abrupt cases
-      return result;
+      return Join.mapAndJoin(
+        realm,
+        elems,
+        concreteSwitchValue => AbstractValue.createFromBinaryOp(realm, "===", switchValue, concreteSwitchValue),
+        concreteSwitchValue => evaluationHelper(ast, concreteSwitchValue, strictCode, env, realm, labelSet)
+      );
     }
   }
 

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -970,17 +970,18 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let values = lenVal.values.getElements();
       let n = values.size;
       if (n > 1 && n < 10) {
+        let a = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), 0);
         return Join.mapAndJoin(
           realm,
           values,
           v => AbstractValue.createFromBinaryOp(realm, "===", v, lenVal, lenVal.expressionLocation),
-          v => doMap(v)
+          v => doMap(v, a)
         );
       }
     }
     return doMap(lenVal.throwIfNotConcrete());
 
-    function doMap(val: ConcreteValue) {
+    function doMap(val: ConcreteValue, resultArray?: ObjectValue) {
       let len = To.ToLength(realm, val);
 
       // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
@@ -992,7 +993,12 @@ export default function(realm: Realm, obj: ObjectValue): void {
       let T = thisArg || realm.intrinsics.undefined;
 
       // 5. Let A be ? ArraySpeciesCreate(O, len).
-      let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), len);
+      let A;
+      if (resultArray === undefined) A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), len);
+      else {
+        A = resultArray;
+        Properties.Set(realm, A, "length", val, true);
+      }
 
       // 6. Let k be 0.
       let k = 0;

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -14,6 +14,7 @@ import {
   AbstractValue,
   ArrayValue,
   BooleanValue,
+  ConcreteValue,
   NullValue,
   NumberValue,
   ObjectValue,
@@ -36,7 +37,7 @@ import {
   Get,
   HasSomeCompatibleType,
 } from "../../methods/index.js";
-import { Create, Properties, To } from "../../singletons.js";
+import { Create, Join, Properties, To } from "../../singletons.js";
 
 export default function(realm: Realm, obj: ObjectValue): void {
   // ECMA262 22.1.3.31
@@ -964,48 +965,65 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 2. Let len be ? ToLength(? Get(O, "length")).
-    let len = To.ToLength(realm, Get(realm, O, "length"));
-
-    // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
-    if (!IsCallable(realm, callbackfn)) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
+    let lenVal = Get(realm, O, "length");
+    if (lenVal instanceof AbstractValue && !lenVal.mightNotBeNumber() && !lenVal.values.isTop()) {
+      let values = lenVal.values.getElements();
+      let n = values.size;
+      if (n > 1 && n < 10) {
+        return Join.mapAndJoin(
+          realm,
+          values,
+          v => AbstractValue.createFromBinaryOp(realm, "===", v, lenVal, lenVal.expressionLocation),
+          v => doMap(v)
+        );
+      }
     }
+    return doMap(lenVal.throwIfNotConcrete());
 
-    // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
-    let T = thisArg || realm.intrinsics.undefined;
+    function doMap(val: ConcreteValue) {
+      let len = To.ToLength(realm, val);
 
-    // 5. Let A be ? ArraySpeciesCreate(O, len).
-    let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), len);
-
-    // 6. Let k be 0.
-    let k = 0;
-
-    // 7. Repeat, while k < len
-    while (k < len) {
-      // a. Let Pk be ! To.ToString(k).
-      let Pk = new StringValue(realm, k + "");
-
-      // b. Let kPresent be ? HasProperty(O, Pk).
-      let kPresent = HasProperty(realm, O, Pk);
-
-      // c. If kPresent is true, then
-      if (kPresent) {
-        // i. Let kValue be ? Get(O, Pk).
-        let kValue = Get(realm, O, Pk);
-
-        // ii. Let mappedValue be ? Call(callbackfn, T, « kValue, k, O »).
-        let mappedValue = Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]);
-
-        // iii. Perform ? CreateDataPropertyOrThrow(A, Pk, mappedValue).
-        Create.CreateDataPropertyOrThrow(realm, A, Pk, mappedValue);
+      // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
+      if (!IsCallable(realm, callbackfn)) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not a function");
       }
 
-      // d. Increase k by 1.
-      k++;
-    }
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      let T = thisArg || realm.intrinsics.undefined;
 
-    // 8. Return A.
-    return A;
+      // 5. Let A be ? ArraySpeciesCreate(O, len).
+      let A = Create.ArraySpeciesCreate(realm, O.throwIfNotConcreteObject(), len);
+
+      // 6. Let k be 0.
+      let k = 0;
+
+      // 7. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! To.ToString(k).
+        let Pk = new StringValue(realm, k + "");
+
+        // b. Let kPresent be ? HasProperty(O, Pk).
+        let kPresent = HasProperty(realm, O, Pk);
+
+        // c. If kPresent is true, then
+        if (kPresent) {
+          // i. Let kValue be ? Get(O, Pk).
+          let kValue = Get(realm, O, Pk);
+
+          // ii. Let mappedValue be ? Call(callbackfn, T, « kValue, k, O »).
+          let mappedValue = Call(realm, callbackfn, T, [kValue, new NumberValue(realm, k), O]);
+
+          // iii. Perform ? CreateDataPropertyOrThrow(A, Pk, mappedValue).
+          Create.CreateDataPropertyOrThrow(realm, A, Pk, mappedValue);
+        }
+
+        // d. Increase k by 1.
+        k++;
+      }
+
+      // 8. Return A.
+      return A;
+    }
   });
 
   // ECMA262 22.1.3.17

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -918,18 +918,18 @@ export class JoinImplementation {
   mapAndJoin(
     realm: Realm,
     values: Set<ConcreteValue>,
-    c: ConcreteValue => Value,
-    f: ConcreteValue => Completion | Value
+    joinConditionFactory: ConcreteValue => Value,
+    functionToMap: ConcreteValue => Completion | Value
   ): Value {
     invariant(values.size > 1);
     let joinedEffects;
     for (let val of values) {
-      let condition = c(val);
+      let condition = joinConditionFactory(val);
       let effects = realm.evaluateForEffects(
         () => {
           invariant(condition instanceof AbstractValue);
           return Path.withCondition(condition, () => {
-            return f(val);
+            return functionToMap(val);
           });
         },
         undefined,

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -32,7 +32,7 @@ import { cloneDescriptor, equalDescriptors, IsDataDescriptor, StrictEqualityComp
 import { construct_empty_effects } from "../realm.js";
 import { Path } from "../singletons.js";
 import { Generator } from "../utils/generator.js";
-import { AbstractValue, EmptyValue, ObjectValue, Value } from "../values/index.js";
+import { AbstractValue, ConcreteValue, EmptyValue, ObjectValue, Value } from "../values/index.js";
 
 import invariant from "../invariant.js";
 
@@ -913,5 +913,50 @@ export class JoinImplementation {
       d3.descriptor2 = d2;
       return d3;
     }
+  }
+
+  mapAndJoin(
+    realm: Realm,
+    values: Set<ConcreteValue>,
+    c: ConcreteValue => Value,
+    f: ConcreteValue => Completion | Value
+  ): Value {
+    invariant(values.size > 1);
+    let joinedEffects;
+    for (let val of values) {
+      let condition = c(val);
+      let effects = realm.evaluateForEffects(
+        () => {
+          invariant(condition instanceof AbstractValue);
+          return Path.withCondition(condition, () => {
+            return f(val);
+          });
+        },
+        undefined,
+        "mapAndJoin"
+      );
+      joinedEffects =
+        joinedEffects === undefined ? effects : this.joinForkOrChoose(realm, condition, effects, joinedEffects);
+    }
+    invariant(joinedEffects !== undefined);
+    let completion = joinedEffects.result;
+    if (completion instanceof PossiblyNormalCompletion) {
+      // in this case one of the branches may complete abruptly, which means that
+      // not all control flow branches join into one flow at this point.
+      // Consequently we have to continue tracking changes until the point where
+      // all the branches come together into one.
+      completion = realm.composeWithSavedCompletion(completion);
+    }
+    // Note that the effects of (non joining) abrupt branches are not included
+    // in joinedEffects, but are tracked separately inside completion.
+    realm.applyEffects(joinedEffects);
+
+    // return or throw completion
+    if (completion instanceof AbruptCompletion) throw completion;
+    if (completion instanceof SimpleNormalCompletion) {
+      completion = completion.value;
+    }
+    invariant(completion instanceof Value);
+    return completion;
   }
 }

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1502,6 +1502,8 @@ export class PropertiesImplementation {
     if (!(value instanceof Value)) return;
     if (!value.mightHaveBeenDeleted()) return;
     invariant(value instanceof AbstractValue); // real empty values should never get here
+    let v = value.$Realm.simplifyAndRefineAbstractValue(value);
+    if (!v.mightHaveBeenDeleted()) return;
     AbstractValue.reportIntrospectionError(value);
     throw new FatalError();
   }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1159,6 +1159,7 @@ export class ResidualHeapSerializer {
     deleteIfMightHaveBeenDeleted: boolean = false
   ): BabelNodeStatement {
     if (mightHaveBeenDeleted) {
+      // We always need to serialize this value in order to keep the invariants happy.
       let serializedValue = this.serializeValue(value);
       let condition;
       if (value instanceof AbstractValue && value.kind === "conditional") {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1264,10 +1264,10 @@ export class ResidualHeapSerializer {
   _serializeValueArray(val: ObjectValue): BabelNodeExpression {
     let remainingProperties = new Map(val.properties);
 
-    const indexPropertyLength = getSuggestedArrayLiteralLength(this.realm, val);
-    // Use the serialized index properties as array initialization list.
-    const initProperties = this._serializeArrayIndexProperties(val, indexPropertyLength, remainingProperties);
-    this._serializeArrayLengthIfNeeded(val, indexPropertyLength, remainingProperties);
+    let [unconditionalLength, assignmentNotNeeded] = getSuggestedArrayLiteralLength(this.realm, val);
+    // Use the unconditional serialized index properties as array initialization list.
+    const initProperties = this._serializeArrayIndexProperties(val, unconditionalLength, remainingProperties);
+    if (!assignmentNotNeeded) this._serializeArrayLengthIfNeeded(val, unconditionalLength, remainingProperties);
     this._emitObjectProperties(val, remainingProperties);
     return t.arrayExpression(initProperties);
   }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -410,10 +410,12 @@ export class ResidualHeapVisitor {
     } else {
       lenProperty = Get(realm, val, "length");
     }
+    let [initialLength, lengthAssignmentNotNeeded] = getSuggestedArrayLiteralLength(realm, val);
+    if (lengthAssignmentNotNeeded) return;
     if (
       lenProperty instanceof AbstractValue
         ? lenProperty.kind !== "widened property"
-        : To.ToLength(realm, lenProperty) !== getSuggestedArrayLiteralLength(realm, val)
+        : To.ToLength(realm, lenProperty) !== initialLength
     ) {
       this.visitValue(lenProperty);
     }

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -9,7 +9,17 @@
 
 /* @flow */
 
-import { ECMAScriptSourceFunctionValue, FunctionValue, ObjectValue, SymbolValue } from "../values/index.js";
+import {
+  AbstractValue,
+  ECMAScriptSourceFunctionValue,
+  EmptyValue,
+  FunctionValue,
+  IntegralValue,
+  NumberValue,
+  ObjectValue,
+  SymbolValue,
+  Value,
+} from "../values/index.js";
 import type { Effects, Realm } from "../realm.js";
 
 import { FatalError } from "../errors.js";
@@ -22,17 +32,41 @@ import type { AdditionalFunctionEffects } from "./types";
 
 /**
  * Get index property list length by searching array properties list for the max index key value plus 1.
+ * If tail elements are conditional, return the minimum length if an assignment to the length property
+ * can be avoided because of that. The boolean part of the result is a flag that indicates if the latter is true.
  */
-export function getSuggestedArrayLiteralLength(realm: Realm, val: ObjectValue): number {
+export function getSuggestedArrayLiteralLength(realm: Realm, val: ObjectValue): [number, boolean] {
   invariant(IsArray(realm, val));
 
-  let length = 0;
+  let minLength = 0,
+    maxLength = 0;
+  let actualLength;
   for (const key of val.properties.keys()) {
-    if (IsArrayIndex(realm, key) && Number(key) >= length) {
-      length = Number(key) + 1;
+    if (IsArrayIndex(realm, key) && Number(key) >= maxLength) {
+      let prevMax = maxLength;
+      maxLength = Number(key) + 1;
+      let elem = val._SafeGetDataPropertyValue(key);
+      if (!elem.mightHaveBeenDeleted()) minLength = maxLength;
+      else if (elem instanceof AbstractValue && elem.kind === "conditional") {
+        let maxLengthVal = new IntegralValue(realm, maxLength);
+        let [c, x, y] = elem.args;
+        if (x instanceof EmptyValue && !y.mightHaveBeenDeleted()) {
+          let prevActual = actualLength === undefined ? new IntegralValue(realm, prevMax) : actualLength;
+          actualLength = AbstractValue.createFromConditionalOp(realm, c, prevActual, maxLengthVal);
+        } else if (y instanceof EmptyValue && !x.mightHaveBeenDeleted()) {
+          let prevActual = actualLength === undefined ? new IntegralValue(realm, prevMax) : actualLength;
+          actualLength = AbstractValue.createFromConditionalOp(realm, c, maxLengthVal, prevActual);
+        } else {
+          actualLength = undefined;
+        }
+      }
     }
   }
-  return length;
+  if (maxLength > minLength && actualLength instanceof AbstractValue) {
+    let lengthVal = val._SafeGetDataPropertyValue("length");
+    if (lengthVal.equals(actualLength)) return [minLength, true];
+  }
+  return [maxLength, false];
 }
 
 export function commonAncestorOf<T>(node1: void | T, node2: void | T, getParent: T => void | T): void | T {

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -15,10 +15,8 @@ import {
   EmptyValue,
   FunctionValue,
   IntegralValue,
-  NumberValue,
   ObjectValue,
   SymbolValue,
-  Value,
 } from "../values/index.js";
 import type { Effects, Realm } from "../realm.js";
 

--- a/src/types.js
+++ b/src/types.js
@@ -828,6 +828,13 @@ export type JoinType = {
     d1: void | Descriptor,
     d2: void | Descriptor
   ): void | Descriptor,
+
+  mapAndJoin(
+    realm: Realm,
+    values: Set<ConcreteValue>,
+    c: (ConcreteValue) => Value,
+    f: (ConcreteValue) => Completion | Value
+  ): Value,
 };
 
 export type CreateType = {

--- a/src/types.js
+++ b/src/types.js
@@ -832,8 +832,8 @@ export type JoinType = {
   mapAndJoin(
     realm: Realm,
     values: Set<ConcreteValue>,
-    c: (ConcreteValue) => Value,
-    f: (ConcreteValue) => Completion | Value
+    joinConditionFactory: (ConcreteValue) => Value,
+    functionToMap: (ConcreteValue) => Completion | Value
   ): Value,
 };
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -62,7 +62,7 @@ export type SerializationContext = {|
   serializeBinding: Binding => BabelNodeIdentifier | BabelNodeMemberExpression,
   getPropertyAssignmentStatement: (
     location: BabelNodeLVal,
-    value: BabelNodeExpression,
+    value: Value,
     mightHaveBeenDeleted: boolean,
     deleteIfMightHaveBeenDeleted: boolean
   ) => BabelNodeStatement,
@@ -597,7 +597,7 @@ export class Generator {
       buildNode: ([objectNode, valueNode], context) =>
         context.getPropertyAssignmentStatement(
           memberExpressionHelper(objectNode, key),
-          valueNode,
+          value,
           value.mightHaveBeenDeleted(),
           /* deleteIfMightHaveBeenDeleted */ true
         ),

--- a/test/serializer/abstract/ArrayMap.js
+++ b/test/serializer/abstract/ArrayMap.js
@@ -1,0 +1,7 @@
+let c = global.__abstract ? __abstract("boolean", "true") : true;
+
+let a = [1];
+if (c) a.push(2);
+let x = a.map(x => x + 42);
+
+global.inspect = function() { JSON.stringify(x); }

--- a/test/serializer/abstract/ArrayMap1.js
+++ b/test/serializer/abstract/ArrayMap1.js
@@ -1,0 +1,8 @@
+let c = global.__abstract ? __abstract("boolean", "true") : true;
+
+let a = [1];
+let sum = 0;
+if (c) a.push(2);
+let x = a.map(x => { sum += x; return x + 42; } );
+
+global.inspect = function() { sum + JSON.stringify(x); }

--- a/test/serializer/abstract/ArrayMap2.js
+++ b/test/serializer/abstract/ArrayMap2.js
@@ -1,0 +1,12 @@
+let c = global.__abstract ? __abstract("boolean", "true") : true;
+
+let a = [1];
+if (c) a.push(2);
+let x;
+try {
+  x = a.map(x => { if (x === 2) throw x; else return x + 42; } );
+} catch (e) {
+  x = e;
+}
+
+global.inspect = function() { JSON.stringify(x); }


### PR DESCRIPTION
Release note: Enhanced handling of Array.map applied to abstract arrays

Fixes #2169.

If an abstract array is the join or a few concrete arrays, we apply the map over all of the concrete arrays and join the results. This is a bit of a hack, much like what we have for switch statements. The code from the latter has been factored out and reused for this.