### PR TITLE
Annotate exported function return types.

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -59,7 +59,7 @@ function deriveGetBinding(realm: Realm, binding: Binding) {
   return realm.generator.deriveAbstract(types, values, [], (_, context) => context.serializeBinding(binding));
 }
 
-export function havocBinding(binding: Binding) {
+export function havocBinding(binding: Binding): void {
   let realm = binding.environment.realm;
   let value = binding.value;
   if (!binding.hasLeaked) {

--- a/src/evaluators/ClassDeclaration.js
+++ b/src/evaluators/ClassDeclaration.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
-import { AbstractValue, Value } from "../values/index.js";
+import { AbstractValue, Value, type ECMAScriptSourceFunctionValue } from "../values/index.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { NullValue, EmptyValue, ObjectValue, ECMAScriptFunctionValue } from "../values/index.js";
 import type {
@@ -58,7 +58,7 @@ export function ClassDefinitionEvaluation(
   className: string | void,
   strictCode: boolean,
   env: LexicalEnvironment
-) {
+): ECMAScriptSourceFunctionValue {
   // 1. Let lex be the LexicalEnvironment of the running execution context.
   let lex = env;
 

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -11,7 +11,13 @@
 
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
-import { AbstractValue, Value, EmptyValue, ECMAScriptSourceFunctionValue } from "../values/index.js";
+import {
+  AbstractValue,
+  Value,
+  EmptyValue,
+  ECMAScriptSourceFunctionValue,
+  type UndefinedValue,
+} from "../values/index.js";
 import {
   AbruptCompletion,
   BreakCompletion,
@@ -45,7 +51,7 @@ type BailOutWrapperInfo = {
 };
 
 // ECMA262 13.7.4.9
-export function CreatePerIterationEnvironment(realm: Realm, perIterationBindings: Array<string>) {
+export function CreatePerIterationEnvironment(realm: Realm, perIterationBindings: Array<string>): UndefinedValue {
   // 1. If perIterationBindings has any elements, then
   if (perIterationBindings.length > 0) {
     // a. Let lastIterationEnv be the running execution context's LexicalEnvironment.

--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -27,7 +27,7 @@ export function GlobalDeclarationInstantiation(
   ast: BabelNodeProgram,
   env: LexicalEnvironment,
   strictCode: boolean
-) {
+): EmptyValue {
   realm.getRunningContext().isStrict = realm.isStrict = strictCode;
 
   // 1. Let envRec be env's EnvironmentRecord.

--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -261,7 +261,7 @@ function createBootloader(realm: Realm, global: ObjectValue | AbstractObjectValu
   return AbstractValue.createAbstractObject(realm, "Bootloader", bootloader);
 }
 
-export function createFbMocks(realm: Realm, global: ObjectValue | AbstractObjectValue) {
+export function createFbMocks(realm: Realm, global: ObjectValue | AbstractObjectValue): void {
   global.$DefineOwnProperty("__DEV__", {
     // TODO: we'll likely want to make this configurable from the outside.
     value: realm.intrinsics.false,

--- a/src/intrinsics/node/utils.js
+++ b/src/intrinsics/node/utils.js
@@ -24,7 +24,7 @@ export function getNodeBufferFromTypedArray(realm: Realm, value: ObjectValue): U
 // Takes a value from the host realm and create it into a Prepack Realm.
 // TODO: Move this to a bigger general purpose proxy between the environments.
 // See issue #644 for more details.
-export function createDeepIntrinsic(realm: Realm, value: mixed, intrinsicName: string) {
+export function createDeepIntrinsic(realm: Realm, value: mixed, intrinsicName: string): Value {
   switch (typeof value) {
     case "undefined":
       return realm.intrinsics.undefined;

--- a/src/methods/abstract.js
+++ b/src/methods/abstract.js
@@ -417,7 +417,7 @@ export function SameValueNonNumber(realm: Realm, x: ConcreteValue, y: ConcreteVa
 }
 
 // Checks if two property keys are identical.
-export function SamePropertyKey(realm: Realm, x: PropertyKeyValue, y: PropertyKeyValue) {
+export function SamePropertyKey(realm: Realm, x: PropertyKeyValue, y: PropertyKeyValue): boolean {
   if (typeof x === "string" && typeof y === "string") {
     return x === y;
   }

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -563,7 +563,7 @@ export function EvaluateDirectCallWithArgList(
 }
 
 // ECMA262 14.6.3
-export function PrepareForTailCall(realm: Realm) {
+export function PrepareForTailCall(realm: Realm): void {
   // 1. Let leafContext be the running execution context.
   let leafContext = realm.getRunningContext();
 

--- a/src/methods/construct.js
+++ b/src/methods/construct.js
@@ -137,7 +137,7 @@ export function SpeciesConstructor(realm: Realm, O: ObjectValue, defaultConstruc
 }
 
 // ECMA 9.2.9
-export function MakeClassConstructor(realm: Realm, F: ECMAScriptSourceFunctionValue) {
+export function MakeClassConstructor(realm: Realm, F: ECMAScriptSourceFunctionValue): UndefinedValue {
   // 1. Assert: F is an ECMAScript function object.
   invariant(F instanceof ECMAScriptSourceFunctionValue, "expected function value");
 

--- a/src/methods/descriptor.js
+++ b/src/methods/descriptor.js
@@ -18,7 +18,7 @@ export function cloneDescriptor(d: void | Descriptor): void | Descriptor {
   return clone;
 }
 
-export function clearDescriptor(d: Descriptor) {
+export function clearDescriptor(d: Descriptor): void {
   delete d.writable;
   delete d.enumerable;
   delete d.configurable;
@@ -27,7 +27,7 @@ export function clearDescriptor(d: Descriptor) {
   delete d.set;
 }
 
-export function copyDescriptor(from: Descriptor, to: Descriptor) {
+export function copyDescriptor(from: Descriptor, to: Descriptor): void {
   if (from.hasOwnProperty("writable")) to.writable = from.writable;
   if (from.hasOwnProperty("enumerable")) to.enumerable = from.enumerable;
   if (from.hasOwnProperty("configurable")) to.configurable = from.configurable;
@@ -40,7 +40,7 @@ export function copyDescriptor(from: Descriptor, to: Descriptor) {
 }
 
 // does not check if the contents of value properties are the same
-export function equalDescriptors(d1: Descriptor, d2: Descriptor) {
+export function equalDescriptors(d1: Descriptor, d2: Descriptor): boolean {
   if (d1.hasOwnProperty("writable")) {
     if (!d2.hasOwnProperty("writable")) return false;
     if (d1.writable !== d2.writable) return false;

--- a/src/methods/destructuring.js
+++ b/src/methods/destructuring.js
@@ -14,7 +14,7 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { Reference } from "../environment.js";
 import type { PropertyKeyValue } from "../types.js";
-import { Value, ObjectValue, UndefinedValue, StringValue } from "../values/index.js";
+import { Value, ObjectValue, UndefinedValue, StringValue, SymbolValue } from "../values/index.js";
 import { AbruptCompletion, SimpleNormalCompletion } from "../completions.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
 import {
@@ -46,7 +46,7 @@ function RestDestructuringAssignmentEvaluation(
   excludedNames: Array<PropertyKeyValue>,
   strictCode: boolean,
   env: LexicalEnvironment
-) {
+): void | boolean | Value {
   let DestructuringAssignmentTarget = property.argument;
 
   let lref;
@@ -84,7 +84,7 @@ function PropertyDestructuringAssignmentEvaluation(
   value: Value,
   strictCode: boolean,
   env: LexicalEnvironment
-) {
+): Array<string | StringValue | SymbolValue> {
   // Base condition for recursive call below
   if (properties.length === 0) {
     return [];
@@ -194,7 +194,7 @@ export function DestructuringAssignmentEvaluation(
   value: Value,
   strictCode: boolean,
   env: LexicalEnvironment
-) {
+): void | boolean | Value {
   if (pattern.type === "ObjectPattern") {
     let AssignmentPropertyList = [],
       AssignmentRestProperty = null;
@@ -298,7 +298,7 @@ export function IteratorDestructuringAssignmentEvaluation(
   iteratorRecord: { $Iterator: ObjectValue, $Done: boolean },
   strictCode: boolean,
   env: LexicalEnvironment
-) {
+): void | boolean | Value {
   let elements = _elements;
   // Check if the last element is a rest element. If so then we want to save the
   // element and handle it separately after we iterate through the other
@@ -555,13 +555,13 @@ export function IteratorDestructuringAssignmentEvaluation(
       invariant(lref);
 
       // a. Return ? PutValue(lref, A).
-      Properties.PutValue(realm, lref, A);
+      return Properties.PutValue(realm, lref, A);
     } else {
       // 6. Let nestedAssignmentPattern be the parse of the source text corresponding to DestructuringAssignmentTarget using either AssignmentPattern or AssignmentPattern[Yield] as the goal symbol depending upon whether this AssignmentElement has the [Yield] parameter.
       let nestedAssignmentPattern = DestructuringAssignmentTarget;
 
       // 7. Return the result of performing DestructuringAssignmentEvaluation of nestedAssignmentPattern with A as the argument.
-      DestructuringAssignmentEvaluation(realm, nestedAssignmentPattern, A, strictCode, env);
+      return DestructuringAssignmentEvaluation(realm, nestedAssignmentPattern, A, strictCode, env);
     }
   }
 }
@@ -574,7 +574,7 @@ export function KeyedDestructuringAssignmentEvaluation(
   propertyName: PropertyKeyValue,
   strictCode: boolean,
   env: LexicalEnvironment
-) {
+): void | boolean | Value {
   let DestructuringAssignmentTarget;
   let Initializer;
 

--- a/src/methods/generator.js
+++ b/src/methods/generator.js
@@ -59,7 +59,7 @@ export function GeneratorStart(
 }
 
 // ECMA26225.3.3.2
-export function GeneratorValidate(realm: Realm, generator: Value) {
+export function GeneratorValidate(realm: Realm, generator: Value): void | "suspendedStart" {
   // 1. If Type(generator) is not Object, throw a TypeError exception.
   if (!(generator instanceof ObjectValue)) {
     throw realm.createErrorThrowCompletion(realm.intrinsics.SyntaxError, "Type(generator) is not Object");

--- a/src/methods/promise.js
+++ b/src/methods/promise.js
@@ -12,7 +12,14 @@
 import type { Realm } from "../realm.js";
 import type { ResolvingFunctions, PromiseCapability, PromiseReaction } from "../types.js";
 import { AbruptCompletion } from "../completions.js";
-import { Value, ObjectValue, StringValue, NativeFunctionValue, FunctionValue } from "../values/index.js";
+import {
+  Value,
+  ObjectValue,
+  StringValue,
+  NativeFunctionValue,
+  FunctionValue,
+  type UndefinedValue,
+} from "../values/index.js";
 import { SameValue } from "../methods/abstract.js";
 import { Construct } from "../methods/construct.js";
 import { Get } from "../methods/get.js";
@@ -23,7 +30,7 @@ import { Create, Properties } from "../singletons.js";
 import invariant from "../invariant.js";
 
 // ECMA262 8.4.1
-export function EnqueueJob(realm: Realm, queueName: string, job: Function, args: Array<any>) {}
+export function EnqueueJob(realm: Realm, queueName: string, job: Function, args: Array<any>): void {}
 
 // ECMA262 25.4.1.5
 export function NewPromiseCapability(realm: Realm, C: Value): PromiseCapability {
@@ -624,7 +631,11 @@ export function RejectPromise(realm: Realm, promise: ObjectValue, reason: Value)
 }
 
 // ECMA262 25.4.1.8
-export function TriggerPromiseReactions(realm: Realm, reactions: Array<PromiseReaction>, argument: Value) {
+export function TriggerPromiseReactions(
+  realm: Realm,
+  reactions: Array<PromiseReaction>,
+  argument: Value
+): UndefinedValue {
   // 1. Repeat for each reaction in reactions, in original insertion order
   for (let reaction of reactions) {
     // a. Perform EnqueueJob("PromiseJobs", PromiseReactionJob, « reaction, argument »).
@@ -635,7 +646,12 @@ export function TriggerPromiseReactions(realm: Realm, reactions: Array<PromiseRe
 }
 
 // ECMA262 25.4.1.9
-export function HostPromiseRejectionTracker(realm: Realm, promise: ObjectValue, operation: "reject" | "handle") {}
+export function HostPromiseRejectionTracker(realm: Realm, promise: ObjectValue, operation: "reject" | "handle"): void {}
 
 // ECMA262 25.4.2.2
-export function PromiseResolveThenableJob(realm: Realm, promiseToResolve: ObjectValue, thenable: Value, then: Value) {}
+export function PromiseResolveThenableJob(
+  realm: Realm,
+  promiseToResolve: ObjectValue,
+  thenable: Value,
+  then: Value
+): void {}

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -209,7 +209,7 @@ export function IntegerIndexedElementSet(realm: Realm, O: ObjectValue, index: nu
 }
 
 // ECMA262 22.2.3.5.1
-export function ValidateTypedArray(realm: Realm, O: Value) {
+export function ValidateTypedArray(realm: Realm, O: Value): ObjectValue {
   O = O.throwIfNotConcrete();
 
   // 1. If Type(O) is not Object, throw a TypeError exception.

--- a/src/prepack-node-environment.js
+++ b/src/prepack-node-environment.js
@@ -34,7 +34,7 @@ export function prepackNodeCLI(
   filename: string,
   options: PrepackOptions = defaultOptions,
   callback: (any, ?{ code: string, map?: SourceMap }) => void
-) {
+): void {
   let serialized;
   try {
     serialized = prepackNodeCLISync(filename, options);

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -46,7 +46,7 @@ export function prepackStdin(
   options: PrepackOptions = defaultOptions,
   processSerializedCode: SerializedResult => void,
   printDiagnostics: boolean => boolean
-) {
+): void | SerializedResult {
   let sourceMapFilename = options.inputSourceMapFilename || "";
   process.stdin.setEncoding("utf8");
   process.stdin.resume();
@@ -86,7 +86,7 @@ export function prepackFile(
   options: PrepackOptions = defaultOptions,
   callback: (any, ?{ code: string, map?: SourceMap }) => void,
   fileErrorHandler?: (err: ?Error) => void
-) {
+): void {
   if (options.compatibility === "node-cli") {
     prepackNodeCLI(filename, options, callback);
     return;
@@ -121,7 +121,7 @@ export function prepackFile(
   });
 }
 
-export function prepackFileSync(filenames: Array<string>, options: PrepackOptions = defaultOptions) {
+export function prepackFileSync(filenames: Array<string>, options: PrepackOptions = defaultOptions): SerializedResult {
   if (options.compatibility === "node-cli") {
     if (filenames.length !== 1) {
       console.error(`Does not support multiple file prepack in node-cli mode.`);

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -406,7 +406,7 @@ export function traverseReactElement(
   realm: Realm,
   reactElement: ObjectValue,
   traversalVisitor: ElementTraversalVisitor
-) {
+): void {
   let typeValue = getProperty(realm, reactElement, "type");
   traversalVisitor.visitType(typeValue);
 

--- a/src/react/experimental-server-rendering/utils.js
+++ b/src/react/experimental-server-rendering/utils.js
@@ -61,7 +61,7 @@ export function isCustomComponent(
 }
 
 // $FlowFixMe: we don't want to provides types here as we inject this function into source
-export function escapeHtml(string) {
+export function escapeHtml(string): string {
   if (typeof string === "boolean" || typeof string === "number") {
     return "" + string;
   }
@@ -152,7 +152,7 @@ export function convertValueToNode(value: Value): ReactNode {
   invariant(false, "TODO");
 }
 
-export function createHtmlEscapeHelper(realm: Realm) {
+export function createHtmlEscapeHelper(realm: Realm): ECMAScriptSourceFunctionValue {
   let escapeHelperAst = parseExpression(escapeHtml.toString(), { plugins: ["flow"] });
   let helper = new ECMAScriptSourceFunctionValue(realm);
   let body = escapeHelperAst.body;
@@ -162,7 +162,7 @@ export function createHtmlEscapeHelper(realm: Realm) {
   return helper;
 }
 
-export function createArrayHelper(realm: Realm) {
+export function createArrayHelper(realm: Realm): ECMAScriptSourceFunctionValue {
   let arrayHelper = `
     function arrayHelper(array) {
       let length = array.length;

--- a/src/react/jsx.js
+++ b/src/react/jsx.js
@@ -74,7 +74,7 @@ export function convertJSXExpressionToIdentifier(
   }
 }
 
-export function convertKeyValueToJSXAttribute(key: string, expr: BabelNodeExpression) {
+export function convertKeyValueToJSXAttribute(key: string, expr: BabelNodeExpression): BabelNode {
   let wrapInContainer = true;
 
   if (expr && t.isStringLiteral(expr) && typeof expr.value === "string") {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -131,7 +131,7 @@ export function isTagName(ast: BabelNode): boolean {
   return ast.type === "JSXIdentifier" && /^[a-z]|\-/.test(((ast: any): BabelNodeJSXIdentifier).name);
 }
 
-export function isReactComponent(name: string) {
+export function isReactComponent(name: string): boolean {
   return name.length > 0 && name[0] === name[0].toUpperCase();
 }
 
@@ -221,7 +221,7 @@ export function addKeyToReactElement(realm: Realm, reactElement: ObjectValue): O
 // we create a unique key for each JSXElement to prevent collisions
 // otherwise React will detect a missing/conflicting key at runtime and
 // this can break the reconcilation of JSXElements in arrays
-export function getUniqueReactElementKey(index?: string, usedReactElementKeys: Set<string>) {
+export function getUniqueReactElementKey(index?: string, usedReactElementKeys: Set<string>): string {
   let key;
   do {
     key = Math.random()
@@ -610,7 +610,11 @@ export function flattenChildren(realm: Realm, array: ArrayValue): ArrayValue {
   return flattenedChildren;
 }
 
-export function evaluateWithNestedParentEffects(realm: Realm, nestedEffects: Array<Effects>, f: () => Effects) {
+export function evaluateWithNestedParentEffects(
+  realm: Realm,
+  nestedEffects: Array<Effects>,
+  f: () => Effects
+): Effects {
   let nextEffects = nestedEffects.slice();
   let modifiedBindings;
   let modifiedProperties;
@@ -847,7 +851,7 @@ function isEventProp(name: string): boolean {
   return name.length > 2 && name[0].toLowerCase() === "o" && name[1].toLowerCase() === "n";
 }
 
-export function getLocationFromValue(expressionLocation: any) {
+export function getLocationFromValue(expressionLocation: any): string {
   // if we can't get a value, then it's likely that the source file was not given
   // (this happens in React tests) so instead don't print any location
   return expressionLocation

--- a/src/serializer/factorify.js
+++ b/src/serializer/factorify.js
@@ -89,7 +89,7 @@ function getObjectKeys(obj: BabelNodeObjectExpression): string | false {
 // TODO #884: Right now, the visitor below only looks into top-level variable declaration
 // with a flat object literal initializer.
 // It should also look into conditional control flow, residual functions, and nested object literals.
-export function factorifyObjects(body: Array<BabelNodeStatement>, factoryNameGenerator: NameGenerator) {
+export function factorifyObjects(body: Array<BabelNodeStatement>, factoryNameGenerator: NameGenerator): void {
   let signatures = Object.create(null);
 
   for (let node of body) {

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -134,7 +134,7 @@ export type ScopeBinding = {
   referentializationScope: ReferentializationScope,
 };
 
-export function AreSameResidualBinding(realm: Realm, x: ResidualFunctionBinding, y: ResidualFunctionBinding) {
+export function AreSameResidualBinding(realm: Realm, x: ResidualFunctionBinding, y: ResidualFunctionBinding): boolean {
   if (x.serializedValue === y.serializedValue) return true;
   if (x.value && x.value === y.value) return true;
   if (x.value instanceof ConcreteValue && y.value instanceof ConcreteValue) {

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -35,46 +35,46 @@ export let Widen: WidenType = (null: any);
 export let concretize: ConcretizeType = (null: any);
 export let Utils: UtilsType = (null: any);
 
-export function setCreate(singleton: CreateType) {
+export function setCreate(singleton: CreateType): void {
   Create = singleton;
 }
 
-export function setEnvironment(singleton: EnvironmentType) {
+export function setEnvironment(singleton: EnvironmentType): void {
   Environment = singleton;
 }
 
-export function setFunctions(singleton: FunctionType) {
+export function setFunctions(singleton: FunctionType): void {
   Functions = singleton;
 }
 
-export function setHavoc(singleton: HavocType) {
+export function setHavoc(singleton: HavocType): void {
   Havoc = singleton;
 }
 
-export function setJoin(singleton: JoinType) {
+export function setJoin(singleton: JoinType): void {
   Join = singleton;
 }
 
-export function setPath(singleton: PathType) {
+export function setPath(singleton: PathType): void {
   Path = singleton;
 }
 
-export function setProperties(singleton: PropertiesType) {
+export function setProperties(singleton: PropertiesType): void {
   Properties = singleton;
 }
 
-export function setTo(singleton: ToType) {
+export function setTo(singleton: ToType): void {
   To = singleton;
 }
 
-export function setWiden(singleton: WidenType) {
+export function setWiden(singleton: WidenType): void {
   Widen = singleton;
 }
 
-export function setConcretize(singleton: ConcretizeType) {
+export function setConcretize(singleton: ConcretizeType): void {
   concretize = singleton;
 }
 
-export function setUtils(singleton: UtilsType) {
+export function setUtils(singleton: UtilsType): void {
   Utils = singleton;
 }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -12,7 +12,7 @@ type JSONValue = Array<JSONValue> | string | number | JSON;
 type JSON = { [key: string]: JSONValue };
 
 // this will mutate the original JSON object
-export function mergeAdjacentJSONTextNodes(node: JSON, removeFunctions: boolean, visitedNodes?: Set<JSON>) {
+export function mergeAdjacentJSONTextNodes(node: JSON, removeFunctions: boolean, visitedNodes?: Set<JSON>): JSONValue {
   if (visitedNodes === undefined) {
     visitedNodes = new Set();
   }
@@ -41,7 +41,7 @@ export function mergeAdjacentJSONTextNodes(node: JSON, removeFunctions: boolean,
           arr.push(concatString);
           concatString = null;
         }
-        arr.push(mergeAdjacentJSONTextNodes(child, removeFunctions, visitedNodes));
+        arr.push(((mergeAdjacentJSONTextNodes(child, removeFunctions, visitedNodes): any): JSON));
       }
     }
     if (concatString !== null) {
@@ -58,7 +58,7 @@ export function mergeAdjacentJSONTextNodes(node: JSON, removeFunctions: boolean,
           node[key] = "function";
         }
       } else if (typeof value === "object" && value !== null) {
-        node[key] = mergeAdjacentJSONTextNodes(((value: any): JSON), removeFunctions, visitedNodes);
+        node[key] = ((mergeAdjacentJSONTextNodes(((value: any): JSON), removeFunctions, visitedNodes): any): JSON);
       }
     }
   }


### PR DESCRIPTION
Release notes: None

I manually reviewed and annotated all exported function return types.
Still TODO: Same for class methods, and then we need some enforcement mechanism.