### PR TITLE
Update the test262 submodule

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -488,7 +488,7 @@ export class Realm {
           "FatalError"
         );
         this.handleError(error);
-        throw new FatalError();
+        throw new FatalError("Timed out");
       }
     }
   }


### PR DESCRIPTION
Release note: Updated the test262 submodule to latest version

Also updated test262-runner.js to deal with time out errors showing up as diagnostics.

Filter out new tests that depend on errors being generated during the parsing phase. Since we depend on Babel for parsing, such issues are out of scope for us.