### PR TITLE
Prevent loops from getting stuck in infinite loops

### DIFF
--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -161,11 +161,11 @@ function ForBodyEvaluation(
       // ii. Perform ? GetValue(incRef).
       Environment.GetValue(realm, incRef);
     } else if (realm.useAbstractInterpretation) {
-      // If we have no increment and we've hit 100 iterations of trying to evaluate
+      // If we have no increment and we've hit 1000 iterations of trying to evaluate
       // this loop body, then see if we have a break, return or throw completion in a
       // guarded condition and fail if it does.
       possibleInfiniteLoopIterations++;
-      if (possibleInfiniteLoopIterations > 100) {
+      if (possibleInfiniteLoopIterations > 1000) {
         failIfContainsBreakOrReturnOrThrowCompletion(realm.savedCompletion);
       }
     }

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -161,11 +161,11 @@ function ForBodyEvaluation(
       // ii. Perform ? GetValue(incRef).
       Environment.GetValue(realm, incRef);
     } else if (realm.useAbstractInterpretation) {
-      // If we have no increment and we've hit 1000 iterations of trying to evaluate
+      // If we have no increment and we've hit 100 iterations of trying to evaluate
       // this loop body, then see if we have a break, return or throw completion in a
       // guarded condition and fail if it does.
       possibleInfiniteLoopIterations++;
-      if (possibleInfiniteLoopIterations > 1000) {
+      if (possibleInfiniteLoopIterations > 100) {
         failIfContainsBreakOrReturnOrThrowCompletion(realm.savedCompletion);
       }
     }

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -166,7 +166,7 @@ function ForBodyEvaluation(
       // guarded condition and fail if it does. We already have logic to guard
       // against loops that are actually infinite. However, because there may be so
       // many forked execution paths, and they're non linear, then it might
-      // computational lead to a something that seems like an infinite loop.
+      // computationally lead to a something that seems like an infinite loop.
       possibleInfiniteLoopIterations++;
       if (possibleInfiniteLoopIterations > 100) {
         failIfContainsBreakOrReturnOrThrowCompletion(realm.savedCompletion);

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -163,7 +163,10 @@ function ForBodyEvaluation(
     } else if (realm.useAbstractInterpretation) {
       // If we have no increment and we've hit 100 iterations of trying to evaluate
       // this loop body, then see if we have a break, return or throw completion in a
-      // guarded condition and fail if it does.
+      // guarded condition and fail if it does. We already have logic to guard
+      // against loops that are actually infinite. However, because there may be so
+      // many forked execution paths, and they're non linear, then it might
+      // computational lead to a something that seems like an infinite loop.
       possibleInfiniteLoopIterations++;
       if (possibleInfiniteLoopIterations > 100) {
         failIfContainsBreakOrReturnOrThrowCompletion(realm.savedCompletion);
@@ -176,7 +179,7 @@ function ForBodyEvaluation(
     if (c === undefined) return;
     if (c instanceof ThrowCompletion || c instanceof BreakCompletion || c instanceof ReturnCompletion) {
       let diagnostic = new CompilerDiagnostic(
-        "break, throw or return with target cannot be guarded by abstract condition",
+        "break, throw or return cannot be guarded by abstract condition",
         c.location,
         "PP0035",
         "FatalError"

--- a/test/serializer/optimized-functions/LoopBailout18.js
+++ b/test/serializer/optimized-functions/LoopBailout18.js
@@ -1,0 +1,31 @@
+function fn(x) {
+  for (
+    var _iterator = x.items,
+      _isArray = Array.isArray(_iterator),
+      _i = 0,
+      _iterator = _isArray ? _iterator : _iterator[Symbol.iterator]();
+    ;
+
+  ) {
+    // ...
+
+    var _ref;
+
+    if (_isArray) {
+      if (_i >= _iterator.length) break;
+      _ref = _iterator[_i++];
+    } else {
+      _i = _iterator.next();
+      if (_i.done) break;
+      _ref = _i.value;
+    }
+
+    var item = _ref;
+  }
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify(fn([1, 2, 3, 4, 5]));
+};

--- a/test/serializer/optimized-functions/LoopBailout19,js
+++ b/test/serializer/optimized-functions/LoopBailout19,js
@@ -1,10 +1,7 @@
 function fn(x, oldItems) {
   var items = [];
-  for (var i; ; ) {
+  for (var i; i < x; ) {
     i++;
-    if (i > x) {
-      break;
-    }
     items.push(oldItem + 2);
   }
   return items;

--- a/test/serializer/optimized-functions/LoopBailout19,js
+++ b/test/serializer/optimized-functions/LoopBailout19,js
@@ -3,7 +3,7 @@ function fn(x, oldItems) {
   for (var i; ; ) {
     i++;
     if (i > x) {
-      breakl
+      break;
     }
     items.push(oldItem + 2);
   }

--- a/test/serializer/optimized-functions/LoopBailout19,js
+++ b/test/serializer/optimized-functions/LoopBailout19,js
@@ -1,0 +1,17 @@
+function fn(x, oldItems) {
+  var items = [];
+  for (var i; ; ) {
+    i++;
+    if (i > x) {
+      breakl
+    }
+    items.push(oldItem + 2);
+  }
+  return items;
+}
+
+global.__optimize && __optimize(fn);
+
+inspect = function() {
+  return JSON.stringify(fn(5, [1, 2, 3, 4, 5]));
+};

--- a/test/serializer/optimized-functions/LoopBailout19.js
+++ b/test/serializer/optimized-functions/LoopBailout19.js
@@ -2,6 +2,7 @@ function fn(x, oldItems) {
   var items = [];
   for (var i; i < x; ) {
     i++;
+    var oldItem = oldItems[i];
     items.push(oldItem + 2);
   }
   return items;


### PR DESCRIPTION
Release notes: stop abstract loops from getting stuck in infinite loops when body contains a return, throw or break completion

Fixes https://github.com/facebook/prepack/issues/2053. This PR adds logic to "for loops" where they might get stuck in an infinite loop when there is no incrementor but there is a return, throw or break completion in the loop body. We check this via a new function `andfailIfContainsBreakOrReturnOrThrowCompletion` and only do this after `100` iterations of evaluating the loop body. I was thinking of making the iteration count configurable but wanted feedback on the approach first. I tried `1000` iterations, but it actually ended up taking about 2 minutes to evaluate the test case :/