### PR TITLE
Debugger accept array of sourcefiles (rather than string)

### DIFF
--- a/src/debugger/adapter/DebugAdapter.js
+++ b/src/debugger/adapter/DebugAdapter.js
@@ -114,10 +114,9 @@ class PrepackDebugSession extends DebugSession {
     let adapterChannel = new AdapterChannel(inFilePath, outFilePath);
     this._adapterChannel = adapterChannel;
     this._registerMessageCallbacks();
-    let separatedSourceFiles = args.sourceFile.trim().split(/\s+/g); // Split on all whitespace
     let launchArgs: PrepackLaunchArguments = {
       kind: "launch",
-      sourceFiles: separatedSourceFiles,
+      sourceFiles: args.sourceFiles,
       prepackRuntime: args.prepackRuntime,
       prepackArguments: args.prepackArguments,
       debugInFilePath: inFilePath,

--- a/src/debugger/common/types.js
+++ b/src/debugger/common/types.js
@@ -162,7 +162,7 @@ export type EvaluateResult = {
 export type LaunchRequestArguments = {
   ...DebugProtocol.LaunchRequestArguments,
   noDebug?: boolean,
-  sourceFile: string,
+  sourceFiles: Array<string>,
   prepackRuntime: string,
   prepackArguments: Array<string>,
 };

--- a/src/debugger/mock-ui/UISession.js
+++ b/src/debugger/mock-ui/UISession.js
@@ -157,7 +157,7 @@ export class UISession {
   _processInitializeResponse(response: DebugProtocol.InitializeResponse) {
     let launchArgs: LaunchRequestArguments = {
       prepackRuntime: this._prepackRuntime,
-      sourceFile: this._sourceFiles.join(" "),
+      sourceFiles: this._sourceFiles,
       prepackArguments: this._prepackArguments,
     };
     this._sendLaunchRequest(launchArgs);


### PR DESCRIPTION
Release Notes: Landed Nuclide change to pass sourcefiles as array instead of string. Updating receiving behavior here to match. 