### PR TITLE
Allow for loops with abstract termination conditions to unroll

### DIFF
--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -13,6 +13,7 @@ import type { Realm } from "../../realm.js";
 import {
   Value,
   AbstractValue,
+  BooleanValue,
   ConcreteValue,
   FunctionValue,
   StringValue,
@@ -76,6 +77,7 @@ export function createAbstract(
 
   let { type, template, functionResultType } = parseTypeNameOrTemplate(realm, typeNameOrTemplate);
   let optionsMap = options ? options.properties : new Map();
+  let values = type === BooleanValue ? [realm.intrinsics.true, realm.intrinsics.false] : [];
 
   let result;
   let locString,
@@ -104,7 +106,7 @@ export function createAbstract(
     } else {
       realm.saveNameString(name);
     }
-    result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(name), type, [], kind);
+    result = AbstractValue.createFromTemplate(realm, buildExpressionTemplate(name), type, values, kind);
     result.intrinsicName = name;
   }
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -605,6 +605,12 @@ export default class AbstractValue extends Value {
       kind === "template for property name condition"
         ? ValuesDomain.topVal
         : ValuesDomain.binaryOp(realm, op, leftValues, rightValues);
+    if (!resultValues.isTop()) {
+      let values = resultValues.getElements();
+      if (values.size === 1) {
+        for (let val of values) return val;
+      }
+    }
     let [hash, args] = kind === undefined ? hashBinary(op, left, right) : hashCall(kind, left, right);
     let result = new AbstractValue(realm, resultTypes, resultValues, hash, args, ([x, y]) =>
       t.binaryExpression(op, x, y)

--- a/test/serializer/abstract/ForLoop3.js
+++ b/test/serializer/abstract/ForLoop3.js
@@ -1,0 +1,8 @@
+let c = global.__abstract ? __abstract("boolean", "true") : true;
+let l = c ? 1 : 2;
+let sum = 0;
+for (let i = 0; i < l; i++) sum++;
+
+global.inspect = function() {
+  return sum;
+};


### PR DESCRIPTION
Release note: Certain for loops with abstract termination conditions can now be Prepacked

Resolves issue: #2019

If the termination condition involves an abstract value with a finite set of possibilities, such as in the test case, then it may be possible to unroll the loop a finite list of conditional executions of the loop body. Checking that this is possible is hard, so we speculatively unroll up to 10 times and give up if the termination condition does not become deterministically true during that time. Because such deep if trees cause the simplifier to do exponentially more work, we also limit the amount of simplification operations that can be done for a loop iteration before we give up.