### PR TITLE
Add serializer mode for test262 execution

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-module.exports = function (api) {
+module.exports = function(api) {
   api.cache(true);
 
   const plugins = [
@@ -24,12 +24,15 @@ module.exports = function (api) {
   if (process.env.NODE_ENV === "production") {
     return {
       presets: [
-        ["@babel/env", {
-          "targets": {
-            "ie": "10",
+        [
+          "@babel/env",
+          {
+            targets: {
+              ie: "10",
+            },
+            forceAllTransforms: true,
           },
-          forceAllTransforms: true,
-        }],
+        ],
         "@babel/preset-flow",
       ],
       plugins,
@@ -38,13 +41,18 @@ module.exports = function (api) {
   // Default
   return {
     presets: [
-      ["@babel/env", {
-        "targets": {
-          "node": "6.10",
-        }
-      }],
+      [
+        "@babel/env",
+        {
+          targets: {
+            node: "6.10",
+          },
+        },
+      ],
       "@babel/preset-flow",
     ],
     plugins,
+    // `lib` files are already compiled with Babel. Don't try to compile them again.
+    ignore: ["lib/**/*.js"],
   };
 };

--- a/scripts/test262-runner.js
+++ b/scripts/test262-runner.js
@@ -1183,8 +1183,8 @@ var print = () => {}; // noop for now
   }
 
   const context = vm.createContext({
-    // NOTE: Workaround since Prepack serializes code that expects a global `TypedArray` class which does not exist per
-    // the ECMAScript specification.
+    // TODO(#2292): Workaround since Prepack serializes code that expects a global `TypedArray` class which does not
+    // exist per the ECMAScript specification.
     TypedArray: Object.getPrototypeOf(Int8Array),
   });
 

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -13,7 +13,7 @@ import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility, ReactOutputTypes, InvariantModeTypes } from "./options";
 import { Realm } from "./realm.js";
 import type { DebuggerConfigArguments } from "./types";
-import type { BabelNodeFile } from "babel-types";
+import type { BabelNodeFile } from "@babel/types";
 
 export type PrepackOptions = {|
   additionalGlobals?: Realm => void,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -13,6 +13,7 @@ import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility, ReactOutputTypes, InvariantModeTypes } from "./options";
 import { Realm } from "./realm.js";
 import type { DebuggerConfigArguments } from "./types";
+import type { BabelNodeFile } from "babel-types";
 
 export type PrepackOptions = {|
   additionalGlobals?: Realm => void,
@@ -58,6 +59,7 @@ export type PrepackOptions = {|
   debugOutFilePath?: string,
   abstractValueImpliesMax?: number,
   debuggerConfigArgs?: DebuggerConfigArguments,
+  onParse?: BabelNodeFile => void,
 |};
 
 export function getRealmOptions({

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -63,7 +63,7 @@ export function prepackSources(
     return { code: "", map: undefined };
   } else if (options.serialize === true || options.residual !== true) {
     let serializer = new Serializer(realm, getSerializerOptions(options));
-    let serialized = serializer.init(sources, options.sourceMaps);
+    let serialized = serializer.init(sources, options.sourceMaps, options.onParse);
 
     //Turn off the debugger if there is one
     if (realm.debuggerInstance) {

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -67,7 +67,11 @@ export class Serializer {
   modules: Modules;
   options: SerializerOptions;
 
-  _execute(sources: Array<SourceFile>, sourceMaps?: boolean = false): { [string]: string } {
+  _execute(
+    sources: Array<SourceFile>,
+    sourceMaps?: boolean = false,
+    onParse?: t.BabelNodeFile => void
+  ): { [string]: string } {
     let realm = this.realm;
     let [res, code] = realm.$GlobalEnv.executeSources(sources, "script", ast => {
       let realmPreludeGenerator = realm.preludeGenerator;
@@ -79,6 +83,7 @@ export class Serializer {
         forbiddenNames.add(((node: any): BabelNodeIdentifier).name);
         return true;
       });
+      if (onParse) onParse(ast);
     });
 
     if (res instanceof AbruptCompletion) {
@@ -118,7 +123,11 @@ export class Serializer {
     return true;
   }
 
-  init(sources: Array<SourceFile>, sourceMaps?: boolean = false): void | SerializedResult {
+  init(
+    sources: Array<SourceFile>,
+    sourceMaps?: boolean = false,
+    onParse?: t.BabelNodeFile => void
+  ): void | SerializedResult {
     let realmStatistics = this.realm.statistics;
     invariant(realmStatistics instanceof SerializerStatistics, "serialization requires SerializerStatistics");
     let statistics: SerializerStatistics = realmStatistics;
@@ -129,7 +138,7 @@ export class Serializer {
         this.logger.logInformation(`Evaluating initialization path...`);
       }
 
-      let code = this._execute(sources);
+      let code = this._execute(sources, sourceMaps, onParse);
       let environmentRecordIdAfterGlobalCode = EnvironmentRecord.nextId;
 
       if (this.logger.hasErrors()) return undefined;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -31,6 +31,7 @@ import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js";
 import { LazyObjectsSerializer } from "./LazyObjectsSerializer.js";
 import * as t from "@babel/types";
+import type { BabelNodeFile } from "@babel/types";
 import { ResidualHeapRefCounter } from "./ResidualHeapRefCounter";
 import { ResidualHeapGraphGenerator } from "./ResidualHeapGraphGenerator";
 import { Referentializer } from "./Referentializer.js";
@@ -70,7 +71,7 @@ export class Serializer {
   _execute(
     sources: Array<SourceFile>,
     sourceMaps?: boolean = false,
-    onParse?: t.BabelNodeFile => void
+    onParse?: BabelNodeFile => void
   ): { [string]: string } {
     let realm = this.realm;
     let [res, code] = realm.$GlobalEnv.executeSources(sources, "script", ast => {
@@ -126,7 +127,7 @@ export class Serializer {
   init(
     sources: Array<SourceFile>,
     sourceMaps?: boolean = false,
-    onParse?: t.BabelNodeFile => void
+    onParse?: BabelNodeFile => void
   ): void | SerializedResult {
     let realmStatistics = this.realm.statistics;
     invariant(realmStatistics instanceof SerializerStatistics, "serialization requires SerializerStatistics");


### PR DESCRIPTION
I want to better understand the bugs we have in abstract evaluation. One of my ideas to do this is to replace all the literals in test262 tests with abstract values and see what our test coverage is. The first step to do this is to serialize the test262 sources after running them in Prepack and checking if their generated JavaScript runs correctly. This PR does that by adding a `--serializer` flag.

With my methodology, all test262 harnesses are serialized every time since they are in the global scope. This unfortunately seems to be unavoidable since doing otherwise would change program semantics and break the tests.

Running `time yarn test-test262` takes about 2 minutes and has a 98% pass rate. Running `time yarn test-test262 --serializer` takes about 5 minutes and has a 95% pass rate. [Here’s a diff of the two  results.](https://gist.github.com/calebmer/1c9fe396b63ba055458c599c2be18a58)

[Here is a selection of some of the bugs](https://gist.github.com/calebmer/1ac381096a4aa7be1fc7dc2163276ab4) in the serializer caught by running test262 with the Prepack serializer. I might open issues for these, but they can be a bit pedantic. I might fix some of them depending on how important they are to the React code we want to compile.

Notably we have:

- Lots of invariants being triggered. I particularly saw [a lot of this invariant](https://github.com/facebook/prepack/blob/7d355ef4c5f4d939742814714a78ef9b1279f9b4/src/serializer/ResidualHeapVisitor.js#L531). (An example of this is [`07.md`](https://gist.github.com/calebmer/1ac381096a4aa7be1fc7dc2163276ab4#file-07-md).)
- Lots of values that are visited, but not serialized. (An example of this is [`01.md`](https://gist.github.com/calebmer/1ac381096a4aa7be1fc7dc2163276ab4#file-01-md).)
- Some incorrect outputs only caught by executing code. Could not be caught by static analysis. Particularly around class serialization.

I’ll build off this PR to get coverage for the abstract evaluator next, but I found these results interesting on their own so decided to do this in two PRs.