### PR TITLE
Move abstract Object.assign temporals into a helper function

### DIFF
--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -38,7 +38,6 @@ import {
   HasSomeCompatibleType,
 } from "../../methods/index.js";
 import { Create, Havoc, Properties as Props, To } from "../../singletons.js";
-import type { BabelNodeExpression } from "babel-types";
 import * as t from "babel-types";
 import invariant from "../../invariant.js";
 
@@ -273,31 +272,7 @@ export default function(realm: Realm): NativeFunctionValue {
         // but now that it is partial we need to set the _isSimple flag.
         to.makeSimple();
 
-        // Tell serializer that it may add properties to to only after temporalTo has been emitted
-        let temporalArgs = [to, ...delayedSources];
-        let preludeGenerator = realm.preludeGenerator;
-        invariant(preludeGenerator !== undefined);
-        let temporalTo = AbstractValue.createTemporalFromBuildFunction(
-          realm,
-          ObjectValue,
-          temporalArgs,
-          ([targetNode, ...sourceNodes]: Array<BabelNodeExpression>) => {
-            return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), [targetNode, ...sourceNodes]);
-          },
-          {
-            skipInvariant: true,
-            mutatesOnly: [to],
-            temporalType: "OBJECT_ASSIGN",
-          }
-        );
-        invariant(temporalTo instanceof AbstractObjectValue);
-        if (to instanceof AbstractObjectValue) {
-          temporalTo.values = to.values;
-        } else {
-          invariant(to instanceof ObjectValue);
-          temporalTo.values = new ValuesDomain(to);
-        }
-        to.temporalAlias = temporalTo;
+        AbstractValue.createAbstractObjectAssign(realm, to, delayedSources);
       }
       return to;
     });

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -375,15 +375,7 @@ export function applyGetDerivedStateFromProps(
         // is not simple. however, given getDerivedStateFromProps is
         // meant to be pure, we can assume that there are no getters on
         // the partial abstract state
-        AbstractValue.createTemporalFromBuildFunction(
-          realm,
-          ObjectValue,
-          [newState, prevState, state],
-          ([..._args]) => {
-            return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), ((_args: any): Array<any>));
-          },
-          { skipInvariant: true, mutatesOnly: [newState], temporalType: "OBJECT_ASSIGN" }
-        );
+        AbstractValue.createAbstractObjectAssign(realm, newState, [prevState, state]);
         newState.makeSimple();
         newState.makePartial();
         newState.makeFinal();
@@ -398,19 +390,7 @@ export function applyGetDerivedStateFromProps(
         if (realm.isInPureScope() && e instanceof FatalError) {
           let preludeGenerator = realm.preludeGenerator;
           invariant(preludeGenerator !== undefined);
-          AbstractValue.createTemporalFromBuildFunction(
-            realm,
-            ObjectValue,
-            [objectAssign, newState, prevState, state],
-            ([..._args]) => {
-              return t.callExpression(preludeGenerator.memoizeReference("Object.assign"), ((_args: any): Array<any>));
-            },
-            {
-              skipInvariant: true,
-              mutatesOnly: [newState],
-              temporalType: "OBJECT_ASSIGN",
-            }
-          );
+          AbstractValue.createAbstractObjectAssign(realm, newState, [prevState, state]);
           newState.makeSimple();
           newState.makePartial();
           return newState;


### PR DESCRIPTION
Release notes: none

As per Nikolai's comment https://github.com/facebook/prepack/pull/2206#discussion_r201142434, this PR moves the creation of the `Object.assign` abstract temporals into their own static abstract value creation method.