### PR TITLE
Small tweak to solve a pressing instance of a more general problem

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -326,8 +326,9 @@ export class JoinImplementation {
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof SimpleNormalCompletion) {
         nc.value = AbstractValue.createFromConditionalOp(realm, joinCondition, pnc.alternate.value, v);
+        pnc.alternateEffects.result = nc;
+        nc.effects = pnc.alternateEffects;
         pnc.alternate = nc;
-        pnc.alternateEffects.result = pnc.alternate;
       } else {
         invariant(pnc.alternate instanceof PossiblyNormalCompletion);
         this.updatePossiblyNormalCompletionWithConditionalSimpleNormalCompletion(
@@ -340,8 +341,9 @@ export class JoinImplementation {
     } else {
       if (pnc.consequent instanceof SimpleNormalCompletion) {
         nc.value = AbstractValue.createFromConditionalOp(realm, joinCondition, pnc.consequent.value, v);
+        pnc.consequentEffects.result = nc;
+        nc.effects = pnc.consequentEffects;
         pnc.consequent = nc;
-        pnc.consequentEffects.result = pnc.consequent;
       } else {
         invariant(pnc.consequent instanceof PossiblyNormalCompletion);
         this.updatePossiblyNormalCompletionWithConditionalSimpleNormalCompletion(

--- a/test/serializer/abstract/Compose.js
+++ b/test/serializer/abstract/Compose.js
@@ -1,0 +1,17 @@
+function bar(y) {
+  if (y) {
+    throw Error("Foo");
+  }
+  return null;
+}
+
+function fn(x, y) {
+  if (x) {
+    bar(y)
+  }
+  return 123;
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() { return fn(true, false); }


### PR DESCRIPTION
Release note: none

Resolves #2238 

This is a quick fix for the above issue. The underlying cause is that we do not construct completions with effects, but rely on incremental updates in special situations, such as the constructor for ForkedAbruptCompletions.

I'll try to fix the underlying cause in a subsequent PR.