### PR TITLE
Nested abstract conditional fixes

### DIFF
--- a/test/serializer/optimized-functions/NestedConditions.js
+++ b/test/serializer/optimized-functions/NestedConditions.js
@@ -1,0 +1,481 @@
+(function() {
+  function fn1(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      // return 3;
+    }
+  }
+
+  function fn2(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      // return 3;
+    }
+  }
+
+  function fn3(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      return 3;
+    }
+  }
+
+  function fn4(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      // return 3;
+    }
+  }
+
+  function fn5(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      return 3;
+    }
+  }
+
+  function fn6(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      return 3;
+    }
+  }
+
+  function fn7(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      return 3;
+    }
+  }
+
+  function fn8(arg) {
+    if (arg.foo) {
+      // return 3;
+    } else {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    }
+  }
+
+  function fn9(arg) {
+    if (arg.foo) {
+      // return 3;
+    } else {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    }
+  }
+
+  function fn10(arg) {
+    if (arg.foo) {
+      return 3;
+    } else {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        // return 2;
+      }
+    }
+  }
+
+  function fn11(arg) {
+    if (arg.foo) {
+      // return 3;
+    } else {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    }
+  }
+
+  function fn12(arg) {
+    if (arg.foo) {
+      return 3;
+    } else {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    }
+  }
+
+  function fn13(arg) {
+    if (arg.foo) {
+      return 3;
+    } else {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    }
+  }
+
+  function fn14(arg) {
+    if (arg.foo) {
+      return 3;
+    } else {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    }
+  }
+
+  function fn15(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      if (arg.qux) {
+        // return 3;
+      } else {
+        // return 4;
+      }
+    }
+  }
+
+  function fn16(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        // return 3;
+      } else {
+        // return 4;
+      }
+    }
+  }
+
+  function fn17(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        // return 4;
+      }
+    }
+  }
+
+  function fn18(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      if (arg.qux) {
+        // return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  function fn19(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        // return 3;
+      } else {
+        // return 4;
+      }
+    }
+  }
+
+  function fn20(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        // return 4;
+      }
+    }
+  }
+
+  function fn21(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      if (arg.qux) {
+        // return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  function fn22(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        // return 4;
+      }
+    }
+  }
+
+  function fn23(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        // return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  function fn24(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  function fn25(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        // return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  function fn26(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        // return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  function fn27(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        // return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  function fn28(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        // return 4;
+      }
+    }
+  }
+
+  function fn29(arg) {
+    if (arg.foo) {
+      if (arg.bar) {
+        return 1;
+      } else {
+        return 2;
+      }
+    } else {
+      if (arg.qux) {
+        return 3;
+      } else {
+        return 4;
+      }
+    }
+  }
+
+  if (global.__optimize) {
+    __optimize(fn1);
+    __optimize(fn2);
+    __optimize(fn3);
+    __optimize(fn4);
+    __optimize(fn5);
+    __optimize(fn6);
+    __optimize(fn7);
+    __optimize(fn8);
+    __optimize(fn9);
+    __optimize(fn10);
+    __optimize(fn11);
+    __optimize(fn12);
+    __optimize(fn13);
+    __optimize(fn14);
+    __optimize(fn15);
+    __optimize(fn16);
+    __optimize(fn17);
+    __optimize(fn18);
+    __optimize(fn19);
+    __optimize(fn20);
+    __optimize(fn21);
+    __optimize(fn22);
+    __optimize(fn23);
+    __optimize(fn24);
+    __optimize(fn25);
+    __optimize(fn26);
+    __optimize(fn27);
+    __optimize(fn28);
+    __optimize(fn29);
+  }
+
+  global.inspect = function() {
+    const cases = [
+      { foo: true, bar: true },
+      { foo: false, bar: true },
+      { foo: true, bar: false },
+      { foo: false, bar: false },
+    ];
+    return JSON.stringify([
+      ...cases.map(fn1),
+      ...cases.map(fn2),
+      ...cases.map(fn3),
+      ...cases.map(fn4),
+      ...cases.map(fn5),
+      ...cases.map(fn6),
+      ...cases.map(fn7),
+      ...cases.map(fn8),
+      ...cases.map(fn9),
+      ...cases.map(fn10),
+      ...cases.map(fn11),
+      ...cases.map(fn12),
+      ...cases.map(fn13),
+      ...cases.map(fn14),
+      ...cases.map(fn15),
+      ...cases.map(fn16),
+      ...cases.map(fn17),
+      ...cases.map(fn18),
+      ...cases.map(fn19),
+      ...cases.map(fn20),
+      ...cases.map(fn21),
+      ...cases.map(fn22),
+      ...cases.map(fn23),
+      ...cases.map(fn24),
+      ...cases.map(fn25),
+      ...cases.map(fn26),
+      ...cases.map(fn27),
+      ...cases.map(fn28),
+      ...cases.map(fn29),
+    ]);
+  };
+})();


### PR DESCRIPTION
Fixes #1867 and fixes #2058 which are issues blocking the React compiler.

Test case from #1867 copied below:

```js
(function() {
  function fn(arg) {
    if (arg.foo) {
      if (arg.bar) {
        return 42;
      }
    }
  }

  if (global.__optimize) {
    __optimize(fn);
  }

  global.inspect = function() {
    return JSON.stringify([
        fn(null),
        fn({}),
        fn({foo: true}),
    ]);
  };
})();
```

The fix is almost entirely in `joinOrForkResults` where I remove the call to `updatePossiblyNormalCompletionWithConditionalSimpleNormalCompletion` and replace it with a new `PossiblyNormalCompletion`. Here’s my understanding of the issue and the previous strategy. Hopefully @hermanventer can correct me if I’m wrong or explain why it needs to be the way it was.

In our program above when we are joining the `arg.foo` consequent with its alternate we have the following completion for the `arg.foo` consequent:

- `PossiblyNormalCompletion` (join condition is `arg.bar`)
  - `ReturnCompletion(42)` (value of `42`)
  - `SimpleNormalCompletion(empty)` (there is no `else`)

We are joining this with an alternate of `SimpleNormalCompletion` since there is no `else` on the `arg.foo` if-statement. Before we would try and “sneak into” the two branches and add an abstract conditional to the result. However, the implementation was limited so we we only updated `SimpleNormalCompletion`. This meant we ended up changing our above completion to:

- `PossiblyNormalCompletion` (join condition is `arg.bar`)
  - `ReturnCompletion(42)`
  - `SimpleNormalCompletion(arg.foo ? empty : empty)`

The only change being the second `SimpleNormalCompletion` is now `arg.foo ? empty : empty`. This would serialize into roughly:

```js
function f() {
  return _$1 ? 42 : undefined;
}
```

Where `_$1` is not declared! Since we were serializing a `PossiblyNormalCompletion` with a join condition of `arg.bar` and the `arg.foo ? empty : empty` abstract conditional simplified to just `empty` which means we never emit `arg.foo` so never emit `arg.bar` which has a dependency on `arg.foo`.

My strategy was to nest the `PossiblyNormalCompletion` in another `PossiblyNormalCompletion`. So the final completion for the code sample at the top of this PR is:

- `PossiblyNormalCompletion` (join condition is `arg.foo`)
  - consequent: `PossiblyNormalCompletion` (join condition is `arg.bar`)
    - consequent: `ReturnCompletion(42)`
    - alternate: `SimpleNormalCompletion(empty)`
  - alternate: `SimpleNormalCompletion(empty)`

I’m confused as to why this was not done in the first place and instead an update strategy was used.

I then wrote a test (now in `test/serializer/optimized-functions/NestedConditions.js`) to enumerate a bunch of nested conditional cases. The rest of the fixes come from there. Notably the refactor of `replacePossiblyNormalCompletionWithForkedAbruptCompletion` which did not produce the same output when `consequent` and `alternate` were flipped.