### PR TITLE
Fix join of SimpleNormal with PossiblyNormal completions.

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -88,6 +88,9 @@ export class BreakCompletion extends AbruptCompletion {
 export class ReturnCompletion extends AbruptCompletion {
   constructor(value: Value, precedingEffects: void | Effects, location: ?BabelNodeSourceLocation) {
     super(value, precedingEffects, location);
+    if (value instanceof EmptyValue) {
+      this.value = value.$Realm.intrinsics.undefined;
+    }
   }
 }
 

--- a/src/types.js
+++ b/src/types.js
@@ -32,7 +32,6 @@ import {
   AbruptCompletion,
   Completion,
   ForkedAbruptCompletion,
-  SimpleNormalCompletion,
   PossiblyNormalCompletion,
   NormalCompletion,
 } from "./completions.js";
@@ -740,20 +739,6 @@ export type JoinType = {
     // effects collected after pnc was constructed
     e: Effects
   ): ForkedAbruptCompletion,
-
-  updatePossiblyNormalCompletionWithConditionalSimpleNormalCompletion(
-    realm: Realm,
-    joinCondition: AbstractValue,
-    pnc: PossiblyNormalCompletion,
-    nc: SimpleNormalCompletion
-  ): void,
-
-  updatePossiblyNormalCompletionWithInverseConditionalSimpleNormalCompletion(
-    realm: Realm,
-    joinCondition: AbstractValue,
-    pnc: PossiblyNormalCompletion,
-    nc: SimpleNormalCompletion
-  ): void,
 
   extractAndJoinCompletionsOfType(CompletionType: typeof AbruptCompletion, realm: Realm, c: AbruptCompletion): Effects,
 

--- a/test/serializer/abstract/Throw10.js
+++ b/test/serializer/abstract/Throw10.js
@@ -1,0 +1,14 @@
+let c1 = global.__abstract ? __abstract("boolean", "true") : true;
+let c2 = global.__abstract ? __abstract("boolean", "false") : false;
+
+function foo(cond) {
+  if (cond) throw "I am an error too!";
+}
+
+if (c2) {
+  foo(c1);
+}
+
+inspect = function() {
+  return "success";
+};


### PR DESCRIPTION
Release note: none

When joining a SimpleNormalCompletion with a PossiblyNormalCompletion, do not move the join condition to a leaf position.
