### PR TITLE
Ensure temporal assignments are not lost when the value does not change.

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -731,7 +731,8 @@ export class PropertiesImplementation {
       }
       if (!identical) break;
     }
-    if (identical) {
+    // Only return here if the assigment is not temporal.
+    if (identical && (O === realm.$GlobalObject || (O !== undefined && !O.isIntrinsic()))) {
       return true;
     }
 

--- a/test/serializer/abstract/DoWhile13.js
+++ b/test/serializer/abstract/DoWhile13.js
@@ -1,0 +1,8 @@
+let template = global.__abstract ? __abstract({x: __abstract("number")}, "({ set x(v) { console.log(v); } })") : { set x(v) { console.log(v); } };
+let n = global.__abstract ? __abstract('number', '(2)') : 2;
+let i = 0;
+do {
+  template.x = 3;
+} while (++i < n);
+
+inspect = function() { return template.x; }


### PR DESCRIPTION
Release note: Fix temporal assignments to intrinsics that happen inside non deterministic loops

Tweak the property set logic to not short circuit when the target object is intrinsic and the RH value is the same as the current (tracked) property value.

Also fix the code generator for loop bodies to not get upset when the lh side is temporal, but rh side is not widened (because it is a constant).