### PR TITLE
Fix problem with stack location entries

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -50,12 +50,16 @@ export default function(
   }
 
   // ECMA262 12.3.4.1
-  realm.setNextExecutionContextLocation(ast.loc);
 
   // 1. Let ref be the result of evaluating MemberExpression.
   let ref = env.evaluate(ast.callee, strictCode);
 
-  return evaluateReference(ref, ast, strictCode, env, realm);
+  let previousLoc = realm.setNextExecutionContextLocation(ast.loc);
+  try {
+    return evaluateReference(ref, ast, strictCode, env, realm);
+  } finally {
+    realm.setNextExecutionContextLocation(previousLoc);
+  }
 }
 
 function evaluateReference(

--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -97,6 +97,7 @@ function buildStack(realm: Realm, context: ObjectValue) {
 
   for (let executionContext of stack.reverse()) {
     let caller = executionContext.caller;
+    if (!executionContext.loc) continue; // compiler generated helper for destructuring arguments
     let locString = describeLocation(
       realm,
       caller ? caller.function : undefined,

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -15,7 +15,6 @@ import { FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { ECMAScriptFunctionValue } from "../values/index.js";
 import { Completion, ReturnCompletion, AbruptCompletion, NormalCompletion } from "../completions.js";
-import { ExecutionContext } from "../realm.js";
 import { GlobalEnvironmentRecord, ObjectEnvironmentRecord } from "../environment.js";
 import {
   AbstractValue,
@@ -1044,7 +1043,7 @@ export class FunctionImplementation {
     ctx.suspend();
 
     // 13. Let evalCxt be a new ECMAScript code execution context.
-    let evalCxt = new ExecutionContext();
+    let evalCxt = realm.createExecutionContext();
     evalCxt.isStrict = strictEval;
 
     // 14. Set the evalCxt's Function to null.

--- a/src/realm.js
+++ b/src/realm.js
@@ -1610,26 +1610,18 @@ export class Realm {
 
   createExecutionContext(): ExecutionContext {
     let context = new ExecutionContext();
-
     let loc = this.nextContextLocation;
     if (loc) {
       context.setLocation(loc);
       this.nextContextLocation = null;
     }
-
     return context;
   }
 
-  setNextExecutionContextLocation(loc: ?BabelNodeSourceLocation) {
-    if (!loc) return;
-
-    //if (this.nextContextLocation) {
-    //  throw new ThrowCompletion(
-    //    Construct(this, this.intrinsics.TypeError, [new StringValue(this, "Already have a context location that we haven't used yet")])
-    //  );
-    //} else {
+  setNextExecutionContextLocation(loc: ?BabelNodeSourceLocation): ?BabelNodeSourceLocation {
+    let previousValue = this.nextContextLocation;
     this.nextContextLocation = loc;
-    //}
+    return previousValue;
   }
 
   reportIntrospectionError(message?: void | string | StringValue) {

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -84,7 +84,7 @@ export class Functions {
     realm.handleError(
       new CompilerDiagnostic(
         `Optimized Function Value ${location} is an not a function or react element`,
-        undefined,
+        realm.currentLocation,
         "PP0033",
         "FatalError"
       )

--- a/test/error-handler/FinalObjectCannotBeMutated.js
+++ b/test/error-handler/FinalObjectCannotBeMutated.js
@@ -1,4 +1,4 @@
-// expected errors: [{"location":{"start":{"line":7,"column":16},"end":{"line":7,"column":18},"source":"test/error-handler/FinalObjectCannotBeMutated.js"},"severity":"FatalError","errorCode":"PP0026","callStack":"Error\n    at f (unknown)"}]
+// expected errors: [{"location":{"start":{"line":7,"column":16},"end":{"line":7,"column":18},"source":"test/error-handler/FinalObjectCannotBeMutated.js"},"severity":"FatalError","errorCode":"PP0026","callStack":"Error\n    "}]
 (function () {
     function f() {
         let o = {};


### PR DESCRIPTION
Release note: Improve source location information

Changes to make sure that the source location of the call expression appears in the corresponding execution context record. Also emit execution records with no source location from stack traces. These are due to calls to internal helper methods for iterating over objects and arrays for argument destructuring.

Finally fix a CompilerDiagnostic construction call to include a source location.