### PR TITLE
Fix React library visiting logic

### DIFF
--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -115,23 +115,21 @@ export class ResidualReactElementVisitor {
     // our React element serializer we serialize some values (namely `React.createElement` and `React.Fragment`) that do
     // not necessarily appear in our source code. We must manually visit these values in our visitor pass for the values
     // to be serializable.
-    {
-      if (this.realm.react.output === "create-element") {
-        const reactLibraryObject = this._getReactLibraryValue();
-        invariant(reactLibraryObject instanceof ObjectValue);
-        const createElement = reactLibraryObject.properties.get("createElement");
-        invariant(createElement !== undefined);
-        const reactCreateElement = Get(this.realm, reactLibraryObject, "createElement");
-        // Our `createElement` value will be used in the prelude of the optimized function we serialize to initialize
-        // our hoisted React elements. So we need to ensure that we visit our value in a scope above our own to allow
-        // the function to be used in our optimized function prelude. We use our global scope to accomplish this. We are
-        // a "friend" class of `ResidualHeapVisitor` so we call one of its private methods.
-        this.residualHeapVisitor._visitInUnrelatedScope(this.residualHeapVisitor.globalGenerator, reactCreateElement);
-      }
-      if (isReactFragment) {
-        const reactLibraryObject = this._getReactLibraryValue();
-        this.residualHeapVisitor.visitValue(reactLibraryObject);
-      }
+    if (this.realm.react.output === "create-element") {
+      const reactLibraryObject = this._getReactLibraryValue();
+      invariant(reactLibraryObject instanceof ObjectValue);
+      const createElement = reactLibraryObject.properties.get("createElement");
+      invariant(createElement !== undefined);
+      const reactCreateElement = Get(this.realm, reactLibraryObject, "createElement");
+      // Our `createElement` value will be used in the prelude of the optimized function we serialize to initialize
+      // our hoisted React elements. So we need to ensure that we visit our value in a scope above our own to allow
+      // the function to be used in our optimized function prelude. We use our global scope to accomplish this. We are
+      // a "friend" class of `ResidualHeapVisitor` so we call one of its private methods.
+      this.residualHeapVisitor._visitInUnrelatedScope(this.residualHeapVisitor.globalGenerator, reactCreateElement);
+    }
+    if (isReactFragment) {
+      const reactLibraryObject = this._getReactLibraryValue();
+      this.residualHeapVisitor.visitValue(reactLibraryObject);
     }
 
     // determine if this ReactElement node tree is going to be hoistable

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -311,3 +311,7 @@ it("Dynamic ReactElement type #3", () => {
 it("Dynamic ReactElement type #4", () => {
   runTest(__dirname + "/FunctionalComponents/dynamic-type4.js");
 });
+
+it("Hoist Fragment", () => {
+  runTest(__dirname + "/FunctionalComponents/hoist-fragment.js");
+});

--- a/test/react/FunctionalComponents/hoist-fragment.js
+++ b/test/react/FunctionalComponents/hoist-fragment.js
@@ -1,0 +1,22 @@
+const React = require("react");
+
+function Root(props) {
+  return (
+    <React.Fragment>
+      <React.Fragment>
+        <div />
+      </React.Fragment>
+    </React.Fragment>
+  );
+}
+
+Root.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [["hoist fragments render", renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(Root);
+}
+
+module.exports = Root;

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -2848,6 +2848,130 @@ ReactStatistics {
 }
 `;
 
+exports[`Hoist Fragment: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Root",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Hoist Fragment: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Root",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Hoist Fragment: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Root",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Hoist Fragment: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Root",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Mutations - not-safe 1: (JSX => JSX) 1`] = `"Failed to render React component root \\"Bar\\" due to side-effects from mutating the binding \\"x\\""`;
 
 exports[`Mutations - not-safe 1: (JSX => createElement) 1`] = `"Failed to render React component root \\"Bar\\" due to side-effects from mutating the binding \\"x\\""`;

--- a/test/react/setupReactTests.js
+++ b/test/react/setupReactTests.js
@@ -113,12 +113,8 @@ function setupReactTests() {
     statistics: Object,
   |} {
     let code = `(function() {
-      // For some reason, the serializer fails if React is not
-      // reachable from a global in tests. This field isn't used.
-      // TODO: figure out why this is necessary in tests.
-      window.___unused_React = require('react');
-      ${source}
-    })()`;
+${source}
+})()`;
     let prepackOptions = {
       errorHandler: diag => {
         diagnosticLog.push(diag);


### PR DESCRIPTION
> I’m learning the Prepack/React Fusion codebase, so incorrect assumptions and limited a understanding of systems on my part are both very likely.

While I was experimenting with the React Compiler codebase I found the following invariant violation with the test case after that when using `create-element` as the `reactOutput`.

```
Invariant Violation: value must have been visited
```

```js
const React = require("react");

__evaluatePureFunction(() => {
  function Foo(props) {
    return <React.Fragment />;
  }

  __optimizeReactComponentTree(Foo);

  module.exports = Foo;
});
```

[[Prepack REPL]](https://prepack.io/repl.html#MYewdgzgLgBASgUwIbFgXhgJwQRwK4CW2AFAETYpSkCUA3AFD0D6TCAbkgDZ5JQIAKebADE8YVAXDFi1GGgB8MAN70YMAGZiJ4GMJAhiAB0whDEWSrVrsUIWBgAeRJQB0wzEgDmAWwRhYAPTyDGoAvoxqLKZQBN4EAF4IzqgAwiDehuB+UAAq2AjEeiB0ETDeIAAmeJwILggAHpmYUBByuvoMoSVAA)

After digging in more, I discovered that this was the same issue which required some clowniness in the React Compiler tests to workaround.

https://github.com/facebook/prepack/blob/e3f4262c9dafce766835acdaff39af04de231fae/test/react/setupReactTests.js#L116-L119

The problem with my example is that the React library was not being visited when a `React.Fragment` appeared even though the serializer needed the library to be visited to output code.

This diff makes sure we visit the React library when we see a `React.Fragment` and makes sure we don’t over visit the React library in `jsx` mode.

I also refactored this area of the code and added comments. Let me know if my refactors or comments don’t make sense.