### PR TITLE
Support string with abstract argument

### DIFF
--- a/src/intrinsics/ecma262/String.js
+++ b/src/intrinsics/ecma262/String.js
@@ -10,7 +10,7 @@
 /* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
-import { NativeFunctionValue, NumberValue, StringValue, SymbolValue } from "../../values/index.js";
+import { NativeFunctionValue, NumberValue, StringValue, SymbolValue, Value } from "../../values/index.js";
 import { Get, GetPrototypeFromConstructor, SymbolDescriptiveString } from "../../methods/index.js";
 import { Create, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
@@ -18,7 +18,7 @@ import invariant from "../../invariant.js";
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 21.1.1
   let func = new NativeFunctionValue(realm, "String", "String", 1, (context, [value], argCount, NewTarget) => {
-    let s: ?StringValue;
+    let s: ?Value;
 
     // 1. If no arguments were passed to this function invocation, let s be "".
     if (argCount === 0) {
@@ -38,6 +38,7 @@ export default function(realm: Realm): NativeFunctionValue {
     if (!NewTarget) return s;
 
     // 4. Return ? StringCreate(s, ? GetPrototypeFromConstructor(NewTarget, "%StringPrototype%")).
+    s = s.throwIfNotConcreteString();
     return Create.StringCreate(realm, s, GetPrototypeFromConstructor(realm, NewTarget, "StringPrototype"));
   });
 

--- a/src/intrinsics/ecma262/String.js
+++ b/src/intrinsics/ecma262/String.js
@@ -31,7 +31,7 @@ export default function(realm: Realm): NativeFunctionValue {
       }
 
       // b. Let s be ? ToString(value).
-      s = new StringValue(realm, To.ToStringPartial(realm, value));
+      s = To.ToStringValue(realm, value);
     }
 
     // 3. If NewTarget is undefined, return s.

--- a/src/methods/to.js
+++ b/src/methods/to.js
@@ -719,29 +719,19 @@ export class ToImplementation {
 
   ToStringValue(realm: Realm, val: Value): Value {
     if (val.getType() === StringValue) return val;
-    let str;
-    if (typeof val === "string") {
-      str = val;
-    } else if (val instanceof NumberValue) {
-      str = val.value + "";
-    } else if (val instanceof UndefinedValue) {
-      str = "undefined";
-    } else if (val instanceof NullValue) {
-      str = "null";
-    } else if (val instanceof SymbolValue) {
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
-    } else if (val instanceof BooleanValue) {
-      str = val.value ? "true" : "false";
-    } else if (val instanceof ObjectValue) {
+    if (val instanceof ObjectValue) {
       let primValue = this.ToPrimitiveOrAbstract(realm, val, "string");
       if (primValue.getType() === StringValue) return primValue;
-      str = this.ToStringPartial(realm, primValue);
+      let str = this.ToStringPartial(realm, primValue);
+      return new StringValue(realm, str);
+    } else if (val instanceof ConcreteValue) {
+      let str = this.ToString(realm, val);
+      return new StringValue(realm, str);
     } else if (val instanceof AbstractValue) {
       return this.ToStringAbstract(realm, val);
     } else {
       invariant(false, "unknown value type, can't coerce to string");
     }
-    return new StringValue(realm, str);
   }
 
   ToStringAbstract(realm: Realm, value: AbstractValue): AbstractValue {
@@ -749,7 +739,7 @@ export class ToImplementation {
       let result;
       // If the property is not a string we need to coerce it.
       let coerceToString = createOperationDescriptor("COERCE_TO_STRING");
-      if (value.mightNotBeNumber() && !value.isSimpleObject()) {
+      if (value.mightBeObject() && !value.isSimpleObject()) {
         // If this might be a non-simple object, we need to coerce this at a
         // temporal point since it can have side-effects.
         // We can't rely on comparison to do it later, even if

--- a/test/serializer/abstract/ToString3.js
+++ b/test/serializer/abstract/ToString3.js
@@ -1,0 +1,7 @@
+var a = String(global.__abstract ? __abstract("string", '"foo"') : "foo");
+var b = String(global.__abstract ? __abstract("number", "42") : 42);
+var c = String(global.__abstract ? __abstract("boolean", "true") : true);
+
+inspect = function() {
+  return JSON.stringify({ a, b, c });
+};


### PR DESCRIPTION
I was seeing `throwIfNotConcrete` a lot for `String()` calls on abstract values in #2297. The fix is relatively quick.