### PR TITLE
For abstract objects, look into values domain for IsCall

### DIFF
--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -109,7 +109,8 @@ export function IsCallable(realm: Realm, _func: Value): boolean {
   if (func.isSimpleObject()) return false;
 
   // 2. If argument has a [[Call]] internal method, return true.
-  func = func.throwIfNotConcreteObject();
+  if (func instanceof AbstractObjectValue) func = func.getTemplate();
+  else func = func.throwIfNotConcreteObject();
   if (func.$Call) return true;
 
   // 3. Return false.

--- a/src/methods/is.js
+++ b/src/methods/is.js
@@ -108,9 +108,18 @@ export function IsCallable(realm: Realm, _func: Value): boolean {
   if (HasCompatibleType(func, FunctionValue)) return true;
   if (func.isSimpleObject()) return false;
 
+  if (func instanceof AbstractObjectValue && !func.values.isTop()) {
+    let result;
+    for (let element of func.values.getElements()) {
+      let isCallable = IsCallable(realm, element);
+      if (result === undefined) result = isCallable;
+      else if (result !== isCallable) func.throwIfNotConcreteObject();
+    }
+    if (result !== undefined) return result;
+  }
+
   // 2. If argument has a [[Call]] internal method, return true.
-  if (func instanceof AbstractObjectValue) func = func.getTemplate();
-  else func = func.throwIfNotConcreteObject();
+  func = func.throwIfNotConcreteObject();
   if (func.$Call) return true;
 
   // 3. Return false.

--- a/test/serializer/abstract/UseAbstractObjectValueTemplateInIsCall.js
+++ b/test/serializer/abstract/UseAbstractObjectValueTemplateInIsCall.js
@@ -1,0 +1,4 @@
+let obj = global.__abstract ? __abstract({}, "obj") : {};
+let func = global.__abstract ? __abstract(function(){}, "func") : function(){};
+global.result = (typeof obj) + "/" + (typeof func);
+global.inspect = function() { return global.result; }

--- a/test/serializer/abstract/UseAbstractObjectValueTemplateInIsCall.js
+++ b/test/serializer/abstract/UseAbstractObjectValueTemplateInIsCall.js
@@ -1,4 +1,6 @@
 let obj = global.__abstract ? __abstract({}, "obj") : {};
-let func = global.__abstract ? __abstract(function(){}, "func") : function(){};
-global.result = (typeof obj) + "/" + (typeof func);
-global.inspect = function() { return global.result; }
+let func = global.__abstract ? __abstract(function() {}, "func") : function() {};
+global.result = typeof obj + "/" + typeof func;
+global.inspect = function() {
+  return global.result;
+};


### PR DESCRIPTION
Release notes: None

IsCall used to fail on abstract values even if they have a set of values in their domain.
This in turn would make `typeof` not work on abstract values.
This makes it work, and adds a regression test.