### PR TITLE
Optimize Object.assign calls by merging the temporal entries together where possible

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -520,9 +520,8 @@ export default function(realm: Realm): ObjectValue {
     let unfiltered;
     if (text instanceof AbstractValue && text.kind === "JSON.stringify(...)") {
       // Enable cloning via JSON.parse(JSON.stringify(...)).
-      let gen = realm.preludeGenerator;
-      invariant(gen); // text is abstract, so we are doing abstract interpretation
-      let temporalBuildNodeEntryArgs = gen.derivedIds.get(text.intrinsicName);
+      // text is abstract, so we are doing abstract interpretation
+      let temporalBuildNodeEntryArgs = realm.derivedIds.get(text.intrinsicName);
       invariant(temporalBuildNodeEntryArgs !== undefined);
       let args = temporalBuildNodeEntryArgs.args;
       invariant(args[0] instanceof Value); // since text.kind === "JSON.stringify(...)"

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -63,7 +63,11 @@ function attemptToMergeEquivalentObjectAssigns(callbacks: VisitEntryCallbacks, v
     }
     // Check if the "to" was definitely an Object.assign, it should
     // be a snapshot AbstractObjectValue
-    if (possibleOtherObjectAssignTo instanceof AbstractObjectValue) {
+    if (
+      possibleOtherObjectAssignTo instanceof AbstractObjectValue &&
+      // We don't handle conditions for now, this can be done at a later stage
+      possibleOtherObjectAssignTo.kind !== "conditional"
+    ) {
       let otherTemporalBuildNodeEntry = realm.getTemporalBuildNodeEntryArgsFromDerivedValue(
         possibleOtherObjectAssignTo
       );

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -13,6 +13,7 @@ import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
+import { attemptToMergeEquivalentObjectAssigns } from "../../utils/generator.js";
 import { AbruptCompletion, PossiblyNormalCompletion } from "../../completions.js";
 import {
   AbstractValue,
@@ -41,92 +42,6 @@ import { Create, Havoc, Properties as Props, To } from "../../singletons.js";
 import type { BabelNodeExpression } from "babel-types";
 import * as t from "babel-types";
 import invariant from "../../invariant.js";
-import type { VisitEntryCallbacks } from "../../utils/generator.js";
-
-// This function attempts to optimize Object.assign calls, by merging mulitple
-// calls into one another where possible. For example:
-//
-// var a = Object.assign({}, someAbstact);
-// var b = Object.assign({}, a);
-//
-// Becomes:
-// var b = Object.assign({}, someAbstract, a);
-//
-// This is a recursive function, so it will attempt to do this multiple times
-// until it can no longer do so, or if a particular Object.assign is visited
-// and thus it is not possible to merge the Object.assign calls together.
-export function attemptToMergeEquivalentObjectAssigns(callbacks: VisitEntryCallbacks, value: Value): boolean {
-  if (!(value instanceof AbstractObjectValue)) {
-    return false;
-  }
-  let realm = value.$Realm;
-  let temporalBuildNodeEntry = realm.getTemporalBuildNodeEntryArgsFromDerivedValue(value);
-  if (temporalBuildNodeEntry === undefined) {
-    return false;
-  }
-  let args = temporalBuildNodeEntry.args;
-  // If we are Object.assigning 3 or more args
-  if (args.length < 3) {
-    return false;
-  }
-  // Then scan through the args after the "to" of this Object.assign, to see if any
-  // other sources are the "to" of a previous Object.assign call
-  for (let i = 2; i < args.length; i++) {
-    let possibleOtherObjectAssignTo = args[i];
-    // Ensure that the "to" value can be omitted
-    if (!callbacks.canOmit(possibleOtherObjectAssignTo)) {
-      continue;
-    }
-    // Check if the "to" was definitely an Object.assign, it should
-    // be a snapshot AbstractObjectValue
-    if (
-      possibleOtherObjectAssignTo instanceof AbstractObjectValue &&
-      // We don't handle conditions for now, this can be done at a later stage
-      possibleOtherObjectAssignTo.kind !== "conditional"
-    ) {
-      let otherTemporalBuildNodeEntry = realm.getTemporalBuildNodeEntryArgsFromDerivedValue(
-        possibleOtherObjectAssignTo
-      );
-      if (otherTemporalBuildNodeEntry === undefined) {
-        continue;
-      }
-      let otherArgs = otherTemporalBuildNodeEntry.args;
-      let objectAssingFunc = realm.intrinsics.Object.$Get("assign", realm.intrinsics.Object);
-      // Object.assign has at least 2 args and the first is that of Object.assign native function
-      if (otherArgs.length < 3 || otherArgs[0] !== objectAssingFunc) {
-        continue;
-      }
-      let to = args[1];
-      // If we cannot omit the "to" value that means it's being used, so we shall not try to
-      // optimize this Object.assign.
-      if (!callbacks.canOmit(to)) {
-        let newArgs = [objectAssingFunc, to];
-        for (let x = 2; x < otherArgs.length; x++) {
-          newArgs.push(otherArgs[x]);
-        }
-        for (let x = 2; x < args.length; x++) {
-          let arg = args[x];
-          // We don't want to add the "to" that we're merging with!
-          if (arg !== possibleOtherObjectAssignTo) {
-            newArgs.push(arg);
-          }
-        }
-        // We now mutate the args in place with the above new args, clearing out the old args.
-        // The end result should be a merged Object.assign and one less temporal entry.
-        // The previous Object.assign temporal's "to" is no longer being used anywhere and should
-        // now dead-code away nicely.
-        args.length = 0;
-        args.push(...newArgs);
-        // Lastly, because we want to possibly merge many Object.assigns, not only two, we do this
-        // process again from the start. Given we've mutated in place the args, this will work.
-        attemptToMergeEquivalentObjectAssigns(callbacks, value);
-        return false;
-      }
-      return true;
-    }
-  }
-  return false;
-}
 
 function handleObjectAssignSnapshot(
   to: ObjectValue | AbstractObjectValue,

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -43,6 +43,18 @@ import * as t from "babel-types";
 import invariant from "../../invariant.js";
 import type { VisitEntryCallbacks } from "../../utils/generator.js";
 
+// This function attempts to optimize Object.assign calls, by merging mulitple
+// calls into one another where possible. For example:
+//
+// var a = Object.assign({}, someAbstact);
+// var b = Object.assign({}, a);
+//
+// Becomes:
+// var b = Object.assign({}, someAbstract, a);
+//
+// This is a recursive function, so it will attempt to do this multiple times
+// until it can no longer do so, or if a particular Object.assign is visited
+// and thus it is not possible to merge the Object.assign calls together.
 export function attemptToMergeEquivalentObjectAssigns(callbacks: VisitEntryCallbacks, value: Value): boolean {
   if (!(value instanceof AbstractObjectValue)) {
     return false;

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -13,7 +13,6 @@ import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { optimizeObjectAssignTemporalEntry } from "../../utils/generator.js";
 import { AbruptCompletion, PossiblyNormalCompletion } from "../../completions.js";
 import {
   AbstractValue,
@@ -286,7 +285,7 @@ export default function(realm: Realm): NativeFunctionValue {
           {
             skipInvariant: true,
             mutatesOnly: [to],
-            optimizationFn: optimizeObjectAssignTemporalEntry,
+            temporalType: "OBJECT_ASSIGN",
           }
         );
         invariant(temporalTo instanceof AbstractObjectValue);

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -13,7 +13,7 @@ import { TypesDomain, ValuesDomain } from "../../domains/index.js";
 import { FatalError } from "../../errors.js";
 import { Realm } from "../../realm.js";
 import { NativeFunctionValue } from "../../values/index.js";
-import { attemptToMergeEquivalentObjectAssigns } from "../../utils/generator.js";
+import { optimizeObjectAssignTemporalEntry } from "../../utils/generator.js";
 import { AbruptCompletion, PossiblyNormalCompletion } from "../../completions.js";
 import {
   AbstractValue,
@@ -286,7 +286,7 @@ export default function(realm: Realm): NativeFunctionValue {
           {
             skipInvariant: true,
             mutatesOnly: [to],
-            customOptimizationFn: attemptToMergeEquivalentObjectAssigns,
+            optimizationFn: optimizeObjectAssignTemporalEntry,
           }
         );
         invariant(temporalTo instanceof AbstractObjectValue);

--- a/src/react/ReactEquivalenceSet.js
+++ b/src/react/ReactEquivalenceSet.js
@@ -143,12 +143,12 @@ export class ReactEquivalenceSet {
     if (!this.residualReactElementVisitor.wasTemporalAliasDeclaredInCurrentScope(temporalAlias)) {
       return temporalAlias;
     }
-    let temporalBuildNodeEntryArgs = this.realm.getTemporalBuildNodeEntryArgsFromDerivedValue(temporalAlias);
+    let temporalBuildNodeEntry = this.realm.getTemporalBuildNodeEntryFromDerivedValue(temporalAlias);
 
-    if (temporalBuildNodeEntryArgs === undefined) {
+    if (temporalBuildNodeEntry === undefined) {
       return temporalAlias;
     }
-    let temporalArgs = temporalBuildNodeEntryArgs.args;
+    let temporalArgs = temporalBuildNodeEntry.args;
     if (temporalArgs.length === 0) {
       return temporalAlias;
     }
@@ -169,9 +169,9 @@ export class ReactEquivalenceSet {
         }
       } else if (arg instanceof AbstractObjectValue && !arg.values.isTop() && arg.kind !== "conditional") {
         // Might be a temporal, so let's check
-        let childTemporalBuildNodeEntryArgs = this.realm.getTemporalBuildNodeEntryArgsFromDerivedValue(arg);
+        let childTemporalBuildNodeEntry = this.realm.getTemporalBuildNodeEntryFromDerivedValue(arg);
 
-        if (childTemporalBuildNodeEntryArgs !== undefined) {
+        if (childTemporalBuildNodeEntry !== undefined) {
           equivalenceArg = this._getTemporalValue(arg, visitedValues);
           invariant(equivalenceArg instanceof AbstractObjectValue);
 

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -37,7 +37,7 @@ import invariant from "../invariant.js";
 import traverse from "babel-traverse";
 import type { ClassComponentMetadata } from "../types.js";
 import type { ReactEvaluatedNode } from "../serializer/types.js";
-import { attemptToMergeEquivalentObjectAssigns } from "../utils/generator.js";
+import { optimizeObjectAssignTemporalEntry } from "../utils/generator.js";
 import { FatalError } from "../errors.js";
 
 const lifecycleMethods = new Set([
@@ -406,7 +406,7 @@ export function applyGetDerivedStateFromProps(
             {
               skipInvariant: true,
               mutatesOnly: [newState],
-              customOptimizationFn: attemptToMergeEquivalentObjectAssigns,
+              optimizationFn: optimizeObjectAssignTemporalEntry,
             }
           );
           newState.makeSimple();

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -37,7 +37,6 @@ import invariant from "../invariant.js";
 import traverse from "babel-traverse";
 import type { ClassComponentMetadata } from "../types.js";
 import type { ReactEvaluatedNode } from "../serializer/types.js";
-import { optimizeObjectAssignTemporalEntry } from "../utils/generator.js";
 import { FatalError } from "../errors.js";
 
 const lifecycleMethods = new Set([
@@ -406,7 +405,7 @@ export function applyGetDerivedStateFromProps(
             {
               skipInvariant: true,
               mutatesOnly: [newState],
-              optimizationFn: optimizeObjectAssignTemporalEntry,
+              temporalType: "OBJECT_ASSIGN",
             }
           );
           newState.makeSimple();

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -37,7 +37,7 @@ import invariant from "../invariant.js";
 import traverse from "babel-traverse";
 import type { ClassComponentMetadata } from "../types.js";
 import type { ReactEvaluatedNode } from "../serializer/types.js";
-import { attemptToMergeEquivalentObjectAssigns } from "../intrinsics/ecma262/Object.js";
+import { attemptToMergeEquivalentObjectAssigns } from "../utils/generator.js";
 import { FatalError } from "../errors.js";
 
 const lifecycleMethods = new Set([

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -19,7 +19,6 @@ import {
   NativeFunctionValue,
   ECMAScriptFunctionValue,
   Value,
-  FunctionValue,
 } from "../values/index.js";
 import * as t from "babel-types";
 import type { BabelNodeIdentifier } from "babel-types";

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -370,6 +370,8 @@ export function applyGetDerivedStateFromProps(
         let c = AbstractValue.createFromLogicalOp(realm, "&&", a, b);
         invariant(c instanceof AbstractValue);
         let newState = new ObjectValue(realm, realm.intrinsics.ObjectPrototype);
+        let preludeGenerator = realm.preludeGenerator;
+        invariant(preludeGenerator !== undefined);
         // we cannot use the standard Object.assign as partial state
         // is not simple. however, given getDerivedStateFromProps is
         // meant to be pure, we can assume that there are no getters on
@@ -377,11 +379,11 @@ export function applyGetDerivedStateFromProps(
         AbstractValue.createTemporalFromBuildFunction(
           realm,
           FunctionValue,
-          [objectAssign, newState, prevState, state],
-          ([methodNode, ..._args]) => {
-            return t.callExpression(methodNode, ((_args: any): Array<any>));
+          [newState, prevState, state],
+          ([..._args]) => {
+            return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), ((_args: any): Array<any>));
           },
-          { skipInvariant: true }
+          { skipInvariant: true, mutatesOnly: [newState], temporalType: "OBJECT_ASSIGN" }
         );
         newState.makeSimple();
         newState.makePartial();
@@ -395,12 +397,14 @@ export function applyGetDerivedStateFromProps(
         objectAssignCall(realm.intrinsics.undefined, [newState, prevState, state]);
       } catch (e) {
         if (realm.isInPureScope() && e instanceof FatalError) {
+          let preludeGenerator = realm.preludeGenerator;
+          invariant(preludeGenerator !== undefined);
           AbstractValue.createTemporalFromBuildFunction(
             realm,
             FunctionValue,
             [objectAssign, newState, prevState, state],
-            ([methodNode, ..._args]) => {
-              return t.callExpression(methodNode, ((_args: any): Array<any>));
+            ([..._args]) => {
+              return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), ((_args: any): Array<any>));
             },
             {
               skipInvariant: true,

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -378,7 +378,7 @@ export function applyGetDerivedStateFromProps(
         // the partial abstract state
         AbstractValue.createTemporalFromBuildFunction(
           realm,
-          FunctionValue,
+          ObjectValue,
           [newState, prevState, state],
           ([..._args]) => {
             return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), ((_args: any): Array<any>));
@@ -401,7 +401,7 @@ export function applyGetDerivedStateFromProps(
           invariant(preludeGenerator !== undefined);
           AbstractValue.createTemporalFromBuildFunction(
             realm,
-            FunctionValue,
+            ObjectValue,
             [objectAssign, newState, prevState, state],
             ([..._args]) => {
               return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), ((_args: any): Array<any>));

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -37,6 +37,7 @@ import invariant from "../invariant.js";
 import traverse from "babel-traverse";
 import type { ClassComponentMetadata } from "../types.js";
 import type { ReactEvaluatedNode } from "../serializer/types.js";
+import { attemptToMergeEquivalentObjectAssigns } from "../intrinsics/ecma262/Object.js";
 import { FatalError } from "../errors.js";
 
 const lifecycleMethods = new Set([
@@ -402,7 +403,11 @@ export function applyGetDerivedStateFromProps(
             ([methodNode, ..._args]) => {
               return t.callExpression(methodNode, ((_args: any): Array<any>));
             },
-            { skipInvariant: true, mutatesOnly: [newState] }
+            {
+              skipInvariant: true,
+              mutatesOnly: [newState],
+              customOptimizationFn: attemptToMergeEquivalentObjectAssigns,
+            }
           );
           newState.makeSimple();
           newState.makePartial();

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -962,7 +962,11 @@ function applyClonedTemporalAlias(realm: Realm, props: ObjectValue, clonedProps:
     ([targetNode, ...sourceNodes]: Array<BabelNodeExpression>) => {
       return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), [targetNode, ...sourceNodes]);
     },
-    { skipInvariant: true }
+    {
+      skipInvariant: true,
+      mutatesOnly: [targetNode],
+      temporalType: "OBJECT_ASSIGN",
+    }
   );
   invariant(temporalTo instanceof AbstractObjectValue);
   invariant(clonedProps instanceof ObjectValue);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -949,9 +949,9 @@ function applyClonedTemporalAlias(realm: Realm, props: ObjectValue, clonedProps:
     // be a better option.
     invariant(false, "TODO applyClonedTemporalAlias conditional");
   }
-  let temporalBuildNodeEntryArgs = realm.getTemporalBuildNodeEntryArgsFromDerivedValue(temporalAlias);
-  invariant(temporalBuildNodeEntryArgs !== undefined);
-  let temporalArgs = temporalBuildNodeEntryArgs.args;
+  let temporalBuildNodeEntry = realm.getTemporalBuildNodeEntryFromDerivedValue(temporalAlias);
+  invariant(temporalBuildNodeEntry !== undefined);
+  let temporalArgs = temporalBuildNodeEntry.args;
   // replace the original props with the cloned one
   let newTemporalArgs = temporalArgs.map(arg => (arg === props ? clonedProps : arg));
 

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -47,6 +47,7 @@ import traverse from "babel-traverse";
 import * as t from "babel-types";
 import type { BabelNodeStatement } from "babel-types";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
+import { attemptToMergeEquivalentObjectAssigns } from "../intrinsics/ecma262/Object.js";
 
 export type ReactSymbolTypes =
   | "react.element"
@@ -1072,7 +1073,11 @@ export function applyObjectAssignConfigsForReactElement(realm: Realm, to: Object
           ([methodNode, ..._args]) => {
             return t.callExpression(methodNode, ((_args: any): Array<any>));
           },
-          { skipInvariant: true, mutatesOnly: [to] }
+          {
+            skipInvariant: true,
+            mutatesOnly: [to],
+            customOptimizationFn: attemptToMergeEquivalentObjectAssigns,
+          }
         );
         invariant(temporalTo instanceof AbstractObjectValue);
         temporalTo.values = new ValuesDomain(to);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -30,7 +30,7 @@ import {
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import { Generator } from "../utils/generator.js";
+import { attemptToMergeEquivalentObjectAssigns, Generator } from "../utils/generator.js";
 import type {
   Descriptor,
   FunctionBodyAstNode,
@@ -47,7 +47,6 @@ import traverse from "babel-traverse";
 import * as t from "babel-types";
 import type { BabelNodeStatement } from "babel-types";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
-import { attemptToMergeEquivalentObjectAssigns } from "../intrinsics/ecma262/Object.js";
 
 export type ReactSymbolTypes =
   | "react.element"

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -30,7 +30,7 @@ import {
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import { attemptToMergeEquivalentObjectAssigns, Generator } from "../utils/generator.js";
+import { optimizeObjectAssignTemporalEntry, Generator } from "../utils/generator.js";
 import type {
   Descriptor,
   FunctionBodyAstNode,
@@ -1075,7 +1075,7 @@ export function applyObjectAssignConfigsForReactElement(realm: Realm, to: Object
           {
             skipInvariant: true,
             mutatesOnly: [to],
-            customOptimizationFn: attemptToMergeEquivalentObjectAssigns,
+            optimizationFn: optimizeObjectAssignTemporalEntry,
           }
         );
         invariant(temporalTo instanceof AbstractObjectValue);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -955,6 +955,7 @@ function applyClonedTemporalAlias(realm: Realm, props: ObjectValue, clonedProps:
 
   let preludeGenerator = realm.preludeGenerator;
   invariant(preludeGenerator !== undefined);
+  let to = newTemporalArgs[0];
   let temporalTo = AbstractValue.createTemporalFromBuildFunction(
     realm,
     ObjectValue,
@@ -964,7 +965,7 @@ function applyClonedTemporalAlias(realm: Realm, props: ObjectValue, clonedProps:
     },
     {
       skipInvariant: true,
-      mutatesOnly: [targetNode],
+      mutatesOnly: [to],
       temporalType: "OBJECT_ASSIGN",
     }
   );

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -30,7 +30,7 @@ import {
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import { optimizeObjectAssignTemporalEntry, Generator } from "../utils/generator.js";
+import { Generator } from "../utils/generator.js";
 import type {
   Descriptor,
   FunctionBodyAstNode,
@@ -1075,7 +1075,7 @@ export function applyObjectAssignConfigsForReactElement(realm: Realm, to: Object
           {
             skipInvariant: true,
             mutatesOnly: [to],
-            optimizationFn: optimizeObjectAssignTemporalEntry,
+            temporalType: "OBJECT_ASSIGN",
           }
         );
         invariant(temporalTo instanceof AbstractObjectValue);

--- a/src/realm.js
+++ b/src/realm.js
@@ -1748,6 +1748,9 @@ export class Realm {
     invariant(name);
     let preludeGenerator = this.preludeGenerator;
     invariant(preludeGenerator !== undefined);
+    if (value instanceof AbstractValue && value.kind === "conditional") {
+      return undefined;
+    }
     let temporalBuildNodeEntryArgs = preludeGenerator.derivedIds.get(name);
     return temporalBuildNodeEntryArgs;
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1745,12 +1745,11 @@ export class Realm {
 
   getTemporalBuildNodeEntryArgsFromDerivedValue(value: Value): void | TemporalBuildNodeEntryArgs {
     let name = value.intrinsicName;
-    invariant(name);
-    let preludeGenerator = this.preludeGenerator;
-    invariant(preludeGenerator !== undefined);
-    if (value instanceof AbstractValue && value.kind === "conditional") {
+    if ((value instanceof AbstractValue && value.kind === "conditional") || !name) {
       return undefined;
     }
+    let preludeGenerator = this.preludeGenerator;
+    invariant(preludeGenerator !== undefined);
     let temporalBuildNodeEntryArgs = preludeGenerator.derivedIds.get(name);
     return temporalBuildNodeEntryArgs;
   }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1754,7 +1754,7 @@ export class Realm {
     return temporalBuildNodeEntry;
   }
 
-  getTemporalGeneratorEntriesReferencingArg(arg: Value): void | Set<TemporalBuildNodeEntry> {
+  getTemporalGeneratorEntriesReferencingArg(arg: AbstractValue | ObjectValue): void | Set<TemporalBuildNodeEntry> {
     return this.temporalEntryArgToEntries.get(arg);
   }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -247,6 +247,7 @@ export class Realm {
     this.partialEvaluators = (Object.create(null): any);
     this.$GlobalEnv = ((undefined: any): LexicalEnvironment);
 
+    this.derivedIds = new Map();
     this.temporalEntryArgToEntries = new Map();
     this.temporalEntryCounter = 0;
 
@@ -343,6 +344,7 @@ export class Realm {
   $GlobalEnv: LexicalEnvironment;
   intrinsics: Intrinsics;
 
+  derivedIds: Map<string, TemporalBuildNodeEntry>;
   temporalEntryArgToEntries: Map<Value, Set<TemporalBuildNodeEntry>>;
   temporalEntryCounter: number;
 
@@ -1748,9 +1750,7 @@ export class Realm {
     if ((value instanceof AbstractValue && value.kind === "conditional") || !name) {
       return undefined;
     }
-    let preludeGenerator = this.preludeGenerator;
-    invariant(preludeGenerator !== undefined);
-    let temporalBuildNodeEntry = preludeGenerator.derivedIds.get(name);
+    let temporalBuildNodeEntry = value.$Realm.derivedIds.get(name);
     return temporalBuildNodeEntry;
   }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -247,6 +247,9 @@ export class Realm {
     this.partialEvaluators = (Object.create(null): any);
     this.$GlobalEnv = ((undefined: any): LexicalEnvironment);
 
+    this.temporalEntryArgToEntries = new Map();
+    this.temporalEntryCounter = 0;
+
     this.instantRender = {
       enabled: opts.instantRender || false,
     };
@@ -339,6 +342,9 @@ export class Realm {
   contextStack: Array<ExecutionContext> = [];
   $GlobalEnv: LexicalEnvironment;
   intrinsics: Intrinsics;
+
+  temporalEntryArgToEntries: Map<Value, Set<TemporalBuildNodeEntry>>;
+  temporalEntryCounter: number;
 
   instantRender: {
     enabled: boolean,
@@ -1754,8 +1760,20 @@ export class Realm {
     return temporalBuildNodeEntry;
   }
 
-  getAllTemporalGeneratorEntriesReferencingArg(arg: Value): Array<TemporalBuildNodeEntry> {
-    // TODO
-    return [];
+  getTemporalGeneratorEntriesReferencingArg(arg: Value): void | Set<TemporalBuildNodeEntry> {
+    return this.temporalEntryArgToEntries.get(arg);
+  }
+
+  saveTemporalGeneratorEntryArgs(temporalBuildNodeEntry: TemporalBuildNodeEntry): void {
+    let args = temporalBuildNodeEntry.args;
+    for (let arg of args) {
+      let temporalEntries = this.temporalEntryArgToEntries.get(arg);
+
+      if (temporalEntries === undefined) {
+        temporalEntries = new Set();
+        this.temporalEntryArgToEntries.set(arg, temporalEntries);
+      }
+      temporalEntries.add(temporalBuildNodeEntry);
+    }
   }
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1747,7 +1747,7 @@ export class Realm {
 
   getTemporalBuildNodeEntryFromDerivedValue(value: Value): void | TemporalBuildNodeEntry {
     let name = value.intrinsicName;
-    if ((value instanceof AbstractValue && value.kind === "conditional") || !name) {
+    if (!name) {
       return undefined;
     }
     let temporalBuildNodeEntry = value.$Realm.derivedIds.get(name);

--- a/src/realm.js
+++ b/src/realm.js
@@ -63,7 +63,7 @@ import {
 import type { Compatibility, RealmOptions, ReactOutputTypes, InvariantModeTypes } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
-import { Generator, PreludeGenerator, type TemporalBuildNodeEntryArgs } from "./utils/generator.js";
+import { Generator, PreludeGenerator, type TemporalBuildNodeEntry } from "./utils/generator.js";
 import { emptyExpression, voidExpression } from "./utils/babelhelpers.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
@@ -1743,14 +1743,19 @@ export class Realm {
     return !this._abstractValuesDefined.has(nameString);
   }
 
-  getTemporalBuildNodeEntryArgsFromDerivedValue(value: Value): void | TemporalBuildNodeEntryArgs {
+  getTemporalBuildNodeEntryFromDerivedValue(value: Value): void | TemporalBuildNodeEntry {
     let name = value.intrinsicName;
     if ((value instanceof AbstractValue && value.kind === "conditional") || !name) {
       return undefined;
     }
     let preludeGenerator = this.preludeGenerator;
     invariant(preludeGenerator !== undefined);
-    let temporalBuildNodeEntryArgs = preludeGenerator.derivedIds.get(name);
-    return temporalBuildNodeEntryArgs;
+    let temporalBuildNodeEntry = preludeGenerator.derivedIds.get(name);
+    return temporalBuildNodeEntry;
+  }
+
+  getAllTemporalGeneratorEntriesReferencingArg(arg: Value): Array<TemporalBuildNodeEntry> {
+    // TODO
+    return [];
   }
 }

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -13,7 +13,6 @@ import {
   AbstractValue,
   ArrayValue,
   BoundFunctionValue,
-  ConcreteValue,
   FunctionValue,
   ObjectValue,
   ProxyValue,
@@ -164,7 +163,7 @@ export class Emitter {
   endEmitting(
     dependency: string | Generator | Value,
     oldBody: SerializedBody,
-    valuesToProcess: void | Set<AbstractValue | ConcreteValue>,
+    valuesToProcess: void | Set<Value>,
     isChild: boolean = false
   ) {
     invariant(!this._finalized);
@@ -207,7 +206,7 @@ export class Emitter {
 
     return lastBody;
   }
-  processValues(valuesToProcess: Set<AbstractValue | ConcreteValue>) {
+  processValues(valuesToProcess: Set<Value>) {
     for (let value of valuesToProcess) this._processValue(value);
   }
   finalize() {
@@ -468,10 +467,9 @@ export class Emitter {
   emitNowOrAfterWaitingForDependencies(dependencies: Array<Value>, func: () => void, targetBody: SerializedBody) {
     this.emitAfterWaiting(this.getReasonToWaitForDependencies(dependencies), dependencies, func, targetBody);
   }
-  declare(value: AbstractValue | ConcreteValue) {
+  declare(value: Value) {
     invariant(!this._finalized);
     invariant(!this._activeValues.has(value));
-    invariant(value instanceof ConcreteValue || value.hasIdentifier());
     invariant(this._isEmittingActiveGenerator());
     invariant(!this.cannotDeclare());
     invariant(!this._body.done);
@@ -488,10 +486,10 @@ export class Emitter {
     // Bodies of the following types will never contain any (temporal) abstract value declarations.
     return this._body.type === "DelayInitializations" || this._body.type === "LazyObjectInitializer";
   }
-  hasBeenDeclared(value: AbstractValue | ConcreteValue): boolean {
+  hasBeenDeclared(value: Value): boolean {
     return this.getDeclarationBody(value) !== undefined;
   }
-  getDeclarationBody(value: AbstractValue | ConcreteValue): void | SerializedBody {
+  getDeclarationBody(value: Value): void | SerializedBody {
     for (let b = this._body; b !== undefined; b = b.parentBody) {
       if (b.declaredValues !== undefined && b.declaredValues.has(value)) {
         return b;

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -21,7 +21,7 @@ import {
 } from "../values/index.js";
 import type { BabelNodeStatement } from "babel-types";
 import type { SerializedBody } from "./types.js";
-import { Generator, type TemporalBuildNodeEntryArgs } from "../utils/generator.js";
+import { Generator, type TemporalBuildNodeEntry } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import { BodyReference } from "./types.js";
 import { ResidualFunctions } from "./ResidualFunctions.js";
@@ -67,7 +67,7 @@ export class Emitter {
     residualFunctions: ResidualFunctions,
     referencedDeclaredValues: Map<Value, void | FunctionValue>,
     conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
-    derivedIds: Map<string, TemporalBuildNodeEntryArgs>
+    derivedIds: Map<string, TemporalBuildNodeEntry>
   ) {
     this._mainBody = { type: "MainGenerator", parentBody: undefined, entries: [], done: false };
     this._waitingForValues = new Map();

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -16,7 +16,6 @@ import {
   AbstractValue,
   BooleanValue,
   BoundFunctionValue,
-  ConcreteValue,
   ECMAScriptSourceFunctionValue,
   EmptyValue,
   FunctionValue,
@@ -2083,7 +2082,7 @@ export class ResidualHeapSerializer {
   _withGeneratorScope(
     type: "Generator" | "AdditionalFunction",
     generator: Generator,
-    valuesToProcess: void | Set<AbstractValue | ConcreteValue>,
+    valuesToProcess: void | Set<Value>,
     callback: SerializedBody => void,
     isChildOverride?: boolean
   ): Array<BabelNodeStatement> {
@@ -2108,10 +2107,7 @@ export class ResidualHeapSerializer {
     let context = {
       serializeValue: this.serializeValue.bind(this),
       serializeBinding: this.serializeBinding.bind(this),
-      serializeGenerator: (
-        generator: Generator,
-        valuesToProcess: Set<AbstractValue | ConcreteValue>
-      ): Array<BabelNodeStatement> =>
+      serializeGenerator: (generator: Generator, valuesToProcess: Set<Value>): Array<BabelNodeStatement> =>
         this._withGeneratorScope("Generator", generator, valuesToProcess, () => generator.serialize(context)),
       initGenerator: (generator: Generator) => {
         let activeGeneratorBody = this._getActiveBodyOfGenerator(generator);
@@ -2127,7 +2123,7 @@ export class ResidualHeapSerializer {
       emit: (statement: BabelNodeStatement) => {
         this.emitter.emit(statement);
       },
-      processValues: (valuesToProcess: Set<AbstractValue | ConcreteValue>) => {
+      processValues: (valuesToProcess: Set<Value>) => {
         this.emitter.processValues(valuesToProcess);
       },
       getPropertyAssignmentStatement: this._getPropertyAssignmentStatement.bind(this),
@@ -2143,7 +2139,7 @@ export class ResidualHeapSerializer {
         }
         return canOmit;
       },
-      declare: (value: AbstractValue | ConcreteValue) => {
+      declare: (value: Value) => {
         this.emitter.declare(value);
       },
       emitPropertyModification: (propertyBinding: PropertyBinding) => {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -195,7 +195,7 @@ export class ResidualHeapSerializer {
       this.residualFunctions,
       referencedDeclaredValues,
       conditionalFeasibility,
-      this.preludeGenerator.derivedIds
+      this.realm.derivedIds
     );
     this.mainBody = this.emitter.getBody();
     this.residualHeapInspector = residualHeapInspector;
@@ -1897,7 +1897,7 @@ export class ResidualHeapSerializer {
     if (serializedValue.type === "Identifier") {
       let id = ((serializedValue: any): BabelNodeIdentifier);
       invariant(
-        !this.preludeGenerator.derivedIds.has(id.name) ||
+        !this.realm.derivedIds.has(id.name) ||
           this.emitter.cannotDeclare() ||
           this.emitter.hasBeenDeclared(val) ||
           (this.emitter.emittingToAdditionalFunction() && this.referencedDeclaredValues.get(val) === undefined),
@@ -2281,7 +2281,7 @@ export class ResidualHeapSerializer {
 
     this.generator.serialize(this._getContext());
     this.getStatistics().generators++;
-    invariant(this.emitter.declaredCount() <= this.preludeGenerator.derivedIds.size);
+    invariant(this.emitter.declaredCount() <= this.realm.derivedIds.size);
 
     // TODO #20: add timers
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1104,9 +1104,6 @@ export class ResidualHeapVisitor {
           action: () => entry.visit(callbacks, generator),
         });
       },
-      updateEntryInPlace: (entryToMutate: TemporalBuildNodeEntry, newEntry: TemporalBuildNodeEntry) => {
-        entryToMutate.args = newEntry.args;
-      },
       visitModifiedObjectProperty: (binding: PropertyBinding) => {
         let fixpoint_rerun = () => {
           if (this.values.has(binding.object)) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1104,6 +1104,13 @@ export class ResidualHeapVisitor {
           action: () => entry.visit(callbacks, generator),
         });
       },
+      replaceAndRecordDelayedEntry: (generator, originalEntry: GeneratorEntry, newEntry: GeneratorEntry) => {
+        generator.replaceEntry(originalEntry, newEntry);
+        this.delayedActions.push({
+          scope: generator,
+          action: () => newEntry.visit(callbacks, generator),
+        });
+      },
       visitModifiedObjectProperty: (binding: PropertyBinding) => {
         let fixpoint_rerun = () => {
           if (this.values.has(binding.object)) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -34,7 +34,7 @@ import {
 import { describeLocation } from "../intrinsics/ecma262/Error.js";
 import * as t from "babel-types";
 import type { BabelNodeBlockStatement } from "babel-types";
-import { Generator } from "../utils/generator.js";
+import { Generator, TemporalBuildNodeEntry } from "../utils/generator.js";
 import type { GeneratorEntry, VisitEntryCallbacks } from "../utils/generator.js";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";
@@ -1104,12 +1104,8 @@ export class ResidualHeapVisitor {
           action: () => entry.visit(callbacks, generator),
         });
       },
-      replaceAndRecordDelayedEntry: (generator, originalEntry: GeneratorEntry, newEntry: GeneratorEntry) => {
-        generator.replaceEntry(originalEntry, newEntry);
-        this.delayedActions.push({
-          scope: generator,
-          action: () => newEntry.visit(callbacks, generator),
-        });
+      updateEntryInPlace: (entryToMutate: TemporalBuildNodeEntry, newEntry: TemporalBuildNodeEntry) => {
+        entryToMutate.args = newEntry.args;
       },
       visitModifiedObjectProperty: (binding: PropertyBinding) => {
         let fixpoint_rerun = () => {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -34,7 +34,7 @@ import {
 import { describeLocation } from "../intrinsics/ecma262/Error.js";
 import * as t from "babel-types";
 import type { BabelNodeBlockStatement } from "babel-types";
-import { Generator, TemporalBuildNodeEntry } from "../utils/generator.js";
+import { Generator } from "../utils/generator.js";
 import type { GeneratorEntry, VisitEntryCallbacks } from "../utils/generator.js";
 import traverse from "babel-traverse";
 import invariant from "../invariant.js";

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -10,7 +10,7 @@
 /* @flow strict-local */
 
 import { DeclarativeEnvironmentRecord, type Binding } from "../environment.js";
-import { ConcreteValue, Value, ObjectValue, AbstractValue } from "../values/index.js";
+import { ConcreteValue, ObjectValue, Value } from "../values/index.js";
 import type { ECMAScriptSourceFunctionValue, FunctionValue } from "../values/index.js";
 import type { BabelNodeExpression, BabelNodeStatement, BabelNodeMemberExpression } from "babel-types";
 import { SameValue } from "../methods/abstract.js";
@@ -34,7 +34,7 @@ export type SerializedBody = {
   type: SerializedBodyType,
   entries: Array<BabelNodeStatement>,
   done: boolean,
-  declaredValues?: Map<AbstractValue | ConcreteValue, SerializedBody>,
+  declaredValues?: Map<Value, SerializedBody>,
   parentBody?: SerializedBody,
   nestingLevel?: number,
   processing?: boolean,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1142,6 +1142,10 @@ export class Generator {
     let index = this._entries.indexOf(entry);
     invariant(index !== -1);
     this._entries[index] = replacement;
+    if (replacement instanceof TemporalBuildNodeEntry && replacement.declared !== undefined) {
+      invariant(replacement.declared.intrinsicName);
+      this.preludeGenerator.derivedIds.set(replacement.declared.intrinsicName, replacement);
+    }
   }
 }
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1366,6 +1366,10 @@ export function attemptToMergeEquivalentObjectAssigns(
       let otherArgsToUse = [];
       for (let x = 2; x < otherArgs.length; x++) {
         let arg = otherArgs[x];
+        // The arg might have been havoced, so ensure we do not continue in this case
+        if (arg instanceof ObjectValue && arg.mightBeHavocedObject()) {
+          continue loopThroughArgs;
+        }
         if (arg instanceof ObjectValue || arg instanceof AbstractValue) {
           let temporalGeneratorEntries = realm.getTemporalGeneratorEntriesReferencingArg(arg);
           // We need to now check if there are any other temporal entries that exist

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -84,7 +84,6 @@ export type VisitEntryCallbacks = {|
   canOmit: Value => boolean,
   recordDeclaration: (AbstractValue | ObjectValue) => void,
   recordDelayedEntry: (Generator, GeneratorEntry) => void,
-  updateEntryInPlace: (TemporalBuildNodeEntry, TemporalBuildNodeEntry) => void,
   visitModifiedObjectProperty: PropertyBinding => void,
   visitModifiedBinding: Binding => [ResidualFunctionBinding, Value],
   visitBindingAssignment: (Binding, Value) => Value,
@@ -258,7 +257,7 @@ export class TemporalObjectAssignEntry extends TemporalBuildNodeEntry {
       }
       // We have an optimized temporal entry, so replace the current temporal
       // entry and visit that entry instead.
-      callbacks.updateEntryInPlace(this, result);
+      this.args = result.args;
     } else if (result === "POSSIBLE_OPTIMIZATION") {
       callbacks.recordDelayedEntry(containingGenerator, this);
       return false;

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1388,6 +1388,8 @@ export function attemptToMergeEquivalentObjectAssigns(
               if (temporalGeneratorEntry instanceof TemporalObjectAssignEntry) {
                 continue;
               }
+              // TODO: what if the temporalGeneratorEntry can be omitted and not needed?
+
               // If the index of this entry exist between start and end indexes,
               // then we cannot optimize and merge the TemporalObjectAssignEntry
               // because another generator entry has a dependency on the Object.assign

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -127,11 +127,11 @@ export class GeneratorEntry {
     invariant(false, "GeneratorEntry is an abstract base class");
   }
 
-  happensAfter(entry: GeneratorEntry): boolean {
+  notEqualToAndDoesNotHappenAfter(entry: GeneratorEntry): boolean {
     return this.index > entry.index;
   }
 
-  happensBefore(entry: GeneratorEntry): boolean {
+  notEqualToAndDoesNotHappenBefore(entry: GeneratorEntry): boolean {
     return this.index < entry.index;
   }
 
@@ -1386,8 +1386,8 @@ export function attemptToMergeEquivalentObjectAssigns(
               // because another generator entry may have a dependency on the Object.assign
               // TemporalObjectAssignEntry we're trying to merge.
               if (
-                temporalGeneratorEntry.happensAfter(otherTemporalBuildNodeEntry) &&
-                temporalGeneratorEntry.happensBefore(temporalBuildNodeEntry)
+                temporalGeneratorEntry.notEqualToAndDoesNotHappenAfter(otherTemporalBuildNodeEntry) &&
+                temporalGeneratorEntry.notEqualToAndDoesNotHappenBefore(temporalBuildNodeEntry)
               ) {
                 continue loopThroughArgs;
               }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -126,11 +126,11 @@ export class GeneratorEntry {
     invariant(false, "GeneratorEntry is an abstract base class");
   }
 
-  notEqualToAndDoesNotHappenAfter(entry: GeneratorEntry): boolean {
+  notEqualToAndDoesNotHappenBefore(entry: GeneratorEntry): boolean {
     return this.index > entry.index;
   }
 
-  notEqualToAndDoesNotHappenBefore(entry: GeneratorEntry): boolean {
+  notEqualToAndDoesNotHappenAfter(entry: GeneratorEntry): boolean {
     return this.index < entry.index;
   }
 
@@ -1124,8 +1124,6 @@ export class Generator {
     return res;
   }
 
-  // PITFALL Warning: adding a new kind of TemporalBuildNodeEntry that is not the result of a join or composition
-  // will break this purgeEntriesWithGeneratorDepencies.
   _addEntry(entryArgs: TemporalBuildNodeEntryArgs): TemporalBuildNodeEntry {
     let entry;
     if (entryArgs.temporalType === "OBJECT_ASSIGN") {
@@ -1372,7 +1370,7 @@ export function attemptToMergeEquivalentObjectAssigns(
           let temporalGeneratorEntries = realm.getTemporalGeneratorEntriesReferencingArg(arg);
           // We need to now check if there are any other temporal entries that exist
           // between the Object.assign TemporalObjectAssignEntry that we're trying to
-          // merge and the current TemporalObjectAssignEntry we're going to mergin into.
+          // merge and the current TemporalObjectAssignEntry we're going to merge into.
           if (temporalGeneratorEntries !== undefined) {
             for (let temporalGeneratorEntry of temporalGeneratorEntries) {
               // If the entry is that of another Object.assign, then
@@ -1383,13 +1381,13 @@ export function attemptToMergeEquivalentObjectAssigns(
               }
               // TODO: what if the temporalGeneratorEntry can be omitted and not needed?
 
-              // If the index of this entry exist between start and end indexes,
+              // If the index of this entry exists between start and end indexes,
               // then we cannot optimize and merge the TemporalObjectAssignEntry
               // because another generator entry may have a dependency on the Object.assign
               // TemporalObjectAssignEntry we're trying to merge.
               if (
-                temporalGeneratorEntry.notEqualToAndDoesNotHappenAfter(otherTemporalBuildNodeEntry) &&
-                temporalGeneratorEntry.notEqualToAndDoesNotHappenBefore(temporalBuildNodeEntry)
+                temporalGeneratorEntry.notEqualToAndDoesNotHappenBefore(otherTemporalBuildNodeEntry) &&
+                temporalGeneratorEntry.notEqualToAndDoesNotHappenAfter(temporalBuildNodeEntry)
               ) {
                 continue loopThroughArgs;
               }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1372,27 +1372,29 @@ export function attemptToMergeEquivalentObjectAssigns(
       let otherArgsToUse = [];
       for (let x = 2; x < otherArgs.length; x++) {
         let arg = otherArgs[x];
-        let temporalGeneratorEntries = realm.getTemporalGeneratorEntriesReferencingArg(arg);
-        // We need to now check if there are any other temporal entries that exist
-        // between the Object.assign TemporalObjectAssignEntry (start) that we're trying
-        // to merge and the current TemporalObjectAssignEntry we're going to mergin into (end)
-        let startIndex = otherTemporalBuildNodeEntry.index;
-        let endIndex = temporalBuildNodeEntry.index;
+        if (arg instanceof ObjectValue || arg instanceof AbstractValue) {
+          let temporalGeneratorEntries = realm.getTemporalGeneratorEntriesReferencingArg(arg);
+          // We need to now check if there are any other temporal entries that exist
+          // between the Object.assign TemporalObjectAssignEntry (start) that we're trying
+          // to merge and the current TemporalObjectAssignEntry we're going to mergin into (end)
+          let startIndex = otherTemporalBuildNodeEntry.index;
+          let endIndex = temporalBuildNodeEntry.index;
 
-        if (temporalGeneratorEntries !== undefined) {
-          for (let temporalGeneratorEntry of temporalGeneratorEntries) {
-            // If the entry is that of another Object.assign, then
-            // we know that this entry isn't going to cause issues
-            // with merging the TemporalObjectAssignEntry.
-            if (temporalGeneratorEntry instanceof TemporalObjectAssignEntry) {
-              continue;
-            }
-            // If the index of this entry exist between start and end indexes,
-            // then we cannot optimize and merge the TemporalObjectAssignEntry
-            // because another generator entry has a dependency on the Object.assign
-            // TemporalObjectAssignEntry we're trying to merge.
-            if (temporalGeneratorEntry.index > startIndex && temporalGeneratorEntry.index < endIndex) {
-              continue loopThroughArgs;
+          if (temporalGeneratorEntries !== undefined) {
+            for (let temporalGeneratorEntry of temporalGeneratorEntries) {
+              // If the entry is that of another Object.assign, then
+              // we know that this entry isn't going to cause issues
+              // with merging the TemporalObjectAssignEntry.
+              if (temporalGeneratorEntry instanceof TemporalObjectAssignEntry) {
+                continue;
+              }
+              // If the index of this entry exist between start and end indexes,
+              // then we cannot optimize and merge the TemporalObjectAssignEntry
+              // because another generator entry has a dependency on the Object.assign
+              // TemporalObjectAssignEntry we're trying to merge.
+              if (temporalGeneratorEntry.index > startIndex && temporalGeneratorEntry.index < endIndex) {
+                continue loopThroughArgs;
+              }
             }
           }
         }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -20,7 +20,13 @@ import type {
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
-import { type VisitEntryCallbacks, PreludeGenerator } from "../utils/generator.js";
+import {
+  Generator,
+  PreludeGenerator,
+  type TemporalBuildNodeEntry,
+  type TemporalBuildNodeEntryOptimizationStatus,
+  type VisitEntryCallbacks,
+} from "../utils/generator.js";
 import buildExpressionTemplate from "../utils/builder.js";
 
 import {
@@ -784,7 +790,11 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: Value) => boolean,
+      optimizationFn?: (
+        VisitEntryCallbacks,
+        Generator,
+        TemporalBuildNodeEntry
+      ) => TemporalBuildNodeEntryOptimizationStatus,
     |}
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
@@ -825,7 +835,11 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: Value) => boolean,
+      optimizationFn?: (
+        VisitEntryCallbacks,
+        Generator,
+        TemporalBuildNodeEntry
+      ) => TemporalBuildNodeEntryOptimizationStatus,
     |}
   ): AbstractValue | UndefinedValue {
     let types = new TypesDomain(resultType);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -20,12 +20,7 @@ import type {
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
-import {
-  Generator,
-  PreludeGenerator,
-  type TemporalBuildNodeEntry,
-  type VisitEntryCallbacks,
-} from "../utils/generator.js";
+import { PreludeGenerator, type TemporalBuildNodeType } from "../utils/generator.js";
 import buildExpressionTemplate from "../utils/builder.js";
 
 import {
@@ -789,7 +784,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => void | boolean,
+      temporalType?: TemporalBuildNodeType,
     |}
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
@@ -830,7 +825,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => void | boolean,
+      temporalType?: TemporalBuildNodeType,
     |}
   ): AbstractValue | UndefinedValue {
     let types = new TypesDomain(resultType);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -20,7 +20,7 @@ import type {
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue } from "../types.js";
-import { PreludeGenerator } from "../utils/generator.js";
+import { type VisitEntryCallbacks, PreludeGenerator } from "../utils/generator.js";
 import buildExpressionTemplate from "../utils/builder.js";
 
 import {
@@ -784,7 +784,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: AbstractObjectValue) => boolean,
+      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: Value) => boolean,
     |}
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
@@ -825,7 +825,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: AbstractObjectValue) => boolean,
+      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: Value) => boolean,
     |}
   ): AbstractValue | UndefinedValue {
     let types = new TypesDomain(resultType);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -142,11 +142,10 @@ export default class AbstractValue extends Value {
   addSourceNamesTo(names: Array<string>, visited: Set<AbstractValue> = new Set()) {
     if (visited.has(this)) return;
     visited.add(this);
-    let gen = this.$Realm.preludeGenerator;
+    let realm = this.$Realm;
     function add_intrinsic(name: string) {
       if (name.startsWith("_$")) {
-        if (gen === undefined) return;
-        let temporalBuildNodeEntryArgs = gen.derivedIds.get(name);
+        let temporalBuildNodeEntryArgs = realm.derivedIds.get(name);
         invariant(temporalBuildNodeEntryArgs !== undefined);
         add_args(temporalBuildNodeEntryArgs.args);
       } else if (names.indexOf(name) < 0) {

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -24,7 +24,6 @@ import {
   Generator,
   PreludeGenerator,
   type TemporalBuildNodeEntry,
-  type TemporalBuildNodeEntryOptimizationStatus,
   type VisitEntryCallbacks,
 } from "../utils/generator.js";
 import buildExpressionTemplate from "../utils/builder.js";
@@ -790,11 +789,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      optimizationFn?: (
-        VisitEntryCallbacks,
-        Generator,
-        TemporalBuildNodeEntry
-      ) => TemporalBuildNodeEntryOptimizationStatus,
+      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => boolean,
     |}
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
@@ -835,11 +830,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      optimizationFn?: (
-        VisitEntryCallbacks,
-        Generator,
-        TemporalBuildNodeEntry
-      ) => TemporalBuildNodeEntryOptimizationStatus,
+      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => boolean,
     |}
   ): AbstractValue | UndefinedValue {
     let types = new TypesDomain(resultType);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -784,6 +784,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
+      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: AbstractObjectValue) => boolean,
     |}
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
@@ -824,6 +825,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
+      customOptimizationFn?: (callbacks: VisitEntryCallbacks, value: AbstractObjectValue) => boolean,
     |}
   ): AbstractValue | UndefinedValue {
     let types = new TypesDomain(resultType);

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -789,7 +789,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => boolean,
+      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => void | boolean,
     |}
   ): AbstractValue {
     invariant(resultType !== UndefinedValue);
@@ -830,7 +830,7 @@ export default class AbstractValue extends Value {
       isPure?: boolean,
       skipInvariant?: boolean,
       mutatesOnly?: Array<Value>,
-      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => boolean,
+      optimizationFn?: (VisitEntryCallbacks, Generator, TemporalBuildNodeEntry) => void | boolean,
     |}
   ): AbstractValue | UndefinedValue {
     let types = new TypesDomain(resultType);

--- a/test/serializer/optimized-functions/DeadObjectAssign.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign.js
@@ -1,4 +1,5 @@
 // Copies of assign\(:0
+
 global.f = function() {
   var x = global.__abstract ? global.__abstract({}, "({})") : {};
   global.__makeSimple && __makeSimple(x);

--- a/test/serializer/optimized-functions/DeadObjectAssign10.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign10.js
@@ -1,0 +1,14 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. So DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(foo, bar) {
+  var a = Object.assign({}, foo, bar, {a: 1});
+  var b = Object.assign({}, a, {a: 2});
+  var c = Object.assign({}, b, {a: 2}, {d: 5});
+  return c;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({b: 1}, {c: 2})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign10.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign10.js
@@ -1,5 +1,5 @@
 // Copies of _5:2
-// _5 is the variable for Object.assign. So DeadObjectAssign4.js for
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign10.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign10.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$B:2
+// inline expressions
+
+// _$B is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign11.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign11.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$B:2
+// inline expressions
+
+// _$B is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign11.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign11.js
@@ -1,0 +1,16 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(foo, bar) {
+  var a = Object.assign({}, foo, bar, {a: 1});
+  foo = {};
+  var b = Object.assign({}, a, {a: 2});
+  bar = {};
+  var c = Object.assign({}, b, {a: 2}, {d: 5});
+  return c;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({b: 1}, {c: 2})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign12.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign12.js
@@ -1,5 +1,7 @@
-// Copies of _A:4
-// _A is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$D:4
+// inline expressions
+
+// _$D is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(x, foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign12.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign12.js
@@ -1,0 +1,20 @@
+// Copies of _A:4
+// _A is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(x, foo, bar) {
+  var a = Object.assign({}, foo, bar, {a: 1});
+  foo = {};
+  var b
+  if (x) {
+    b = Object.assign({}, a, {a: 2});
+  } else {
+    b = Object.assign({}, a, {a: 5});
+  }
+  var c = Object.assign({}, b, {a: 2}, {d: 5});
+  return c;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f(false, {b: 1}, {c: 2})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign13.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign13.js
@@ -1,5 +1,7 @@
-// Copies of _8:3
-// _8 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$7:3
+// inline expressions
+
+// _$7 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(x, foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign13.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign13.js
@@ -1,0 +1,13 @@
+// Copies of _8:3
+// _8 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(x, foo) {
+  var a = Object.assign({}, foo);
+  
+  return x ? Object.assign({}, a, {a: 1}) : Object.assign({}, a, {a: 2})
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return f(false, {a: 3}); }

--- a/test/serializer/optimized-functions/DeadObjectAssign13.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign13.js
@@ -10,4 +10,4 @@ function f(x, foo) {
 
 if (global.__optimize) __optimize(f);
 
-global.inspect = function() { return f(false, {a: 3}); }
+global.inspect = function() { return JSON.stringify(f(false, {a: 3})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign14.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign14.js
@@ -1,5 +1,7 @@
-// Copies of _8:3
-// _8 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$4:3
+// inline expressions
+
+// _$4 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(x, foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign14.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign14.js
@@ -17,4 +17,4 @@ function f(x, foo) {
 
 if (global.__optimize) __optimize(f);
 
-global.inspect = function() { return f(false, {a: 3}); }
+global.inspect = function() { return JSON.stringify(f(false, {a: 3})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign14.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign14.js
@@ -1,0 +1,20 @@
+// Copies of _8:3
+// _8 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(x, foo) {
+  var a = Object.assign({}, foo);
+  var b = Object.assign({}, a);
+  // b gets visited
+  var someVal = b;
+  if (x) {
+    // a gets visited
+    someVal = a;
+  }
+  // a should still exist
+  return someVal;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return f(false, {a: 3}); }

--- a/test/serializer/optimized-functions/DeadObjectAssign15.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign15.js
@@ -1,5 +1,7 @@
-// Copies of _7:3
-// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$4:3
+// inline expressions
+
+// _$4 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(x, foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign15.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign15.js
@@ -20,4 +20,4 @@ function f(x, foo) {
 
 if (global.__optimize) __optimize(f);
 
-global.inspect = function() { return f(false, {a: 3}); }
+global.inspect = function() { return JSON.stringify(f(false, {a: 3})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign15.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign15.js
@@ -1,0 +1,23 @@
+// Copies of _7:3
+// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(x, foo) {
+  var a = Object.assign({}, foo);
+  var b = Object.assign({}, a);
+  // b gets visited
+  var someVal = b;
+  if (x) {
+    // a gets visited
+    function foo() {
+      return a;
+    }
+    someVal = foo;
+  }
+  // a should still exist
+  return someVal;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return f(false, {a: 3}); }

--- a/test/serializer/optimized-functions/DeadObjectAssign16.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign16.js
@@ -1,4 +1,4 @@
-// Copies of _7:2
+// Copies of _7:3
 // _7 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 

--- a/test/serializer/optimized-functions/DeadObjectAssign16.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign16.js
@@ -1,5 +1,7 @@
-// Copies of _7:3
-// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$4:3
+// inline expressions
+
+// _$4 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(o) {

--- a/test/serializer/optimized-functions/DeadObjectAssign16.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign16.js
@@ -1,0 +1,14 @@
+// Copies of _7:2
+// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(o) {
+  var p = Object.assign({}, o);
+  o.x = 42;
+  var q = Object.assign({}, p);
+  return q;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({x: 10})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign17.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign17.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$C:2
+// inline expressions
+
+// _$C is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(o) {

--- a/test/serializer/optimized-functions/DeadObjectAssign17.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign17.js
@@ -1,0 +1,15 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(o) {
+  var p = Object.assign({}, o, {a: 1});
+  var p2 = Object.assign({}, o, {a: 2});
+  var q = Object.assign({}, p, {a: 3});
+  var q2 = Object.assign({}, q, {a: 4});
+  return q2;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({a: 10})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign18.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign18.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$C:3
+// inline expressions
+
+// _$C is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(o) {

--- a/test/serializer/optimized-functions/DeadObjectAssign18.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign18.js
@@ -1,0 +1,15 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(o) {
+  var p = Object.assign({}, o, {a: 1});
+  var q = Object.assign({}, p, {a: 3});
+  var p2 = Object.assign({}, o, {a: 2});
+  var q2 = Object.assign({}, p2, {a: 4});
+  return [q, q2];
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({a: 10})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign19.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign19.js
@@ -1,0 +1,17 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(o) {
+  var p = Object.assign({}, o, {a: 1});
+  var p2 = Object.assign({}, o, {a: 2});
+  p2.a = 100;
+  var q = Object.assign({}, p, {a: 3});
+  var q2 = Object.assign({}, q, {a: 4});
+  var q2 = Object.assign({}, q2, p2, {a: 1}, p2);
+  return q2;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({a: 10})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign19.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign19.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$H:3
+// inline expressions
+
+// _$H is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(o) {

--- a/test/serializer/optimized-functions/DeadObjectAssign2.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign2.js
@@ -1,4 +1,5 @@
 // Copies of .assign;:1
+
 global.f = function() {
   var x = global.__abstract ? global.__abstract({}, "({a: 1})") : {a: 1};
   var val = {};

--- a/test/serializer/optimized-functions/DeadObjectAssign20.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign20.js
@@ -1,0 +1,16 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(o) {
+  var p = Object.assign({}, o);
+  var l = {};
+  var q = Object.assign({}, p, l);
+  l.x = 42;
+  var r = Object.assign({}, q);
+  return r;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({x: 10})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign20.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign20.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$5:2
+// inline expressions
+
+// _$5 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(o) {

--- a/test/serializer/optimized-functions/DeadObjectAssign21.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign21.js
@@ -1,0 +1,26 @@
+// Copies of _A:4
+// _A is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(o1, o2, g, h) {
+  let a = Object.assign({}, o1);
+  let b = Object.assign({}, o2);
+  g(a, b);
+  let p = Object.assign({}, o1);
+  h(o2); // can mutate o1 !
+  let q = Object.assign({}, p);
+  return q;
+}
+
+if (global.__optimize) __optimize(f);
+
+inspect = function() {
+  return f({}, {}, 
+    function(o1, o2) {
+      o2.o1 = o1;
+    },
+    function(o2) {
+      o2.o1.x = 42;
+    }
+  ).x;
+}

--- a/test/serializer/optimized-functions/DeadObjectAssign21.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign21.js
@@ -1,6 +1,21 @@
-// Copies of _A:4
-// _A is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$E:4
+// inline expressions
+
+// _$E is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
+
+function f(o) {
+  var p = Object.assign({}, o, {a: 1});
+  var q = Object.assign({}, p, {a: 3});
+  var p2 = Object.assign({}, o, {a: 2});
+  var q2 = Object.assign({}, p2, {a: 4});
+  return [q, q2];
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({a: 10})); }
+
 
 function f(o1, o2, g, h) {
   let a = Object.assign({}, o1);

--- a/test/serializer/optimized-functions/DeadObjectAssign22.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign22.js
@@ -1,6 +1,21 @@
-// Copies of _9:3
-// _9 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$A:3
+// inline expressions
+
+// _$A is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
+
+function f(o) {
+  var p = Object.assign({}, o, {a: 1});
+  var q = Object.assign({}, p, {a: 3});
+  var p2 = Object.assign({}, o, {a: 2});
+  var q2 = Object.assign({}, p2, {a: 4});
+  return [q, q2];
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({a: 10})); }
+
 
 function f(o2, g, h) {
   let o1 = {};

--- a/test/serializer/optimized-functions/DeadObjectAssign22.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign22.js
@@ -1,0 +1,25 @@
+// Copies of _9:3
+// _9 is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(o2, g, h) {
+  let o1 = {};
+  g(o1, o2); // leaks o1
+  let p = Object.assign({}, o1);
+  h(o2); // can mutate o1 !
+  let q = Object.assign({}, p);
+  return q;
+}
+
+if (global.__optimize) __optimize(f);
+
+inspect = function() {
+  return f({},
+    function(o1, o2) {
+      o2.o1 = o1;
+    },
+    function(o2) {
+      o2.o1.x = 42;
+    }
+  ).x;
+}

--- a/test/serializer/optimized-functions/DeadObjectAssign3.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign3.js
@@ -1,4 +1,5 @@
 // Copies of assign\(:0
+
 global.f = function() {
   var x = global.__abstract ? global.__abstract({}, "({})") : {};
   global.__makeSimple && __makeSimple(x);

--- a/test/serializer/optimized-functions/DeadObjectAssign4.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign4.js
@@ -1,0 +1,17 @@
+// Copies of _5:2
+// Why? _5 is the variable for Object.assign, and there should be
+// two copies of it. One for it's declaration and one for its reference.
+// I could not think of another way of getting this test to work only
+// for the compiled output. Passing in values to the optimized function
+// with getters or monkey patching Object.assign breaks because the
+// instances does not match compiled vs non-compiled.
+
+function f(foo) {
+  var a = Object.assign({}, foo);
+  var b = Object.assign({}, a);
+  return b;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return f({}); }

--- a/test/serializer/optimized-functions/DeadObjectAssign4.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign4.js
@@ -1,10 +1,10 @@
-// Copies of _5:2
-// Why? _5 is the variable for Object.assign, and there should be
+// Copies of _\$4:2
+// inline expressions
+
+// Why? _$4 is the variable for Object.assign, and there should be
 // two copies of it. One for it's declaration and one for its reference.
-// I could not think of another way of getting this test to work only
-// for the compiled output. Passing in values to the optimized function
-// with getters or monkey patching Object.assign breaks because output
-// values will never match when we compare compiled vs non-compiled.
+// We use inline expressions on all test iterations to ensure the copies
+// count is always constant.
 
 function f(foo) {
   var a = Object.assign({}, foo);

--- a/test/serializer/optimized-functions/DeadObjectAssign4.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign4.js
@@ -3,8 +3,8 @@
 // two copies of it. One for it's declaration and one for its reference.
 // I could not think of another way of getting this test to work only
 // for the compiled output. Passing in values to the optimized function
-// with getters or monkey patching Object.assign breaks because the
-// instances does not match compiled vs non-compiled.
+// with getters or monkey patching Object.assign breaks because output
+// values will never match when we compare compiled vs non-compiled.
 
 function f(foo) {
   var a = Object.assign({}, foo);

--- a/test/serializer/optimized-functions/DeadObjectAssign5.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign5.js
@@ -1,0 +1,13 @@
+// Copies of _7:3
+// _7 is the variable for Object.assign. So DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(foo) {
+  var a = Object.assign({}, foo);
+  var b = Object.assign({}, a);
+  return [a, b];
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign5.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign5.js
@@ -1,5 +1,7 @@
-// Copies of _7:3
-// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$4:3
+// inline expressions
+
+// _$4 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign5.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign5.js
@@ -1,5 +1,5 @@
 // Copies of _7:3
-// _7 is the variable for Object.assign. So DeadObjectAssign4.js for
+// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign6.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign6.js
@@ -1,5 +1,7 @@
-// Copies of _7:3
-// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$5:3
+// inline expressions
+
+// _$5 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign6.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign6.js
@@ -1,0 +1,14 @@
+// Copies of _7:3
+// _7 is the variable for Object.assign. So DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(foo) {
+  var a = Object.assign({}, foo);
+  var bar = a.x;
+  var b = Object.assign({}, a);
+  return [b, bar];
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({x: 1})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign6.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign6.js
@@ -1,5 +1,5 @@
 // Copies of _7:3
-// _7 is the variable for Object.assign. So DeadObjectAssign4.js for
+// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign7.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign7.js
@@ -1,5 +1,5 @@
 // Copies of _7:2
-// _7 is the variable for Object.assign. So DeadObjectAssign4.js for
+// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign7.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign7.js
@@ -1,0 +1,14 @@
+// Copies of _7:2
+// _7 is the variable for Object.assign. So DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(foo) {
+  var a = Object.assign({}, foo);
+  var bar = a.x;
+  var b = Object.assign({}, a);
+  return [a, bar];
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({x: 1})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign7.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign7.js
@@ -1,5 +1,7 @@
-// Copies of _7:2
-// _7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$5:2
+// inline expressions
+
+// _$5 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo) {

--- a/test/serializer/optimized-functions/DeadObjectAssign8.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign8.js
@@ -1,0 +1,13 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. So DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(foo, bar) {
+  var a = Object.assign({}, foo, bar, {a: 1});
+  var b = Object.assign({}, a);
+  return b;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({b: 1}, {c: 2})); }

--- a/test/serializer/optimized-functions/DeadObjectAssign8.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign8.js
@@ -1,5 +1,5 @@
 // Copies of _5:2
-// _5 is the variable for Object.assign. So DeadObjectAssign4.js for
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign8.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign8.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$6:2
+// inline expressions
+
+// _$6 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign9.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign9.js
@@ -1,5 +1,7 @@
-// Copies of _5:2
-// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
+// Copies of _\$7:2
+// inline expressions
+
+// _$7 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign9.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign9.js
@@ -1,5 +1,5 @@
 // Copies of _5:2
-// _5 is the variable for Object.assign. So DeadObjectAssign4.js for
+// _5 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign9.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign9.js
@@ -1,0 +1,13 @@
+// Copies of _5:2
+// _5 is the variable for Object.assign. So DeadObjectAssign4.js for
+// a larger explanation.
+
+function f(foo, bar) {
+  var a = Object.assign({}, foo, bar, {a: 1});
+  var b = Object.assign({}, a, {a: 2});
+  return b;
+}
+
+if (global.__optimize) __optimize(f);
+
+global.inspect = function() { return JSON.stringify(f({b: 1}, {c: 2})); }


### PR DESCRIPTION
Release notes: adds an optimization to Object.assign that attempts to merge calls together where possible

I frequently see `Objet.assign` calls litter our internal bundle. Many of them can actually be merged together to reduce bloat and runtime overhead (on that matter, `Object.assign` isn't a cheap call). We do this by adding a new `TemporalObjectAssignEntry` entry, that allows us to add some fine-tuning of Object.assign temporal entries we create.

The new `TemporalObjectAssignEntry` entry has an optimization that aims to merge entries by checking if linked nodes, specifically the `Object.assign` calls `to` field, to see if it can literally merge the arguments of many `Object.assign`s together. If a `to` is visited and can't be omitted, it doesn't try to apply this optimization. What we end up with, is a single `Object.assign` call and the others all get dead-code eliminated away because of the `mutatesOnly` logic from earlier.