### PR TITLE
Further optimize Object.assign

### DIFF
--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -41,6 +41,17 @@ import { Create, Havoc, Properties as Props, To } from "../../singletons.js";
 import * as t from "babel-types";
 import invariant from "../../invariant.js";
 
+function snapshotToObjectAndRemoveProperties(
+  to: ObjectValue | AbstractObjectValue,
+  delayedSources: Array<Value>
+): void {
+  // If to has properties, we better remove them because after the temporal call to Object.assign we don't know their values anymore
+  if (to.hasStringOrSymbolProperties()) {
+    // Preserve them in a snapshot and add the snapshot to the sources
+    delayedSources.push(to.getSnapshot({ removeProperties: true }));
+  }
+}
+
 function handleObjectAssignSnapshot(
   to: ObjectValue | AbstractObjectValue,
   frm: ObjectValue | AbstractObjectValue,
@@ -52,16 +63,16 @@ function handleObjectAssignSnapshot(
     AbstractValue.reportIntrospectionError(to);
     throw new FatalError();
   } else {
-    // if to has properties, we better remove them because after the temporal call to Object.assign we don't know their values anymore
-    if (to.hasStringOrSymbolProperties()) {
-      // preserve them in a snapshot and add the snapshot to the sources
-      delayedSources.push(to.getSnapshot({ removeProperties: true }));
-    }
-
     if (frm instanceof ObjectValue && frm.mightBeHavocedObject()) {
+      // "frm" is havoced, so it might contain properties that potentially overwrite
+      // properties already on the "to" object.
+      snapshotToObjectAndRemoveProperties(to, delayedSources);
       // it's not safe to trust any of its values
       delayedSources.push(frm);
     } else if (frm_was_partial) {
+      // "frm" is partial, so it might contain properties that potentially overwrite
+      // properties already on the "to" object.
+      snapshotToObjectAndRemoveProperties(to, delayedSources);
       if (frm instanceof AbstractObjectValue && frm.kind === "explicit conversion to object") {
         // Make it implicit again since it is getting delayed into an Object.assign call.
         delayedSources.push(frm.args[0]);

--- a/test/serializer/optimized-functions/DeadObjectAssign10.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign10.js
@@ -1,7 +1,8 @@
-// Copies of _\$B:2
+// Copies of _\$8\(:1
+// Copies of var _\$8 = _\$7.assign;:1
 // inline expressions
 
-// _$B is the variable for Object.assign. See DeadObjectAssign4.js for
+// _$8 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign11.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign11.js
@@ -1,7 +1,8 @@
-// Copies of _\$B:2
+// Copies of _\$8\(:1
+// Copies of var _\$8 = _\$7.assign;:1
 // inline expressions
 
-// _$B is the variable for Object.assign. See DeadObjectAssign4.js for
+// _$8 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign12.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign12.js
@@ -1,7 +1,8 @@
-// Copies of _\$D:4
+// Copies of _\$A\(:3
+// Copies of var _\$A = _\$9.assign;:1
 // inline expressions
 
-// _$D is the variable for Object.assign. See DeadObjectAssign4.js for
+// _$A is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(x, foo, bar) {

--- a/test/serializer/optimized-functions/DeadObjectAssign13.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign13.js
@@ -1,4 +1,5 @@
-// Copies of _\$7:3
+// Copies of _\$7\(:2
+// Copies of var _\$7 = _\$6.assign;:1
 // inline expressions
 
 // _$7 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign14.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign14.js
@@ -1,4 +1,5 @@
-// Copies of _\$4:3
+// Copies of _\$4\(:2
+// Copies of var _\$4 = _\$3.assign;:1
 // inline expressions
 
 // _$4 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign15.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign15.js
@@ -1,4 +1,5 @@
-// Copies of _\$4:3
+// Copies of _\$4\(:2
+// Copies of var _\$4 = _\$3.assign;:1
 // inline expressions
 
 // _$4 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign16.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign16.js
@@ -1,4 +1,5 @@
-// Copies of _\$4:3
+// Copies of _\$4\(:2
+// Copies of var _\$4 = _\$3.assign;:1
 // inline expressions
 
 // _$4 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign17.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign17.js
@@ -1,7 +1,8 @@
-// Copies of _\$C:2
+// Copies of _\$A\(:1
+// Copies of var _\$A = _\$9.assign;:1
 // inline expressions
 
-// _$C is the variable for Object.assign. See DeadObjectAssign4.js for
+// _$A is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(o) {

--- a/test/serializer/optimized-functions/DeadObjectAssign18.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign18.js
@@ -1,7 +1,8 @@
-// Copies of _\$C:3
+// Copies of _\$A\(:2
+// Copies of var _\$A = _\$9.assign;:1
 // inline expressions
 
-// _$C is the variable for Object.assign. See DeadObjectAssign4.js for
+// _$A is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(o) {

--- a/test/serializer/optimized-functions/DeadObjectAssign19.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign19.js
@@ -1,4 +1,5 @@
-// Copies of _\$H:3
+// Copies of _\$E\(:2
+// Copies of var _\$E = _\$D.assign;:1
 // inline expressions
 
 // _$H is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign20.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign20.js
@@ -1,4 +1,5 @@
-// Copies of _\$5:2
+// Copies of _\$5\(:1
+// Copies of var _\$5 = _\$4.assign;:1
 // inline expressions
 
 // _$5 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign21.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign21.js
@@ -1,4 +1,5 @@
-// Copies of _\$E:4
+// Copies of _\$E\(:3
+// Copies of var _\$E = _\$D.assign;:1
 // inline expressions
 
 // _$E is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign22.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign22.js
@@ -1,4 +1,5 @@
-// Copies of _\$A:3
+// Copies of _\$A\(:2
+// Copies of var _\$A = _\$9.assign;:1
 // inline expressions
 
 // _$A is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign4.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign4.js
@@ -1,7 +1,8 @@
-// Copies of _\$4:2
+// Copies of _\$4\(:1
+// Copies of var _\$4 = _\$3.assign;:1
 // inline expressions
 
-// Why? _$4 is the variable for Object.assign, and there should be
+// Why? _$3 is the variable for Object.assign, and there should be
 // two copies of it. One for it's declaration and one for its reference.
 // We use inline expressions on all test iterations to ensure the copies
 // count is always constant.

--- a/test/serializer/optimized-functions/DeadObjectAssign5.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign5.js
@@ -1,4 +1,5 @@
-// Copies of _\$4:3
+// Copies of _\$4\(:2
+// Copies of var _\$4 = _\$3.assign;:1
 // inline expressions
 
 // _$4 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign6.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign6.js
@@ -1,4 +1,5 @@
-// Copies of _\$5:3
+// Copies of _\$5\(:2
+// Copies of var _\$5 = _\$4.assign;:1
 // inline expressions
 
 // _$5 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign7.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign7.js
@@ -1,4 +1,5 @@
-// Copies of _\$5:2
+// Copies of _\$5\(:1
+// Copies of var _\$5 = _\$4.assign;:1
 // inline expressions
 
 // _$5 is the variable for Object.assign. See DeadObjectAssign4.js for

--- a/test/serializer/optimized-functions/DeadObjectAssign9.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign9.js
@@ -1,7 +1,8 @@
-// Copies of _\$7:2
+// Copies of _\$6\(:1
+// Copies of var _\$6 = _\$5.assign;:1
 // inline expressions
 
-// _$7 is the variable for Object.assign. See DeadObjectAssign4.js for
+// _$6 is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
 function f(foo, bar) {

--- a/test/serializer/optimized-functions/ObjectAssign8.js
+++ b/test/serializer/optimized-functions/ObjectAssign8.js
@@ -1,0 +1,24 @@
+// Copies of return 1;:1
+// We essentially expect "fn" to optimize to "function () { return 1; }"
+
+function fn() {
+  var a = {};
+  var b = {
+    prop1: 1,
+    prop2: 2,
+  };
+  global.__makePartial && __makePartial(b);
+  global.__makeSimple && __makeSimple(b);
+  var c = {
+    prop3: 3,
+    prop4: 4,
+  };
+  Object.assign(a, b, c);
+  return a.prop1;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn();
+};


### PR DESCRIPTION
Release notes: Object.assign should no longer lose values when snapshotting in certain cases

Fixes https://github.com/facebook/prepack/issues/2240. This PR does a few things:

- Improves the value of Object.assign when snapshots are involved. Previously, the `removeProperties` property passed to `getSnapshot` was being called in all cases, now it only does it when it makes sense – i.e. the next "source" is partial. I've explained this in comments and broken this logic out into its own function.
- Removed the duplicate Object.assign logic for `react/utils`, we no longer need this as the fallback route never gets triggered anymore and it's just dead code.
- Updated the dead code tests with assertions to ensure we check the $ variable matches the Object.assign and also updated a few tests that were affected by this PR (as the Object.assign variable changed).