### PR TITLE
Allow __optimize to work in conditional contexts

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -43,10 +43,13 @@ export function createAbstractFunction(realm: Realm, ...additionalValues: Array<
       let name = _name;
       if (name instanceof StringValue) name = name.value;
       if (name !== undefined && typeof name !== "string") {
-        throw new TypeError("intrinsic name argument is not a string");
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "intrinsic name argument is not a string");
       }
       if (options && !(options instanceof ObjectValue)) {
-        throw new TypeError("options must be an ObjectValue if provided");
+        throw realm.createErrorThrowCompletion(
+          realm.intrinsics.TypeError,
+          "options must be an ObjectValue if provided"
+        );
       }
       return createAbstract(realm, typeNameOrTemplate, name, options, ...additionalValues);
     }
@@ -137,7 +140,7 @@ export default function(realm: Realm): void {
           value
         );
       } else {
-        throw new TypeError("Called __optimize on an invalid type");
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Called __optimize on an invalid type");
       }
       return value;
     }),

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -67,6 +67,7 @@ export function createAbstract(
   realm: Realm,
   typeNameOrTemplate?: Value | string,
   name?: string,
+  options?: ObjectValue,
   ...additionalValues: Array<ConcreteValue>
 ): AbstractValue | AbstractObjectValue {
   if (!realm.useAbstractInterpretation) {
@@ -74,6 +75,7 @@ export function createAbstract(
   }
 
   let { type, template, functionResultType } = parseTypeNameOrTemplate(realm, typeNameOrTemplate);
+  let optionsMap = options ? options.properties : new Map();
 
   let result;
   let locString,
@@ -95,7 +97,7 @@ export function createAbstract(
     result = AbstractValue.createFromTemplate(realm, throwTemplate, type, [locVal], kind);
   } else {
     let kind = AbstractValue.makeKind("abstract", name);
-    if (!realm.isNameStringUnique(name)) {
+    if (!optionsMap.get("allowDuplicateNames") && !realm.isNameStringUnique(name)) {
       let error = new CompilerDiagnostic("An abstract value with the same name exists", loc, "PP0019", "FatalError");
       realm.handleError(error);
       throw new FatalError();

--- a/src/realm.js
+++ b/src/realm.js
@@ -136,6 +136,8 @@ export class Tracer {
     newTarget: void | ObjectValue,
     result: void | Reference | Value | AbruptCompletion
   ) {}
+  beginOptimizingFunction(optimizedFunctionId: number, functionValue: FunctionValue) {}
+  endOptimizingFunction(optimizedFunctionId: number) {}
 }
 
 export class ExecutionContext {
@@ -437,14 +439,6 @@ export class Realm {
   nextGeneratorId: number = 0;
   _abstractValuesDefined: Set<string>;
   _checkedObjectIds: Map<ObjectValue | AbstractObjectValue, number>;
-
-  // Have to pass in Tracer type as argument because we can't import them here to avoid increasing flow cycle
-  getTracer<T>(tracerType: T): T | void {
-    let tracers = this.tracers.filter(x => x instanceof tracerType);
-    invariant(tracers.length <= 1, "Looking for a tracer but found multiple.");
-    if (tracers.length === 1) return tracers[0];
-    return undefined;
-  }
 
   // to force flow to type the annotations
   isCompatibleWith(compatibility: Compatibility): boolean {

--- a/src/realm.js
+++ b/src/realm.js
@@ -438,6 +438,14 @@ export class Realm {
   _abstractValuesDefined: Set<string>;
   _checkedObjectIds: Map<ObjectValue | AbstractObjectValue, number>;
 
+  // Have to pass in Tracer type as argument because we can't import them here to avoid increasing flow cycle
+  getTracer<T>(tracerType: T): T | void {
+    let tracers = this.tracers.filter(x => x instanceof tracerType);
+    invariant(tracers.length <= 1, "Looking for a tracer but found multiple.");
+    if (tracers.length === 1) return tracers[0];
+    return undefined;
+  }
+
   // to force flow to type the annotations
   isCompatibleWith(compatibility: Compatibility): boolean {
     return compatibility === this.compatibility;

--- a/src/realm.js
+++ b/src/realm.js
@@ -68,7 +68,6 @@ import { emptyExpression, voidExpression } from "./utils/babelhelpers.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
-import type { LoggingTracer } from "./serializer/LoggingTracer";
 import * as t from "babel-types";
 
 export type BindingEntry = {
@@ -438,8 +437,6 @@ export class Realm {
   nextGeneratorId: number = 0;
   _abstractValuesDefined: Set<string>;
   _checkedObjectIds: Map<ObjectValue | AbstractObjectValue, number>;
-
-  loggingTracer: LoggingTracer | void;
 
   // to force flow to type the annotations
   isCompatibleWith(compatibility: Compatibility): boolean {

--- a/src/realm.js
+++ b/src/realm.js
@@ -68,6 +68,7 @@ import { emptyExpression, voidExpression } from "./utils/babelhelpers.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "babel-types";
+import type { LoggingTracer } from "./serializer/LoggingTracer";
 import * as t from "babel-types";
 
 export type BindingEntry = {
@@ -437,6 +438,8 @@ export class Realm {
   nextGeneratorId: number = 0;
   _abstractValuesDefined: Set<string>;
   _checkedObjectIds: Map<ObjectValue | AbstractObjectValue, number>;
+
+  loggingTracer: LoggingTracer | void;
 
   // to force flow to type the annotations
   isCompatibleWith(compatibility: Compatibility): boolean {

--- a/src/serializer/LoggingTracer.js
+++ b/src/serializer/LoggingTracer.js
@@ -27,6 +27,7 @@ import {
 } from "../values/index.js";
 import { To } from "../singletons.js";
 import invariant from "../invariant.js";
+import { stringOfLocation } from "../utils/babelhelpers.js";
 
 function describeValue(realm: Realm, v: Value): string {
   if (v instanceof NumberValue || v instanceof BooleanValue) return v.value.toString();
@@ -80,5 +81,17 @@ export class LoggingTracer extends Tracer {
   ) {
     let name = this.nesting.pop();
     this.log(`<${name}${result instanceof ThrowCompletion ? ": error" : ""}`);
+  }
+
+  beginOptimizingFunction(optimizedFunctionId: number, functionValue: FunctionValue) {
+    this.log(
+      `>Starting Optimized Function ${optimizedFunctionId} ${
+        functionValue.intrinsicName ? functionValue.intrinsicName : "[unknown name]"
+      } ${functionValue.expressionLocation ? stringOfLocation(functionValue.expressionLocation) : ""}`
+    );
+  }
+
+  endOptimizingFunction(optimizedFunctionId: number) {
+    this.log(`<Ending Optimized Function ${optimizedFunctionId}`);
   }
 }

--- a/src/serializer/LoggingTracer.js
+++ b/src/serializer/LoggingTracer.js
@@ -49,8 +49,8 @@ export class LoggingTracer extends Tracer {
   realm: Realm;
   nesting: Array<string>;
 
-  log(message: string) {
-    console.log(`[calls] ${this.nesting.map(_ => "  ").join("")}${message}`);
+  log(message: string, prefix: string = "[calls]") {
+    console.log(`${prefix} ${this.nesting.map(_ => "  ").join("")}${message}`);
   }
 
   beginEvaluateForEffects(state: any) {

--- a/src/serializer/LoggingTracer.js
+++ b/src/serializer/LoggingTracer.js
@@ -49,8 +49,8 @@ export class LoggingTracer extends Tracer {
   realm: Realm;
   nesting: Array<string>;
 
-  log(message: string, prefix: string = "[calls]") {
-    console.log(`${prefix} ${this.nesting.map(_ => "  ").join("")}${message}`);
+  log(message: string) {
+    console.log(`[calls] ${this.nesting.map(_ => "  ").join("")}${message}`);
   }
 
   beginEvaluateForEffects(state: any) {

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -23,6 +23,7 @@ import {
   FunctionValue,
   ObjectValue,
   UndefinedValue,
+  EmptyValue,
   Value,
 } from "../values/index.js";
 import { Get } from "../methods/index.js";
@@ -32,6 +33,7 @@ import { ReactStatistics } from "./types";
 import type { AdditionalFunctionEffects, WriteEffects } from "./types";
 import { convertConfigObjectToReactComponentTreeConfig, valueIsKnownReactAbstraction } from "../react/utils.js";
 import { applyOptimizedReactComponents, optimizeReactComponentTreeRoot } from "../react/optimizing.js";
+import { stringOfLocation } from "../utils/babelhelpers";
 import * as t from "babel-types";
 
 type AdditionalFunctionEntry = {
@@ -57,6 +59,20 @@ export class Functions {
 
   __optimizedFunctionEntryOfValue(value: Value): AdditionalFunctionEntry | void {
     let realm = this.realm;
+
+    if (value instanceof AbstractValue) {
+      // if we conditionally called __optimize, we may have an AbstractValue that is the union of Empty or Undefined and
+      // a function/component to optimize
+      let elements = value.values.getElements();
+      if (elements) {
+        let possibleValues = [...elements].filter(
+          element => !(element instanceof EmptyValue || element instanceof UndefinedValue)
+        );
+        if (possibleValues.length === 1) {
+          value = possibleValues[0];
+        }
+      }
+    }
     if (value instanceof ECMAScriptSourceFunctionValue) {
       // additional function logic
       return { value };
@@ -100,7 +116,7 @@ export class Functions {
       realm.intrinsics.undefined
     );
     invariant(globalRecordedAdditionalFunctionsMap instanceof ObjectValue);
-    for (let funcId of globalRecordedAdditionalFunctionsMap.getOwnPropertyKeysArray()) {
+    for (let funcId of globalRecordedAdditionalFunctionsMap.getOwnPropertyKeysArray(true)) {
       let property = globalRecordedAdditionalFunctionsMap.properties.get(funcId);
       if (property) {
         let value = property.descriptor && property.descriptor.value;
@@ -195,9 +211,19 @@ export class Functions {
       }
     };
 
+    let optimizedFunctionId = 0;
     let getEffectsFromAdditionalFunctionAndNestedFunctions = functionValue => {
+      let currentOptimizedFunctionId = optimizedFunctionId++;
       additionalFunctionStack.push(functionValue);
       invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
+      let loggingTracer = this.realm.loggingTracer;
+      if (loggingTracer)
+        loggingTracer.log(
+          `>Starting Optimized Function ${currentOptimizedFunctionId} ${
+            functionValue.intrinsicName ? functionValue.intrinsicName : "[unknown name]"
+          } ${functionValue.expressionLocation ? stringOfLocation(functionValue.expressionLocation) : ""}`,
+          "[optimized functions]"
+        );
       let call = this._callOfFunction(functionValue);
       let effects: Effects = this.realm.evaluatePure(
         () => this.realm.evaluateForEffectsInGlobalEnv(call, undefined, "additional function"),
@@ -238,6 +264,8 @@ export class Functions {
         return null;
       }, additionalFunctionEffects.effects);
       invariant(additionalFunctionStack.pop() === functionValue);
+      if (loggingTracer)
+        loggingTracer.log(`<Ending Optimized Function ${currentOptimizedFunctionId}`, "[optimized functions]");
     };
 
     while (additionalFunctionsToProcess.length > 0) {

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -217,10 +217,8 @@ export class Functions {
       let currentOptimizedFunctionId = optimizedFunctionId++;
       additionalFunctionStack.push(functionValue);
       invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
-      let loggingTracers = this.realm.tracers.filter(x => x instanceof LoggingTracer);
-      let loggingTracer = loggingTracers.length > 0 ? loggingTracers[0] : undefined;
+      let loggingTracer = this.realm.getTracer(LoggingTracer);
       if (loggingTracer) {
-        invariant(loggingTracer instanceof LoggingTracer);
         loggingTracer.log(
           `>Starting Optimized Function ${currentOptimizedFunctionId} ${
             functionValue.intrinsicName ? functionValue.intrinsicName : "[unknown name]"
@@ -269,7 +267,6 @@ export class Functions {
       }, additionalFunctionEffects.effects);
       invariant(additionalFunctionStack.pop() === functionValue);
       if (loggingTracer) {
-        invariant(loggingTracer instanceof LoggingTracer);
         loggingTracer.log(`<Ending Optimized Function ${currentOptimizedFunctionId}`, "[optimized functions]");
       }
     };

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -54,7 +54,6 @@ export class Serializer {
     if (serializerOptions.trace) {
       let loggingTracer = new LoggingTracer(this.realm);
       this.realm.tracers.push(loggingTracer);
-      this.realm.loggingTracer = loggingTracer;
     }
 
     this.options = serializerOptions;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -51,7 +51,11 @@ export class Serializer {
       !!serializerOptions.accelerateUnsupportedRequires
     );
     this.functions = new Functions(this.realm, this.modules.moduleTracer);
-    if (serializerOptions.trace) this.realm.tracers.push(new LoggingTracer(this.realm));
+    if (serializerOptions.trace) {
+      let loggingTracer = new LoggingTracer(this.realm);
+      this.realm.tracers.push(loggingTracer);
+      this.realm.loggingTracer = loggingTracer;
+    }
 
     this.options = serializerOptions;
   }

--- a/src/utils/babelhelpers.js
+++ b/src/utils/babelhelpers.js
@@ -14,6 +14,7 @@ import type {
   BabelNodeMemberExpression,
   BabelNodeStringLiteral,
   BabelNodeIdentifier,
+  BabelNodeSourceLocation,
 } from "babel-types";
 import * as t from "babel-types";
 
@@ -56,4 +57,8 @@ export function memberExpressionHelper(
     computed = true;
   }
   return t.memberExpression(object, propertyExpression, computed);
+}
+
+export function stringOfLocation(location: BabelNodeSourceLocation): string {
+  return `${location.start.line}:${location.start.column} ${location.end.line}:${location.end.line}`;
 }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -530,7 +530,7 @@ export default class ObjectValue extends ConcreteValue {
     });
   }
 
-  getOwnPropertyKeysArray(): Array<string> {
+  getOwnPropertyKeysArray(allowAbstractKeys: ?true): Array<string> {
     if (this.isPartialObject() || this.mightBeHavocedObject() || this.unknownProperty !== undefined) {
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();
@@ -546,8 +546,10 @@ export default class ObjectValue extends ConcreteValue {
       if (!pv.mightHaveBeenDeleted()) return true;
       // The property may or may not be there at runtime.
       // We can at best return an abstract keys array.
-      // For now just terminate.
+      // For now, unless the caller has told us that is okay,
+      // just terminate.
       invariant(pv instanceof AbstractValue);
+      if (allowAbstractKeys) return true;
       AbstractValue.reportIntrospectionError(pv);
       throw new FatalError();
     });

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -530,7 +530,7 @@ export default class ObjectValue extends ConcreteValue {
     });
   }
 
-  getOwnPropertyKeysArray(allowAbstractKeys: ?true): Array<string> {
+  getOwnPropertyKeysArray(allowAbstractKeys: boolean = false): Array<string> {
     if (this.isPartialObject() || this.mightBeHavocedObject() || this.unknownProperty !== undefined) {
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();

--- a/test/serializer/additional-functions/NestedOptimizedFunction14.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction14.js
@@ -1,3 +1,5 @@
+// skip this test for now
+// we don't know how to optimize the union of two different functions
 (function () {
     function f(x, y, z) {
         var g;

--- a/test/serializer/additional-functions/NestedOptimizedFunction16.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction16.js
@@ -1,3 +1,4 @@
+// skip this test for now
 (function () {
 
   var fn2 = function(item, self) {

--- a/test/serializer/additional-functions/register_conditionally.js
+++ b/test/serializer/additional-functions/register_conditionally.js
@@ -1,4 +1,3 @@
-// throws introspection error
 let abstract_bool = global.__abstract ? global.__abstract("boolean", "(false)") : false;
 
 function func1() {

--- a/test/serializer/optimized-functions/ConditionallyOptimizedFunction.js
+++ b/test/serializer/optimized-functions/ConditionallyOptimizedFunction.js
@@ -1,0 +1,8 @@
+// does not contain:1 + 2
+(function () {
+    function g() {
+        return 1 + 2;
+    }
+    if (global.__optimize && __abstract("boolean", "true")) __optimize(g);
+    global.inspect = function() { return g(); }
+})();

--- a/test/serializer/optimized-functions/OptimizedConditionalFunction.js
+++ b/test/serializer/optimized-functions/OptimizedConditionalFunction.js
@@ -1,0 +1,11 @@
+// does not contain:1 + 2
+(function () {
+    let f = (global.__abstract ? __abstract("boolean", "true") : true) ?
+    {
+      g: function g() {
+        return 1 + 2;
+      }
+    } : {};
+    if (global.__optimize) __optimize(f.g);
+    global.inspect = function() { return f.g(); }
+})();


### PR DESCRIPTION
Release Notes: None

Before `__optimize` wouldn't work when called in a conditional context, now if `__optimize` is called in some conditional context, we extract the FunctionValue from the AbstractValue in the `__optimizedFunctions` map.

Also fixes a bug where __optimize would silently noop when given something other than an `ECMAScriptSourceFunctionValue` causing two tests to fail with `TypeError`. Issue #2213 is setup to track this.