### PR TITLE
Follow up renaming GeneratorEntry

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -521,9 +521,9 @@ export default function(realm: Realm): ObjectValue {
     if (text instanceof AbstractValue && text.kind === "JSON.stringify(...)") {
       // Enable cloning via JSON.parse(JSON.stringify(...)).
       // text is abstract, so we are doing abstract interpretation
-      let temporalBuildNodeEntryArgs = realm.derivedIds.get(text.intrinsicName);
-      invariant(temporalBuildNodeEntryArgs !== undefined);
-      let args = temporalBuildNodeEntryArgs.args;
+      let temporalOperationEntryArgs = realm.derivedIds.get(text.intrinsicName);
+      invariant(temporalOperationEntryArgs !== undefined);
+      let args = temporalOperationEntryArgs.args;
       invariant(args[0] instanceof Value); // since text.kind === "JSON.stringify(...)"
       let inputClone = args[0]; // A temporal copy of the object that was the argument to stringify
       // Clone it so that every call to parse produces a different instance from stringify's clone

--- a/src/react/ReactEquivalenceSet.js
+++ b/src/react/ReactEquivalenceSet.js
@@ -142,12 +142,12 @@ export class ReactEquivalenceSet {
     if (!this.residualReactElementVisitor.wasTemporalAliasDeclaredInCurrentScope(temporalAlias)) {
       return temporalAlias;
     }
-    let temporalBuildNodeEntry = this.realm.getTemporalBuildNodeEntryFromDerivedValue(temporalAlias);
+    let temporalOperationEntry = this.realm.getTemporalOperationEntryFromDerivedValue(temporalAlias);
 
-    if (temporalBuildNodeEntry === undefined) {
+    if (temporalOperationEntry === undefined) {
       return temporalAlias;
     }
-    let temporalArgs = temporalBuildNodeEntry.args;
+    let temporalArgs = temporalOperationEntry.args;
     if (temporalArgs.length === 0) {
       return temporalAlias;
     }
@@ -168,9 +168,9 @@ export class ReactEquivalenceSet {
         }
       } else if (arg instanceof AbstractObjectValue && !arg.values.isTop() && arg.kind !== "conditional") {
         // Might be a temporal, so let's check
-        let childTemporalBuildNodeEntry = this.realm.getTemporalBuildNodeEntryFromDerivedValue(arg);
+        let childTemporalOperationEntry = this.realm.getTemporalOperationEntryFromDerivedValue(arg);
 
-        if (childTemporalBuildNodeEntry !== undefined) {
+        if (childTemporalOperationEntry !== undefined) {
           equivalenceArg = this._getTemporalValue(arg, visitedValues);
           invariant(equivalenceArg instanceof AbstractObjectValue);
 

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -948,12 +948,12 @@ function applyClonedTemporalAlias(realm: Realm, props: ObjectValue, clonedProps:
     // be a better option.
     invariant(false, "TODO applyClonedTemporalAlias conditional");
   }
-  let temporalBuildNodeEntry = realm.getTemporalBuildNodeEntryFromDerivedValue(temporalAlias);
-  if (!(temporalBuildNodeEntry instanceof TemporalObjectAssignEntry)) {
+  let temporalOperationEntry = realm.getTemporalOperationEntryFromDerivedValue(temporalAlias);
+  if (!(temporalOperationEntry instanceof TemporalObjectAssignEntry)) {
     invariant(false, "TODO nont TemporalObjectAssignEntry");
   }
-  invariant(temporalBuildNodeEntry !== undefined);
-  let temporalArgs = temporalBuildNodeEntry.args;
+  invariant(temporalOperationEntry !== undefined);
+  let temporalArgs = temporalOperationEntry.args;
   // replace the original props with the cloned one
   let [to, ...sources] = temporalArgs.map(arg => (arg === props ? clonedProps : arg));
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -68,7 +68,7 @@ import {
   createOperationDescriptor,
   Generator,
   PreludeGenerator,
-  type TemporalBuildNodeEntry,
+  type TemporalOperationEntry,
 } from "./utils/generator.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
@@ -382,8 +382,8 @@ export class Realm {
   $GlobalEnv: LexicalEnvironment;
   intrinsics: Intrinsics;
 
-  derivedIds: Map<string, TemporalBuildNodeEntry>;
-  temporalEntryArgToEntries: Map<Value, Set<TemporalBuildNodeEntry>>;
+  derivedIds: Map<string, TemporalOperationEntry>;
+  temporalEntryArgToEntries: Map<Value, Set<TemporalOperationEntry>>;
   temporalEntryCounter: number;
 
   instantRender: {
@@ -1816,21 +1816,21 @@ export class Realm {
     return !this._abstractValuesDefined.has(nameString);
   }
 
-  getTemporalBuildNodeEntryFromDerivedValue(value: Value): void | TemporalBuildNodeEntry {
+  getTemporalOperationEntryFromDerivedValue(value: Value): void | TemporalOperationEntry {
     let name = value.intrinsicName;
     if (!name) {
       return undefined;
     }
-    let temporalBuildNodeEntry = value.$Realm.derivedIds.get(name);
-    return temporalBuildNodeEntry;
+    let temporalOperationEntry = value.$Realm.derivedIds.get(name);
+    return temporalOperationEntry;
   }
 
-  getTemporalGeneratorEntriesReferencingArg(arg: AbstractValue | ObjectValue): void | Set<TemporalBuildNodeEntry> {
+  getTemporalGeneratorEntriesReferencingArg(arg: AbstractValue | ObjectValue): void | Set<TemporalOperationEntry> {
     return this.temporalEntryArgToEntries.get(arg);
   }
 
-  saveTemporalGeneratorEntryArgs(temporalBuildNodeEntry: TemporalBuildNodeEntry): void {
-    let args = temporalBuildNodeEntry.args;
+  saveTemporalGeneratorEntryArgs(temporalOperationEntry: TemporalOperationEntry): void {
+    let args = temporalOperationEntry.args;
     for (let arg of args) {
       let temporalEntries = this.temporalEntryArgToEntries.get(arg);
 
@@ -1838,7 +1838,7 @@ export class Realm {
         temporalEntries = new Set();
         this.temporalEntryArgToEntries.set(arg, temporalEntries);
       }
-      temporalEntries.add(temporalBuildNodeEntry);
+      temporalEntries.add(temporalOperationEntry);
     }
   }
 }

--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -21,7 +21,7 @@ import {
 } from "../values/index.js";
 import type { BabelNodeStatement } from "@babel/types";
 import type { SerializedBody } from "./types.js";
-import { Generator, type TemporalBuildNodeEntry } from "../utils/generator.js";
+import { Generator, type TemporalOperationEntry } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import { BodyReference } from "./types.js";
 import { ResidualFunctions } from "./ResidualFunctions.js";
@@ -67,7 +67,7 @@ export class Emitter {
     residualFunctions: ResidualFunctions,
     referencedDeclaredValues: Map<Value, void | FunctionValue>,
     conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
-    derivedIds: Map<string, TemporalBuildNodeEntry>
+    derivedIds: Map<string, TemporalOperationEntry>
   ) {
     this._mainBody = { type: "MainGenerator", parentBody: undefined, entries: [], done: false };
     this._waitingForValues = new Map();

--- a/src/serializer/ResidualReactElementVisitor.js
+++ b/src/serializer/ResidualReactElementVisitor.js
@@ -29,7 +29,7 @@ import {
   hardModifyReactObjectPropertyBinding,
 } from "../react/utils.js";
 import invariant from "../invariant.js";
-import { TemporalBuildNodeEntry } from "../utils/generator.js";
+import { TemporalOperationEntry } from "../utils/generator.js";
 import { ReactEquivalenceSet } from "../react/ReactEquivalenceSet.js";
 import { ReactElementSet } from "../react/ReactElementSet.js";
 import { ReactPropsSet } from "../react/ReactPropsSet.js";
@@ -165,7 +165,7 @@ export class ResidualReactElementVisitor {
     // temporal value was declared in one of the entries
     for (let i = 0; i < scope._entries.length; i++) {
       let entry = scope._entries[i];
-      if (entry instanceof TemporalBuildNodeEntry) {
+      if (entry instanceof TemporalOperationEntry) {
         if (entry.declared === temporalAlias) {
           return true;
         }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -138,9 +138,9 @@ export type OperationDescriptorType =
   | "UPDATE_INCREMENTOR"
   | "WIDEN_ABSTRACT_PROPERTY"
   | "WIDEN_ABSTRACT_PROPERTY_ASSIGNMENT"
-  | "WIDENED_IDENTIFIER"
   | "WIDEN_PROPERTY"
-  | "WIDEN_PROPERTY_ASSIGNMENT";
+  | "WIDEN_PROPERTY_ASSIGNMENT"
+  | "WIDENED_IDENTIFIER";
 
 export type OperationDescriptor = {
   data: OperationDescriptorData,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -138,7 +138,9 @@ export type OperationDescriptorType =
   | "UPDATE_INCREMENTOR"
   | "WIDEN_ABSTRACT_PROPERTY"
   | "WIDEN_ABSTRACT_PROPERTY_ASSIGNMENT"
-  | "WIDEN_PROPERTY";
+  | "WIDENED_IDENTIFIER"
+  | "WIDEN_PROPERTY"
+  | "WIDEN_PROPERTY_ASSIGNMENT";
 
 export type OperationDescriptor = {
   data: OperationDescriptorData,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -58,99 +58,91 @@ import type {
 import { memberExpressionHelper } from "./babelhelpers.js";
 import { concretize, Utils } from "../singletons.js";
 import type { SerializerOptions } from "../options.js";
+import type { ShapeInformationInterface } from "../types.js";
 import * as t from "@babel/types";
 
 export type OperationDescriptorType =
-  | "IDENTIFIER"
-  | "SINGLE_ARG"
-  | "REBUILT_OBJECT"
-  | "CONSOLE_LOG"
-  | "FOR_IN"
-  | "DO_WHILE"
-  | "CONCRETE_MODEL"
-  | "BINARY_EXPRESSION"
-  | "LOGICAL_EXPRESSION"
-  | "CONDITIONAL_EXPRESSION"
-  | "UNARY_EXPRESSION"
   | "ABSTRACT_FROM_TEMPLATE"
-  | "GLOBAL_ASSIGNMENT"
-  | "GLOBAL_DELETE"
-  | "EMIT_PROPERTY_ASSIGNMENT"
-  | "ABSTRACT_PROPERTY"
-  | "JOIN_GENERATORS"
-  | "APPEND_GENERATOR"
-  | "DEFINE_PROPERTY"
-  | "PROPERTY_DELETE"
-  | "THROW"
-  | "CONDITIONAL_THROW"
-  | "COERCE_TO_STRING"
-  | "ABSTRACT_FROM_TEMPLATE"
-  | "FOR_STATEMENT_FUNC"
-  | "NEW_EXPRESSION"
-  | "OBJECT_ASSIGN"
-  | "OBJECT_SET_PARTIAL"
-  | "OBJECT_GET_PARTIAL"
-  | "OBJECT_PROTO_HAS_OWN_PROPERTY"
-  | "OBJECT_PROTO_GET_OWN_PROPERTY_DESCRIPTOR"
-  | "ABSTRACT_OBJECT_SET_PARTIAL"
-  | "ABSTRACT_OBJECT_SET_PARTIAL_VALUE"
+  | "ABSTRACT_OBJECT_GET"
   | "ABSTRACT_OBJECT_GET_PARTIAL"
   | "ABSTRACT_OBJECT_GET_PROTO_OF"
-  | "ABSTRACT_OBJECT_GET"
-  | "DIRECT_CALL_WITH_ARG_LIST"
+  | "ABSTRACT_OBJECT_SET_PARTIAL"
+  | "ABSTRACT_OBJECT_SET_PARTIAL_VALUE"
+  | "ABSTRACT_PROPERTY"
+  | "APPEND_GENERATOR"
+  | "ASSUME_CALL"
+  | "BABEL_HELPERS_OBJECT_WITHOUT_PROPERTIES"
+  | "BINARY_EXPRESSION"
   | "CALL_ABSTRACT_FUNC"
   | "CALL_ABSTRACT_FUNC_THIS"
   | "CALL_BAILOUT"
+  | "CANNOT_BECOME_OBJECT"
+  | "COERCE_TO_STRING"
+  | "CONCRETE_MODEL"
+  | "CONDITIONAL_EXPRESSION"
+  | "CONDITIONAL_PROPERTY_ASSIGNMENT"
+  | "CONDITIONAL_THROW"
+  | "CONSOLE_LOG"
+  | "DEFINE_PROPERTY"
+  | "DERIVED_ABSTRACT_INVARIANT"
+  | "DIRECT_CALL_WITH_ARG_LIST"
+  | "DO_WHILE"
   | "EMIT_CALL"
   | "EMIT_CALL_AND_CAPTURE_RESULT"
+  | "EMIT_PROPERTY_ASSIGNMENT"
+  | "FB_MOCKS_BOOTLOADER_LOAD_MODULES"
+  | "FB_MOCKS_MAGIC_GLOBAL_FUNCTION"
+  | "FOR_IN"
+  | "FOR_STATEMENT_FUNC"
+  | "FULL_INVARIANT"
+  | "FULL_INVARIANT_ABSTRACT"
+  | "FULL_INVARIANT_FUNCTION"
   | "GET_BINDING"
-  | "LOCAL_ASSIGNMENT"
-  | "LOGICAL_PROPERTY_ASSIGNMENT"
-  | "CONDITIONAL_PROPERTY_ASSIGNMENT"
-  | "PROPERTY_ASSIGNMENT"
-  | "MODULES_REQUIRE"
-  | "RESIDUAL_CALL"
-  | "ASSUME_CALL"
-  | "CANNOT_BECOME_OBJECT"
-  | "UPDATE_INCREMENTOR"
-  | "WIDENED_IDENTIFIER"
-  | "WIDEN_PROPERTY"
-  | "WIDEN_ABSTRACT_PROPERTY"
-  | "WIDEN_PROPERTY_ASSIGNMENT"
-  | "WIDEN_ABSTRACT_PROPERTY_ASSIGNMENT"
+  | "GLOBAL_ASSIGNMENT"
+  | "GLOBAL_DELETE"
+  | "IDENTIFIER"
   | "INVARIANT"
   | "INVARIANT_APPEND"
-  | "DERIVED_ABSTRACT_INVARIANT"
+  | "JOIN_GENERATORS"
+  | "LOCAL_ASSIGNMENT"
+  | "LOGICAL_EXPRESSION"
+  | "LOGICAL_PROPERTY_ASSIGNMENT"
+  | "MODULES_REQUIRE"
+  | "NEW_EXPRESSION"
+  | "OBJECT_ASSIGN"
+  | "OBJECT_GET_PARTIAL"
+  | "OBJECT_PROTO_GET_OWN_PROPERTY_DESCRIPTOR"
+  | "OBJECT_PROTO_HAS_OWN_PROPERTY"
+  | "OBJECT_SET_PARTIAL"
+  | "PROPERTY_ASSIGNMENT"
+  | "PROPERTY_DELETE"
   | "PROPERTY_INVARIANT"
-  | "FULL_INVARIANT"
-  | "FULL_INVARIANT_FUNCTION"
-  | "FULL_INVARIANT_ABSTRACT"
-  | "UNKNOWN_ARRAY_METHOD_CALL"
-  | "UNKNOWN_ARRAY_METHOD_PROPERTY_CALL"
-  | "UNKNOWN_ARRAY_LENGTH"
-  | "UNKNOWN_ARRAY_GET_PARTIAL"
-  | "BABEL_HELPERS_OBJECT_WITHOUT_PROPERTIES"
-  | "REACT_DEFAULT_PROPS_HELPER"
-  | "REACT_TEMPORAL_FUNC"
   | "REACT_CREATE_CONTEXT_PROVIDER"
-  | "REACT_SSR_REGEX_CONSTANT"
-  | "REACT_SSR_PREV_TEXT_NODE"
-  | "REACT_SSR_RENDER_VALUE_HELPER"
-  | "REACT_SSR_TEMPLATE_LITERAL"
+  | "REACT_DEFAULT_PROPS_HELPER"
   | "REACT_NATIVE_STRING_LITERAL"
   | "REACT_RELAY_MOCK_CONTAINER"
-  | "FB_MOCKS_BOOTLOADER_LOAD_MODULES"
-  | "FB_MOCKS_MAGIC_GLOBAL_FUNCTION";
-
-export type DerivedExpressionBuildNodeFunction = (
-  Array<BabelNodeExpression>,
-  SerializationContext,
-  Set<AbstractValue | ObjectValue>
-) => BabelNodeExpression;
+  | "REACT_SSR_PREV_TEXT_NODE"
+  | "REACT_SSR_REGEX_CONSTANT"
+  | "REACT_SSR_RENDER_VALUE_HELPER"
+  | "REACT_SSR_TEMPLATE_LITERAL"
+  | "REACT_TEMPORAL_FUNC"
+  | "REBUILT_OBJECT"
+  | "RESIDUAL_CALL"
+  | "SINGLE_ARG"
+  | "THROW"
+  | "UNARY_EXPRESSION"
+  | "UNKNOWN_ARRAY_GET_PARTIAL"
+  | "UNKNOWN_ARRAY_LENGTH"
+  | "UNKNOWN_ARRAY_METHOD_CALL"
+  | "UNKNOWN_ARRAY_METHOD_PROPERTY_CALL"
+  | "UPDATE_INCREMENTOR"
+  | "WIDEN_ABSTRACT_PROPERTY"
+  | "WIDEN_ABSTRACT_PROPERTY_ASSIGNMENT"
+  | "WIDEN_PROPERTY";
 
 export type OperationDescriptor = {
   data: OperationDescriptorData,
-  kind: void | ResidualBuildKind,
+  kind: void | OperationDescriptorKind,
   type: OperationDescriptorType,
 };
 
@@ -185,12 +177,12 @@ export type OperationDescriptorData = {
   violationConditionOperationDescriptor?: OperationDescriptor,
 };
 
-export type ResidualBuildKind = "DERIVED" | "VOID";
+export type OperationDescriptorKind = "DERIVED" | "VOID";
 
 export function createOperationDescriptor(
   type: OperationDescriptorType,
   data?: OperationDescriptorData = {},
-  kind?: ResidualBuildKind
+  kind?: OperationDescriptorKind
 ): OperationDescriptor {
   return {
     data,
@@ -198,8 +190,6 @@ export function createOperationDescriptor(
     type,
   };
 }
-
-import type { ShapeInformationInterface } from "../types.js";
 
 export type SerializationContext = {|
   serializeOperationDescriptor: (
@@ -245,7 +235,7 @@ export class GeneratorEntry {
     // We increment the index of every TemporalOperationEntry created.
     // This should match up as a form of timeline value due to the tree-like
     // structure we use to create entries during evaluation. For example,
-    // if all AST nodes in a BlockStatement resulted in a temporal build node
+    // if all AST nodes in a BlockStatement resulted in a temporal operation
     // for each AST node, then each would have a sequential index as to its
     // position of how it was evaluated in the BlockSstatement.
     this.index = realm.temporalEntryCounter++;
@@ -305,8 +295,8 @@ export class TemporalOperationEntry extends GeneratorEntry {
   mutatesOnly: void | Array<Value>;
 
   toDisplayJson(depth: number): DisplayResult {
-    if (depth <= 0) return `TemporalBuildNode${this.index}`;
-    let obj = { type: "TemporalBuildNode", ...this };
+    if (depth <= 0) return `TemporalOperation${this.index}`;
+    let obj = { type: "TemporalOperation", ...this };
     delete obj.operationDescriptor;
     return Utils.verboseToDisplayJson(obj, depth);
   }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -143,9 +143,9 @@ export default class AbstractValue extends Value {
     let realm = this.$Realm;
     function add_intrinsic(name: string) {
       if (name.startsWith("_$")) {
-        let temporalBuildNodeEntryArgs = realm.derivedIds.get(name);
-        invariant(temporalBuildNodeEntryArgs !== undefined);
-        add_args(temporalBuildNodeEntryArgs.args);
+        let temporalOperationEntryArgs = realm.derivedIds.get(name);
+        invariant(temporalOperationEntryArgs !== undefined);
+        add_args(temporalOperationEntryArgs.args);
       } else if (names.indexOf(name) < 0) {
         names.push(name);
       }

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -128,10 +128,6 @@ export default class AbstractValue extends Value {
   addSourceLocationsTo(locations: Array<BabelNodeSourceLocation>, seenValues?: Set<AbstractValue> = new Set()): void {
     if (seenValues.has(this)) return;
     seenValues.add(this);
-    // TODO: make this work again?
-    // if (this._buildNode && !(this._buildNode instanceof Function)) {
-    //   if (this._buildNode.loc) locations.push(this._buildNode.loc);
-    // }
     for (let val of this.args) {
       if (val instanceof AbstractValue) val.addSourceLocationsTo(locations, seenValues);
     }


### PR DESCRIPTION
Release notes: none

Follow up to https://github.com/facebook/prepack/pull/2296. Renames some classes and types to the new naming format, rather than BuildNode.