### PR TITLE
Symbol Coercion Should Always Throw

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -79,6 +79,23 @@ export function getPureBinaryOperationResultType(
   if (op === "+") {
     let ltype = To.GetToPrimitivePureResultType(realm, lval);
     let rtype = To.GetToPrimitivePureResultType(realm, rval);
+    if (ltype === StringValue || rtype === StringValue) {
+      // If either type is a string, the other one will be called with ToString, so that has to be pure.
+      if (!To.IsToStringPure(realm, rval)) {
+        rtype = undefined;
+      }
+      if (!To.IsToStringPure(realm, lval)) {
+        ltype = undefined;
+      }
+    } else {
+      // Otherwise, they will be called with ToNumber, so that has to be pure.
+      if (!To.IsToNumberPure(realm, rval)) {
+        rtype = undefined;
+      }
+      if (!To.IsToNumberPure(realm, lval)) {
+        ltype = undefined;
+      }
+    }
     if (ltype === undefined || rtype === undefined) {
       if (lval.getType() === SymbolValue || rval.getType() === SymbolValue) {
         // Symbols never implicitly coerce to primitives.

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -22,6 +22,7 @@ import {
   IntegralValue,
   ObjectValue,
   StringValue,
+  SymbolValue,
   UndefinedValue,
   Value,
 } from "../values/index.js";
@@ -63,6 +64,10 @@ export function getPureBinaryOperationResultType(
     let leftPure = purityTest(realm, lval);
     let rightPure = purityTest(realm, rval);
     if (leftPure && rightPure) return typeIfPure;
+    if (lval.getType() === SymbolValue || rval.getType() === SymbolValue) {
+      // Symbols never implicitly coerce to primitives.
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    }
     let loc = !leftPure ? lloc : rloc;
     let error = new CompilerDiagnostic(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
     if (realm.handleError(error) === "Recover") {
@@ -75,6 +80,10 @@ export function getPureBinaryOperationResultType(
     let ltype = To.GetToPrimitivePureResultType(realm, lval);
     let rtype = To.GetToPrimitivePureResultType(realm, rval);
     if (ltype === undefined || rtype === undefined) {
+      if (lval.getType() === SymbolValue || rval.getType() === SymbolValue) {
+        // Symbols never implicitly coerce to primitives.
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+      }
       let loc = ltype === undefined ? lloc : rloc;
       let error = new CompilerDiagnostic(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
       if (realm.handleError(error) === "Recover") {

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -64,10 +64,6 @@ export function getPureBinaryOperationResultType(
     let leftPure = purityTest(realm, lval);
     let rightPure = purityTest(realm, rval);
     if (leftPure && rightPure) return typeIfPure;
-    if (lval.getType() === SymbolValue || rval.getType() === SymbolValue) {
-      // Symbols never implicitly coerce to primitives.
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-    }
     let loc = !leftPure ? lloc : rloc;
     let error = new CompilerDiagnostic(unknownValueOfOrToString, loc, "PP0002", "RecoverableError");
     if (realm.handleError(error) === "Recover") {
@@ -141,6 +137,9 @@ export function getPureBinaryOperationResultType(
     op === "*" ||
     op === "-"
   ) {
+    if (lval.getType() === SymbolValue || rval.getType() === SymbolValue) {
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    }
     return reportErrorIfNotPure(To.IsToNumberPure.bind(To), NumberValue);
   } else if (op === "in" || op === "instanceof") {
     if (rval.mightNotBeObject()) {

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -154,7 +154,11 @@ function evaluateOperation(
   strictCode: boolean,
   realm: Realm
 ): Value {
-  function reportError() {
+  function reportError(value: Value) {
+    if (value.getType() === SymbolValue) {
+      // Symbols never implicitly coerce to primitives.
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
+    }
     let error = new CompilerDiagnostic(
       "might be a symbol or an object with an unknown valueOf or toString or Symbol.toPrimitive method",
       ast.argument.loc,
@@ -173,7 +177,7 @@ function evaluateOperation(
     // 2. Return ? ToNumber(? GetValue(expr)).
     let value = Environment.GetValue(realm, expr);
     if (value instanceof AbstractValue) {
-      if (!To.IsToNumberPure(realm, value)) reportError();
+      if (!To.IsToNumberPure(realm, value)) reportError(value);
       return AbstractValue.createFromUnaryOp(realm, "+", value);
     }
     invariant(value instanceof ConcreteValue);
@@ -188,7 +192,7 @@ function evaluateOperation(
     // 2. Let oldValue be ? ToNumber(? GetValue(expr)).
     let value = Environment.GetValue(realm, expr);
     if (value instanceof AbstractValue) {
-      if (!To.IsToNumberPure(realm, value)) reportError();
+      if (!To.IsToNumberPure(realm, value)) reportError(value);
       return AbstractValue.createFromUnaryOp(realm, "-", value);
     }
     invariant(value instanceof ConcreteValue);
@@ -210,7 +214,7 @@ function evaluateOperation(
     // 2. Let oldValue be ? ToInt32(? GetValue(expr)).
     let value = Environment.GetValue(realm, expr);
     if (value instanceof AbstractValue) {
-      if (!To.IsToNumberPure(realm, value)) reportError();
+      if (!To.IsToNumberPure(realm, value)) reportError(value);
       return AbstractValue.createFromUnaryOp(realm, "~", value);
     }
     invariant(value instanceof ConcreteValue);

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -619,6 +619,7 @@ export class ToImplementation {
   GetToPrimitivePureResultType(realm: Realm, input: Value): void | typeof Value {
     let type = input.getType();
     if (input instanceof PrimitiveValue) return type;
+    if (type === SymbolValue) return undefined;
     if (input instanceof AbstractValue && !input.mightBeObject()) return PrimitiveValue;
     return undefined;
   }

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -619,7 +619,6 @@ export class ToImplementation {
   GetToPrimitivePureResultType(realm: Realm, input: Value): void | typeof Value {
     let type = input.getType();
     if (input instanceof PrimitiveValue) return type;
-    if (type === SymbolValue) return undefined;
     if (input instanceof AbstractValue && !input.mightBeObject()) return PrimitiveValue;
     return undefined;
   }
@@ -712,6 +711,16 @@ export class ToImplementation {
     } else {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "unknown value type, can't coerce to string");
     }
+  }
+
+  IsToStringPure(realm: Realm, input: string | Value): boolean {
+    if (input instanceof Value) {
+      if (this.IsToPrimitivePure(realm, input)) {
+        let type = input.getType();
+        return type !== SymbolValue && type !== PrimitiveValue && type !== Value;
+      }
+    }
+    return true;
   }
 
   ToStringPartial(realm: Realm, val: string | Value): string {

--- a/src/types.js
+++ b/src/types.js
@@ -1014,6 +1014,8 @@ export type ToType = {
     hint: "string" | "number"
   ): AbstractValue | PrimitiveValue,
 
+  IsToStringPure(realm: Realm, input: string | Value): boolean,
+
   // ECMA262 7.1.12
   ToString(realm: Realm, val: string | ConcreteValue): string,
 

--- a/test/serializer/abstract/Symbols5.js
+++ b/test/serializer/abstract/Symbols5.js
@@ -1,0 +1,12 @@
+(function() {
+  let x = global.__abstract ? __abstract("symbol", "(Symbol())") : Symbol();
+  let y;
+  try {
+    y = +x;
+  } catch (e) {
+    y = e instanceof TypeError;
+  }
+  inspect = function() {
+    return y;
+  };
+})();

--- a/test/serializer/abstract/Symbols6.js
+++ b/test/serializer/abstract/Symbols6.js
@@ -1,0 +1,12 @@
+(function() {
+  let x = global.__abstract ? __abstract("symbol", "(Symbol())") : Symbol();
+  let y;
+  try {
+    y = x - 10;
+  } catch (e) {
+    y = e instanceof TypeError;
+  }
+  inspect = function() {
+    return y;
+  };
+})();

--- a/test/serializer/abstract/Symbols7.js
+++ b/test/serializer/abstract/Symbols7.js
@@ -1,0 +1,12 @@
+(function() {
+  let x = global.__abstract ? __abstract("symbol", "(Symbol())") : Symbol();
+  let y;
+  try {
+    y = x + 10;
+  } catch (e) {
+    y = e instanceof TypeError;
+  }
+  inspect = function() {
+    return y;
+  };
+})();


### PR DESCRIPTION
Coercing a symbol to a number or primitive implicitly always throws an error. We generated fatal compiler errors. Instead, this should just be treated as a throw.

This is neat because that means other serializers doesn't have to deal with the expressions involving symbols.
