### PR TITLE
Compose subsequent effects with currently applied affects

### DIFF
--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -306,7 +306,7 @@ function callNativeFunctionValue(
           mightBecomeAnObject(contextVal)
       );
       let completion = f.callCallback(
-        // this is to get around Flow not understand the above invariant
+        // this is to get around Flow not understanding the above invariant
         ((contextVal: any): AbstractObjectValue | ObjectValue | NullValue | UndefinedValue),
         argumentsList,
         env.environmentRecord.$NewTarget

--- a/src/realm.js
+++ b/src/realm.js
@@ -877,6 +877,7 @@ export class Realm {
           this.stopEffectCaptureAndUndoEffects(c);
           Join.updatePossiblyNormalCompletionWithSubsequentEffects(this, c, subsequentEffects);
           this.savedCompletion = undefined;
+          this.applyEffects(subsequentEffects, "subsequentEffects", true);
         }
 
         invariant(this.generator !== undefined);

--- a/test/serializer/optimized-functions/ObjectAssign9.js
+++ b/test/serializer/optimized-functions/ObjectAssign9.js
@@ -1,0 +1,19 @@
+function fn2(shouldError) {
+  if (shouldError) {
+    throw new Error("Error");
+  }
+  return {
+    thisValueShouldExist: true,
+  };
+}
+
+function fn(shouldError) {
+  var a = Object.assign({}, fn2(shouldError));
+  return a.thisValueShouldExist;
+}
+
+this.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn(false);
+};


### PR DESCRIPTION
Release note: none

This fixes a problem reported as a comment in PR #2258.

The underlying problem was that Realm.evaluateForEffects would just append the normal effects, captured since the last non complete join, into the saved partially normal completion that becomes the result of the returned Effects. This is not quite right because applying the resulting Effects should restore the complete set of normal effects that were in force when evaluateForEffects completed.
