### PR TITLE
Add the right command in README to generate prepack.min.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Instead of building, linting, type checking, testing separately, the following d
 The content for [prepack.io](https://prepack.io) resides in the [website directory](https://github.com/facebook/prepack/tree/master/website) of this repository. To make changes, submit a pull request, just like for any code changes.
 
 In order to run the website locally at [localhost:8000](http://localhost:8000):
-1. Build prepack into the website: `yarn build-bundle && mv prepack.min.js website/js`
+1. Build prepack into the website: `yarn build && mv prepack.min.js website/js`
 2. Run `python -m SimpleHTTPServer` (Python 2) or `python -m http.server` (Python 3) from the `website/` directory
 
 ## How to contribute


### PR DESCRIPTION
Release note: none

`yarn build-bundle` needs `lib` directory present else it breaks.