### PR TITLE
Re-enable traverse cache clear

### DIFF
--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -422,7 +422,7 @@ function generateRuntimeForStatement(
     null,
     functionInfo
   );
-  traverse.clearCache();
+  traverse.cache.clear();
   let { usesReturn, usesThrow, usesArguments, usesGotoToLabel, varPatternUnsupported, usesThis } = functionInfo;
 
   if (usesReturn || usesThrow || usesArguments || usesGotoToLabel || varPatternUnsupported) {

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -422,8 +422,7 @@ function generateRuntimeForStatement(
     null,
     functionInfo
   );
-  // Babel 7 removed clearCache
-  // traverse.clearCache();
+  traverse.clearCache();
   let { usesReturn, usesThrow, usesArguments, usesGotoToLabel, varPatternUnsupported, usesThis } = functionInfo;
 
   if (usesReturn || usesThrow || usesArguments || usesGotoToLabel || varPatternUnsupported) {

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -339,7 +339,7 @@ export function convertSimpleClassComponentToFunctionalComponent(
       {},
       undefined
     );
-    traverse.clearCache();
+    traverse.cache.clear();
   });
 }
 

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -339,8 +339,7 @@ export function convertSimpleClassComponentToFunctionalComponent(
       {},
       undefined
     );
-    // Babel 7 removed clearCache
-    // traverse.clearCache();
+    traverse.clearCache();
   });
 }
 

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -566,8 +566,7 @@ export class ResidualHeapVisitor {
         null,
         state
       );
-      // Babel 7 removed clearCache
-      // traverse.clearCache();
+      traverse.clearCache();
       this.functionInfos.set(code, functionInfo);
 
       if (val.isResidual && functionInfo.unbound.size) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -566,7 +566,7 @@ export class ResidualHeapVisitor {
         null,
         state
       );
-      traverse.clearCache();
+      traverse.cache.clear();
       this.functionInfos.set(code, functionInfo);
 
       if (val.isResidual && functionInfo.unbound.size) {

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -75,5 +75,5 @@ export function stripFlowTypeAnnotations(ast: BabelNode): void {
     {},
     undefined
   );
-  traverse.clearCache();
+  traverse.cache.clear();
 }

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -75,6 +75,5 @@ export function stripFlowTypeAnnotations(ast: BabelNode): void {
     {},
     undefined
   );
-  // Babel 7 removed clearCache
-  // traverse.clearCache();
+  traverse.clearCache();
 }

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -107,8 +107,7 @@ function getHavocedFunctionInfo(value: FunctionValue) {
     null,
     functionInfo
   );
-  // Babel 7 removed clearCache
-  // traverse.clearCache();
+  traverse.cache.clear();
   return functionInfo;
 }
 


### PR DESCRIPTION
Release notes: none

Follow up to https://github.com/facebook/prepack/pull/2256. This re-enables Babel traverse cache clearing, but with the Babel 7 API.