### PR TITLE
Add message to error stack

### DIFF
--- a/src/intrinsics/ecma262/Error.js
+++ b/src/intrinsics/ecma262/Error.js
@@ -11,7 +11,14 @@
 
 import type { Realm } from "../../realm.js";
 import type { LexicalEnvironment } from "../../environment.js";
-import { AbstractValue, ObjectValue, FunctionValue, NativeFunctionValue, StringValue } from "../../values/index.js";
+import {
+  AbstractValue,
+  ObjectValue,
+  FunctionValue,
+  NativeFunctionValue,
+  StringValue,
+  Value,
+} from "../../values/index.js";
 import { Get } from "../../methods/index.js";
 import { Create, Properties, To } from "../../singletons.js";
 import invariant from "../../invariant.js";


### PR DESCRIPTION
Because of an ordering bug messages weren’t being added to the error stacks thrown by Prepack. This made debugging runtime issues in generated Prepack code difficult.

### Input

```js
throw new Error("foo");
```

### Output Before

```js
(function() {
  var $$0 = {
    enumerable: false,
    configurable: true,
    writable: true,
  };

  var _$0 = this;

  var _$1 = _$0.Error;
  var _$2 = _$1.prototype;
  var _$3 = _$0.Object;
  var _$4 = _$3.defineProperty;

  var __constructor = function() {};

  var _0 = ((__constructor.prototype = _$2), new __constructor());

  ($$0.value = "Error\n    at /Users/calebmer/prepack/fb-www/input.js:4:7"), _$4(_0, "stack", $$0);
  ($$0.value = "foo"), _$4(_0, "message", $$0);
  throw _0;
}.call(this));
```

### Output After

```js
(function() {
  var $$0 = {
    enumerable: false,
    configurable: true,
    writable: true,
  };

  var _$0 = this;

  var _$1 = _$0.Error;
  var _$2 = _$1.prototype;
  var _$3 = _$0.Object;
  var _$4 = _$3.defineProperty;

  var __constructor = function() {};

  var _0 = ((__constructor.prototype = _$2), new __constructor());

  ($$0.value = "foo"), _$4(_0, "message", $$0);
  ($$0.value = "Error: foo\n    at /Users/calebmer/prepack/fb-www/input.js:4:7"), _$4(_0, "stack", $$0);
  throw _0;
}.call(this));
```