### PR TITLE
Refine operationDescriptor "data" and remove some properties

### DIFF
--- a/src/intrinsics/ecma262/ArrayProto_toString.js
+++ b/src/intrinsics/ecma262/ArrayProto_toString.js
@@ -39,8 +39,8 @@ export default function(realm: Realm): NativeFunctionValue {
         return AbstractValue.createTemporalFromBuildFunction(
           realm,
           StringValue,
-          [array],
-          createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "toString" })
+          [array, new StringValue(realm, "toString")],
+          createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
         );
       }
 

--- a/src/intrinsics/ecma262/ArrayProto_values.js
+++ b/src/intrinsics/ecma262/ArrayProto_values.js
@@ -10,7 +10,7 @@
 /* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
-import { AbstractValue, ArrayValue, NativeFunctionValue, Value } from "../../values/index.js";
+import { AbstractValue, ArrayValue, NativeFunctionValue, StringValue, Value } from "../../values/index.js";
 import { Create, To } from "../../singletons.js";
 import { createOperationDescriptor } from "../../utils/generator.js";
 
@@ -31,8 +31,8 @@ export default function(realm: Realm): NativeFunctionValue {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
-        [O],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "values" })
+        [O, new StringValue(realm, "values")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 

--- a/src/intrinsics/ecma262/ArrayPrototype.js
+++ b/src/intrinsics/ecma262/ArrayPrototype.js
@@ -56,11 +56,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("concat") === undefined
     ) {
-      let newArgs = [O, ...args];
+      let newArgs = [O, new StringValue(realm, "concat"), ...args];
       return ArrayValue.createTemporalWithWidenedNumericProperty(
         realm,
         newArgs,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "concat" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -156,7 +156,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm.isInPureScope() &&
         O.$GetOwnProperty("copyWithin") === undefined
       ) {
-        let args = [O, target];
+        let args = [O, new StringValue(realm, "copyWithin"), target];
         if (start) {
           args.push(start);
         }
@@ -167,7 +167,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
           realm,
           BooleanValue,
           args,
-          createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "copyWithin" })
+          createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
         );
         return O;
       }
@@ -266,8 +266,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
-        [O],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "entries" })
+        [O, new StringValue(realm, "entries")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -288,7 +288,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("every") === undefined
     ) {
-      let args = [O, callbackfn];
+      let args = [O, new StringValue(realm, "every"), callbackfn];
       if (thisArg) {
         args.push(thisArg);
       }
@@ -296,7 +296,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         BooleanValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "every" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -355,7 +355,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("fill") === undefined
     ) {
-      let args = [O, value];
+      let args = [O, new StringValue(realm, "fill"), value];
       if (start) {
         args.push(start);
       }
@@ -366,7 +366,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         Value,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "fill" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
       return O;
     }
@@ -412,14 +412,14 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("filter") === undefined
     ) {
-      let args = [O, callbackfn];
+      let args = [O, new StringValue(realm, "filter"), callbackfn];
       if (thisArg) {
         args.push(thisArg);
       }
       return ArrayValue.createTemporalWithWidenedNumericProperty(
         realm,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "filter" }),
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL"),
         { func: callbackfn, thisVal: thisArg }
       );
     }
@@ -491,7 +491,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("find") === undefined
     ) {
-      let args = [O, predicate];
+      let args = [O, new StringValue(realm, "find"), predicate];
       if (thisArg) {
         args.push(thisArg);
       }
@@ -499,7 +499,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         Value,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "find" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -552,7 +552,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("findIndex") === undefined
     ) {
-      let args = [O, predicate];
+      let args = [O, new StringValue(realm, "findIndex"), predicate];
       if (thisArg) {
         args.push(thisArg);
       }
@@ -560,7 +560,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         NumberValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "findIndex" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -613,7 +613,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("forEach") === undefined
     ) {
-      let args = [O, callbackfn];
+      let args = [O, new StringValue(realm, "forEach"), callbackfn];
       if (thisArg) {
         args.push(thisArg);
       }
@@ -621,7 +621,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         BooleanValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "forEach" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
       return realm.intrinsics.undefined;
     }
@@ -679,7 +679,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm.isInPureScope() &&
         O.$GetOwnProperty("includes") === undefined
       ) {
-        let args = [O, searchElement];
+        let args = [O, new StringValue(realm, "includes"), searchElement];
         if (fromIndex) {
           args.push(fromIndex);
         }
@@ -687,7 +687,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
           realm,
           BooleanValue,
           args,
-          createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "includes" })
+          createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
         );
       }
 
@@ -742,7 +742,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("indexOf") === undefined
     ) {
-      let args = [O, searchElement];
+      let args = [O, new StringValue(realm, "indexOf"), searchElement];
       if (fromIndex) {
         args.push(fromIndex);
       }
@@ -750,7 +750,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         NumberValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "indexOf" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -818,7 +818,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("join") === undefined
     ) {
-      let args = [O];
+      let args = [O, new StringValue(realm, "join")];
       if (separator) {
         args.push(separator);
       }
@@ -826,7 +826,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         StringValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "join" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -899,8 +899,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
-        [O],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "keys" })
+        [O, new StringValue(realm, "keys")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -921,7 +921,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("lastIndexOf") === undefined
     ) {
-      let args = [O, searchElement];
+      let args = [O, new StringValue(realm, "lastIndexOf"), searchElement];
       if (fromIndex) {
         args.push(fromIndex);
       }
@@ -929,7 +929,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         NumberValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "lastIndexOf" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -988,14 +988,14 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("map") === undefined
     ) {
-      let args = [O, callbackfn];
+      let args = [O, new StringValue(realm, "map"), callbackfn];
       if (thisArg) {
         args.push(thisArg);
       }
       return ArrayValue.createTemporalWithWidenedNumericProperty(
         realm,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "map" }),
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL"),
         { func: callbackfn, thisVal: thisArg }
       );
     }
@@ -1084,8 +1084,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
-        [O],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "pop" })
+        [O, new StringValue(realm, "pop")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -1137,8 +1137,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         NumberValue,
-        [O, ...args],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "push" })
+        [O, new StringValue(realm, "push"), ...args],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -1188,7 +1188,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("reduce") === undefined
     ) {
-      let args = [O, callbackfn];
+      let args = [O, new StringValue(realm, "reduce"), callbackfn];
       if (initialValue) {
         args.push(initialValue);
       }
@@ -1196,7 +1196,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         Value,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "reduce" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -1295,7 +1295,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("reduceRight") === undefined
     ) {
-      let args = [O, callbackfn];
+      let args = [O, new StringValue(realm, "reduceRight"), callbackfn];
       if (initialValue) {
         args.push(initialValue);
       }
@@ -1303,7 +1303,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         Value,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "reduceRight" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -1403,8 +1403,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       AbstractValue.createTemporalFromBuildFunction(
         realm,
         ArrayValue,
-        [O],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "reverse" })
+        [O, new StringValue(realm, "reverse")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
       return O;
     }
@@ -1506,8 +1506,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
-        [O],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "shift" })
+        [O, new StringValue(realm, "shift")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -1577,11 +1577,11 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("slice") === undefined
     ) {
-      let newArgs = [O, start, end];
+      let newArgs = [O, new StringValue(realm, "slice"), start, end];
       return ArrayValue.createTemporalWithWidenedNumericProperty(
         realm,
         newArgs,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "slice" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -1653,7 +1653,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("some") === undefined
     ) {
-      let args = [O, callbackfn];
+      let args = [O, new StringValue(realm, "some"), callbackfn];
       if (thisArg) {
         args.push(thisArg);
       }
@@ -1661,7 +1661,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         BooleanValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "some" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -1723,12 +1723,12 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("sort") === undefined
     ) {
-      let args = [O, comparefn];
+      let args = [O, new StringValue(realm, "sort"), comparefn];
       AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "sort" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
       // context is returned instead of O at the end of this method
       // so we do the same here
@@ -1909,7 +1909,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       realm.isInPureScope() &&
       O.$GetOwnProperty("splice") === undefined
     ) {
-      let args = [O, start];
+      let args = [O, new StringValue(realm, "splice"), start];
       if (deleteCount) {
         args.push(deleteCount);
       }
@@ -1920,7 +1920,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
         realm,
         ArrayValue,
         args,
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "splice" })
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -2120,8 +2120,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         StringValue,
-        [array],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "toLocaleString" })
+        [array, new StringValue(realm, "toLocaleString")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 
@@ -2200,8 +2200,8 @@ export default function(realm: Realm, obj: ObjectValue): void {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         NumberValue,
-        [O],
-        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL", { propName: "unshift" })
+        [O, new StringValue(realm, "unshift")],
+        createOperationDescriptor("UNKNOWN_ARRAY_METHOD_PROPERTY_CALL")
       );
     }
 

--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -202,8 +202,8 @@ function createMagicGlobalFunction(realm: Realm, global: ObjectValue | AbstractO
       let val = AbstractValue.createTemporalFromBuildFunction(
         realm,
         FunctionValue,
-        args,
-        createOperationDescriptor("FB_MOCKS_MAGIC_GLOBAL_FUNCTION", { propName: functionName }),
+        [new StringValue(realm, functionName), ...args],
+        createOperationDescriptor("FB_MOCKS_MAGIC_GLOBAL_FUNCTION"),
         { skipInvariant: true, isPure: true }
       );
       invariant(val instanceof AbstractValue);

--- a/src/intrinsics/fb-www/react-native-mocks.js
+++ b/src/intrinsics/fb-www/react-native-mocks.js
@@ -1659,8 +1659,8 @@ export function createMockReactNative(realm: Realm, reactNativeRequireName: stri
   let RCTViewDerivedReference = AbstractValue.createTemporalFromBuildFunction(
     realm,
     StringValue,
-    [],
-    createOperationDescriptor("REACT_NATIVE_STRING_LITERAL", { propName: "RCTView" }),
+    [new StringValue(realm, "RCTView")],
+    createOperationDescriptor("REACT_NATIVE_STRING_LITERAL"),
     { skipInvariant: true, isPure: true }
   );
   invariant(RCTViewDerivedReference instanceof AbstractValue);
@@ -1669,8 +1669,8 @@ export function createMockReactNative(realm: Realm, reactNativeRequireName: stri
   let RCTTextDerivedReference = AbstractValue.createTemporalFromBuildFunction(
     realm,
     StringValue,
-    [],
-    createOperationDescriptor("REACT_NATIVE_STRING_LITERAL", { propName: "RCTText" }),
+    [new StringValue(realm, "RCTText")],
+    createOperationDescriptor("REACT_NATIVE_STRING_LITERAL"),
     { skipInvariant: true, isPure: true }
   );
   invariant(RCTTextDerivedReference instanceof AbstractValue);

--- a/src/intrinsics/fb-www/relay-mocks.js
+++ b/src/intrinsics/fb-www/relay-mocks.js
@@ -10,7 +10,13 @@
 /* @flow */
 
 import type { Realm } from "../../realm.js";
-import { ObjectValue, FunctionValue, AbstractValue, ECMAScriptSourceFunctionValue } from "../../values/index.js";
+import {
+  AbstractValue,
+  ECMAScriptSourceFunctionValue,
+  FunctionValue,
+  ObjectValue,
+  StringValue,
+} from "../../values/index.js";
 import { Create, Environment } from "../../singletons.js";
 import { createAbstract } from "../prepack/utils.js";
 import { Get } from "../../methods/index.js";
@@ -112,8 +118,8 @@ function createReactRelayContainer(
     let value = AbstractValue.createTemporalFromBuildFunction(
       realm,
       FunctionValue,
-      [reactRelay, ...args],
-      createOperationDescriptor("REACT_RELAY_MOCK_CONTAINER", { propName: containerName }),
+      [reactRelay, new StringValue(realm, containerName), ...args],
+      createOperationDescriptor("REACT_RELAY_MOCK_CONTAINER"),
       { skipInvariant: true, isPure: true }
     );
     invariant(value instanceof AbstractValue);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1181,15 +1181,14 @@ export class PropertiesImplementation {
 
       invariant(realm.generator);
       let propName = P;
-      if (P instanceof StringValue) {
-        propName = P.value;
+      if (typeof propName === "string") {
+        propName = new StringValue(realm, propName);
       }
-      invariant(typeof propName === "string");
       let absVal = AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
-        [O._templateFor || O],
-        createOperationDescriptor("ABSTRACT_PROPERTY", { propName }),
+        [O._templateFor || O, propName],
+        createOperationDescriptor("ABSTRACT_PROPERTY"),
         { isPure: true }
       );
       // TODO: We can't be sure what the descriptor will be, but the value will be abstract.
@@ -1216,16 +1215,16 @@ export class PropertiesImplementation {
                 return AbstractValue.createFromBuildFunction(
                   realm,
                   type,
-                  [O._templateFor || O],
-                  createOperationDescriptor("ABSTRACT_PROPERTY", { propName: P }),
+                  [O._templateFor || O, new StringValue(realm, P)],
+                  createOperationDescriptor("ABSTRACT_PROPERTY"),
                   { kind: AbstractValue.makeKind("property", P) }
                 );
               } else {
                 return AbstractValue.createTemporalFromBuildFunction(
                   realm,
                   type,
-                  [O._templateFor || O],
-                  createOperationDescriptor("ABSTRACT_PROPERTY", { propName: P }),
+                  [O._templateFor || O, new StringValue(realm, P)],
+                  createOperationDescriptor("ABSTRACT_PROPERTY"),
                   { skipInvariant: true, isPure: true }
                 );
               }

--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -262,7 +262,6 @@ export class WidenImplementation {
             (key instanceof AbstractValue && !(key.mightNotBeString() && key.mightNotBeNumber()))
           ) {
             if (typeof key === "string") {
-              debugger;
               pathNode = AbstractValue.createFromWidenedProperty(
                 realm,
                 rval,

--- a/src/methods/widen.js
+++ b/src/methods/widen.js
@@ -19,7 +19,7 @@ import { AbruptCompletion, PossiblyNormalCompletion, SimpleNormalCompletion } fr
 import { Reference } from "../environment.js";
 import { cloneDescriptor, equalDescriptors, IsDataDescriptor, StrictEqualityComparison } from "./index.js";
 import { Generator, createOperationDescriptor } from "../utils/generator.js";
-import { AbstractValue, ArrayValue, EmptyValue, Value } from "../values/index.js";
+import { AbstractValue, ArrayValue, EmptyValue, Value, StringValue } from "../values/index.js";
 
 import invariant from "../invariant.js";
 
@@ -262,11 +262,12 @@ export class WidenImplementation {
             (key instanceof AbstractValue && !(key.mightNotBeString() && key.mightNotBeNumber()))
           ) {
             if (typeof key === "string") {
+              debugger;
               pathNode = AbstractValue.createFromWidenedProperty(
                 realm,
                 rval,
-                [b.object],
-                createOperationDescriptor("WIDEN_PROPERTY", { propName: key })
+                [b.object, new StringValue(realm, key)],
+                createOperationDescriptor("WIDEN_PROPERTY")
               );
             } else {
               invariant(key instanceof AbstractValue);
@@ -274,7 +275,7 @@ export class WidenImplementation {
                 realm,
                 rval,
                 [b.object, key],
-                createOperationDescriptor("WIDEN_ABSTRACT_PROPERTY")
+                createOperationDescriptor("WIDEN_PROPERTY")
               );
             }
             // The value of the property at the start of the loop needs to be written to the property
@@ -290,8 +291,8 @@ export class WidenImplementation {
                 generator.emitVoidExpression(
                   rval.types,
                   rval.values,
-                  [b.object, initVal],
-                  createOperationDescriptor("WIDEN_PROPERTY_ASSIGNMENT", { propName: key })
+                  [b.object, new StringValue(realm, key), initVal],
+                  createOperationDescriptor("WIDEN_PROPERTY_ASSIGNMENT")
                 );
               } else {
                 invariant(key instanceof AbstractValue);
@@ -299,7 +300,7 @@ export class WidenImplementation {
                   rval.types,
                   rval.values,
                   [b.object, key, initVal],
-                  createOperationDescriptor("WIDEN_ABSTRACT_PROPERTY_ASSIGNMENT")
+                  createOperationDescriptor("WIDEN_PROPERTY_ASSIGNMENT")
                 );
               }
             }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1686,8 +1686,8 @@ export class Realm {
     if (!propertyValue.isIntrinsic()) {
       propertyValue.intrinsicName = `${path}.${key}`;
       propertyValue.kind = "rebuiltProperty";
-      propertyValue.args = [object];
-      propertyValue.operationDescriptor = createOperationDescriptor("REBUILT_OBJECT", { propName: key });
+      propertyValue.args = [object, new StringValue(this, key)];
+      propertyValue.operationDescriptor = createOperationDescriptor("REBUILT_OBJECT");
       let intrinsicName = propertyValue.intrinsicName;
       invariant(intrinsicName !== undefined);
       this.rebuildNestedProperties(propertyValue, intrinsicName);

--- a/src/realm.js
+++ b/src/realm.js
@@ -1196,8 +1196,8 @@ export class Realm {
       if (typeof keyKey === "string") {
         if (path !== undefined) {
           gen.emitStatement(
-            [key.object, tval || value, this.intrinsics.empty],
-            createOperationDescriptor("CONDITIONAL_PROPERTY_ASSIGNMENT", { binding: key, path, value })
+            [key.object, tval || value, this.intrinsics.empty, new StringValue(this, keyKey)],
+            createOperationDescriptor("CONDITIONAL_PROPERTY_ASSIGNMENT", { path, value })
           );
         } else {
           // RH value was not widened, so it must have been a constant. We don't need to assign that inside the loop.

--- a/src/serializer/ResidualOperationSerializer.js
+++ b/src/serializer/ResidualOperationSerializer.js
@@ -28,7 +28,12 @@ import invariant from "../invariant.js";
 import { type Binding } from "../environment.js";
 import * as t from "@babel/types";
 import { AbstractValue, EmptyValue, ObjectValue, Value } from "../values/index.js";
-import type { BabelNodeBlockStatement, BabelNodeExpression, BabelNodeSpreadElement } from "@babel/types";
+import type {
+  BabelNodeBlockStatement,
+  BabelNodeExpression,
+  BabelNodeSpreadElement,
+  BabelNodeStringLiteral,
+} from "@babel/types";
 import { Utils } from "../singletons.js";
 import type { PropertyBinding } from "../types.js";
 
@@ -90,7 +95,7 @@ export class ResidualOperationSerializer {
 
     switch (type) {
       case "IDENTIFIER":
-        babelNode = this._serializeIdentifier(data);
+        babelNode = this._serializeIdentifier(data, nodes);
         break;
       case "REBUILT_OBJECT":
         babelNode = this._serializeRebuiltObject(data, nodes);
@@ -129,7 +134,7 @@ export class ResidualOperationSerializer {
         babelNode = this._serializeGlobalAssignment(data, nodes);
         break;
       case "GLOBAL_DELETE":
-        babelNode = this._serializeGlobalDelete(data);
+        babelNode = this._serializeGlobalDelete(data, nodes);
         break;
       case "EMIT_PROPERTY_ASSIGNMENT":
         babelNode = this._serializeEmitPropertyAssignment(data, nodes, context);
@@ -197,9 +202,6 @@ export class ResidualOperationSerializer {
       case "ABSTRACT_OBJECT_SET_PARTIAL":
         babelNode = this._serializeAbstractObjectSetPartial(data, nodes);
         break;
-      case "ABSTRACT_OBJECT_SET_PARTIAL_VALUE":
-        babelNode = this._serializeAbstractObjectSetPartialValue(data, nodes);
-        break;
       case "ABSTRACT_OBJECT_GET_PROTO_OF":
         babelNode = this._serializeAbstractObjectGetProtoOf(data, nodes);
         break;
@@ -243,7 +245,7 @@ export class ResidualOperationSerializer {
         babelNode = this._serializeConsoleLog(data, nodes);
         break;
       case "MODULES_REQUIRE":
-        babelNode = this._serializeModulesRequires(data);
+        babelNode = this._serializeModulesRequires(data, nodes);
         break;
       case "RESIDUAL_CALL":
         babelNode = this._serializeResidualCall(data, nodes);
@@ -255,19 +257,13 @@ export class ResidualOperationSerializer {
         babelNode = this._serializeCannotBecomeObject(data, nodes);
         break;
       case "WIDENED_IDENTIFIER":
-        babelNode = this._serializeIdentifier(data);
+        babelNode = this._serializeIdentifier(data, nodes);
         break;
       case "WIDEN_PROPERTY":
         babelNode = this._serializeWidenProperty(data, nodes);
         break;
-      case "WIDEN_ABSTRACT_PROPERTY":
-        babelNode = this._serializeWidenAbstractProperty(data, nodes);
-        break;
       case "WIDEN_PROPERTY_ASSIGNMENT":
         babelNode = this._serializeWidenPropertyAssignment(data, nodes);
-        break;
-      case "WIDEN_ABSTRACT_PROPERTY_ASSIGNMENT":
-        babelNode = this._serializeWidenAbstractPropertyAssignment(data, nodes);
         break;
 
       // Invariants
@@ -318,7 +314,7 @@ export class ResidualOperationSerializer {
         babelNode = this._serializeReactCreateContextProvider(data, nodes);
         break;
       case "REACT_NATIVE_STRING_LITERAL":
-        babelNode = this._serializeReactNativeStringLiteral(data);
+        babelNode = this._serializeReactNativeStringLiteral(data, nodes);
         break;
       case "REACT_RELAY_MOCK_CONTAINER":
         babelNode = this._serializeReactRelayMockContainer(data, nodes);
@@ -349,15 +345,15 @@ export class ResidualOperationSerializer {
   }
 
   _serializeAppendGenerator(
-    { generator, propName: leadingComment }: OperationDescriptorData,
-    node: Array<BabelNodeExpression>,
+    { generator }: OperationDescriptorData,
+    [leadingCommentNode]: Array<BabelNodeExpression>,
     context?: SerializationContext,
     valuesToProcess?: Set<AbstractValue | ObjectValue>
   ) {
     invariant(context !== undefined);
     invariant(generator !== undefined);
-    invariant(leadingComment !== undefined);
     invariant(valuesToProcess !== undefined);
+    let leadingComment = ((leadingCommentNode: any): BabelNodeStringLiteral).value;
     let statements = context.serializeGenerator(generator, valuesToProcess);
     if (statements.length === 1) {
       let statement = statements[0];
@@ -380,12 +376,7 @@ export class ResidualOperationSerializer {
     );
   }
 
-  _serializeWidenAbstractPropertyAssignment(data: OperationDescriptorData, [o, p, v]: Array<BabelNodeExpression>) {
-    return t.assignmentExpression("=", memberExpressionHelper(o, p), v);
-  }
-
-  _serializeWidenPropertyAssignment({ propName }: OperationDescriptorData, [o, v]: Array<BabelNodeExpression>) {
-    invariant(typeof propName === "string");
+  _serializeWidenPropertyAssignment(data: OperationDescriptorData, [o, propName, v]: Array<BabelNodeExpression>) {
     return t.assignmentExpression("=", memberExpressionHelper(o, propName), v);
   }
 
@@ -393,21 +384,14 @@ export class ResidualOperationSerializer {
     return memberExpressionHelper(o, p);
   }
 
-  _serializeWidenProperty({ propName }: OperationDescriptorData, [o]: Array<BabelNodeExpression>) {
-    invariant(typeof propName === "string");
+  _serializeWidenProperty(data: OperationDescriptorData, [o, propName]: Array<BabelNodeExpression>) {
+    debugger;
     return memberExpressionHelper(o, propName);
   }
 
-  _serializeAbstractObjectGet(
-    { propertyGetter, propName: P }: OperationDescriptorData,
-    [o]: Array<BabelNodeExpression>
-  ) {
-    invariant(typeof P === "string");
+  _serializeAbstractObjectGet({ propertyGetter }: OperationDescriptorData, [o, P]: Array<BabelNodeExpression>) {
     return propertyGetter !== undefined
-      ? t.callExpression(t.memberExpression(t.identifier("global"), t.identifier("__prop_" + propertyGetter)), [
-          o,
-          t.stringLiteral(P),
-        ])
+      ? t.callExpression(t.memberExpression(t.identifier("global"), t.identifier("__prop_" + propertyGetter)), [o, P])
       : memberExpressionHelper(o, P);
   }
 
@@ -428,22 +412,21 @@ export class ResidualOperationSerializer {
     return t.callExpression(nodes[0], ((nodes.slice(1): any): Array<BabelNodeExpression | BabelNodeSpreadElement>));
   }
 
-  _serializeModulesRequires({ propName }: OperationDescriptorData) {
-    invariant(propName !== undefined);
-    return t.callExpression(t.identifier("require"), [t.valueToNode(propName)]);
+  _serializeModulesRequires(data: OperationDescriptorData, [propName]: Array<BabelNodeExpression>) {
+    return t.callExpression(t.identifier("require"), [propName]);
   }
 
-  _serializeConcreteModel({ propName }: OperationDescriptorData, [valueNode]: Array<BabelNodeExpression>) {
-    invariant(propName !== undefined);
+  _serializeConcreteModel(data: OperationDescriptorData, [valueNode, propName]: Array<BabelNodeExpression>) {
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
     return t.expressionStatement(
-      t.assignmentExpression("=", this.preludeGenerator.globalReference(propName, false), valueNode)
+      t.assignmentExpression("=", this.preludeGenerator.globalReference(propString, false), valueNode)
     );
   }
 
-  _serializeConsoleLog({ propName }: OperationDescriptorData, nodes: Array<BabelNodeExpression>) {
-    invariant(propName !== undefined);
+  _serializeConsoleLog(data: OperationDescriptorData, [propName, ...nodes]: Array<BabelNodeExpression>) {
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
     return t.expressionStatement(
-      t.callExpression(t.memberExpression(t.identifier("console"), t.identifier(propName)), [...nodes])
+      t.callExpression(t.memberExpression(t.identifier("console"), t.identifier(propString)), [...nodes])
     );
   }
 
@@ -478,13 +461,14 @@ export class ResidualOperationSerializer {
     );
   }
 
-  _serializeFullInvariant({ propName }: OperationDescriptorData, [objectNode, valueNode]: Array<BabelNodeExpression>) {
-    invariant(propName !== undefined);
+  _serializeFullInvariant(
+    data: OperationDescriptorData,
+    [propName, objectNode, valueNode]: Array<BabelNodeExpression>
+  ) {
     return t.binaryExpression("!==", memberExpressionHelper(objectNode, propName), valueNode);
   }
 
-  _serializeFullInvariantFunction({ propName }: OperationDescriptorData, [objectNode]: Array<BabelNodeExpression>) {
-    invariant(typeof propName === "string");
+  _serializeFullInvariantFunction(data: OperationDescriptorData, [propName, objectNode]: Array<BabelNodeExpression>) {
     return t.binaryExpression(
       "!==",
       t.unaryExpression("typeof", memberExpressionHelper(objectNode, propName), true),
@@ -494,7 +478,7 @@ export class ResidualOperationSerializer {
 
   _serializeFullInvariantAbstract(
     { concreteComparisons, typeComparisons }: OperationDescriptorData,
-    [valueNode]: Array<BabelNodeExpression>
+    [propName, valueNode]: Array<BabelNodeExpression>
   ) {
     invariant(concreteComparisons !== undefined);
     invariant(typeComparisons !== undefined);
@@ -513,20 +497,18 @@ export class ResidualOperationSerializer {
     return checks.reduce((expr, newCondition) => t.logicalExpression("&&", expr, newCondition));
   }
 
-  _serializeInvariantAppend({ propName }: OperationDescriptorData, [objectNode]: Array<BabelNodeExpression>) {
-    invariant(typeof propName === "string");
+  _serializeInvariantAppend(data: OperationDescriptorData, [propName, objectNode]: Array<BabelNodeExpression>) {
     return memberExpressionHelper(objectNode, propName);
   }
 
-  _serializePropertyInvariant({ propName, state }: OperationDescriptorData, [objectNode]: Array<BabelNodeExpression>) {
+  _serializePropertyInvariant({ state }: OperationDescriptorData, [propName, objectNode]: Array<BabelNodeExpression>) {
     invariant(state !== undefined);
-    invariant(typeof propName === "string");
     let n = t.callExpression(
       t.memberExpression(
         this.preludeGenerator.memoizeReference("Object.prototype.hasOwnProperty"),
         t.identifier("call")
       ),
-      [objectNode, t.stringLiteral(propName)]
+      [objectNode, propName]
     );
     if (state !== "MISSING") {
       n = t.unaryExpression("!", n, true);
@@ -545,16 +527,19 @@ export class ResidualOperationSerializer {
     return t.binaryExpression(op, oldValNode, t.numericLiteral(1));
   }
 
-  _serializeDerivedAbstractInvariant({ typeofString }: OperationDescriptorData, nodes: Array<BabelNodeExpression>) {
+  _serializeDerivedAbstractInvariant(
+    { typeofString }: OperationDescriptorData,
+    [propName, typeofNode]: Array<BabelNodeExpression>
+  ) {
     invariant(typeofString !== undefined);
-    let condition = t.binaryExpression("!==", t.unaryExpression("typeof", nodes[0]), t.stringLiteral(typeofString));
+    let condition = t.binaryExpression("!==", t.unaryExpression("typeof", typeofNode), t.stringLiteral(typeofString));
     if (typeofString === "object") {
       condition = t.logicalExpression(
         "&&",
         condition,
-        t.binaryExpression("!==", t.unaryExpression("typeof", nodes[0]), t.stringLiteral("function"))
+        t.binaryExpression("!==", t.unaryExpression("typeof", typeofNode), t.stringLiteral("function"))
       );
-      condition = t.logicalExpression("||", condition, t.binaryExpression("===", nodes[0], nullExpression));
+      condition = t.logicalExpression("||", condition, t.binaryExpression("===", typeofNode, nullExpression));
     }
     return condition;
   }
@@ -569,9 +554,10 @@ export class ResidualOperationSerializer {
       t.numericLiteral(this.preludeGenerator.nextInvariantId++),
     ];
     if (appendLastToInvariantOperationDescriptor) {
+      let propName = nodes[0];
       let last = nodes.pop();
       messageComponents.push(t.stringLiteral("): "));
-      messageComponents.push(this.serialize(appendLastToInvariantOperationDescriptor, [last]));
+      messageComponents.push(this.serialize(appendLastToInvariantOperationDescriptor, [propName, last]));
     } else {
       messageComponents.push(t.stringLiteral(")"));
     }
@@ -584,12 +570,12 @@ export class ResidualOperationSerializer {
   }
 
   _serializeReactRelayMockContainer(
-    { propName }: OperationDescriptorData,
-    [reactRelayIdent, ...otherArgs]: Array<BabelNodeExpression>
+    data: OperationDescriptorData,
+    [reactRelayIdent, propName, ...otherArgs]: Array<BabelNodeExpression>
   ) {
-    invariant(typeof propName === "string");
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
     return t.callExpression(
-      t.memberExpression(reactRelayIdent, t.identifier(propName)),
+      t.memberExpression(reactRelayIdent, t.identifier(propString)),
       ((otherArgs: any): Array<any>)
     );
   }
@@ -663,9 +649,8 @@ export class ResidualOperationSerializer {
     return t.expressionStatement(t.assignmentExpression("=", (id: any), v));
   }
 
-  _serializeReactNativeStringLiteral({ propName }: OperationDescriptorData) {
-    invariant(typeof propName === "string");
-    return t.stringLiteral(propName);
+  _serializeReactNativeStringLiteral(data: OperationDescriptorData, [propName]: Array<BabelNodeExpression>) {
+    return propName;
   }
 
   _serializeReactCreateContextProvider(data: OperationDescriptorData, [consumerNode]: Array<BabelNodeExpression>) {
@@ -698,33 +683,33 @@ export class ResidualOperationSerializer {
     return t.callExpression(t.memberExpression(methodNode, t.identifier("call")), [objectNode, nameNode]);
   }
 
-  _serializeRebuiltObject({ propName }: OperationDescriptorData, [node]: Array<BabelNodeExpression>) {
-    invariant(typeof propName === "string");
-    return t.isValidIdentifier(propName)
-      ? t.memberExpression(node, t.identifier(propName), false)
-      : t.memberExpression(node, t.stringLiteral(propName), true);
+  _serializeRebuiltObject(data: OperationDescriptorData, [node, propName]: Array<BabelNodeExpression>) {
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
+    return t.isValidIdentifier(propString)
+      ? t.memberExpression(node, t.identifier(propString), false)
+      : t.memberExpression(node, propName, true);
   }
 
-  _serializeGlobalDelete({ propName }: OperationDescriptorData) {
-    invariant(typeof propName === "string");
-    return t.expressionStatement(t.unaryExpression("delete", this.preludeGenerator.globalReference(propName, false)));
+  _serializeGlobalDelete(data: OperationDescriptorData, [propName]: Array<BabelNodeExpression>) {
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
+    return t.expressionStatement(t.unaryExpression("delete", this.preludeGenerator.globalReference(propString, false)));
   }
 
   _serializeDefineProperty(
-    { object, propName, desc }: OperationDescriptorData,
-    args: Array<BabelNodeExpression>,
+    { object, desc }: OperationDescriptorData,
+    [propName]: Array<BabelNodeExpression>,
     context?: SerializationContext
   ) {
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
     invariant(object !== undefined);
-    invariant(propName !== undefined);
     invariant(desc !== undefined);
     invariant(context !== undefined);
-    return context.emitDefinePropertyBody(object, propName, desc);
+    return context.emitDefinePropertyBody(object, propString, desc);
   }
 
-  _serializeFBMocksMagicGlobalFunction({ propName }: OperationDescriptorData, args: Array<BabelNodeExpression>) {
-    invariant(typeof propName === "string");
-    return t.callExpression(t.identifier(propName), ((args: any): Array<any>));
+  _serializeFBMocksMagicGlobalFunction(data: OperationDescriptorData, [propName, ...args]: Array<BabelNodeExpression>) {
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
+    return t.callExpression(t.identifier(propString), ((args: any): Array<any>));
   }
 
   _serializeFBMocksBootloaderLoadModules(data: OperationDescriptorData, args: Array<BabelNodeExpression>) {
@@ -735,14 +720,6 @@ export class ResidualOperationSerializer {
   }
 
   _serializeAbstractObjectSetPartial(
-    { propName }: OperationDescriptorData,
-    [objectNode, valueNode]: Array<BabelNodeExpression>
-  ) {
-    invariant(typeof propName === "string");
-    return t.expressionStatement(t.assignmentExpression("=", memberExpressionHelper(objectNode, propName), valueNode));
-  }
-
-  _serializeAbstractObjectSetPartialValue(
     data: OperationDescriptorData,
     [objectNode, keyNode, valueNode]: Array<BabelNodeExpression>
   ) {
@@ -768,7 +745,7 @@ export class ResidualOperationSerializer {
     return t.expressionStatement(t.assignmentExpression("=", memberExpressionHelper(objectNode, keyNode), valueNode));
   }
 
-  _serializeIdentifier(data: OperationDescriptorData) {
+  _serializeIdentifier(data: OperationDescriptorData, nodes: Array<BabelNodeExpression>) {
     invariant(typeof data.id === "string");
     return t.identifier(data.id);
   }
@@ -797,11 +774,11 @@ export class ResidualOperationSerializer {
   }
 
   _serializeUnknownArrayMethodPropertyCall(
-    { propName }: OperationDescriptorData,
-    [objNode, ..._args]: Array<BabelNodeExpression>
+    data: OperationDescriptorData,
+    [objNode, propName, ..._args]: Array<BabelNodeExpression>
   ) {
-    invariant(typeof propName === "string");
-    return t.callExpression(t.memberExpression(objNode, t.identifier(propName)), ((_args: any): Array<any>));
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
+    return t.callExpression(t.memberExpression(objNode, t.identifier(propString)), ((_args: any): Array<any>));
   }
 
   _serializeThrow(data: OperationDescriptorData, [argument]: Array<BabelNodeExpression>) {
@@ -841,8 +818,7 @@ export class ResidualOperationSerializer {
     return t.callExpression(helperNode, [valueNode]);
   }
 
-  _serializePropertyDelete({ propName }: OperationDescriptorData, [objectNode]: Array<BabelNodeExpression>) {
-    invariant(propName !== undefined);
+  _serializePropertyDelete(data: OperationDescriptorData, [objectNode, propName]: Array<BabelNodeExpression>) {
     return t.expressionStatement(t.unaryExpression("delete", memberExpressionHelper(objectNode, propName)));
   }
 
@@ -922,13 +898,12 @@ export class ResidualOperationSerializer {
   }
 
   _serializeEmitPropertyAssignment(
-    { propName, value }: OperationDescriptorData,
-    [objectNode, valueNode]: Array<BabelNodeExpression>,
+    { value }: OperationDescriptorData,
+    [objectNode, valueNode, propName]: Array<BabelNodeExpression>,
     context?: SerializationContext
   ) {
     invariant(context !== undefined);
     invariant(value instanceof Value);
-    invariant(typeof propName === "string");
     return context.getPropertyAssignmentStatement(
       memberExpressionHelper(objectNode, propName),
       value,
@@ -937,10 +912,10 @@ export class ResidualOperationSerializer {
     );
   }
 
-  _serializeGlobalAssignment({ propName }: OperationDescriptorData, [valueNode]: Array<BabelNodeExpression>) {
-    invariant(typeof propName === "string");
+  _serializeGlobalAssignment(data: OperationDescriptorData, [valueNode, propName]: Array<BabelNodeExpression>) {
+    let propString = ((propName: any): BabelNodeStringLiteral).value;
     return t.expressionStatement(
-      t.assignmentExpression("=", this.preludeGenerator.globalReference(propName, false), valueNode)
+      t.assignmentExpression("=", this.preludeGenerator.globalReference(propString, false), valueNode)
     );
   }
 
@@ -948,8 +923,7 @@ export class ResidualOperationSerializer {
     return o;
   }
 
-  _serializeAbstractProperty({ propName }: OperationDescriptorData, [o]: Array<BabelNodeExpression>) {
-    invariant(propName !== undefined);
+  _serializeAbstractProperty(data: OperationDescriptorData, [o, propName]: Array<BabelNodeExpression>) {
     return memberExpressionHelper(o, propName);
   }
 

--- a/src/serializer/ResidualOperationSerializer.js
+++ b/src/serializer/ResidualOperationSerializer.js
@@ -527,10 +527,10 @@ export class ResidualOperationSerializer {
   }
 
   _serializeDerivedAbstractInvariant(
-    { typeofString }: OperationDescriptorData,
-    [propName, typeofNode]: Array<BabelNodeExpression>
+    data: OperationDescriptorData,
+    [typeOfStringNode, typeofNode]: Array<BabelNodeExpression>
   ) {
-    invariant(typeofString !== undefined);
+    let typeofString = ((typeOfStringNode: any): BabelNodeStringLiteral).value;
     let condition = t.binaryExpression("!==", t.unaryExpression("typeof", typeofNode), t.stringLiteral(typeofString));
     if (typeofString === "object") {
       condition = t.logicalExpression(

--- a/src/utils/babelhelpers.js
+++ b/src/utils/babelhelpers.js
@@ -52,9 +52,6 @@ export function memberExpressionHelper(
   } else if (t.isStringLiteral(property)) {
     propertyExpression = getAsPropertyNameExpression(((property: any): BabelNodeStringLiteral).value);
     computed = !t.isIdentifier(propertyExpression);
-  } else if (t.isIdentifier(property)) {
-    propertyExpression = getAsPropertyNameExpression(((property: any): BabelNodeStringLiteral).name);
-    computed = !t.isIdentifier(propertyExpression);
   } else {
     propertyExpression = property;
     computed = true;

--- a/src/utils/babelhelpers.js
+++ b/src/utils/babelhelpers.js
@@ -52,6 +52,9 @@ export function memberExpressionHelper(
   } else if (t.isStringLiteral(property)) {
     propertyExpression = getAsPropertyNameExpression(((property: any): BabelNodeStringLiteral).value);
     computed = !t.isIdentifier(propertyExpression);
+  } else if (t.isIdentifier(property)) {
+    propertyExpression = getAsPropertyNameExpression(((property: any): BabelNodeStringLiteral).name);
+    computed = !t.isIdentifier(propertyExpression);
   } else {
     propertyExpression = property;
     computed = true;

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -169,7 +169,6 @@ export type OperationDescriptorData = {
   thisArg?: BaseValue | Value,
   template?: PreludeGenerator => ({}) => BabelNodeExpression,
   typeComparisons?: Set<typeof Value>,
-  typeofString?: string,
   usesThis?: boolean,
   value?: Value,
   violationConditionOperationDescriptor?: OperationDescriptor,
@@ -1089,8 +1088,8 @@ export class Generator {
       // Verify that the types are as expected, a failure of this invariant
       // should mean the model is wrong.
       this._emitInvariant(
-        [new StringValue(this.realm, ""), res, res],
-        createOperationDescriptor("DERIVED_ABSTRACT_INVARIANT", { typeofString }),
+        [new StringValue(this.realm, typeofString), res, res],
+        createOperationDescriptor("DERIVED_ABSTRACT_INVARIANT"),
         createOperationDescriptor("SINGLE_ARG")
       );
     }

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -249,8 +249,8 @@ export class ModuleTracer extends Tracer {
             result = AbstractValue.createTemporalFromBuildFunction(
               realm,
               Value,
-              [],
-              createOperationDescriptor("MODULES_REQUIRE", { propName })
+              [new StringValue(realm, propName)],
+              createOperationDescriptor("MODULES_REQUIRE")
             );
           } else {
             result = effects.result;

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -518,8 +518,8 @@ export default class AbstractObjectValue extends AbstractValue {
         let propAbsVal = AbstractValue.createTemporalFromBuildFunction(
           this.$Realm,
           type,
-          [ob],
-          createOperationDescriptor("ABSTRACT_OBJECT_GET", { propertyGetter, propName: P }),
+          [ob, new StringValue(this.$Realm, P)],
+          createOperationDescriptor("ABSTRACT_OBJECT_GET", { propertyGetter }),
           {
             skipInvariant: true,
             isPure: true,
@@ -766,18 +766,15 @@ export default class AbstractObjectValue extends AbstractValue {
             let generator = this.$Realm.generator;
             invariant(generator);
 
-            if (P instanceof StringValue) {
-              P = P.value;
-            }
             if (typeof P === "string") {
               generator.emitStatement(
-                [Receiver, V],
-                createOperationDescriptor("ABSTRACT_OBJECT_SET_PARTIAL", { propName: P })
+                [Receiver, new StringValue(this.$Realm, P), V],
+                createOperationDescriptor("ABSTRACT_OBJECT_SET_PARTIAL")
               );
             } else {
               // Coercion can only have effects on anything reachable from the key.
               Havoc.value(this.$Realm, P);
-              generator.emitStatement([Receiver, P, V], createOperationDescriptor("ABSTRACT_OBJECT_SET_PARTIAL_VALUE"));
+              generator.emitStatement([Receiver, P, V], createOperationDescriptor("ABSTRACT_OBJECT_SET_PARTIAL"));
             }
             return this.$Realm.intrinsics.undefined;
           },


### PR DESCRIPTION
Release notes: none

This refines the `operationDescriptor`  `data` object and removes a bunch of properties, but mainly `propName`. Instead we now feed this around in args, mainly as a `StringValue` removing a bunch of confusing existing logic.