### PR TITLE
Add ability to rewrite generated code via global.__output

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -113,20 +113,20 @@ export default function(realm: Realm): void {
     configurable: true,
   });
 
-  let additonalFunctionUid = 0;
+  let additionalFunctionUid = 0;
   // Allows dynamically registering optimized functions.
   // WARNING: these functions will get exposed at global scope and called there.
   // NB: If we interpret one of these calls in an evaluateForEffects context
   //     that is not subsequently applied, the function will not be registered
   //     (because prepack won't have a correct value for the FunctionValue itself)
   global.$DefineOwnProperty("__optimize", {
-    value: new NativeFunctionValue(realm, "global.__optimize", "__optimize", 0, (context, [value, config]) => {
+    value: new NativeFunctionValue(realm, "global.__optimize", "__optimize", 1, (context, [value, config]) => {
       // only optimize functions for now
       if (value instanceof ECMAScriptSourceFunctionValue) {
         realm.assignToGlobal(
           t.memberExpression(
             t.memberExpression(t.identifier("global"), t.identifier("__optimizedFunctions")),
-            t.identifier("" + additonalFunctionUid++)
+            t.identifier("" + additionalFunctionUid++)
           ),
           value
         );

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -77,9 +77,9 @@ function run(
     --invariantMode          Whether to throw an exception or call a console function to log an invariant violation; default = throw.
     --emitConcreteModel      Synthesize concrete model values for abstract models(defined by __assumeDataProperty).
     --version                Output the version number.
-    --repro                  Create a zip file with all information needed to reproduce a Prepack run"
-    --cpuprofile             Create a CPU profile file for the run that can be loaded into the Chrome JavaScript CPU Profile viewer",
-    --debugDiagnosticSeverity      FatalError | RecoverableError | Warning | Information (default = FatalError). Diagnostic level at which debugger will stop
+    --repro                  Create a zip file with all information needed to reproduce a Prepack run.
+    --cpuprofile             Create a CPU profile file for the run that can be loaded into the Chrome JavaScript CPU Profile viewer.
+    --debugDiagnosticSeverity  FatalError | RecoverableError | Warning | Information (default = FatalError). Diagnostic level at which debugger will stop.
     --debugBuckRoot          Root directory that buck assumes when creating sourcemap paths.
   `;
   let args = Array.from(process.argv);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -2303,8 +2303,6 @@ export class ResidualHeapSerializer {
 
     Array.prototype.push.apply(this.prelude, this.preludeGenerator.prelude);
 
-    this.modules.resolveInitializedModules();
-
     this.emitter.finalize();
 
     this.residualFunctions.residualFunctionInitializers.factorifyInitializers(this.factoryNameGenerator);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -93,6 +93,9 @@ export class Serializer {
     return code;
   }
 
+  // When global.__output is an object, then this function replaces the global generator
+  // with one that declares global variables corresponding to the key-value pairs in the __output object,
+  // effectively rewriting the roots for visiting/serialization.
   processOutputEntries(): boolean {
     let realm = this.realm;
     let output = this.logger.tryQuery(() => Get(realm, realm.$GlobalObject, "__output"), realm.intrinsics.undefined);

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -418,7 +418,6 @@ export class Modules {
   }
 
   resolveInitializedModules(): void {
-    this.initializedModules.clear();
     let globalInitializedModulesMap = this._getGlobalProperty("__initializedModules");
     invariant(globalInitializedModulesMap instanceof ObjectValue);
     for (let moduleId of globalInitializedModulesMap.properties.keys()) {

--- a/test/serializer/basic/__output.js
+++ b/test/serializer/basic/__output.js
@@ -1,0 +1,10 @@
+(function() {
+    function f() { return "__output" in global; }
+    if (global.__abstract) {
+        // we are running under Prepack
+        global.__output = { inspect: f };
+    } else {
+        // we are not running under Prepack
+        global.inspect = f;
+    }
+})();


### PR DESCRIPTION
Release notes: Add ability to rewrite generated code via global.__output

When a special global variable __output is set to an object,
then all global generator entries are forgotten
and replaced by a series of assignments to reflecting the key-value
pairs of the __output object.

This is needed for instant render to emit single render functions only.