### PR TITLE
Traverse all normal paths when pushing path conditions

### DIFF
--- a/src/evaluators/TryStatement.js
+++ b/src/evaluators/TryStatement.js
@@ -13,6 +13,7 @@ import type { Effects, Realm } from "../realm.js";
 import { type LexicalEnvironment } from "../environment.js";
 import {
   AbruptCompletion,
+  ErasedAbruptCompletion,
   ForkedAbruptCompletion,
   PossiblyNormalCompletion,
   ThrowCompletion,
@@ -112,7 +113,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         },
         "composeNestedThrowEffectsWithHandler/1"
       );
-      c.updateConsequentKeepingCurrentEffects(new AbruptCompletion(realm.intrinsics.empty));
+      c.updateConsequentKeepingCurrentEffects(new ErasedAbruptCompletion(realm.intrinsics.empty));
     }
     priorEffects.pop();
     let alternate = c.alternate;
@@ -129,7 +130,7 @@ export default function(ast: BabelNodeTryStatement, strictCode: boolean, env: Le
         },
         "composeNestedThrowEffectsWithHandler/2"
       );
-      c.updateAlternateKeepingCurrentEffects(new AbruptCompletion(realm.intrinsics.empty));
+      c.updateAlternateKeepingCurrentEffects(new ErasedAbruptCompletion(realm.intrinsics.empty));
     }
     priorEffects.pop();
     return Join.joinForkOrChoose(realm, c.joinCondition, consequentEffects, alternateEffects);

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -486,8 +486,7 @@ export function OrdinaryCallEvaluateBody(
 
           // Stash the remaining completions in the realm start tracking the effects that need to be appended
           // to the normal branch at the next join point.
-          realm.savedCompletion = remainingCompletions;
-          realm.captureEffects(remainingCompletions); // so that we can join the normal path with them later on
+          realm.composeWithSavedCompletion(remainingCompletions);
           return c;
         } finally {
           realm.incorporatePriorSavedCompletion(priorSavedCompletion);

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -15,7 +15,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { Reference } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
 import { Value, ObjectValue, UndefinedValue, StringValue } from "../values/index.js";
-import { NormalCompletion, AbruptCompletion } from "../completions.js";
+import { AbruptCompletion, SimpleNormalCompletion } from "../completions.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
   RequireObjectCoercible,
@@ -280,7 +280,7 @@ export function DestructuringAssignmentEvaluation(
 
     // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
     if (iteratorRecord.$Done === false) {
-      let completion = IteratorClose(realm, iterator, new NormalCompletion(realm.intrinsics.undefined));
+      let completion = IteratorClose(realm, iterator, new SimpleNormalCompletion(realm.intrinsics.undefined));
       if (completion instanceof AbruptCompletion) {
         throw completion;
       }

--- a/src/methods/environment.js
+++ b/src/methods/environment.js
@@ -36,7 +36,7 @@ import {
   Reference,
   LexicalEnvironment,
 } from "../environment.js";
-import { NormalCompletion, AbruptCompletion } from "../completions.js";
+import { AbruptCompletion, SimpleNormalCompletion } from "../completions.js";
 import { FatalError } from "../errors.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
@@ -659,7 +659,7 @@ export class EnvironmentImplementation {
 
       // 4. If iteratorRecord.[[Done]] is false, return ? IteratorClose(iterator, result).
       if (iteratorRecord.$Done === false) {
-        let completion = IteratorClose(realm, iterator, new NormalCompletion(realm.intrinsics.undefined));
+        let completion = IteratorClose(realm, iterator, new SimpleNormalCompletion(realm.intrinsics.undefined));
         if (completion instanceof AbruptCompletion) {
           throw completion;
         }

--- a/src/realm.js
+++ b/src/realm.js
@@ -55,9 +55,10 @@ import { cloneDescriptor, Construct } from "./methods/index.js";
 import {
   AbruptCompletion,
   Completion,
-  SimpleNormalCompletion,
+  ErasedAbruptCompletion,
   ForkedAbruptCompletion,
   PossiblyNormalCompletion,
+  SimpleNormalCompletion,
   ThrowCompletion,
 } from "./completions.js";
 import type { Compatibility, RealmOptions, ReactOutputTypes, InvariantModeTypes } from "./options.js";
@@ -1254,16 +1255,85 @@ export class Realm {
       this.captureEffects(savedCompletion);
       this.savedCompletion = savedCompletion;
     }
+    let realm = this;
     pushPathConditionsLeadingToNormalCompletion(completion);
     return completion.value;
 
-    function pushPathConditionsLeadingToNormalCompletion(c: PossiblyNormalCompletion) {
-      if (c.consequent instanceof AbruptCompletion) {
+    function pushPathConditionsLeadingToNormalCompletion(c: ForkedAbruptCompletion | PossiblyNormalCompletion) {
+      if (allPathsAreAbrupt(c.consequent)) {
         Path.pushInverseAndRefine(c.joinCondition);
-        if (c.alternate instanceof PossiblyNormalCompletion) pushPathConditionsLeadingToNormalCompletion(c.alternate);
-      } else if (c.alternate instanceof AbruptCompletion) {
+        if (c.alternate instanceof PossiblyNormalCompletion || c.alternate instanceof ForkedAbruptCompletion)
+          pushPathConditionsLeadingToNormalCompletion(c.alternate);
+      } else if (allPathsAreAbrupt(c.alternate)) {
         Path.pushAndRefine(c.joinCondition);
-        if (c.consequent instanceof PossiblyNormalCompletion) pushPathConditionsLeadingToNormalCompletion(c.consequent);
+        if (c.consequent instanceof PossiblyNormalCompletion || c.consequent instanceof ForkedAbruptCompletion)
+          pushPathConditionsLeadingToNormalCompletion(c.consequent);
+      } else if (allPathsAreNormal(c.consequent)) {
+        if (!allPathsAreNormal(c.alternate)) {
+          let alternatePC = getNormalPathConditionFor(c.alternate);
+          let disjunct = AbstractValue.createFromLogicalOp(realm, "||", c.joinCondition, alternatePC);
+          Path.pushAndRefine(disjunct);
+        }
+      } else if (allPathsAreNormal(c.alternate)) {
+        let consequentPC = getNormalPathConditionFor(c.consequent);
+        let inverse = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition);
+        let disjunct = AbstractValue.createFromLogicalOp(realm, "||", inverse, consequentPC);
+        Path.pushAndRefine(disjunct);
+      } else {
+        let jc = c.joinCondition;
+        let consequentPC = AbstractValue.createFromLogicalOp(realm, "&&", jc, getNormalPathConditionFor(c.consequent));
+        let ijc = AbstractValue.createFromUnaryOp(realm, "!", jc);
+        let alternatePC = AbstractValue.createFromLogicalOp(realm, "&&", ijc, getNormalPathConditionFor(c.alternate));
+        let disjunct = AbstractValue.createFromLogicalOp(realm, "||", consequentPC, alternatePC);
+        Path.pushAndRefine(disjunct);
+      }
+    }
+
+    function allPathsAreAbrupt(c: Completion): boolean {
+      if (c instanceof ForkedAbruptCompletion) return allPathsAreAbrupt(c.consequent) && allPathsAreAbrupt(c.alternate);
+      if (c instanceof AbruptCompletion) return !(c instanceof ErasedAbruptCompletion);
+      return false;
+    }
+
+    function allPathsAreNormal(c: Completion): boolean {
+      if (c instanceof PossiblyNormalCompletion || c instanceof ForkedAbruptCompletion)
+        return allPathsAreNormal(c.consequent) && allPathsAreNormal(c.alternate);
+      if (c instanceof AbruptCompletion) return c instanceof ErasedAbruptCompletion;
+      return true;
+    }
+
+    function getNormalPathConditionFor(c: Completion): Value {
+      invariant(c instanceof PossiblyNormalCompletion || c instanceof ForkedAbruptCompletion);
+      if (allPathsAreAbrupt(c.consequent)) {
+        invariant(!allPathsAreAbrupt(c.alternate));
+        let inverse = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition);
+        if (allPathsAreNormal(c.alternate)) return inverse;
+        return AbstractValue.createFromLogicalOp(realm, "&&", inverse, getNormalPathConditionFor(c.alternate));
+      } else if (allPathsAreAbrupt(c.alternate)) {
+        invariant(!allPathsAreAbrupt(c.consequent));
+        if (allPathsAreNormal(c.consequent)) return c.joinCondition;
+        return AbstractValue.createFromLogicalOp(realm, "&&", c.joinCondition, getNormalPathConditionFor(c.consequent));
+      } else if (allPathsAreNormal(c.consequent)) {
+        // In principle the simplifier shoud reduce the result of the else clause to this case. This does less work.
+        invariant(!allPathsAreNormal(c.alternate));
+        invariant(!allPathsAreAbrupt(c.alternate));
+        let ijc = AbstractValue.createFromUnaryOp(realm, "!", c.joinCondition);
+        let alternatePC = AbstractValue.createFromLogicalOp(realm, "&&", ijc, getNormalPathConditionFor(c.alternate));
+        return AbstractValue.createFromLogicalOp(realm, "||", c.joinCondition, alternatePC);
+      } else if (allPathsAreNormal(c.alternate)) {
+        // In principle the simplifier shoud reduce the result of the else clause to this case. This does less work.
+        invariant(!allPathsAreNormal(c.consequent));
+        invariant(!allPathsAreAbrupt(c.consequent));
+        let jc = c.joinCondition;
+        let consequentPC = AbstractValue.createFromLogicalOp(realm, "&&", jc, getNormalPathConditionFor(c.consequent));
+        let ijc = AbstractValue.createFromUnaryOp(realm, "!", jc);
+        return AbstractValue.createFromLogicalOp(realm, "||", consequentPC, ijc);
+      } else {
+        let jc = c.joinCondition;
+        let consequentPC = AbstractValue.createFromLogicalOp(realm, "&&", jc, getNormalPathConditionFor(c.consequent));
+        let ijc = AbstractValue.createFromUnaryOp(realm, "!", jc);
+        let alternatePC = AbstractValue.createFromLogicalOp(realm, "&&", ijc, getNormalPathConditionFor(c.alternate));
+        return AbstractValue.createFromLogicalOp(realm, "||", consequentPC, alternatePC);
       }
     }
   }

--- a/test/serializer/abstract/PathConditions.js
+++ b/test/serializer/abstract/PathConditions.js
@@ -1,0 +1,19 @@
+// does not contain:3 ===
+let n1 = global.__abstract ? __abstract("number", "1") : 1;
+
+function f1() {
+  if (n1 === 1) return 10;
+  if (n1 === 2) throw 20;
+  if (n1 === 3) return 30;
+  throw 40;
+}
+
+try {
+  var x = f1();
+  if (n1 === 2) console.log(200);
+  if (n1 === 1 || n1 === 3) console.log(300);
+} catch (e) {
+  x = e;
+}
+
+inspect = function() { return x; }

--- a/test/serializer/abstract/PathConditions2.js
+++ b/test/serializer/abstract/PathConditions2.js
@@ -1,0 +1,27 @@
+let n1 = global.__abstract ? __abstract("number", "1") : 1;
+
+function f1() {
+  if (n1 > 10) {
+    if (n1 > 20) {
+      throw 100;
+    } else {
+      return 200;
+    }
+  } else {
+    if (n1 > 3) {
+      if (n1 > 4) {
+        throw 300;
+      } else {
+        return 400;
+      }
+    } else {
+      if (n1 > 2) {
+        return 500;
+      }
+    }
+  }
+}
+
+var x = f1();
+
+inspect = function() { return x; }

--- a/test/serializer/abstract/PathConditions3.js
+++ b/test/serializer/abstract/PathConditions3.js
@@ -1,0 +1,33 @@
+let n1 = global.__abstract ? __abstract("number", "1") : 1;
+
+function f1() {
+  if (n1 > 10) {
+    if (n1 > 20) {
+      throw 100;
+    } else {
+      return 200;
+    }
+  } else {
+    if (n1 > 3) {
+      if (n1 > 4) {
+        throw 300;
+      } else {
+        return 400;
+      }
+    } else {
+      if (n1 > 2) {
+        return 500;
+      } else {
+        throw 600;
+      }
+    }
+  }
+}
+
+try {
+  var x = f1();
+} catch (e) {
+  x = e;
+}
+
+inspect = function() { return x; }


### PR DESCRIPTION
Release note: none

Resolves: #2207

When a PossiblyNormalCompletion has more than one normal path, it is not correct to push only the path leading to the nominally normal completion. Surprisingly, this has not caused all sorts of havoc so far, but clearly this needs fixing.

Interestingly, these changes did uncover some latent bugs, hence the additional changes here.

Testing this more thoroughly will be much easier once PNC composition is fixed. That will take a while, but this PR will help facilitate that.