### PR TITLE
Ensure Object.assign merge optimization properly accounts for prefix args

### DIFF
--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1367,6 +1367,11 @@ export function attemptToMergeEquivalentObjectAssigns(
       let otherArgsToUse = [];
       for (let x = 1; x < otherArgs.length; x++) {
         let arg = otherArgs[x];
+        // If this arg is a known arg of the root, then we can't merge these Object.assigns
+        // as they share the same args.
+        if (args.includes(arg)) {
+          continue loopThroughArgs;
+        }
         // The arg might have been havoced, so ensure we do not continue in this case
         if (arg instanceof ObjectValue && arg.mightBeHavocedObject()) {
           continue loopThroughArgs;

--- a/test/serializer/optimized-functions/DeadObjectAssign23.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign23.js
@@ -1,3 +1,5 @@
+import { ATTRIBUTE_NAME_CHAR } from "../../../lib/react/experimental-server-rendering/dom-config";
+
 // Copies of _\$C\(:2
 // Copies of var _\$C = _\$B.assign;:1
 // inline expressions
@@ -5,19 +7,11 @@
 // _$C is the variable for Object.assign. See DeadObjectAssign4.js for
 // a larger explanation.
 
-function fn2(obj, x) {
-  return Object.assign({}, x, { a: 1 });
-}
-
-function fn3(obj, x) {
-  return Object.assign({}, x, { b: 1 });
-}
-
 function fn(obj, x) {
-  var a = fn2(obj, x);
-  var b = fn3(obj, x);
+  var a = Object.assign({}, x, { a: 1 });
+  var b = Object.assign({}, x, { b: 1 });
 
-  if (obj.cond3) {
+  if (obj.cond) {
     var c = Object.assign({}, a, b);
 
     return c.a + c.b;
@@ -29,9 +23,7 @@ this.__optimize && __optimize(fn);
 inspect = function() {
   return fn(
     {
-      cond1: false,
-      cond2: false,
-      cond3: true,
+      cond: true,
     },
     { a: 0, b: 0 }
   );

--- a/test/serializer/optimized-functions/DeadObjectAssign23.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign23.js
@@ -1,5 +1,3 @@
-import { ATTRIBUTE_NAME_CHAR } from "../../../lib/react/experimental-server-rendering/dom-config";
-
 // Copies of _\$C\(:2
 // Copies of var _\$C = _\$B.assign;:1
 // inline expressions

--- a/test/serializer/optimized-functions/DeadObjectAssign23.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign23.js
@@ -27,9 +27,12 @@ function fn(obj, x) {
 this.__optimize && __optimize(fn);
 
 inspect = function() {
-  return fn({
-    cond1: false,
-    cond2: false,
-    cond3: true,
-  }, { a: 0, b: 0 })
-}
+  return fn(
+    {
+      cond1: false,
+      cond2: false,
+      cond3: true,
+    },
+    { a: 0, b: 0 }
+  );
+};

--- a/test/serializer/optimized-functions/DeadObjectAssign23.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign23.js
@@ -1,0 +1,35 @@
+// Copies of _\$C\(:2
+// Copies of var _\$C = _\$B.assign;:1
+// inline expressions
+
+// _$C is the variable for Object.assign. See DeadObjectAssign4.js for
+// a larger explanation.
+
+function fn2(obj, x) {
+  return Object.assign({}, x, { a: 1 });
+}
+
+function fn3(obj, x) {
+  return Object.assign({}, x, { b: 1 });
+}
+
+function fn(obj, x) {
+  var a = fn2(obj, x);
+  var b = fn3(obj, x);
+
+  if (obj.cond3) {
+    var c = Object.assign({}, a, b);
+
+    return c.a + c.b;
+  }
+}
+
+this.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn({
+    cond1: false,
+    cond2: false,
+    cond3: true,
+  }, { a: 0, b: 0 })
+}

--- a/test/serializer/optimized-functions/DeadObjectAssign24.js
+++ b/test/serializer/optimized-functions/DeadObjectAssign24.js
@@ -1,5 +1,5 @@
-// Copies of _\$C\(:1
-// Copies of var _\$C = _\$B.assign;:1
+// Copies of _\$D\(:1
+// Copies of var _\$D = _\$C.assign;:1
 // inline expressions
 
 // _$C is the variable for Object.assign. See DeadObjectAssign4.js for
@@ -10,7 +10,7 @@ function fn(obj, x) {
   var b = Object.assign({}, x, { b: 1 });
 
   if (obj.cond) {
-    var c = Object.assign({}, a, b);
+    var c = Object.assign({}, a, b, a);
 
     return c.a + c.b;
   }


### PR DESCRIPTION
Release notes: none

When we check to do the temporal `Object.assign` merge optimization, we should properly account for any "prefix" args that occur before "to" and the "suffix" args. Test case added that came up in testing.