### PR TITLE
Only havoc abstract value args when really necessary

### DIFF
--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -455,6 +455,13 @@ class ObjectValueHavocingVisitor {
       // then it might be one of the arguments that created
       // this value. See #2179.
 
+      if (val.kind === "conditional") {
+        // For a conditional, we only have to visit each case. Not the condition itself.
+        this.visitValue(val.args[1]);
+        this.visitValue(val.args[2]);
+        return;
+      }
+
       // To ensure that we don't forget to provide arguments
       // that can be havoced, we require at least one argument.
       let whitelistedKind =
@@ -466,6 +473,9 @@ class ObjectValueHavocingVisitor {
         "Havoced unknown object requires havocable arguments"
       );
 
+      // TODO: This is overly conservative. We recursively havoc all the inputs
+      // to this operation whether or not they can possible be part of the
+      // result value or not.
       for (let i = 0, n = val.args.length; i < n; i++) {
         this.visitValue(val.args[i]);
       }

--- a/test/serializer/pure-functions/AbstractObject.js
+++ b/test/serializer/pure-functions/AbstractObject.js
@@ -1,0 +1,19 @@
+let c = global.__abstract ? __abstract('boolean', '(true)') : true;
+
+function test(fn) {
+  let knownObj = {x:1};
+  let knownObj2 = {y:3};
+  let conditionalObj = c ? knownObj : knownObj2;
+  fn(conditionalObj); // This must havoc both known objects
+  return 'Result-' + (knownObj.x + 3);
+}
+
+if (global.__optimize) {
+  __optimize(test);
+}
+
+inspect = function() {
+  return test(function(o) {
+    o.x++;
+  });
+}

--- a/test/serializer/pure-functions/AbstractObject2.js
+++ b/test/serializer/pure-functions/AbstractObject2.js
@@ -1,0 +1,19 @@
+let c = global.__abstract ? __abstract('boolean', '(true)') : true;
+let unknownObj = global.__abstract ? __abstract('object', '({})') : {};
+
+function test(fn) {
+  let knownObj = {x:1};
+  let conditionalUnknownObj = c ? knownObj : unknownObj;
+  fn(conditionalUnknownObj); // This must havoc the known obj
+  return 'Result-' + (knownObj.x + 3);
+}
+
+if (global.__optimize) {
+  __optimize(test);
+}
+
+inspect = function() {
+  return test(function(o) {
+    o.x++;
+  });
+}

--- a/test/serializer/pure-functions/AbstractObjectOptimizable.js
+++ b/test/serializer/pure-functions/AbstractObjectOptimizable.js
@@ -1,0 +1,18 @@
+// does contain:Result-4
+
+let unknownObj = global.__abstract ? __abstract('object', '({})') : {};
+
+function test(fn) {
+  let knownObj = {x:1};
+  let equalityTest = knownObj === unknownObj;
+  fn(equalityTest); // This should not havoc the known obj
+  return 'Result-' + (knownObj.x + 3);
+}
+
+if (global.__optimize) {
+  __optimize(test);
+}
+
+inspect = function() {
+  return test(function() {});
+}


### PR DESCRIPTION
Fixes #2179

In #2179 I describe why we might need to havoc some args to abstract values sometimes. This adds an invariant to ensure that we always have args in the cases we need to havoc.

If this abstract value cannot be an object, then we don't need to havoc since there's nothing that can be mutated.

If this has a known values domain, then we know the possible objects. We only need to havoc those, not the args.