### PR TITLE
Refactor and clean up realm.reportSideEffectCallbacks

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -65,8 +65,10 @@ export class ThrowCompletion extends AbruptCompletion {
     super(value, precedingEffects, location);
     this.nativeStack = nativeStack || new Error().stack;
     let realm = value.$Realm;
-    if (realm.isInPureScope() && realm.reportSideEffectCallback !== undefined) {
-      realm.reportSideEffectCallback("EXCEPTION_THROWN", undefined, location);
+    if (realm.isInPureScope()) {
+      for (let callback of realm.reportSideEffectCallbacks) {
+        callback("EXCEPTION_THROWN", undefined, location);
+      }
     }
   }
 


### PR DESCRIPTION
Release notes: none

The previous way we deal with side-effect callbacks was confusing and hard to understand. This PR now introduces a Set to store callbacks in and the old logic has been removed.