### PR TITLE
Removes temporalAliasArgs for an existing approach using the preludeGenerator

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -522,8 +522,10 @@ export default function(realm: Realm): ObjectValue {
       // Enable cloning via JSON.parse(JSON.stringify(...)).
       let gen = realm.preludeGenerator;
       invariant(gen); // text is abstract, so we are doing abstract interpretation
-      let args = gen.derivedIds.get(text.intrinsicName);
-      invariant(args && args[0] instanceof Value); // since text.kind === "JSON.stringify(...)"
+      let temporalBuildNodeEntryArgs = gen.derivedIds.get(text.intrinsicName);
+      invariant(temporalBuildNodeEntryArgs !== undefined);
+      let args = temporalBuildNodeEntryArgs.args;
+      invariant(args[0] instanceof Value); // since text.kind === "JSON.stringify(...)"
       let inputClone = args[0]; // A temporal copy of the object that was the argument to stringify
       // Clone it so that every call to parse produces a different instance from stringify's clone
       let parseResult; // A clone of inputClone, because every call to parse produces a new object

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -295,10 +295,6 @@ export default function(realm: Realm): NativeFunctionValue {
           temporalTo.values = new ValuesDomain(to);
         }
         to.temporalAlias = temporalTo;
-        // Store the args for the temporal so we can easily clone
-        // and reconstruct the temporal at another point, rather than
-        // mutate the existing temporal
-        realm.temporalAliasArgs.set(temporalTo, temporalArgs);
       }
       return to;
     });

--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -127,10 +127,6 @@ function createBabelHelpers(realm: Realm, global: ObjectValue | AbstractObjectVa
           let template = createObjectWithoutProperties(obj, keys);
           value.values = new ValuesDomain(template);
         }
-        // Store the args for the temporal so we can easily clone
-        // and reconstruct the temporal at another point, rather than
-        // mutate the existing temporal
-        realm.temporalAliasArgs.set(value, temporalArgs);
         // as we are returning an abstract object, we mark it as simple
         value.makeSimple();
         return value;

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -206,10 +206,6 @@ function createPropsObject(
           temporalTo.values = new ValuesDomain(props);
         }
         props.temporalAlias = temporalTo;
-        // Store the args for the temporal so we can easily clone
-        // and reconstruct the temporal at another point, rather than
-        // mutate the existing temporal
-        realm.temporalAliasArgs.set(temporalTo, temporalArgs);
       }
     }
   } else {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -948,8 +948,9 @@ function applyClonedTemporalAlias(realm: Realm, props: ObjectValue, clonedProps:
     // be a better option.
     invariant(false, "TODO applyClonedTemporalAlias conditional");
   }
-  let temporalArgs = realm.temporalAliasArgs.get(temporalAlias);
-  invariant(temporalArgs !== undefined);
+  let temporalBuildNodeEntryArgs = realm.getTemporalBuildNodeEntryArgsFromDerivedValue(temporalAlias);
+  invariant(temporalBuildNodeEntryArgs !== undefined);
+  let temporalArgs = temporalBuildNodeEntryArgs.args;
   // replace the original props with the cloned one
   let newTemporalArgs = temporalArgs.map(arg => (arg === props ? clonedProps : arg));
 
@@ -966,10 +967,6 @@ function applyClonedTemporalAlias(realm: Realm, props: ObjectValue, clonedProps:
   invariant(clonedProps instanceof ObjectValue);
   temporalTo.values = new ValuesDomain(clonedProps);
   clonedProps.temporalAlias = temporalTo;
-  // Store the args for the temporal so we can easily clone
-  // and reconstruct the temporal at another point, rather than
-  // mutate the existing temporal
-  realm.temporalAliasArgs.set(temporalTo, newTemporalArgs);
 }
 
 export function cloneProps(realm: Realm, props: ObjectValue, newChildren?: Value): ObjectValue {
@@ -1079,10 +1076,6 @@ export function applyObjectAssignConfigsForReactElement(realm: Realm, to: Object
         invariant(temporalTo instanceof AbstractObjectValue);
         temporalTo.values = new ValuesDomain(to);
         to.temporalAlias = temporalTo;
-        // Store the args for the temporal so we can easily clone
-        // and reconstruct the temporal at another point, rather than
-        // mutate the existing temporal
-        realm.temporalAliasArgs.set(temporalTo, temporalArgs);
         return;
       } else {
         throw error;

--- a/src/realm.js
+++ b/src/realm.js
@@ -63,7 +63,7 @@ import {
 import type { Compatibility, RealmOptions, ReactOutputTypes, InvariantModeTypes } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
-import { Generator, PreludeGenerator } from "./utils/generator.js";
+import { Generator, PreludeGenerator, type TemporalBuildNodeEntryArgs } from "./utils/generator.js";
 import { emptyExpression, voidExpression } from "./utils/babelhelpers.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
@@ -246,7 +246,6 @@ export class Realm {
     this.evaluators = (Object.create(null): any);
     this.partialEvaluators = (Object.create(null): any);
     this.$GlobalEnv = ((undefined: any): LexicalEnvironment);
-    this.temporalAliasArgs = new WeakMap();
 
     this.instantRender = {
       enabled: opts.instantRender || false,
@@ -338,12 +337,6 @@ export class Realm {
   contextStack: Array<ExecutionContext> = [];
   $GlobalEnv: LexicalEnvironment;
   intrinsics: Intrinsics;
-
-  // temporalAliasArgs is used to map a temporal abstract object value
-  // to its respective temporal args used to originally create the temporal.
-  // This is used to "clone" immutable objects where they have a dependency
-  // on a temporal alias (for example, Object.assign) when used with snapshotting
-  temporalAliasArgs: WeakMap<AbstractObjectValue | ObjectValue, Array<Value>>;
 
   instantRender: {
     enabled: boolean,
@@ -1744,5 +1737,14 @@ export class Realm {
 
   isNameStringUnique(nameString: string): boolean {
     return !this._abstractValuesDefined.has(nameString);
+  }
+
+  getTemporalBuildNodeEntryArgsFromDerivedValue(value: Value): void | TemporalBuildNodeEntryArgs {
+    let name = value.intrinsicName;
+    invariant(name);
+    let preludeGenerator = this.preludeGenerator;
+    invariant(preludeGenerator !== undefined);
+    let temporalBuildNodeEntryArgs = preludeGenerator.derivedIds.get(name);
+    return temporalBuildNodeEntryArgs;
   }
 }

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -22,7 +22,7 @@ import {
 } from "../values/index.js";
 import type { BabelNodeStatement } from "babel-types";
 import type { SerializedBody } from "./types.js";
-import { Generator } from "../utils/generator.js";
+import { Generator, type TemporalBuildNodeEntryArgs } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import { BodyReference } from "./types.js";
 import { ResidualFunctions } from "./ResidualFunctions.js";
@@ -68,7 +68,7 @@ export class Emitter {
     residualFunctions: ResidualFunctions,
     referencedDeclaredValues: Map<Value, void | FunctionValue>,
     conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
-    derivedIds: Map<string, Array<Value>>
+    derivedIds: Map<string, TemporalBuildNodeEntryArgs>
   ) {
     this._mainBody = { type: "MainGenerator", parentBody: undefined, entries: [], done: false };
     this._waitingForValues = new Map();

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -931,7 +931,7 @@ export class Generator {
       value.intrinsicNameGenerated = true;
       value._isScopedTemplate = true; // because this object doesn't exist ahead of time, and the visitor would otherwise declare it in the common scope
     }
-    let temporalBuildNodeEntryArgs = {
+    this._addDerivedEntry(id.name, {
       isPure: optionalArgs ? optionalArgs.isPure : undefined,
       declared: value,
       args,
@@ -945,9 +945,7 @@ export class Generator {
           ),
         ]);
       },
-    };
-    this.preludeGenerator.derivedIds.set(id.name, temporalBuildNodeEntryArgs);
-    this._addEntry(temporalBuildNodeEntryArgs);
+    });
     return value;
   }
 
@@ -977,7 +975,7 @@ export class Generator {
       id,
       options
     );
-    let temporalBuildNodeEntryArgs = {
+    this._addDerivedEntry(id.name, {
       isPure: optionalArgs ? optionalArgs.isPure : undefined,
       declared: res,
       args,
@@ -992,9 +990,7 @@ export class Generator {
         ]);
       },
       mutatesOnly: optionalArgs ? optionalArgs.mutatesOnly : undefined,
-    };
-    this._addEntry(temporalBuildNodeEntryArgs);
-    this.preludeGenerator.derivedIds.set(id.name, temporalBuildNodeEntryArgs);
+    });
     let type = types.getType();
     res.intrinsicName = id.name;
     if (optionalArgs && optionalArgs.skipInvariant) return res;
@@ -1074,8 +1070,13 @@ export class Generator {
 
   // PITFALL Warning: adding a new kind of TemporalBuildNodeEntry that is not the result of a join or composition
   // will break this purgeEntriesWithGeneratorDepencies.
-  _addEntry(entry: TemporalBuildNodeEntryArgs) {
+  _addEntry(entry: TemporalBuildNodeEntryArgs): void {
     this._entries.push(new TemporalBuildNodeEntry(entry));
+  }
+
+  _addDerivedEntry(id: string, entry: TemporalBuildNodeEntryArgs): void {
+    this._addEntry(entry);
+    this.preludeGenerator.derivedIds.set(id, entry);
   }
 
   appendGenerator(other: Generator, leadingComment: string): void {

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -147,7 +147,7 @@ export default class AbstractValue extends Value {
       if (name.startsWith("_$")) {
         if (gen === undefined) return;
         let temporalBuildNodeEntryArgs = gen.derivedIds.get(name);
-        if (temporalBuildNodeEntryArgs === undefined) return;
+        invariant(temporalBuildNodeEntryArgs !== undefined);
         add_args(temporalBuildNodeEntryArgs.args);
       } else if (names.indexOf(name) < 0) {
         names.push(name);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -146,7 +146,9 @@ export default class AbstractValue extends Value {
     function add_intrinsic(name: string) {
       if (name.startsWith("_$")) {
         if (gen === undefined) return;
-        add_args(gen.derivedIds.get(name));
+        let temporalBuildNodeEntryArgs = gen.derivedIds.get(name);
+        if (temporalBuildNodeEntryArgs === undefined) return;
+        add_args(temporalBuildNodeEntryArgs.args);
       } else if (names.indexOf(name) < 0) {
         names.push(name);
       }


### PR DESCRIPTION
Release notes: none

As pointed out by Herman in https://github.com/facebook/prepack/pull/2193#discussion_r199628160. We don't need `temporalAliasArgs`, so this PR removes it from the codebase and uses the existing way via the preludeGenerator.

This also adds a helper function to make it easier to relate derived abstract values to their temporal args. Furthermore, `derivedIds` now stores the `TemporalBuildNodeEntryArgs` rather than `Array<Value>`, as the follow up PRs for doing the React related logic need to access more than just the array of args, it also needs access to `isPure`, `skipInvariant` etc so it can properly clone derived abstract values.