### PR TITLE
Make sure that Completion.effects and Effects.result are consistent

### DIFF
--- a/src/evaluators/BreakStatement.js
+++ b/src/evaluators/BreakStatement.js
@@ -21,5 +21,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): Value {
-  throw new BreakCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
+  throw new BreakCompletion(realm.intrinsics.empty, undefined, ast.loc, ast.label && ast.label.name);
 }

--- a/src/evaluators/ContinueStatement.js
+++ b/src/evaluators/ContinueStatement.js
@@ -21,5 +21,5 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): Value {
-  throw new ContinueCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
+  throw new ContinueCompletion(realm.intrinsics.empty, undefined, ast.loc, ast.label && ast.label.name);
 }

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -167,7 +167,7 @@ export function ForInOfHeadEvaluation(
     // a. If exprValue.[[Value]] is null or undefined, then
     if (exprValue instanceof NullValue || exprValue instanceof UndefinedValue) {
       // i. Return Completion{[[Type]]: break, [[Value]]: empty, [[Target]]: empty}.
-      throw new BreakCompletion(realm.intrinsics.empty, expr.loc, null);
+      throw new BreakCompletion(realm.intrinsics.empty, undefined, expr.loc, null);
     }
 
     // b. Let obj be ToObject(exprValue).

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -211,7 +211,7 @@ function ForBodyEvaluation(
     // Incorporate the savedCompletion (we should only get called if there is one).
     invariant(realm.savedCompletion !== undefined);
     if (valueOrCompletionAtLoopContinuePoint instanceof Value)
-      valueOrCompletionAtLoopContinuePoint = new ContinueCompletion(valueOrCompletionAtLoopContinuePoint);
+      valueOrCompletionAtLoopContinuePoint = new ContinueCompletion(valueOrCompletionAtLoopContinuePoint, undefined);
     let abruptCompletion = Functions.incorporateSavedCompletion(realm, valueOrCompletionAtLoopContinuePoint);
     invariant(abruptCompletion instanceof AbruptCompletion);
 
@@ -251,7 +251,7 @@ function ForBodyEvaluation(
 
     // Incorporate the savedCompletion if there is one.
     if (valueOrCompletionAtUnconditionalExit instanceof Value)
-      valueOrCompletionAtUnconditionalExit = new BreakCompletion(valueOrCompletionAtUnconditionalExit);
+      valueOrCompletionAtUnconditionalExit = new BreakCompletion(valueOrCompletionAtUnconditionalExit, undefined);
     let abruptCompletion = Functions.incorporateSavedCompletion(realm, valueOrCompletionAtUnconditionalExit);
     invariant(abruptCompletion instanceof AbruptCompletion);
 

--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -273,7 +273,7 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
         // Join e with the remaining completions
         let normalGenerator = e.generator;
         e.generator = new Generator(realm, "dummy", normalGenerator.pathConditions); // This generator comes after everything else.
-        let r = (e.result = new ThrowCompletion(realm.intrinsics.empty));
+        let r = new ThrowCompletion(realm.intrinsics.empty, e);
         let fc = Join.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, res, r, e);
         let allEffects = Join.extractAndJoinCompletionsOfType(ThrowCompletion, realm, fc);
         realm.applyEffects(allEffects, "all code", true);

--- a/src/evaluators/ReturnStatement.js
+++ b/src/evaluators/ReturnStatement.js
@@ -28,5 +28,5 @@ export default function(
   } else {
     arg = realm.intrinsics.undefined;
   }
-  throw new ReturnCompletion(arg, ast.loc);
+  throw new ReturnCompletion(arg, undefined, ast.loc);
 }

--- a/src/evaluators/ThrowStatement.js
+++ b/src/evaluators/ThrowStatement.js
@@ -24,5 +24,5 @@ export default function(
 ): Value {
   let exprRef = env.evaluate(ast.argument, strictCode);
   let exprValue = Environment.GetValue(realm, exprRef);
-  throw new ThrowCompletion(exprValue, ast.loc);
+  throw new ThrowCompletion(exprValue, undefined, ast.loc);
 }

--- a/src/intrinsics/ecma262/GeneratorPrototype.js
+++ b/src/intrinsics/ecma262/GeneratorPrototype.js
@@ -30,7 +30,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let g = context;
 
     // 2. Let C be Completion{[[Type]]: return, [[Value]]: value, [[Target]]: empty}.
-    let C = new ReturnCompletion(value, realm.currentLocation);
+    let C = new ReturnCompletion(value, undefined, realm.currentLocation);
 
     // 3. Return ? GeneratorResumeAbrupt(g, C).
     return GeneratorResumeAbrupt(realm, g, C);
@@ -42,7 +42,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let g = context;
 
     // 2. Let C be Completion{[[Type]]: throw, [[Value]]: exception, [[Target]]: empty}.
-    let C = new ReturnCompletion(exception, realm.currentLocation);
+    let C = new ReturnCompletion(exception, undefined, realm.currentLocation);
 
     // 3. Return ? GeneratorResumeAbrupt(g, C).
     return GeneratorResumeAbrupt(realm, g, C);

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -323,7 +323,7 @@ function callNativeFunctionValue(
     }
   };
 
-  const wrapInReturnCompletion = contextVal => new ReturnCompletion(contextVal, realm.currentLocation);
+  const wrapInReturnCompletion = contextVal => new ReturnCompletion(contextVal, undefined, realm.currentLocation);
 
   if (context instanceof AbstractObjectValue && context.kind === "conditional") {
     let [condValue, consequentVal, alternateVal] = context.args;
@@ -379,7 +379,7 @@ export function OrdinaryCallEvaluateBody(
       GeneratorStart(realm, G, code);
 
       // 4. Return Completion{[[Type]]: return, [[Value]]: G, [[Target]]: empty}.
-      return new ReturnCompletion(G, realm.currentLocation);
+      return new ReturnCompletion(G, undefined, realm.currentLocation);
     } else {
       // TODO #1586: abstractRecursionSummarization is disabled for now, as it is likely too limiting
       // (as observed in large internal tests).
@@ -455,7 +455,7 @@ export function OrdinaryCallEvaluateBody(
           // converge into a single flow using their joint effects to update the post join point state.
           if (!(c instanceof ReturnCompletion)) {
             if (!(c instanceof AbruptCompletion)) {
-              c = new ReturnCompletion(realm.intrinsics.undefined, realm.currentLocation);
+              c = new ReturnCompletion(realm.intrinsics.undefined, undefined, realm.currentLocation);
             }
           }
           invariant(c instanceof AbruptCompletion);

--- a/src/partial-evaluators/BreakStatement.js
+++ b/src/partial-evaluators/BreakStatement.js
@@ -21,6 +21,6 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): [BreakCompletion, BabelNodeBreakStatement, Array<BabelNodeStatement>] {
-  let result = new BreakCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
+  let result = new BreakCompletion(realm.intrinsics.empty, undefined, ast.loc, ast.label && ast.label.name);
   return [result, ast, []];
 }

--- a/src/partial-evaluators/ContinueStatement.js
+++ b/src/partial-evaluators/ContinueStatement.js
@@ -21,6 +21,6 @@ export default function(
   env: LexicalEnvironment,
   realm: Realm
 ): [ContinueCompletion, BabelNodeContinueStatement, Array<BabelNodeStatement>] {
-  let result = new ContinueCompletion(realm.intrinsics.empty, ast.loc, ast.label && ast.label.name);
+  let result = new ContinueCompletion(realm.intrinsics.empty, undefined, ast.loc, ast.label && ast.label.name);
   return [result, ast, []];
 }

--- a/src/partial-evaluators/ReturnStatement.js
+++ b/src/partial-evaluators/ReturnStatement.js
@@ -27,6 +27,6 @@ export default function(
   } else {
     result = realm.intrinsics.undefined;
   }
-  if (!(result instanceof AbruptCompletion)) result = new ReturnCompletion(result, ast.loc);
+  if (!(result instanceof AbruptCompletion)) result = new ReturnCompletion(result, undefined, ast.loc);
   return [result, ast, []];
 }

--- a/src/partial-evaluators/ThrowStatement.js
+++ b/src/partial-evaluators/ThrowStatement.js
@@ -24,7 +24,7 @@ export default function(
 ): [Completion | Value, BabelNode, Array<BabelNodeStatement>] {
   let [argValue, argAst, io] = env.partiallyEvaluateCompletionDeref(ast.argument, strictCode);
   if (argValue instanceof Value) {
-    let c = new ThrowCompletion(argValue, ast.loc);
+    let c = new ThrowCompletion(argValue, undefined, ast.loc);
     let s = t.throwStatement((argAst: any)); // will be an expression because argValue is a Value
     return [c, s, io];
   }

--- a/src/types.js
+++ b/src/types.js
@@ -764,6 +764,7 @@ export type JoinType = {
   collapseResults(
     realm: Realm,
     joinCondition: AbstractValue,
+    precedingEffects: Effects,
     result1: EvaluationResult,
     result2: EvaluationResult
   ): Completion,

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -67,7 +67,7 @@ export default function(
         loc: e.loc,
         stackDecorated: false,
       };
-      throw new ThrowCompletion(error, e.loc);
+      throw new ThrowCompletion(error, undefined, e.loc);
     } else {
       throw e;
     }

--- a/src/values/NativeFunctionValue.js
+++ b/src/values/NativeFunctionValue.js
@@ -119,6 +119,7 @@ export default class NativeFunctionValue extends ECMAScriptFunctionValue {
     }
     return new ReturnCompletion(
       this.callback(context, argsList, originalLength, newTarget),
+      undefined,
       this.$Realm.currentLocation
     );
   }


### PR DESCRIPTION
Release note: none

I'm trying to move from a world where we pass arounds effects and completions separately to a world where only completions are passed around. To get there, we need to get a one to one correspondence between completions and the effects that they complete. This is not currently the case and getting there seems to be quite a bit of work.

To make things more reviewable, I'm breaking out the first part of that. Hence, the todos in the code.

This bit only sets up Effects to always make itself be the value of the effects property of its completion (result). Because of existing cases where a single completion can complete several Effects objects, there is an exemption for such cases, along with todos.