### PR TITLE
Print output of inspect function in verbose mode

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -581,6 +581,12 @@ function runTest(name, code, options: PrepackOptions, args) {
             if (actualStack) console.log(actualStack);
             return Promise.resolve(false);
           } else if (type === "RETURN") {
+            if (args.verbose) {
+              console.log(chalk.underline("output of inspect() on original code"));
+              console.log(expected);
+              console.log(chalk.underline("output of inspect() on last generated code iteration"));
+              console.log(actual);
+            }
             return value;
           } else if (type === "MARKER") {
             return undefined;


### PR DESCRIPTION
It is useful to compare the output of the two types of runs when a test succeeds but is expected not to.

Example output with the --verbose flag set:

```
output of inspect() on original code
{"foo":42,"now":1}
output of inspect() on last generated code iteration
{"foo":42,"now":1}
```