### PR TITLE
Special case "x === undefined || x === null" kind of expressions

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -318,6 +318,7 @@ function runTest(name, code, options: PrepackOptions, args) {
   options.invariantLevel = code.includes("// omit invariants") || args.verbose ? 0 : 99;
   if (code.includes("// emit concrete model")) options.emitConcreteModel = true;
   if (code.includes("// exceeds stack limit")) options.maxStackDepth = 10;
+  if (code.includes("// instant render")) options.instantRender = true;
   if (code.includes("// react")) {
     options.reactEnabled = true;
     options.reactOutput = "jsx";

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -79,7 +79,8 @@ export type AbstractValueKind =
   | "global.JSON.parse(A)"
   | "JSON.stringify(...)"
   | "JSON.parse(...)"
-  | "global.Math.imul(A, B)";
+  | "global.Math.imul(A, B)"
+  | "global.__cannotBecomeObject(A)";
 
 // Use AbstractValue.makeKind to make a kind from one of these prefices.
 type AbstractValueKindPrefix =

--- a/test/serializer/instant-render/NotNull.js
+++ b/test/serializer/instant-render/NotNull.js
@@ -1,0 +1,17 @@
+// instant render
+// add at runtime:global.__cannotBecomeObject = a => a === undefined || a === null;
+// does not contain:void 0
+
+let a = global.__abstract ? __abstract(undefined, "(true)") : true;
+
+let x1 = a === undefined || a === null;
+let x2 = a === undefined || null === a;
+let x3 = undefined === a || a === null;
+let x4 = undefined === a || null === a;
+
+let x5 = a === null || a === undefined;
+let x6 = a === null || undefined === a;
+let x7 = null === a || a === undefined;
+let x8 = null === a || undefined === a;
+
+global.inspect = function() { return [x1, x2, x3, x4, x5, x6, x7, x8].join(" "); }


### PR DESCRIPTION
Release note: special case expression simplification for Instant Render

When instant render is enabled turn x === undefined || x === null into __cannotBecomeObject(x) so that Instant Render can easily compile it down to a single byte code.