### PR TITLE
 Clone completions when they complete composed effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "yarn build-prepack && yarn build-bundle",
     "build-scripts": "babel scripts --out-dir lib --source-maps",
-    "build-bundle": "webpack-cli",
+    "build-bundle": "webpack-cli --silent",
     "build-prepack": "babel src --out-dir lib --source-maps",
     "watch": "babel src scripts --out-dir lib --watch --source-maps --verbose",
     "lint": "eslint src scripts",

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -351,7 +351,7 @@ function getErrorHandlerWithWarningCapture(
 }
 
 function runTest(name, code, options: PrepackOptions, args) {
-  console.log(chalk.inverse(name) + " " + JSON.stringify(options));
+  if (!args.fast && args.filter === "") console.log(chalk.inverse(name) + " " + JSON.stringify(options));
   let compatibility = code.includes("// jsc") ? "jsc-600-1-4-17" : undefined;
   let initializeMoreModules = code.includes("// initialize more modules");
   let delayUnsupportedRequires = code.includes("// delay unsupported requires");
@@ -666,17 +666,17 @@ function runTest(name, code, options: PrepackOptions, args) {
               console.error(chalk.red(`Code generation did not reach fixed point after ${max} iterations!`));
             }
 
-            console.log(chalk.underline("original code"));
-            console.log(code);
-            console.log(chalk.underline("output of inspect() on original code"));
-            console.log(expected);
+            console.error(chalk.underline("original code"));
+            console.error(code);
+            console.error(chalk.underline("output of inspect() on original code"));
+            console.error(expected);
             for (let ii = 0; ii < codeIterations.length; ii++) {
-              console.log(chalk.underline(`generated code in iteration ${ii}`));
-              console.log(codeIterations[ii]);
+              console.error(chalk.underline(`generated code in iteration ${ii}`));
+              console.error(codeIterations[ii]);
             }
-            console.log(chalk.underline("output of inspect() on last generated code iteration"));
-            console.log(actual);
-            if (actualStack) console.log(actualStack);
+            console.error(chalk.underline("output of inspect() on last generated code iteration"));
+            console.error(actual);
+            if (actualStack) console.error(actualStack);
             return Promise.resolve(false);
           } else if (type === "RETURN") {
             return value;
@@ -880,6 +880,7 @@ function main(): void {
     }
     process.exit(1);
   }
+  if (args.fast && args.filter === "") (console: any).error = function() {};
   (args && args.cpuprofilePath ? runWithCpuProfiler : run)(args)
     .then(function(result) {
       if (!result) {

--- a/src/completions.js
+++ b/src/completions.js
@@ -16,9 +16,13 @@ import { AbstractValue, EmptyValue, Value } from "./values/index.js";
 
 export class Completion {
   constructor(value: Value, precedingEffects: void | Effects, location: ?BabelNodeSourceLocation, target?: ?string) {
+    let e = precedingEffects;
+    if (e !== undefined) {
+      if (e.result === undefined) e.result = this;
+      else e = new Effects(this, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+    }
     this.value = value;
-    this.effects = precedingEffects;
-    if (precedingEffects !== undefined) precedingEffects.result = this;
+    this.effects = e;
     this.target = target;
     this.location = location;
     invariant(this.constructor !== Completion, "Completion is an abstract base class");
@@ -28,6 +32,10 @@ export class Completion {
   effects: void | Effects;
   target: ?string;
   location: ?BabelNodeSourceLocation;
+
+  shallowCloneWithoutEffects(): Completion {
+    invariant(false, "Completion.shallowCloneWithoutEffects is an abstract base method and should not be called");
+  }
 
   toDisplayString(): string {
     return "[" + this.constructor.name + " value " + (this.value ? this.value.toDisplayString() : "undefined") + "]";
@@ -40,11 +48,19 @@ export class NormalCompletion extends Completion {
     super(value, precedingEffects, location, target);
     invariant(this.constructor !== NormalCompletion, "NormalCompletion is an abstract base class");
   }
+
+  shallowCloneWithoutEffects(): NormalCompletion {
+    invariant(false, "NormalCompletion.shallowCloneWithoutEffects is an abstract base method and should not be called");
+  }
 }
 
 // SimpleNormalCompletions are returned just like spec completions. This class exists as the parallel for
 // PossiblyNormalCompletion to make comparisons easier.
-export class SimpleNormalCompletion extends NormalCompletion {}
+export class SimpleNormalCompletion extends NormalCompletion {
+  shallowCloneWithoutEffects(): SimpleNormalCompletion {
+    return new SimpleNormalCompletion(this.value, undefined, this.location, this.target);
+  }
+}
 
 // Abrupt completions are thrown as exeptions, to make it a easier
 // to quickly get to the matching high level construct.
@@ -52,6 +68,10 @@ export class AbruptCompletion extends Completion {
   constructor(value: Value, precedingEffects: void | Effects, location: ?BabelNodeSourceLocation, target?: ?string) {
     super(value, precedingEffects, location, target);
     invariant(this.constructor !== AbruptCompletion, "AbruptCompletion is an abstract base class");
+  }
+
+  shallowCloneWithoutEffects(): AbruptCompletion {
+    invariant(false, "AbruptCompletion.shallowCloneWithoutEffects is an abstract base method and should not be called");
   }
 }
 
@@ -73,17 +93,29 @@ export class ThrowCompletion extends AbruptCompletion {
   }
 
   nativeStack: string;
+
+  shallowCloneWithoutEffects(): ThrowCompletion {
+    return new ThrowCompletion(this.value, undefined, this.location, this.nativeStack);
+  }
 }
 
 export class ContinueCompletion extends AbruptCompletion {
   constructor(value: Value, precedingEffects: void | Effects, location: ?BabelNodeSourceLocation, target: ?string) {
     super(value, precedingEffects, location, target || null);
   }
+
+  shallowCloneWithoutEffects(): ContinueCompletion {
+    return new ContinueCompletion(this.value, undefined, this.location, this.target);
+  }
 }
 
 export class BreakCompletion extends AbruptCompletion {
   constructor(value: Value, precedingEffects: void | Effects, location: ?BabelNodeSourceLocation, target: ?string) {
     super(value, precedingEffects, location, target || null);
+  }
+
+  shallowCloneWithoutEffects(): BreakCompletion {
+    return new BreakCompletion(this.value, undefined, this.location, this.target);
   }
 }
 
@@ -93,6 +125,10 @@ export class ReturnCompletion extends AbruptCompletion {
     if (value instanceof EmptyValue) {
       this.value = value.$Realm.intrinsics.undefined;
     }
+  }
+
+  shallowCloneWithoutEffects(): ReturnCompletion {
+    return new ReturnCompletion(this.value, undefined, this.location);
   }
 }
 
@@ -106,18 +142,31 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
     alternateEffects: Effects
   ) {
     super(realm.intrinsics.empty, undefined, consequent.location);
-    invariant(consequentEffects);
-    invariant(alternateEffects);
+    invariant(consequentEffects.result === consequent);
+    invariant(consequent.effects === consequentEffects);
+    invariant(alternateEffects.result === alternate);
+    invariant(alternate.effects === alternateEffects);
     this.joinCondition = joinCondition;
-    consequent.effects = consequentEffects;
     this.consequent = consequent;
-    alternate.effects = alternateEffects;
     this.alternate = alternate;
   }
 
   joinCondition: AbstractValue;
   consequent: AbruptCompletion;
   alternate: AbruptCompletion;
+
+  shallowCloneWithoutEffects(): ForkedAbruptCompletion {
+    let consequentEffects = this.consequentEffects;
+    let alternateEffects = this.alternateEffects;
+    return new ForkedAbruptCompletion(
+      this.value.$Realm,
+      this.joinCondition,
+      this.consequent,
+      consequentEffects,
+      this.alternate,
+      alternateEffects
+    );
+  }
 
   // For convenience, this.consequent.effects should always be defined, but accessing it directly requires
   // verifying that with an invariant.
@@ -219,12 +268,12 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     savedEffects: void | Effects = undefined
   ) {
     invariant(consequent === consequentEffects.result);
+    invariant(consequent.effects === consequentEffects);
     invariant(alternate === alternateEffects.result);
+    invariant(alternate.effects === alternateEffects);
     invariant(consequent instanceof NormalCompletion || alternate instanceof NormalCompletion);
     super(value, undefined, consequent.location);
     this.joinCondition = joinCondition;
-    consequent.effects = consequentEffects;
-    alternate.effects = alternateEffects;
     this.consequent = consequent;
     this.alternate = alternate;
     this.savedEffects = savedEffects;
@@ -237,6 +286,23 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   savedEffects: void | Effects;
   // The path conditions that applied at the time of the oldest fork that caused this completion to arise.
   savedPathConditions: Array<AbstractValue>;
+
+  shallowCloneWithoutEffects(): PossiblyNormalCompletion {
+    let consequentEffects = this.consequentEffects;
+    let alternateEffects = this.alternateEffects;
+    invariant(this.consequent === consequentEffects.result);
+    invariant(this.alternate === alternateEffects.result);
+    return new PossiblyNormalCompletion(
+      this.value,
+      this.joinCondition,
+      this.consequent,
+      consequentEffects,
+      this.alternate,
+      alternateEffects,
+      this.savedPathConditions,
+      this.savedEffects
+    );
+  }
 
   // For convenience, this.consequent.effects should always be defined, but accessing it directly requires
   // verifying that with an invariant.
@@ -252,19 +318,17 @@ export class PossiblyNormalCompletion extends NormalCompletion {
 
   updateConsequentKeepingCurrentEffects(newConsequent: Completion): PossiblyNormalCompletion {
     if (newConsequent instanceof NormalCompletion) this.value = newConsequent.value;
-    let effects = this.consequentEffects;
-    newConsequent.effects = effects;
-    newConsequent.effects.result = newConsequent;
-    this.consequent = newConsequent;
+    let e = this.consequentEffects;
+    let effects = new Effects(newConsequent, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+    this.consequent = effects.result;
     return this;
   }
 
   updateAlternateKeepingCurrentEffects(newAlternate: Completion): PossiblyNormalCompletion {
     if (newAlternate instanceof NormalCompletion) this.value = newAlternate.value;
-    let effects = this.alternateEffects;
-    newAlternate.effects = effects;
-    newAlternate.effects.result = newAlternate;
-    this.alternate = newAlternate;
+    let e = this.alternateEffects;
+    let effects = new Effects(newAlternate, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+    this.alternate = effects.result;
     return this;
   }
 

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { CompilerDiagnostic, FatalError } from "../errors.js";
-import { AbruptCompletion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
 import { Effects } from "../realm.js";
 import { type LexicalEnvironment, type BaseValue, mightBecomeAnObject } from "../environment.js";
@@ -180,11 +180,15 @@ function callBothFunctionsAndJoinTheirEffects(
     "callBothFunctionsAndJoinTheirEffects/2"
   );
 
+  let r1 = e1.result;
+  if (r1 instanceof Completion) r1 = r1.shallowCloneWithoutEffects();
+  let r2 = e2.result;
+  if (r2 instanceof Completion) r2 = r2.shallowCloneWithoutEffects();
   let joinedEffects = Join.joinForkOrChoose(
     realm,
     cond,
-    new Effects(e1.result, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
-    new Effects(e2.result, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
+    new Effects(r1, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
+    new Effects(r2, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
   );
   let completion = joinedEffects.result;
   if (completion instanceof SimpleNormalCompletion) completion = completion.value;

--- a/src/evaluators/ForOfStatement.js
+++ b/src/evaluators/ForOfStatement.js
@@ -62,7 +62,7 @@ export function TryToApplyEffectsOfJoiningBranches(realm: Realm, c: ForkedAbrupt
     realm.applyEffects(joinedEffects, "end of loop body");
   } else if (jr instanceof ForkedAbruptCompletion) {
     if (jr.containsBreakOrContinue()) {
-      // todo: extract the continue completions, apply those while stashing the other comletions
+      // todo: extract the continue completions, apply those while stashing the other completions
       // in realm.savedCompletion. This may need customization depending on the caller.
       AbstractValue.reportIntrospectionError(jr.joinCondition);
       throw new FatalError();

--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -92,7 +92,13 @@ export default function(
     joinedEffects = Join.joinForkOrChoose(
       realm,
       lval,
-      new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2),
+      new Effects(
+        result2.shallowCloneWithoutEffects(),
+        generator2,
+        modifiedBindings2,
+        modifiedProperties2,
+        createdObjects2
+      ),
       new Effects(new SimpleNormalCompletion(lval), generator1, modifiedBindings1, modifiedProperties1, createdObjects1)
     );
   } else {
@@ -106,7 +112,13 @@ export default function(
         modifiedProperties1,
         createdObjects1
       ),
-      new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2)
+      new Effects(
+        result2.shallowCloneWithoutEffects(),
+        generator2,
+        modifiedBindings2,
+        modifiedProperties2,
+        createdObjects2
+      )
     );
   }
   let completion = joinedEffects.result;

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { AbruptCompletion, PossiblyNormalCompletion } from "../completions.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
 import { InfeasiblePathError } from "../errors.js";
 import { construct_empty_effects, type Realm, Effects } from "../realm.js";
 import type { PropertyKeyValue, CallableObjectValue } from "../types.js";
@@ -164,6 +164,8 @@ export function OrdinaryGet(
   }
   // Join the effects, creating an abstract view of what happened, regardless
   // of the actual value of ownDesc.joinCondition.
+  if (result1 instanceof Completion) result1 = result1.shallowCloneWithoutEffects();
+  if (result2 instanceof Completion) result2 = result2.shallowCloneWithoutEffects();
   let joinedEffects = Join.joinForkOrChoose(
     realm,
     joinCondition,

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -154,22 +154,25 @@ export class JoinImplementation {
     invariant(c.savedEffects === undefined); // the caller should ensure this
     let savedPathConditions = pnc.savedPathConditions;
     if (pnc.consequent instanceof AbruptCompletion) {
+      let na;
       if (pnc.alternate instanceof SimpleNormalCompletion) {
         let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.alternateEffects;
-        let newAlternateEffects = new Effects(c, generator, modifiedBindings, modifiedProperties, createdObjects);
+        na = c.shallowCloneWithoutEffects();
+        let newAlternateEffects = new Effects(na, generator, modifiedBindings, modifiedProperties, createdObjects);
+        if (priorEffects) newAlternateEffects = realm.composeEffects(priorEffects, newAlternateEffects);
         return new PossiblyNormalCompletion(
           c.value,
           pnc.joinCondition,
           pnc.consequent,
           pnc.consequentEffects,
-          c,
-          !priorEffects ? newAlternateEffects : realm.composeEffects(priorEffects, newAlternateEffects),
+          newAlternateEffects.result,
+          newAlternateEffects,
           savedPathConditions,
           pnc.savedEffects
         );
       }
       invariant(pnc.alternate instanceof PossiblyNormalCompletion);
-      let na = this.composePossiblyNormalCompletions(realm, pnc.alternate, c, priorEffects);
+      na = this.composePossiblyNormalCompletions(realm, pnc.alternate, c, priorEffects);
       let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.alternateEffects;
       let newAlternateEffects = new Effects(na, generator, modifiedBindings, modifiedProperties, createdObjects);
       return new PossiblyNormalCompletion(
@@ -183,14 +186,17 @@ export class JoinImplementation {
         pnc.savedEffects
       );
     } else {
+      let nc;
       if (pnc.consequent instanceof SimpleNormalCompletion) {
         let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.consequentEffects;
-        let newConsequentEffects = new Effects(c, generator, modifiedBindings, modifiedProperties, createdObjects);
+        nc = c.shallowCloneWithoutEffects();
+        let newConsequentEffects = new Effects(nc, generator, modifiedBindings, modifiedProperties, createdObjects);
+        if (priorEffects) newConsequentEffects = realm.composeEffects(priorEffects, newConsequentEffects);
         return new PossiblyNormalCompletion(
           c.value,
           pnc.joinCondition,
-          c,
-          !priorEffects ? newConsequentEffects : realm.composeEffects(priorEffects, newConsequentEffects),
+          newConsequentEffects.result,
+          newConsequentEffects,
           pnc.alternate,
           pnc.alternateEffects,
           savedPathConditions,
@@ -198,7 +204,7 @@ export class JoinImplementation {
         );
       }
       invariant(pnc.consequent instanceof PossiblyNormalCompletion);
-      let nc = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
+      nc = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
       let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.consequentEffects;
       let newConsequentEffects = new Effects(nc, generator, modifiedBindings, modifiedProperties, createdObjects);
       return new PossiblyNormalCompletion(
@@ -224,21 +230,25 @@ export class JoinImplementation {
     pnc.value = v.value;
     if (pnc.consequent instanceof AbruptCompletion) {
       if (pnc.alternate instanceof SimpleNormalCompletion) {
-        pnc.alternateEffects.result = v;
-        v.effects = realm.composeEffects(pnc.alternateEffects, subsequentEffects);
-        pnc.alternate = v;
+        let ce = realm.composeEffects(pnc.alternateEffects, subsequentEffects);
+        pnc.alternate = ce.result;
       } else {
         invariant(pnc.alternate instanceof PossiblyNormalCompletion);
         this.updatePossiblyNormalCompletionWithSubsequentEffects(realm, pnc.alternate, subsequentEffects);
       }
     } else {
       if (pnc.consequent instanceof SimpleNormalCompletion) {
-        pnc.consequentEffects.result = v;
-        v.effects = realm.composeEffects(pnc.consequentEffects, subsequentEffects);
-        pnc.consequent = v;
+        let ce = realm.composeEffects(pnc.consequentEffects, subsequentEffects);
+        pnc.consequent = ce.result;
       } else {
         invariant(pnc.consequent instanceof PossiblyNormalCompletion);
         this.updatePossiblyNormalCompletionWithSubsequentEffects(realm, pnc.consequent, subsequentEffects);
+      }
+      if (pnc.alternate instanceof SimpleNormalCompletion) {
+        let ce = realm.composeEffects(pnc.alternateEffects, subsequentEffects);
+        pnc.alternate = ce.result;
+      } else if (pnc.alternate instanceof PossiblyNormalCompletion) {
+        this.updatePossiblyNormalCompletionWithSubsequentEffects(realm, pnc.alternate, subsequentEffects);
       }
     }
   }
@@ -246,15 +256,14 @@ export class JoinImplementation {
   updatePossiblyNormalCompletionWithValue(realm: Realm, pnc: PossiblyNormalCompletion, v: Value): void {
     let updateNonAbruptCompletionWithValue = (c: Completion, val: Value) => {
       if (c instanceof SimpleNormalCompletion) {
-        let nc = new SimpleNormalCompletion(val);
-        pnc = pnc.updateAlternateKeepingCurrentEffects(nc);
-        c.value = val;
+        c.value = v;
       } else if (c instanceof PossiblyNormalCompletion) {
         this.updatePossiblyNormalCompletionWithValue(realm, c, val);
       } else {
         invariant(false);
       }
     };
+    pnc.value = v;
     let pncc = pnc.consequent;
     let pnca = pnc.alternate;
     if (pncc instanceof AbruptCompletion) {
@@ -285,12 +294,15 @@ export class JoinImplementation {
     // effects collected after pnc was constructed
     e: Effects
   ): ForkedAbruptCompletion {
-    // set up e with ac as the completion. It's OK to do this repeatedly since ac is not changed by recursive calls.
+    ac = ac.shallowCloneWithoutEffects();
     e.result = ac;
+    ac.effects = e;
     let pncc = pnc.consequent;
     if (pncc instanceof AbruptCompletion) {
       // todo: simplify with implied path condition
       e = realm.composeEffects(pnc.alternateEffects, e);
+      invariant(e.result instanceof AbruptCompletion);
+      ac = e.result;
       if (pnc.alternate instanceof SimpleNormalCompletion) {
         return new ForkedAbruptCompletion(realm, pnc.joinCondition, pncc, pnc.consequentEffects, ac, e);
       }
@@ -305,26 +317,26 @@ export class JoinImplementation {
         nc = this.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, pncc, ac, e);
         let ce = pnc.consequentEffects;
         nce = new Effects(nc, ce.generator, ce.modifiedBindings, ce.modifiedProperties, ce.createdObjects);
+        ac = ac.shallowCloneWithoutEffects();
+        e = new Effects(ac, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
       } else {
         invariant(pncc instanceof SimpleNormalCompletion);
-        nc = ac;
         nce = realm.composeEffects(pnc.consequentEffects, e);
+        invariant(nce.result instanceof AbruptCompletion);
+        nc = nce.result;
+        ac = ac.shallowCloneWithoutEffects();
+        e = new Effects(ac, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
       }
       let pnca = pnc.alternate;
       let na, nae;
-      // TODO (hermanv) if we use e as is, it ends up being applied twice when the join of the normal
-      // path is applied to the current state. Follow up with a PR that allows Effects to get deeply cloned
-      // and then clone e at this point.
-      e = construct_empty_effects(realm);
-      // Note that ac may depend on the effects in the original e, so use e.result until the cloning is done.
-      ac = (e.result: any);
       if (pnca instanceof PossiblyNormalCompletion) {
         na = this.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, pnca, ac, e);
         let ae = pnc.alternateEffects;
         nae = new Effects(na, ae.generator, ae.modifiedBindings, ae.modifiedProperties, ae.createdObjects);
       } else if (pnca instanceof SimpleNormalCompletion) {
-        na = ac;
         nae = realm.composeEffects(pnc.alternateEffects, e);
+        invariant(nae.result instanceof AbruptCompletion);
+        na = nae.result;
       } else {
         invariant(pnca instanceof AbruptCompletion);
         na = pnca;
@@ -345,7 +357,9 @@ export class JoinImplementation {
       if (v2 instanceof EmptyValue) return v1 || realm.intrinsics.undefined;
       return AbstractValue.createFromConditionalOp(realm, joinCondition, v1, v2);
     };
+    c = c.shallowCloneWithoutEffects();
     let ce = construct_empty_effects(realm, c);
+    a = a.shallowCloneWithoutEffects();
     let ae = construct_empty_effects(realm, a);
     let rv = this.joinValues(realm, c.value, a.value, getAbstractValue);
     invariant(rv instanceof Value);
@@ -361,7 +375,7 @@ export class JoinImplementation {
   extractAndJoinCompletionsOfType(CompletionType: typeof AbruptCompletion, realm: Realm, c: AbruptCompletion): Effects {
     let emptyEffects = construct_empty_effects(realm);
     if (c instanceof CompletionType) {
-      emptyEffects.result = c;
+      emptyEffects.result = c.shallowCloneWithoutEffects();
       return emptyEffects;
     }
     if (!(c instanceof ForkedAbruptCompletion)) {
@@ -404,7 +418,9 @@ export class JoinImplementation {
     let e = this.joinForkOrChoose(realm, c.joinCondition, ce, ae);
     if (e.result instanceof ForkedAbruptCompletion) {
       if (e.result.consequent instanceof CompletionType && e.result.alternate instanceof CompletionType) {
-        e.result = this.collapseResults(realm, e.result.joinCondition, e, e.result.consequent, e.result.alternate);
+        let result = this.collapseResults(realm, e.result.joinCondition, e, e.result.consequent, e.result.alternate);
+        e = result.effects;
+        invariant(e !== undefined);
       }
     }
     return e;
@@ -422,6 +438,7 @@ export class JoinImplementation {
       modifiedProperties: modifiedProperties1,
       createdObjects: createdObjects1,
     } = e1;
+    invariant(result1.effects === e1);
 
     let {
       result: result2,
@@ -430,6 +447,7 @@ export class JoinImplementation {
       modifiedProperties: modifiedProperties2,
       createdObjects: createdObjects2,
     } = e2;
+    invariant(result2.effects === e2);
 
     let result = this.joinOrForkResults(realm, joinCondition, result1, result2, e1, e2);
     if (result1 instanceof AbruptCompletion) {
@@ -476,8 +494,10 @@ export class JoinImplementation {
       let e1 = this.joinNestedEffects(realm, c.consequent, c.consequentEffects);
       let e2 = this.joinNestedEffects(realm, c.alternate, c.alternateEffects);
       let e3 = this.joinForkOrChoose(realm, c.joinCondition, e1, e2);
-      this.collapseResults(realm, c.joinCondition, e3, e1.result, e2.result);
-      return e3;
+      let r = this.collapseResults(realm, c.joinCondition, e3, e1.result, e2.result);
+      let re = r.effects;
+      invariant(re !== undefined);
+      return re;
     }
     if (precedingEffects !== undefined) return precedingEffects;
     let result = construct_empty_effects(realm);
@@ -542,6 +562,10 @@ export class JoinImplementation {
     e1: Effects,
     e2: Effects
   ): Completion {
+    invariant(result1.effects === e1);
+    invariant(e1.result === result1);
+    invariant(result2.effects === e2);
+    invariant(e2.result === result2);
     let getAbstractValue = (v1: void | Value, v2: void | Value) => {
       return AbstractValue.createFromConditionalOp(realm, joinCondition, v1, v2);
     };

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -9,7 +9,7 @@
 
 /* @flow */
 
-import { AbruptCompletion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
 import { construct_empty_effects, type Realm, Effects } from "../realm.js";
 import type { Descriptor, PropertyBinding, PropertyKeyValue } from "../types.js";
 import {
@@ -321,6 +321,8 @@ export class PropertiesImplementation {
 
       // Join the effects, creating an abstract view of what happened, regardless
       // of the actual value of ownDesc.joinCondition.
+      if (result1 instanceof Completion) result1 = result1.shallowCloneWithoutEffects();
+      if (result2 instanceof Completion) result2 = result2.shallowCloneWithoutEffects();
       let joinedEffects = Join.joinForkOrChoose(
         realm,
         joinCondition,

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -110,18 +110,20 @@ function callBothFunctionsAndJoinTheirEffects(
     undefined,
     "callBothFunctionsAndJoinTheirEffects/1"
   );
+  let r1 = e1.result.shallowCloneWithoutEffects();
 
   const e2 = realm.evaluateForEffects(
     () => EvaluateCall(func2, func2, ast, argVals, strictCode, env, realm),
     undefined,
     "callBothFunctionsAndJoinTheirEffects/2"
   );
+  let r2 = e2.result.shallowCloneWithoutEffects();
 
   let joinedEffects = Join.joinForkOrChoose(
     realm,
     cond,
-    new Effects(e1.result, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
-    new Effects(e2.result, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
+    new Effects(r1, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
+    new Effects(r2, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
   );
   let joinedCompletion = joinedEffects.result;
   if (joinedCompletion instanceof PossiblyNormalCompletion) {

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -77,12 +77,14 @@ export default function(
   // Join the effects, creating an abstract view of what happened, regardless
   // of the actual value of exprValue.
   const ce = consequentEffects;
+  let cr = ce.result.shallowCloneWithoutEffects();
   const ae = alternateEffects;
+  let ar = ae.result.shallowCloneWithoutEffects();
   let joinedEffects = Join.joinForkOrChoose(
     realm,
     exprValue,
-    new Effects(ce.result, ce.generator, ce.modifiedBindings, ce.modifiedProperties, ce.createdObjects),
-    new Effects(ae.result, ae.generator, ae.modifiedBindings, ae.modifiedProperties, ae.createdObjects)
+    new Effects(cr, ce.generator, ce.modifiedBindings, ce.modifiedProperties, ce.createdObjects),
+    new Effects(ar, ae.generator, ae.modifiedBindings, ae.modifiedProperties, ae.createdObjects)
   );
   completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -10,7 +10,7 @@
 /* @flow */
 
 import { Realm, Effects } from "../realm.js";
-import { AbruptCompletion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
+import { AbruptCompletion, Completion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
 import type { BabelNode, BabelNodeJSXIdentifier } from "@babel/types";
 import { parseExpression } from "@babel/parser";
 import {
@@ -623,6 +623,7 @@ export function evaluateWithNestedParentEffects(
   if (nextEffects.length !== 0) {
     let effects = nextEffects.shift();
     value = effects.result;
+    if (value instanceof Completion) value = value.shallowCloneWithoutEffects();
     createdObjects = effects.createdObjects;
     modifiedBindings = effects.modifiedBindings;
     modifiedProperties = effects.modifiedProperties;

--- a/test/serializer/additional-functions/EmitPropertyRegressionTest.js
+++ b/test/serializer/additional-functions/EmitPropertyRegressionTest.js
@@ -1,4 +1,4 @@
-// expected Warning: PP0023
+// expected Warning: PP1007,PP0023
 (function() {
   function URI(other) {
     if (other.foo) {

--- a/test/serializer/additional-functions/conditions2.js
+++ b/test/serializer/additional-functions/conditions2.js
@@ -1,4 +1,4 @@
-// expected Warning: PP0023
+// expected Warning: PP1007,PP0023
 if (!this.__evaluatePureFunction) {
   this.__evaluatePureFunction = function(f) {
     return f();

--- a/test/serializer/optimized-functions/ThrowOrReturn2.js
+++ b/test/serializer/optimized-functions/ThrowOrReturn2.js
@@ -1,0 +1,34 @@
+function foo(cond) {
+  var d = {};
+
+  if (cond) {
+    throw "I am an error!";
+  }
+
+  return d;
+}
+
+function fn(cond, cond2) {
+  var a = {};
+  var b = {
+    prop1: 1,
+  };
+  if (global.__makeSimple) {
+    global.__makePartial(b);
+    global.__makeSimple(b);
+  }
+  Object.assign(a, b);
+
+  if (cond2) {
+    var res = Object.assign(foo(cond), b);
+    return res.prop1;
+  }
+
+  return 2; //a.prop1;
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return fn(true, false);
+}

--- a/test/serializer/optimized-functions/ThrowOrReturn2.js
+++ b/test/serializer/optimized-functions/ThrowOrReturn2.js
@@ -24,11 +24,11 @@ function fn(cond, cond2) {
     return res.prop1;
   }
 
-  return 2; //a.prop1;
+  return a.prop1;
 }
 
 if (global.__optimize) __optimize(fn);
 
 inspect = function() {
   return fn(true, false);
-}
+};

--- a/test/serializer/optimized-functions/ThrowOrReturn3.js
+++ b/test/serializer/optimized-functions/ThrowOrReturn3.js
@@ -1,0 +1,19 @@
+function fn2(sholdError) {
+  if (sholdError) {
+    throw new Error("Error");
+  }
+  return {
+    thisValueShouldExist: true,
+  };
+}
+
+function fn(sholdError) {
+  var a = Object.assign({}, fn2(sholdError));
+  return a.thisValueShouldExist;
+}
+
+if (global.__optimize) __optimize(fn);
+
+inspect = function() {
+  return fn(true, false);
+};


### PR DESCRIPTION
Release note: none

The main part of this PR is to ensure that completions and the effects they complete are always 1-1.

Along the way some bugs got fixed #2241.

This also includes a little side project: limiting the console spew when doing "yarn test-serializer --fast", which is something I do all the time and I'm much happier this way.
