### PR TITLE
Fix bug with unknown arrays during React reconciliation

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -197,7 +197,7 @@ export function valueIsLegacyCreateClassComponent(realm: Realm, value: Value): b
 }
 
 export function valueIsFactoryClassComponent(realm: Realm, value: Value): boolean {
-  if (value instanceof ObjectValue) {
+  if (value instanceof ObjectValue && !ArrayValue.isIntrinsicAndHasWidenedNumericProperty(value)) {
     return To.ToBooleanPartial(realm, Get(realm, value, "render"));
   }
   return false;

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -166,6 +166,10 @@ it("Handle mapped arrays 2", () => {
   runTest(__dirname + "/FunctionalComponents/array-map2.js");
 });
 
+it("Handle mapped arrays 3", () => {
+  runTest(__dirname + "/FunctionalComponents/array-map3.js");
+});
+
 it("Handle mapped arrays from Array.from", () => {
   runTest(__dirname + "/FunctionalComponents/array-from.js");
 });

--- a/test/react/FunctionalComponents/array-map3.js
+++ b/test/react/FunctionalComponents/array-map3.js
@@ -1,0 +1,23 @@
+var React = require("react");
+
+function App(props) {
+  var items = Array.from(props.items);
+
+  var nested = function(item) {
+    return item;
+  };
+
+  return items.map(nested);
+}
+
+App.getTrials = function(renderer, Root) {
+  let items = [0, 0];
+  renderer.update(<Root items={items} />);
+  return [["simple render array map", renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -2616,6 +2616,74 @@ ReactStatistics {
 }
 `;
 
+exports[`Handle mapped arrays 3: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Handle mapped arrays 3: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Handle mapped arrays 3: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 1,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Handle mapped arrays 3: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 1,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Handle mapped arrays from Array.from: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,


### PR DESCRIPTION
Release notes: none

Fixes a bug with `valueIsFactoryClassComponent` not taking into account unknown arrays. 