### PR TITLE
[WIP] Diff generators and their entries and build normalized linked replacements

### DIFF
--- a/src/serializer/ResidualHeapDiffer.js
+++ b/src/serializer/ResidualHeapDiffer.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import { Realm } from "../realm.js";
+import { Generator } from "../utils/generator.js";
+import { Value } from "../values/index.js";
+
+export type NormalizedDiffFunction = {
+  name: string,
+  params: Array<string>,
+  body: Generator,
+};
+
+export type NormalizedGeneratorDiffResult = {
+  normalizedDiffFunctions: Array<NormalizedDiffFunction>,
+  generatorReplacements: Map<
+    Generator,
+    { args: Array<Value>, func: NormalizedDiffFunction, usesReturn: boolean, usesThis: boolean }
+  >,
+};
+
+export class ResidualHeapDiffer {
+  constructor(realm: Realm, generatorsByHash: Map<string, Set<Generator>>) {
+    this.realm = realm;
+    this.generatorsByHash = generatorsByHash;
+  }
+  realm: Realm;
+  generatorsByHash: Map<string, Set<Generator>>;
+
+  // returns NormalizedGeneratorDiffResult
+  diffAndNormalizeGenerators() {
+    // TODO
+  }
+}

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1198,8 +1198,12 @@ export class ResidualHeapVisitor {
     return callbacks;
   }
 
-  _captureGeneratorHash(generator: Generator) {
+  _captureGeneratorHash(generator: Generator): void {
     let hash = generator.getHash();
+    if (hash === "[Generator]") {
+      // This is a generator with no entries in it
+      return;
+    }
     let generators = this.generatorsByHash.get(hash);
 
     if (generators === undefined) {

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -37,6 +37,7 @@ import { ResidualHeapGraphGenerator } from "./ResidualHeapGraphGenerator";
 import { Referentializer } from "./Referentializer.js";
 import { Get } from "../methods/index.js";
 import { ObjectValue, Value } from "../values/index.js";
+import { ResidualHeapDiffer } from "./ResidualHeapDiffer.js";
 
 export class Serializer {
   constructor(realm: Realm, serializerOptions: SerializerOptions = {}) {
@@ -195,6 +196,10 @@ export class Serializer {
         );
         statistics.deepTraversal.measure(() => residualHeapVisitor.visitRoots());
         if (this.logger.hasErrors()) return undefined;
+
+        let heapDiffer = new ResidualHeapDiffer(this.realm, residualHeapVisitor.generatorsByHash);
+        let normalizedGeneratorMap = heapDiffer.diffAndCreateNormalizedGeneratorMap();
+        normalizedGeneratorMap; // to make CI pass
 
         if (this.realm.react.verbose) {
           this.logger.logInformation(`Serializing evaluated nodes...`);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -198,8 +198,8 @@ export class Serializer {
         if (this.logger.hasErrors()) return undefined;
 
         let heapDiffer = new ResidualHeapDiffer(this.realm, residualHeapVisitor.generatorsByHash);
-        let normalizedGeneratorMap = heapDiffer.diffAndCreateNormalizedGeneratorMap();
-        normalizedGeneratorMap; // to make CI pass
+        let normalizedGeneratorDiffResult = heapDiffer.diffAndNormalizeGenerators();
+        normalizedGeneratorDiffResult; // to make CI pass
 
         if (this.realm.react.verbose) {
           this.logger.logInformation(`Serializing evaluated nodes...`);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -263,6 +263,10 @@ export class GeneratorEntry {
     return this.index < entry.index;
   }
 
+  getHash() {
+    invariant(false, "GeneratorEntry is an abstract base class");
+  }
+
   index: number;
 }
 
@@ -366,6 +370,26 @@ export class TemporalOperationEntry extends GeneratorEntry {
   getDependencies(): void | Array<Generator> {
     return this.dependencies;
   }
+
+  getHash(): string {
+    let hashString = "[TemporalOperation";
+
+    if (this.declared !== undefined) {
+      hashString += " Declared";
+    }
+    if (this.operationDescriptor !== undefined) {
+      let { kind, type } = this.operationDescriptor;
+      hashString += ` OperationDescriptor=${kind ? kind : ""}&${type}`;
+    }
+    let dependencies = this.getDependencies();
+    if (dependencies !== undefined) {
+      for (let i = 0; i < dependencies.length; i++) {
+        let dependency = dependencies[i];
+        hashString += ` Dependency_${i}=${dependency.getHash()}`;
+      }
+    }
+    return `${hashString}]`;
+  }
 }
 
 export class TemporalObjectAssignEntry extends TemporalOperationEntry {
@@ -397,6 +421,10 @@ export class TemporalObjectAssignEntry extends TemporalOperationEntry {
       return false;
     }
     return super.visit(callbacks, containingGenerator);
+  }
+
+  getHash(): string {
+    return `[TemporalObjectAssign_${super.getHash()}]`;
   }
 }
 
@@ -443,6 +471,10 @@ class ModifiedPropertyEntry extends GeneratorEntry {
   getDependencies(): void | Array<Generator> {
     return undefined;
   }
+
+  getHash(): string {
+    return `${this.toDisplayString()}`;
+  }
 }
 
 type ModifiedBindingEntryArgs = {|
@@ -479,6 +511,10 @@ class ModifiedBindingEntry extends GeneratorEntry {
   getDependencies(): void | Array<Generator> {
     return undefined;
   }
+
+  getHash(): string {
+    return `${this.toDisplayString()}`;
+  }
 }
 
 class ReturnValueEntry extends GeneratorEntry {
@@ -511,6 +547,10 @@ class ReturnValueEntry extends GeneratorEntry {
 
   getDependencies(): void | Array<Generator> {
     return undefined;
+  }
+
+  getHash(): string {
+    return `${this.toDisplayString()}`;
   }
 }
 
@@ -568,6 +608,19 @@ class IfThenElseEntry extends GeneratorEntry {
   getDependencies(): void | Array<Generator> {
     return [this.consequentGenerator, this.alternateGenerator];
   }
+
+  getHash(): string {
+    let hashString = "[IfThenElseEntry";
+
+    let dependencies = this.getDependencies();
+    if (dependencies !== undefined) {
+      for (let i = 0; i < dependencies.length; i++) {
+        let dependency = dependencies[i];
+        hashString += ` Dependency_${i}=${dependency.getHash()}`;
+      }
+    }
+    return `${hashString}]`;
+  }
 }
 
 class BindingAssignmentEntry extends GeneratorEntry {
@@ -599,6 +652,10 @@ class BindingAssignmentEntry extends GeneratorEntry {
 
   getDependencies(): void | Array<Generator> {
     return undefined;
+  }
+
+  getHash(): string {
+    return `${this.toDisplayString()}`;
   }
 }
 
@@ -1108,6 +1165,15 @@ export class Generator {
     } else {
       visitFn();
     }
+  }
+
+  getHash(): string {
+    let hashString = "[Generator";
+    for (let i = 0; i < this._entries.length; i++) {
+      let entry = this._entries[i];
+      hashString += ` Entry_${i}=${entry.getHash()}`;
+    }
+    return hashString + "]";
   }
 
   serialize(context: SerializationContext): void {


### PR DESCRIPTION
*Note: This is not finished, it's barely started. I'm hoping to first show code to start discussion.*

- [x] Build a very naive and un-tested hasher/de-dupe key for generators and their entries to show the concept
- [ ] Prove out concept and iron out/revise implementation and design based on feedback
- [ ] Add tests around de-dupe keys/hashing and diffing
- [ ] Complete de-dupe keys/hashing logic (if that's the path we take)
- [ ] Add diffing logic (if that's the path we take)
- [ ] Add heuristics to check when not to normalize (when the generator is small enough to always inline?)
- [ ] Ensure `this` and `return` are correctly handled

For a long time, Prepack has had the heuristic to inline everything it possibly can. One might say that this is bad and leads to bloat, but it's actually not the cause of bloat at all. The cause of bloat is the fact our serializer makes no real attempts to de-duplicate code (other some logic related to functions, but that doesn't really occur much in real-world scenarios). One such way is to "diff" generators and generate normalize functions with generator entries that have been duplicated many times from the results of inlining.

In order to diff generators, we first need to understand their shapes and have a relatively inexpensive/quick way to know if generators are of similar shapes. By shape, I mean that one or many generators shape a deep structure, irrelevant of any independent values. After the recent refactor around buildNodes changing to become operation descriptors, we now have much better knowledge over what generator entries do and can create de-dupe keys/hashes far more confidently (as shown at the start of this PR). More work is still to be done there, but we can internally normalize many of the operations then this PR and its theory will also improve too.

For example these generators are not equivalent, but can be deduplicated.

Generator 1:
```js
{
  foo(a);
  return x;
}
```
Generator 2:
```js
{
  foo(b);
  return x;
}
```

The generator tree is currently a directed acyclic graph (DAG), where generators may have many parents in theory, so it adds some complexity. Due to the fact we are very likely to re-visit the same generator many times. Furthermore, our equivalence system comes into play (CSE, ReactElement, Object.assign etc) and because of dependencies causing fix point re-entries, we need to calculate de-dupe keys/hashes many times too because the de-dupe keys/hashes might change.

Once we've got fixed de-dupe keys/hashes after the visiting has finished we can then begin diffing the generators that we found to have the same de-dupe keys/hashes (we store them in a Map by de-dupe keys/hash). Between all generators of the same has, we find where they all differentiate in any of the generator entries and we mark those points as dynamic and thus an abstract value. Once we've done this recursively, we create a new deep generator with all these new values marked. We then construct a function in the serialization phase and link any places where the old generators occur to a call for this new function.

Taking the example above, you'd get this generator as the diff result (for example):

```js
{
  foo(__abstract());
  return __abstract();
}
```

The following is a test case and the expected output if this PR was fully implemented in the current design spec:

```js
__evaluatePureFunction(function() {

  var abstractFunction = __abstract("function", "abstractFunction");

  function foo() {
    abstractFunction(1);
    abstractFunction(2);
  }

  function fn() {
    foo();
    foo();
    foo();
  }

  fn();

});
```

Output now:

```js
(function () {
  var _0 = abstractFunction;

  var _$0 = _0(1);

  var _$1 = _0(2);

  var _$2 = _0(1);

  var _$3 = _0(2);

  var _$4 = _0(1);

  var _$5 = _0(2);
})();
```

Output after PR:

```js
(function () {
  var _0 = abstractFunction;

 var _1 = function() {
   var _$0 = _0(1);

   var _$1 = _0(2);
 }

  _1();
  _1();
  _1();
})();
```