### PR TITLE
Cleanup Effects cloning

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -19,7 +19,7 @@ export class Completion {
     let e = precedingEffects;
     if (e !== undefined) {
       if (e.result === undefined) e.result = this;
-      else e = new Effects(this, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+      else e = e.shallowCloneWithResult(this);
     }
     this.value = value;
     this.effects = e;
@@ -183,13 +183,7 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
   updateConsequentKeepingCurrentEffects(newConsequent: AbruptCompletion): AbruptCompletion {
     let e = this.consequent.effects;
     invariant(e);
-    newConsequent.effects = new Effects(
-      newConsequent,
-      e.generator,
-      e.modifiedBindings,
-      e.modifiedProperties,
-      e.createdObjects
-    );
+    newConsequent.effects = e.shallowCloneWithResult(newConsequent);
     this.consequent = newConsequent;
     return this;
   }
@@ -197,13 +191,7 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
   updateAlternateKeepingCurrentEffects(newAlternate: AbruptCompletion): AbruptCompletion {
     let e = this.alternate.effects;
     invariant(e);
-    newAlternate.effects = new Effects(
-      newAlternate,
-      e.generator,
-      e.modifiedBindings,
-      e.modifiedProperties,
-      e.createdObjects
-    );
+    newAlternate.effects = e.shallowCloneWithResult(newAlternate);
     this.alternate = newAlternate;
     return this;
   }
@@ -319,7 +307,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   updateConsequentKeepingCurrentEffects(newConsequent: Completion): PossiblyNormalCompletion {
     if (newConsequent instanceof NormalCompletion) this.value = newConsequent.value;
     let e = this.consequentEffects;
-    let effects = new Effects(newConsequent, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+    let effects = e.shallowCloneWithResult(newConsequent);
     this.consequent = effects.result;
     return this;
   }
@@ -327,7 +315,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   updateAlternateKeepingCurrentEffects(newAlternate: Completion): PossiblyNormalCompletion {
     if (newAlternate instanceof NormalCompletion) this.value = newAlternate.value;
     let e = this.alternateEffects;
-    let effects = new Effects(newAlternate, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+    let effects = e.shallowCloneWithResult(newAlternate);
     this.alternate = effects.result;
     return this;
   }

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -12,7 +12,6 @@
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion, Completion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
-import { Effects } from "../realm.js";
 import { type LexicalEnvironment, type BaseValue, mightBecomeAnObject } from "../environment.js";
 import { EnvironmentRecord } from "../environment.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -184,12 +183,7 @@ function callBothFunctionsAndJoinTheirEffects(
   if (r1 instanceof Completion) r1 = r1.shallowCloneWithoutEffects();
   let r2 = e2.result;
   if (r2 instanceof Completion) r2 = r2.shallowCloneWithoutEffects();
-  let joinedEffects = Join.joinForkOrChoose(
-    realm,
-    cond,
-    new Effects(r1, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
-    new Effects(r2, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
-  );
+  let joinedEffects = Join.joinForkOrChoose(realm, cond, e1.shallowCloneWithResult(r1), e2.shallowCloneWithResult(r2));
   let completion = joinedEffects.result;
   if (completion instanceof SimpleNormalCompletion) completion = completion.value;
   if (completion instanceof PossiblyNormalCompletion) {

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -154,11 +154,11 @@ export class JoinImplementation {
     invariant(c.savedEffects === undefined); // the caller should ensure this
     let savedPathConditions = pnc.savedPathConditions;
     if (pnc.consequent instanceof AbruptCompletion) {
+      let ae = pnc.alternateEffects;
       let na;
       if (pnc.alternate instanceof SimpleNormalCompletion) {
-        let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.alternateEffects;
         na = c.shallowCloneWithoutEffects();
-        let newAlternateEffects = new Effects(na, generator, modifiedBindings, modifiedProperties, createdObjects);
+        let newAlternateEffects = ae.shallowCloneWithResult(na);
         if (priorEffects) newAlternateEffects = realm.composeEffects(priorEffects, newAlternateEffects);
         return new PossiblyNormalCompletion(
           c.value,
@@ -173,8 +173,7 @@ export class JoinImplementation {
       }
       invariant(pnc.alternate instanceof PossiblyNormalCompletion);
       na = this.composePossiblyNormalCompletions(realm, pnc.alternate, c, priorEffects);
-      let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.alternateEffects;
-      let newAlternateEffects = new Effects(na, generator, modifiedBindings, modifiedProperties, createdObjects);
+      let newAlternateEffects = ae.shallowCloneWithResult(na);
       return new PossiblyNormalCompletion(
         c.value,
         pnc.joinCondition,
@@ -186,11 +185,11 @@ export class JoinImplementation {
         pnc.savedEffects
       );
     } else {
+      let ce = pnc.consequentEffects;
       let nc;
       if (pnc.consequent instanceof SimpleNormalCompletion) {
-        let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.consequentEffects;
         nc = c.shallowCloneWithoutEffects();
-        let newConsequentEffects = new Effects(nc, generator, modifiedBindings, modifiedProperties, createdObjects);
+        let newConsequentEffects = ce.shallowCloneWithResult(nc);
         if (priorEffects) newConsequentEffects = realm.composeEffects(priorEffects, newConsequentEffects);
         return new PossiblyNormalCompletion(
           c.value,
@@ -205,8 +204,7 @@ export class JoinImplementation {
       }
       invariant(pnc.consequent instanceof PossiblyNormalCompletion);
       nc = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
-      let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.consequentEffects;
-      let newConsequentEffects = new Effects(nc, generator, modifiedBindings, modifiedProperties, createdObjects);
+      let newConsequentEffects = ce.shallowCloneWithResult(nc);
       return new PossiblyNormalCompletion(
         c.value,
         pnc.joinCondition,
@@ -296,13 +294,13 @@ export class JoinImplementation {
   ): ForkedAbruptCompletion {
     let recurse = (xpnc, xe, nac, ne): [ForkedAbruptCompletion, Effects] => {
       let nx = this.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, xpnc, nac, ne);
-      let nxe = new Effects(nx, xe.generator, xe.modifiedBindings, xe.modifiedProperties, xe.createdObjects);
+      let nxe = xe.shallowCloneWithResult(nx);
       return [nx, nxe];
     };
 
     let cloneEffects = () => {
       let nac = ac.shallowCloneWithoutEffects();
-      let ne = new Effects(nac, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+      let ne = e.shallowCloneWithResult(nac);
       return [nac, ne];
     };
 

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -11,7 +11,6 @@
 
 import type { BabelNodeCallExpression, BabelNodeExpression, BabelNodeStatement } from "@babel/types";
 import type { Realm } from "../realm.js";
-import { Effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
 import { AbruptCompletion, Completion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
@@ -119,12 +118,7 @@ function callBothFunctionsAndJoinTheirEffects(
   );
   let r2 = e2.result.shallowCloneWithoutEffects();
 
-  let joinedEffects = Join.joinForkOrChoose(
-    realm,
-    cond,
-    new Effects(r1, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
-    new Effects(r2, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
-  );
+  let joinedEffects = Join.joinForkOrChoose(realm, cond, e1.shallowCloneWithResult(r1), e2.shallowCloneWithResult(r2));
   let joinedCompletion = joinedEffects.result;
   if (joinedCompletion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -12,7 +12,6 @@
 import type { BabelNodeIfStatement, BabelNodeStatement } from "@babel/types";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
-import { Effects } from "../realm.js";
 
 import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
 import { Reference } from "../environment.js";
@@ -83,8 +82,8 @@ export default function(
   let joinedEffects = Join.joinForkOrChoose(
     realm,
     exprValue,
-    new Effects(cr, ce.generator, ce.modifiedBindings, ce.modifiedProperties, ce.createdObjects),
-    new Effects(ar, ae.generator, ae.modifiedBindings, ae.modifiedProperties, ae.createdObjects)
+    ce.shallowCloneWithResult(cr),
+    ae.shallowCloneWithResult(ar)
   );
   completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -128,6 +128,10 @@ export class Effects {
   canBeApplied: boolean;
   _id: number;
 
+  shallowCloneWithResult(result: Completion): Effects {
+    return new Effects(result, this.generator, this.modifiedBindings, this.modifiedProperties, this.createdObjects);
+  }
+
   toDisplayString(): string {
     return Utils.jsonToDisplayString(this, 10);
   }


### PR DESCRIPTION
Release note: none

This is just a small code cleanup. Instead of cloning an Effects instance by directly calling the constructor of the clone, now call a clone method and supply only the parameter we want to change.

This is a mechanical refactor.