### PR TITLE
[WIP] Lint against redeclared variables

### DIFF
--- a/scripts/debug-fb-www.js
+++ b/scripts/debug-fb-www.js
@@ -86,10 +86,13 @@ let components = new Map();
 let startTime = Date.now();
 let uniqueEvaluatedComponents = 0;
 
-function compileSource(source) {
+function compileSource(originalCode) {
   let serialized;
   try {
-    serialized = prepackSources([{ filePath: inputPath, fileContents: source, sourceMapContents: "" }], prepackOptions);
+    serialized = prepackSources(
+      [{ filePath: inputPath, fileContents: originalCode, sourceMapContents: "" }],
+      prepackOptions
+    );
   } catch (e) {
     console.log(`\n${chalk.inverse(`=== Diagnostics Log ===`)}\n`);
     errorsCaptured.forEach(error => printError(error));
@@ -97,7 +100,7 @@ function compileSource(source) {
   }
   return {
     stats: serialized.reactStatistics,
-    code: serialized.code,
+    compiledCode: serialized.code,
   };
 }
 
@@ -112,9 +115,11 @@ async function readComponentsList() {
   }
 }
 
-function lintCompiledSource(source) {
+function lintCompiledCode(compiledCode, originalCode) {
   let linter = new Linter();
-  let errors = linter.verify(source, lintConfig);
+  let lintDirectives = originalCode.split("\n").filter(line => line.startsWith("/* eslint-"));
+  let codeToLint = `${lintDirectives.join("\n")}\n${compiledCode}`;
+  let errors = linter.verify(codeToLint, lintConfig);
   if (errors.length > 0) {
     console.log(`\n${chalk.inverse(`=== Validation Failed ===`)}\n`);
     for (let error of errors) {
@@ -125,10 +130,10 @@ function lintCompiledSource(source) {
 }
 
 async function compileFile() {
-  let source = await readFileAsync(inputPath, "utf8");
-  let { stats, code } = await compileSource(source);
-  await writeFileAsync(outputPath, code);
-  lintCompiledSource(code);
+  let originalCode = await readFileAsync(inputPath, "utf8");
+  let { stats, compiledCode } = await compileSource(originalCode);
+  await writeFileAsync(outputPath, compiledCode);
+  lintCompiledCode(compiledCode, originalCode);
   // $FlowFixMe: no idea what this is about
   return stats;
 }

--- a/scripts/lint-config.js
+++ b/scripts/lint-config.js
@@ -18,6 +18,7 @@ module.exports = {
   },
   rules: {
     "no-undef": "error",
+    "no-redeclare": "error",
     "no-use-before-define": ["error", { variables: false, functions: false }],
   },
   parserOptions: {

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -601,7 +601,9 @@ function runTest(name, code, options: PrepackOptions, args) {
               );
             }
             // lint output
-            lintCompiledSource(codeToRun);
+            const lintDirectives = code.split("\n").filter(line => line.startsWith("/* eslint-"));
+            const codeToLint = `${lintDirectives.join("\n")}\n${codeToRun}`;
+            lintCompiledSource(codeToLint);
             let actualPromise;
             if (execSpec) {
               actualPromise = execExternal(execSpec, codeToRun);

--- a/test/serializer/abstract/ForInStatement11b.js
+++ b/test/serializer/abstract/ForInStatement11b.js
@@ -7,8 +7,8 @@ for (var p in ob) {
 }
 
 let tgt = {};
-for (var p in ob) {
-  tgt[p] = ob2[p];
+for (var q in ob) {
+  tgt[q] = ob2[q];
 }
 
 inspect = function() {

--- a/test/serializer/additional-functions/arguments3.js
+++ b/test/serializer/additional-functions/arguments3.js
@@ -1,4 +1,5 @@
 // does not contain:x = 5;
+/* eslint-disable no-redeclare */
 
 function additional1(argument, argument) {
   var z = { foo: argument };


### PR DESCRIPTION
There was recently a regression that caused variables to get redeclared: https://github.com/facebook/prepack/pull/2255#issuecomment-405923183.

To catch issues like this, I'm introducing `no-redeclare` as an additional lint rule that runs on serializer tests. I'm also adding a way to disable individual lint warnings since there's a case where we intentionally test code that's not-so-great.

This is still not sufficient because we *do* emit redeclaring variables. I don't know if it's a recent issue or not, but I think it needs fixing. So I'm sending this PR as the first step to surface these issues. Once they get fixed, we can merge this.