### PR TITLE
Use string.indexOf instead of string.search when the search str is RE

### DIFF
--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -503,7 +503,7 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
 
     // 7. Search string for the first occurrence of searchString and
     //    let pos be the index within string of the first code unit of the matched substring and
-    let pos = string.search(searchString);
+    let pos = string.indexOf(searchString);
 
     //    let matched be searchString.
     let matched = searchString;

--- a/test/serializer/trivial/GlobalVariable.js
+++ b/test/serializer/trivial/GlobalVariable.js
@@ -1,4 +1,4 @@
 // does not contain:void 0
 var x = 1;
-x = 2;
+x = '['.replace('[', '[a-z]');
 inspect = function() { return x; }


### PR DESCRIPTION
Release note: Fixed bug in String.replace

In step 7 when it says "Search string for the first occurrence of searchString", use indexOf not search, since the latter expects searchString to be a regular expression.

Resolves issue: #2192