### PR TITLE
Deduplicate object creation code in a non-branched setting

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -278,6 +278,7 @@ export class ResidualHeapVisitor {
   }
 
   visitObjectProperties(obj: ObjectValue, kind?: ObjectKind): void {
+    // In non-instant render mode, properties of leaked objects are generated via assignments
     let { skipPrototype, constructor } = getObjectPrototypeMetadata(this.realm, obj);
     if (obj.temporalAlias !== undefined) return;
 
@@ -304,6 +305,15 @@ export class ResidualHeapVisitor {
         continue;
       }
       if (propertyBindingValue.pathNode !== undefined) continue; // property is written to inside a loop
+
+      // Leaked object. Properties are set via assignments
+      // TODO #2259: Make deduplication in the face of leaking work for custom accessors
+      if (
+        !obj.mightNotBeHavocedObject() &&
+        (descriptor !== undefined && (descriptor.get === undefined && descriptor.set === undefined))
+      )
+        continue;
+
       invariant(propertyBindingValue);
       this.visitObjectProperty(propertyBindingValue);
     }

--- a/test/serializer/optimized-functions/ConditionallyLeakedBinding.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedBinding.js
@@ -1,0 +1,22 @@
+(function() {
+  function f(c, g) {
+    let x = 23;
+    let y = 0;
+    if (c) {
+      x = Date.now();
+      function h() {
+        y = x;
+        x++;
+      }
+      g(h);
+      return x - y;
+    } else {
+      x = Date.now();
+      return x - y;
+    }
+  }
+  global.__optimize && __optimize(f);
+  global.inspect = function() {
+    return f(true, g => g());
+  };
+})();

--- a/test/serializer/optimized-functions/ConditionallyLeakedObject1.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedObject1.js
@@ -1,0 +1,17 @@
+(function() {
+  function f(g, c) {
+    let o = { foo: 42 };
+    if (c) {
+      g(o);
+    } else {
+      o.foo = 2;
+    }
+
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = function() {
+    return JSON.stringify(f(o => o, false));
+  };
+})();

--- a/test/serializer/optimized-functions/ConditionallyLeakedObject2.js
+++ b/test/serializer/optimized-functions/ConditionallyLeakedObject2.js
@@ -1,0 +1,17 @@
+(function() {
+  function f(g, c) {
+    let o = { foo: 42 };
+    if (c) {
+      g(o);
+    } else {
+      o.x = 1;
+    }
+
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = function() {
+    return JSON.stringify(f(o => o, false));
+  };
+})();

--- a/test/serializer/optimized-functions/LeakObjectWithSetter.js
+++ b/test/serializer/optimized-functions/LeakObjectWithSetter.js
@@ -1,0 +1,17 @@
+(function() {
+  function f(g) {
+    let o = {
+      foo: 1,
+      set x(v) {
+        this.foo += 1;
+      },
+    };
+    g(o);
+    return o;
+  }
+
+  global.__optimize && __optimize(f);
+  inspect = () => {
+    JSON.stringify(f(o => o));
+  };
+})();

--- a/test/serializer/optimized-functions/LeakedCustomObjectInMultipleScopes.js
+++ b/test/serializer/optimized-functions/LeakedCustomObjectInMultipleScopes.js
@@ -1,0 +1,17 @@
+function f(g, c) {
+  let o = { foo: {} };
+  o.__proto__ = {};
+
+  if (c) {
+    g(o);
+  } else {
+    o.foo = { bar: 5 };
+    g(o);
+  }
+  return o;
+}
+
+global.__optimize && __optimize(f);
+inspect = function() {
+  return f(o => o);
+};

--- a/test/serializer/optimized-functions/LeakedObjectCodeDuplication.js
+++ b/test/serializer/optimized-functions/LeakedObjectCodeDuplication.js
@@ -1,0 +1,12 @@
+// Copies of 42:1
+function f(g) {
+  var o = {};
+  o.foo = 42;
+  g(o);
+  return o;
+}
+
+global.__optimize && __optimize(f);
+inspect = function() {
+  return f(o => o);
+};


### PR DESCRIPTION
This pull request breaks out the first part of #2185, which deduplicates object creation when leaking is unconditional to begin with. No changes are made to how leaking works. Only to how leak information is used by the serializer and visitor.