### PR TITLE
Cleanup of generator.js and moves out Babel serialization logic

### DIFF
--- a/scripts/detect_bad_deps.js
+++ b/scripts/detect_bad_deps.js
@@ -12,7 +12,7 @@
 import madge from "madge";
 import { exec } from "child_process";
 
-const MAX_CYCLE_LEN = 57; // NEVER EVER increase this value
+const MAX_CYCLE_LEN = 56; // NEVER EVER increase this value
 
 const cmd = "flow check --profile --merge-timeout 0";
 exec(cmd, function(error, stdout, stderr) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -64,12 +64,8 @@ import {
 import type { Compatibility, RealmOptions, ReactOutputTypes, InvariantModeTypes } from "./options.js";
 import invariant from "./invariant.js";
 import seedrandom from "seedrandom";
-import {
-  createOperationDescriptor,
-  Generator,
-  PreludeGenerator,
-  type TemporalOperationEntry,
-} from "./utils/generator.js";
+import { createOperationDescriptor, Generator, type TemporalOperationEntry } from "./utils/generator.js";
+import { PreludeGenerator } from "./utils/PreludeGenerator.js";
 import { Environment, Functions, Join, Properties, To, Widen, Path } from "./singletons.js";
 import type { ReactSymbolTypes } from "./react/utils.js";
 import type { BabelNode, BabelNodeSourceLocation, BabelNodeLVal, BabelNodeStatement } from "@babel/types";

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -14,7 +14,7 @@ import type { SerializerOptions } from "../options.js";
 import * as t from "@babel/types";
 import generate from "@babel/generator";
 import type { BabelNodeStatement, BabelNodeExpression, BabelNodeIdentifier } from "@babel/types";
-import { NameGenerator } from "../utils/PreludeGenerator";
+import { NameGenerator } from "../utils/NameGenerator";
 import invariant from "../invariant.js";
 import type { ResidualFunctionBinding, ScopeBinding, FunctionInstance } from "./types.js";
 import { type ReferentializationScope } from "./types.js";

--- a/src/serializer/Referentializer.js
+++ b/src/serializer/Referentializer.js
@@ -14,7 +14,7 @@ import type { SerializerOptions } from "../options.js";
 import * as t from "@babel/types";
 import generate from "@babel/generator";
 import type { BabelNodeStatement, BabelNodeExpression, BabelNodeIdentifier } from "@babel/types";
-import { NameGenerator } from "../utils/generator.js";
+import { NameGenerator } from "../utils/PreludeGenerator";
 import invariant from "../invariant.js";
 import type { ResidualFunctionBinding, ScopeBinding, FunctionInstance } from "./types.js";
 import { type ReferentializationScope } from "./types.js";

--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -12,7 +12,7 @@
 import { FunctionValue, Value } from "../values/index.js";
 import * as t from "@babel/types";
 import type { BabelNodeStatement } from "@babel/types";
-import { NameGenerator } from "../utils/PreludeGenerator.js";
+import { NameGenerator } from "../utils/NameGenerator.js";
 import traverseFast from "../utils/traverse-fast.js";
 import invariant from "../invariant.js";
 import { voidExpression, nullExpression } from "../utils/babelhelpers.js";

--- a/src/serializer/ResidualFunctionInitializers.js
+++ b/src/serializer/ResidualFunctionInitializers.js
@@ -12,7 +12,7 @@
 import { FunctionValue, Value } from "../values/index.js";
 import * as t from "@babel/types";
 import type { BabelNodeStatement } from "@babel/types";
-import { NameGenerator } from "../utils/generator.js";
+import { NameGenerator } from "../utils/PreludeGenerator.js";
 import traverseFast from "../utils/traverse-fast.js";
 import invariant from "../invariant.js";
 import { voidExpression, nullExpression } from "../utils/babelhelpers.js";

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -28,7 +28,7 @@ import type {
   BabelNodeArrowFunctionExpression,
 } from "@babel/types";
 import type { FunctionBodyAstNode } from "../types.js";
-import type { NameGenerator } from "../utils/generator.js";
+import type { NameGenerator } from "../utils/PreludeGenerator.js";
 import invariant from "../invariant.js";
 import type {
   ResidualFunctionBinding,

--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -28,7 +28,7 @@ import type {
   BabelNodeArrowFunctionExpression,
 } from "@babel/types";
 import type { FunctionBodyAstNode } from "../types.js";
-import type { NameGenerator } from "../utils/PreludeGenerator.js";
+import type { NameGenerator } from "../utils/NameGenerator.js";
 import invariant from "../invariant.js";
 import type {
   ResidualFunctionBinding,

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -42,7 +42,8 @@ import type {
   BabelNodeFunctionExpression,
 } from "@babel/types";
 import { Generator } from "../utils/generator.js";
-import { PreludeGenerator, NameGenerator } from "../utils/PreludeGenerator.js";
+import { PreludeGenerator } from "../utils/PreludeGenerator.js";
+import { NameGenerator } from "../utils/NameGenerator.js";
 import type { OperationDescriptor, SerializationContext } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import type {

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -41,7 +41,8 @@ import type {
   BabelNodeFile,
   BabelNodeFunctionExpression,
 } from "@babel/types";
-import { Generator, PreludeGenerator, NameGenerator } from "../utils/generator.js";
+import { Generator } from "../utils/generator.js";
+import { PreludeGenerator, NameGenerator } from "../utils/PreludeGenerator.js";
 import type { OperationDescriptor, SerializationContext } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import type {
@@ -2144,8 +2145,31 @@ export class ResidualHeapSerializer {
 
         return ((serializedValue: any): BabelNodeStatement);
       },
-      serializeValue: this.serializeValue.bind(this),
       serializeBinding: this.serializeBinding.bind(this),
+      serializeBindingAssignment: (binding: Binding, bindingValue: Value) => {
+        let serializeBinding = this.serializeBinding(binding);
+        let serializedValue = context.serializeValue(bindingValue);
+        return t.expressionStatement(t.assignmentExpression("=", serializeBinding, serializedValue));
+      },
+      serializeCondition: (
+        condition: Value,
+        consequentGenerator: Generator,
+        alternateGenerator: Generator,
+        valuesToProcess: Set<AbstractValue | ObjectValue>
+      ) => {
+        let serializedCondition = this.serializeValue(condition);
+        let consequentBody = context.serializeGenerator(consequentGenerator, valuesToProcess);
+        let alternateBody = context.serializeGenerator(alternateGenerator, valuesToProcess);
+        return t.ifStatement(serializedCondition, t.blockStatement(consequentBody), t.blockStatement(alternateBody));
+      },
+      serializeDebugScopeComment(declared: ObjectValue | AbstractValue) {
+        let s = t.emptyStatement();
+        s.leadingComments = [({ type: "BlockComment", value: `declaring ${declared.intrinsicName || "?"}` }: any)];
+        return s;
+      },
+      serializeReturnValue: (val: Value) => {
+        return t.returnStatement(this.serializeValue(val));
+      },
       serializeGenerator: (
         generator: Generator,
         valuesToProcess: Set<AbstractValue | ObjectValue>
@@ -2153,6 +2177,7 @@ export class ResidualHeapSerializer {
         this._withGeneratorScope("Generator", generator, valuesToProcess, () =>
           generator.serialize(((context: any): SerializationContext))
         ),
+      serializeValue: this.serializeValue.bind(this),
       initGenerator: (generator: Generator) => {
         let activeGeneratorBody = this._getActiveBodyOfGenerator(generator);
         invariant(activeGeneratorBody === this.emitter.getBody(), "generator to init must be current emitter body");

--- a/src/serializer/ResidualHeapValueIdentifiers.js
+++ b/src/serializer/ResidualHeapValueIdentifiers.js
@@ -12,7 +12,8 @@
 import { Value } from "../values/index.js";
 import type { BabelNodeIdentifier } from "@babel/types";
 import invariant from "../invariant.js";
-import type { PreludeGenerator, NameGenerator } from "../utils/PreludeGenerator.js";
+import type { PreludeGenerator } from "../utils/PreludeGenerator.js";
+import type { NameGenerator } from "../utils/NameGenerator.js";
 import * as t from "@babel/types";
 
 // This class maintains a map of values to babel identifiers.

--- a/src/serializer/ResidualHeapValueIdentifiers.js
+++ b/src/serializer/ResidualHeapValueIdentifiers.js
@@ -12,7 +12,7 @@
 import { Value } from "../values/index.js";
 import type { BabelNodeIdentifier } from "@babel/types";
 import invariant from "../invariant.js";
-import type { NameGenerator, PreludeGenerator } from "../utils/generator";
+import type { PreludeGenerator, NameGenerator } from "../utils/PreludeGenerator.js";
 import * as t from "@babel/types";
 
 // This class maintains a map of values to babel identifiers.

--- a/src/serializer/ResidualOperationSerializer.js
+++ b/src/serializer/ResidualOperationSerializer.js
@@ -12,11 +12,11 @@
 import { Realm } from "../realm.js";
 import {
   Generator,
-  PreludeGenerator,
   type SerializationContext,
   type OperationDescriptor,
   type OperationDescriptorData,
 } from "../utils/generator.js";
+import { PreludeGenerator } from "../utils/PreludeGenerator.js";
 import {
   emptyExpression,
   memberExpressionHelper,

--- a/src/serializer/factorify.js
+++ b/src/serializer/factorify.js
@@ -11,7 +11,7 @@
 
 import * as t from "@babel/types";
 import type { BabelNodeStatement, BabelNodeObjectExpression, BabelNodeLVal } from "@babel/types";
-import { NameGenerator } from "../utils/generator.js";
+import { NameGenerator } from "../utils/PreludeGenerator";
 
 function isLiteral(node) {
   switch (node.type) {

--- a/src/serializer/factorify.js
+++ b/src/serializer/factorify.js
@@ -11,7 +11,7 @@
 
 import * as t from "@babel/types";
 import type { BabelNodeStatement, BabelNodeObjectExpression, BabelNodeLVal } from "@babel/types";
-import { NameGenerator } from "../utils/PreludeGenerator";
+import { NameGenerator } from "../utils/NameGenerator";
 
 function isLiteral(node) {
   switch (node.type) {

--- a/src/utils/NameGenerator.js
+++ b/src/utils/NameGenerator.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import invariant from "../invariant.js";
+
+function escapeInvalidIdentifierCharacters(s: string): string {
+  let res = "";
+  for (let c of s)
+    if ((c >= "0" && c <= "9") || (c >= "a" && c <= "z") || (c >= "A" && c <= "Z")) res += c;
+    else res += "_" + c.charCodeAt(0);
+  return res;
+}
+
+const base62characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+function base62encode(n: number): string {
+  invariant((n | 0) === n && n >= 0);
+  if (n === 0) return "0";
+  let s = "";
+  while (n > 0) {
+    let f = n % base62characters.length;
+    s = base62characters[f] + s;
+    n = (n - f) / base62characters.length;
+  }
+  return s;
+}
+
+export class NameGenerator {
+  constructor(forbiddenNames: Set<string>, debugNames: boolean, uniqueSuffix: string, prefix: string) {
+    this.prefix = prefix;
+    this.uidCounter = 0;
+    this.debugNames = debugNames;
+    this.forbiddenNames = forbiddenNames;
+    this.uniqueSuffix = uniqueSuffix;
+  }
+  prefix: string;
+  uidCounter: number;
+  debugNames: boolean;
+  forbiddenNames: Set<string>;
+  uniqueSuffix: string;
+  generate(debugSuffix: ?string): string {
+    let id;
+    do {
+      id = this.prefix + base62encode(this.uidCounter++);
+      if (this.uniqueSuffix.length > 0) id += this.uniqueSuffix;
+      if (this.debugNames) {
+        if (debugSuffix) id += "_" + escapeInvalidIdentifierCharacters(debugSuffix);
+        else id += "_";
+      }
+    } while (this.forbiddenNames.has(id));
+    return id;
+  }
+}

--- a/src/utils/PreludeGenerator.js
+++ b/src/utils/PreludeGenerator.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import * as t from "@babel/types";
+import { memberExpressionHelper } from "./babelhelpers.js";
+import type {
+  BabelNodeIdentifier,
+  BabelNodeThisExpression,
+  BabelNodeStatement,
+  BabelNodeMemberExpression,
+} from "@babel/types";
+import invariant from "../invariant.js";
+
+export class PreludeGenerator {
+  constructor(debugNames: ?boolean, uniqueSuffix: ?string) {
+    this.prelude = [];
+    this.memoizedRefs = new Map();
+    this.nameGenerator = new NameGenerator(new Set(), !!debugNames, uniqueSuffix || "", "_$");
+    this.usesThis = false;
+    this.declaredGlobals = new Set();
+    this.nextInvariantId = 0;
+  }
+
+  prelude: Array<BabelNodeStatement>;
+  memoizedRefs: Map<string, BabelNodeIdentifier>;
+  nameGenerator: NameGenerator;
+  usesThis: boolean;
+  declaredGlobals: Set<string>;
+  nextInvariantId: number;
+
+  createNameGenerator(prefix: string): NameGenerator {
+    return new NameGenerator(
+      this.nameGenerator.forbiddenNames,
+      this.nameGenerator.debugNames,
+      this.nameGenerator.uniqueSuffix,
+      prefix
+    );
+  }
+
+  convertStringToMember(str: string): BabelNodeIdentifier | BabelNodeThisExpression | BabelNodeMemberExpression {
+    return str
+      .split(".")
+      .map(name => {
+        if (name === "global") {
+          return this.memoizeReference(name);
+        } else if (name === "this") {
+          return t.thisExpression();
+        } else {
+          return t.identifier(name);
+        }
+      })
+      .reduce((obj, prop) => t.memberExpression(obj, prop));
+  }
+
+  globalReference(key: string, globalScope: boolean = false): BabelNodeIdentifier | BabelNodeMemberExpression {
+    if (globalScope && t.isValidIdentifier(key)) return t.identifier(key);
+    return memberExpressionHelper(this.memoizeReference("global"), key);
+  }
+
+  memoizeReference(key: string): BabelNodeIdentifier {
+    let ref = this.memoizedRefs.get(key);
+    if (ref) return ref;
+
+    let init;
+    if (key.includes("(") || key.includes("[")) {
+      // Horrible but effective hack:
+      // Some internal object have intrinsic names such as
+      //    ([][Symbol.iterator]().__proto__.__proto__)
+      // and
+      //    RegExp.prototype[Symbol.match]
+      // which get turned into a babel node here.
+      // TODO: We should properly parse such a string, and memoize all references in it separately.
+      // Instead, we just turn it into a funky identifier, which Babel seems to accept.
+      init = t.identifier(key);
+    } else if (key === "global") {
+      this.usesThis = true;
+      init = t.thisExpression();
+    } else {
+      let i = key.lastIndexOf(".");
+      if (i === -1) {
+        init = t.memberExpression(this.memoizeReference("global"), t.identifier(key));
+      } else {
+        init = t.memberExpression(this.memoizeReference(key.substr(0, i)), t.identifier(key.substr(i + 1)));
+      }
+    }
+    ref = t.identifier(this.nameGenerator.generate(key));
+    this.prelude.push(t.variableDeclaration("var", [t.variableDeclarator(ref, init)]));
+    this.memoizedRefs.set(key, ref);
+    return ref;
+  }
+}
+
+function escapeInvalidIdentifierCharacters(s: string): string {
+  let res = "";
+  for (let c of s)
+    if ((c >= "0" && c <= "9") || (c >= "a" && c <= "z") || (c >= "A" && c <= "Z")) res += c;
+    else res += "_" + c.charCodeAt(0);
+  return res;
+}
+
+const base62characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+function base62encode(n: number): string {
+  invariant((n | 0) === n && n >= 0);
+  if (n === 0) return "0";
+  let s = "";
+  while (n > 0) {
+    let f = n % base62characters.length;
+    s = base62characters[f] + s;
+    n = (n - f) / base62characters.length;
+  }
+  return s;
+}
+
+export class NameGenerator {
+  constructor(forbiddenNames: Set<string>, debugNames: boolean, uniqueSuffix: string, prefix: string) {
+    this.prefix = prefix;
+    this.uidCounter = 0;
+    this.debugNames = debugNames;
+    this.forbiddenNames = forbiddenNames;
+    this.uniqueSuffix = uniqueSuffix;
+  }
+  prefix: string;
+  uidCounter: number;
+  debugNames: boolean;
+  forbiddenNames: Set<string>;
+  uniqueSuffix: string;
+  generate(debugSuffix: ?string): string {
+    let id;
+    do {
+      id = this.prefix + base62encode(this.uidCounter++);
+      if (this.uniqueSuffix.length > 0) id += this.uniqueSuffix;
+      if (this.debugNames) {
+        if (debugSuffix) id += "_" + escapeInvalidIdentifierCharacters(debugSuffix);
+        else id += "_";
+      }
+    } while (this.forbiddenNames.has(id));
+    return id;
+  }
+}

--- a/src/utils/PreludeGenerator.js
+++ b/src/utils/PreludeGenerator.js
@@ -17,7 +17,7 @@ import type {
   BabelNodeStatement,
   BabelNodeMemberExpression,
 } from "@babel/types";
-import invariant from "../invariant.js";
+import { NameGenerator } from "./NameGenerator.js";
 
 export class PreludeGenerator {
   constructor(debugNames: ?boolean, uniqueSuffix: ?string) {
@@ -95,53 +95,5 @@ export class PreludeGenerator {
     this.prelude.push(t.variableDeclaration("var", [t.variableDeclarator(ref, init)]));
     this.memoizedRefs.set(key, ref);
     return ref;
-  }
-}
-
-function escapeInvalidIdentifierCharacters(s: string): string {
-  let res = "";
-  for (let c of s)
-    if ((c >= "0" && c <= "9") || (c >= "a" && c <= "z") || (c >= "A" && c <= "Z")) res += c;
-    else res += "_" + c.charCodeAt(0);
-  return res;
-}
-
-const base62characters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-function base62encode(n: number): string {
-  invariant((n | 0) === n && n >= 0);
-  if (n === 0) return "0";
-  let s = "";
-  while (n > 0) {
-    let f = n % base62characters.length;
-    s = base62characters[f] + s;
-    n = (n - f) / base62characters.length;
-  }
-  return s;
-}
-
-export class NameGenerator {
-  constructor(forbiddenNames: Set<string>, debugNames: boolean, uniqueSuffix: string, prefix: string) {
-    this.prefix = prefix;
-    this.uidCounter = 0;
-    this.debugNames = debugNames;
-    this.forbiddenNames = forbiddenNames;
-    this.uniqueSuffix = uniqueSuffix;
-  }
-  prefix: string;
-  uidCounter: number;
-  debugNames: boolean;
-  forbiddenNames: Set<string>;
-  uniqueSuffix: string;
-  generate(debugSuffix: ?string): string {
-    let id;
-    do {
-      id = this.prefix + base62encode(this.uidCounter++);
-      if (this.uniqueSuffix.length > 0) id += this.uniqueSuffix;
-      if (this.debugNames) {
-        if (debugSuffix) id += "_" + escapeInvalidIdentifierCharacters(debugSuffix);
-        else id += "_";
-      }
-    } while (this.forbiddenNames.has(id));
-    return id;
   }
 }

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -11,7 +11,7 @@
 
 import buildTemplate from "@babel/template";
 import type { BabelNodeExpression } from "@babel/types";
-import type { PreludeGenerator } from "./generator.js";
+import type { PreludeGenerator } from "./PreludeGenerator.js";
 import invariant from "../invariant.js";
 
 const placeholders = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -18,7 +18,8 @@ import type {
 } from "@babel/types";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import type { Realm } from "../realm.js";
-import { createOperationDescriptor, PreludeGenerator, type OperationDescriptor } from "../utils/generator.js";
+import { createOperationDescriptor, type OperationDescriptor } from "../utils/generator.js";
+import { PreludeGenerator } from "../utils/PreludeGenerator.js";
 import type { PropertyKeyValue, ShapeInformationInterface } from "../types.js";
 import buildExpressionTemplate from "../utils/builder.js";
 


### PR DESCRIPTION
Release notes: none

This cleans up generator.js in the following ways:

- pulls our NameGenerator and PreludeGenerator into it's own module
- takes out the Babel coupling with Generator and puts the serialization logic into the serializer instead

This is of many PRs to help clean up the serialization/generator logic.