### PR TITLE
Ensure we handle numeric properties on $GetPartial path

### DIFF
--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -25,7 +25,6 @@ import {
   ObjectValue,
   ProxyValue,
   StringValue,
-  SymbolValue,
   UndefinedValue,
   Value,
 } from "../values/index.js";
@@ -555,7 +554,7 @@ export function GetTemplateObject(realm: Realm, templateLiteral: BabelNodeTempla
   return template;
 }
 
-export function GetFromArrayWithWidenedNumericProperty(realm: Realm, arr: ArrayValue, P: string | SymbolValue): Value {
+export function GetFromArrayWithWidenedNumericProperty(realm: Realm, arr: ArrayValue, P: string | Value): Value {
   let proto = arr.$GetPrototypeOf();
   invariant(proto instanceof ObjectValue && proto === realm.intrinsics.ArrayPrototype);
   if (typeof P === "string") {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -819,6 +819,10 @@ export default class ObjectValue extends ConcreteValue {
       if (desc !== undefined) {
         let val = desc.value;
         invariant(val instanceof AbstractValue);
+        if (val.kind === "widened numeric property") {
+          invariant(Receiver instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(Receiver));
+          return GetFromArrayWithWidenedNumericProperty(this.$Realm, Receiver, P instanceof StringValue ? P.value : P);
+        }
         result = this.specializeJoin(val, P);
       }
     }

--- a/test/serializer/optimized-functions/ArrayFrom5.js
+++ b/test/serializer/optimized-functions/ArrayFrom5.js
@@ -1,0 +1,12 @@
+function fn(x, y) {
+  var foo = Array.from(x);
+
+  return foo[y] + 5;
+}
+
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify([10], 0)
+};


### PR DESCRIPTION
Release notes: none

We were missing logic for handling abstract arrays with unknown numeric properties when we attempt to get a partial value on the array. I've added a regression test too.