### PR TITLE
Move generators from PNC normal branches to joined normal effects

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -449,14 +449,18 @@ export class JoinImplementation {
     } = e2;
     invariant(result2.effects === e2);
 
+    let emptyEffects = construct_empty_effects(realm);
+
     let result = this.joinOrForkResults(realm, joinCondition, result1, result2, e1, e2);
     if (result1 instanceof AbruptCompletion) {
       if (!(result2 instanceof AbruptCompletion)) {
         invariant(result instanceof PossiblyNormalCompletion);
+        e2.generator = emptyEffects.generator;
         return new Effects(result, generator2, modifiedBindings2, modifiedProperties2, createdObjects2);
       }
     } else if (result2 instanceof AbruptCompletion) {
       invariant(result instanceof PossiblyNormalCompletion);
+      e1.generator = emptyEffects.generator;
       return new Effects(result, generator1, modifiedBindings1, modifiedProperties1, createdObjects1);
     }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -1066,8 +1066,8 @@ export class Realm {
         // not all control flow branches join into one flow at this point.
         // Consequently we have to continue tracking changes until the point where
         // all the branches come together into one.
+        this.applyEffects(joinedEffects, "evaluateWithAbstractConditional");
         completion = this.composeWithSavedCompletion(completion);
-        this.applyEffects(joinedEffects, "evaluateWithAbstractConditional", false);
       } else {
         this.applyEffects(joinedEffects, "evaluateWithAbstractConditional");
       }

--- a/test/serializer/optimized-functions/NestedTemporalJoinConditions.js
+++ b/test/serializer/optimized-functions/NestedTemporalJoinConditions.js
@@ -1,0 +1,15 @@
+function fn(str, start, length) {
+  var size = str.length;
+  var posA = 0;
+  if (start > 0) {
+    if (posA >= size) {
+      return posA;
+    }
+  }
+}
+
+if (global.__optimize) __optimize(fn);
+
+global.inspect = function() {
+  return true;
+};


### PR DESCRIPTION
Release note: none

Generators that end up in joined effects, need to disappear from the generators in the forked completions from which they have been extracted. Also, they need to be applied to the generator containing the timeline in which the fork occurs, before the fork occurs.

With some luck, this may fix a lot of issues.