### PR TITLE
Address code duplication issues by making object leaking unconditional

### DIFF
--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -13,13 +13,14 @@ import * as Singletons from "./singletons.js";
 import { CreateImplementation } from "./methods/create.js";
 import { EnvironmentImplementation } from "./methods/environment.js";
 import { FunctionImplementation } from "./methods/function.js";
-import { HavocImplementation } from "./utils/havoc.js";
+import { HavocImplementation, MaterializeImplementation } from "./utils/havoc.js";
 import { JoinImplementation } from "./methods/join.js";
 import { PathImplementation } from "./utils/paths.js";
 import { PropertiesImplementation } from "./methods/properties.js";
 import { ToImplementation } from "./methods/to.js";
 import { WidenImplementation } from "./methods/widen.js";
 import { concretize } from "./utils/ConcreteModelConverter.js";
+
 import * as utils from "./utils.js";
 
 export default function() {
@@ -27,6 +28,7 @@ export default function() {
   Singletons.setEnvironment(new EnvironmentImplementation());
   Singletons.setFunctions(new FunctionImplementation());
   Singletons.setHavoc(new HavocImplementation());
+  Singletons.setMaterialize(new MaterializeImplementation());
   Singletons.setJoin(new JoinImplementation());
   Singletons.setPath(new PathImplementation());
   Singletons.setProperties((new PropertiesImplementation(): any));

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -63,7 +63,7 @@ function handleObjectAssignSnapshot(
     AbstractValue.reportIntrospectionError(to);
     throw new FatalError();
   } else {
-    if (frm instanceof ObjectValue && frm.mightBeHavocedObject()) {
+    if (frm instanceof ObjectValue && frm.isLeakedObject()) {
       // "frm" is havoced, so it might contain properties that potentially overwrite
       // properties already on the "to" object.
       snapshotToObjectAndRemoveProperties(to, delayedSources);

--- a/src/methods/integrity.js
+++ b/src/methods/integrity.js
@@ -20,7 +20,7 @@ type IntegrityLevels = "sealed" | "frozen";
 
 // ECMA262 9.1.4.1
 export function OrdinaryPreventExtensions(realm: Realm, O: ObjectValue): boolean {
-  if (O.mightBeHavocedObject() && O.getExtensible()) {
+  if (O.isLeakedObject() && O.getExtensible()) {
     // todo: emit a diagnostic messsage
     throw new FatalError();
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1503,7 +1503,11 @@ export class Realm {
     // of the joined generator at the final join point.
     // This is the point at which other accesses to the leaked
     // object have been accounted for and generator entries have been
-    // created for them.
+    // created for them. 
+    //
+    // The appendGenerator flag accounts for a lot of the complexity
+    // of how this works. This is to be clarified (work in progress).
+
     if (appendGenerator && leakedObjects !== undefined && leakedObjects.size !== 0) {
       for (let lo of leakedObjects) {
         Materialize.materialize(this, lo);

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -16,6 +16,7 @@ import type {
   FunctionType,
   HavocType,
   JoinType,
+  MaterializeType,
   PathType,
   PropertiesType,
   ToType,
@@ -27,12 +28,14 @@ export let Create: CreateType = (null: any);
 export let Environment: EnvironmentType = (null: any);
 export let Functions: FunctionType = (null: any);
 export let Havoc: HavocType = (null: any);
+export let Materialize: MaterializeType = (null: any);
 export let Join: JoinType = (null: any);
 export let Path: PathType = (null: any);
 export let Properties: PropertiesType = (null: any);
 export let To: ToType = (null: any);
 export let Widen: WidenType = (null: any);
 export let concretize: ConcretizeType = (null: any);
+
 export let Utils: UtilsType = (null: any);
 
 export function setCreate(singleton: CreateType): void {
@@ -49,6 +52,10 @@ export function setFunctions(singleton: FunctionType): void {
 
 export function setHavoc(singleton: HavocType): void {
   Havoc = singleton;
+}
+
+export function setMaterialize(singleton: MaterializeType): void {
+  Materialize = singleton;
 }
 
 export function setJoin(singleton: JoinType): void {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1371,7 +1371,7 @@ export function attemptToMergeEquivalentObjectAssigns(
       for (let x = 1; x < otherArgs.length; x++) {
         let arg = otherArgs[x];
         // The arg might have been havoced, so ensure we do not continue in this case
-        if (arg instanceof ObjectValue && arg.mightBeHavocedObject()) {
+        if (arg instanceof ObjectValue && arg.isLeakedObject()) {
           continue loopThroughArgs;
         }
         if (arg instanceof ObjectValue || arg instanceof AbstractValue) {

--- a/test/serializer/optimized-functions/ConditionallyLeakedBinding.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedBinding.js
@@ -1,0 +1,22 @@
+(function() {
+  function f(c, g) {
+    let x = 23;
+    let y = 0;
+    if (c) {
+      x = Date.now();
+      function h() {
+        y = x;
+        x++;
+      }
+      g(h);
+      return x - y;
+    } else {
+      x = Date.now();
+      return x - y;
+    }
+  }
+  global.__optimize && __optimize(f);
+  global.inspect = function() {
+    return f(true, g => g());
+  };
+})();

--- a/test/serializer/optimized-functions/ConditionallyLeakedObject1.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedObject1.js
@@ -1,0 +1,19 @@
+// copies of 42:1
+
+(function() {
+  function f(g, c) {
+    let o = { foo: 42 };
+    if (c) {
+      g(o);
+    } else {
+      o.foo = 2;
+    }
+
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = function() {
+    return JSON.stringify(f(o => o, false));
+  };
+})();

--- a/test/serializer/optimized-functions/ConditionallyLeakedObject2.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedObject2.js
@@ -1,0 +1,19 @@
+// copies of 42:1
+
+(function() {
+  function f(g, c) {
+    let o = { foo: 42 };
+    if (c) {
+      g(o);
+    } else {
+      o.bar = 2;
+    }
+
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = function() {
+    return JSON.stringify(f(o => o, false));
+  };
+})();

--- a/test/serializer/optimized-functions/ConditionallyLeakedObject3.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedObject3.js
@@ -1,0 +1,20 @@
+// copies of 42:1
+
+(function() {
+  function f(g, c) {
+    let o = { foo: 42 };
+    if (c) {
+      g(o);
+      return o;
+    } else {
+      o.bar = 2;
+    }
+
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = function() {
+    return JSON.stringify(f(o => o, false));
+  };
+})();

--- a/test/serializer/optimized-functions/ConditionallyLeakedObject4.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedObject4.js
@@ -1,0 +1,23 @@
+// copies of 42:1
+
+(function() {
+  function f(g, c, d) {
+    let o = { foo: 42 };
+    if (c) {
+      if (d) {
+        g(o);
+      } else {
+        o.foo = 1;
+      }
+    } else {
+      o.foo = 2;
+    }
+
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = function() {
+    return JSON.stringify(f(o => o, false, false));
+  };
+})();

--- a/test/serializer/optimized-functions/LeakObjectWithSetter.js
+++ b/test/serializer/optimized-functions/LeakObjectWithSetter.js
@@ -1,0 +1,17 @@
+(function() {
+  function f(g) {
+    let o = {
+      foo: 1,
+      set x(v) {
+        this.foo += 1;
+      },
+    };
+    g(o);
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = () => {
+    JSON.stringify(f(o => o));
+  };
+})();

--- a/test/serializer/optimized-functions/LeakedObjectCodeDuplication.js
+++ b/test/serializer/optimized-functions/LeakedObjectCodeDuplication.js
@@ -1,0 +1,12 @@
+// Copies of 42:1
+function f(g) {
+  var o = {};
+  o.foo = 42;
+  g(o);
+  return o;
+}
+
+global.__optimize && __optimize(f);
+inspect = function() {
+  return f(o => o);
+};


### PR DESCRIPTION
Release notes: Fixed an issue that was causing code duplication

This change is modeled after #2125 and makes object leaking unconditional in the same ways as declarative bindings now are. It resolves #2083 and its conditional variant (checked in as the test ConditionallyLeakedObject.js). Additionally, it renames the _isHavoced flag and the API to it to use the term "leak" instead of "havoc" to clarify the difference between tainting the future analysis of an object on the one hand, and losing information about its currently tracked values on the other.

Possible follow ups:
- Selective object serialization via literals even in the face of leaking
- More complete test coverage over getters and setters