### PR TITLE
 Simplify forked completion constructors

### DIFF
--- a/src/completions.js
+++ b/src/completions.js
@@ -19,7 +19,7 @@ export class Completion {
     let e = precedingEffects;
     if (e !== undefined) {
       if (e.result === undefined) e.result = this;
-      else e = new Effects(this, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+      else e = e.shallowCloneWithResult(this);
     }
     this.value = value;
     this.effects = e;
@@ -183,13 +183,7 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
   updateConsequentKeepingCurrentEffects(newConsequent: AbruptCompletion): AbruptCompletion {
     let e = this.consequent.effects;
     invariant(e);
-    newConsequent.effects = new Effects(
-      newConsequent,
-      e.generator,
-      e.modifiedBindings,
-      e.modifiedProperties,
-      e.createdObjects
-    );
+    newConsequent.effects = e.shallowCloneWithResult(newConsequent);
     this.consequent = newConsequent;
     return this;
   }
@@ -197,13 +191,7 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
   updateAlternateKeepingCurrentEffects(newAlternate: AbruptCompletion): AbruptCompletion {
     let e = this.alternate.effects;
     invariant(e);
-    newAlternate.effects = new Effects(
-      newAlternate,
-      e.generator,
-      e.modifiedBindings,
-      e.modifiedProperties,
-      e.createdObjects
-    );
+    newAlternate.effects = e.shallowCloneWithResult(newAlternate);
     this.alternate = newAlternate;
     return this;
   }
@@ -319,7 +307,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   updateConsequentKeepingCurrentEffects(newConsequent: Completion): PossiblyNormalCompletion {
     if (newConsequent instanceof NormalCompletion) this.value = newConsequent.value;
     let e = this.consequentEffects;
-    let effects = new Effects(newConsequent, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+    let effects = e.shallowCloneWithResult(newConsequent);
     this.consequent = effects.result;
     return this;
   }
@@ -327,7 +315,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
   updateAlternateKeepingCurrentEffects(newAlternate: Completion): PossiblyNormalCompletion {
     if (newAlternate instanceof NormalCompletion) this.value = newAlternate.value;
     let e = this.alternateEffects;
-    let effects = new Effects(newAlternate, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+    let effects = e.shallowCloneWithResult(newAlternate);
     this.alternate = effects.result;
     return this;
   }

--- a/src/completions.js
+++ b/src/completions.js
@@ -133,19 +133,8 @@ export class ReturnCompletion extends AbruptCompletion {
 }
 
 export class ForkedAbruptCompletion extends AbruptCompletion {
-  constructor(
-    realm: Realm,
-    joinCondition: AbstractValue,
-    consequent: AbruptCompletion,
-    consequentEffects: Effects,
-    alternate: AbruptCompletion,
-    alternateEffects: Effects
-  ) {
+  constructor(realm: Realm, joinCondition: AbstractValue, consequent: AbruptCompletion, alternate: AbruptCompletion) {
     super(realm.intrinsics.empty, undefined, consequent.location);
-    invariant(consequentEffects.result === consequent);
-    invariant(consequent.effects === consequentEffects);
-    invariant(alternateEffects.result === alternate);
-    invariant(alternate.effects === alternateEffects);
     this.joinCondition = joinCondition;
     this.consequent = consequent;
     this.alternate = alternate;
@@ -156,16 +145,7 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
   alternate: AbruptCompletion;
 
   shallowCloneWithoutEffects(): ForkedAbruptCompletion {
-    let consequentEffects = this.consequentEffects;
-    let alternateEffects = this.alternateEffects;
-    return new ForkedAbruptCompletion(
-      this.value.$Realm,
-      this.joinCondition,
-      this.consequent,
-      consequentEffects,
-      this.alternate,
-      alternateEffects
-    );
+    return new ForkedAbruptCompletion(this.value.$Realm, this.joinCondition, this.consequent, this.alternate);
   }
 
   // For convenience, this.consequent.effects should always be defined, but accessing it directly requires
@@ -233,9 +213,7 @@ export class ForkedAbruptCompletion extends AbruptCompletion {
       this.value.$Realm.intrinsics.empty,
       this.joinCondition,
       this.consequent,
-      this.consequentEffects,
       this.alternate,
-      this.alternateEffects,
       []
     );
   }
@@ -249,16 +227,10 @@ export class PossiblyNormalCompletion extends NormalCompletion {
     value: Value,
     joinCondition: AbstractValue,
     consequent: Completion,
-    consequentEffects: Effects,
     alternate: Completion,
-    alternateEffects: Effects,
     savedPathConditions: Array<AbstractValue>,
     savedEffects: void | Effects = undefined
   ) {
-    invariant(consequent === consequentEffects.result);
-    invariant(consequent.effects === consequentEffects);
-    invariant(alternate === alternateEffects.result);
-    invariant(alternate.effects === alternateEffects);
     invariant(consequent instanceof NormalCompletion || alternate instanceof NormalCompletion);
     super(value, undefined, consequent.location);
     this.joinCondition = joinCondition;
@@ -284,9 +256,7 @@ export class PossiblyNormalCompletion extends NormalCompletion {
       this.value,
       this.joinCondition,
       this.consequent,
-      consequentEffects,
       this.alternate,
-      alternateEffects,
       this.savedPathConditions,
       this.savedEffects
     );

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -12,7 +12,6 @@
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { AbruptCompletion, Completion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
-import { Effects } from "../realm.js";
 import { type LexicalEnvironment, type BaseValue, mightBecomeAnObject } from "../environment.js";
 import { EnvironmentRecord } from "../environment.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
@@ -184,12 +183,7 @@ function callBothFunctionsAndJoinTheirEffects(
   if (r1 instanceof Completion) r1 = r1.shallowCloneWithoutEffects();
   let r2 = e2.result;
   if (r2 instanceof Completion) r2 = r2.shallowCloneWithoutEffects();
-  let joinedEffects = Join.joinForkOrChoose(
-    realm,
-    cond,
-    new Effects(r1, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
-    new Effects(r2, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
-  );
+  let joinedEffects = Join.joinForkOrChoose(realm, cond, e1.shallowCloneWithResult(r1), e2.shallowCloneWithResult(r2));
   let completion = joinedEffects.result;
   if (completion instanceof SimpleNormalCompletion) completion = completion.value;
   if (completion instanceof PossiblyNormalCompletion) {

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -164,23 +164,19 @@ export class JoinImplementation {
           c.value,
           pnc.joinCondition,
           pnc.consequent,
-          pnc.consequentEffects,
           newAlternateEffects.result,
-          newAlternateEffects,
           savedPathConditions,
           pnc.savedEffects
         );
       }
       invariant(pnc.alternate instanceof PossiblyNormalCompletion);
       na = this.composePossiblyNormalCompletions(realm, pnc.alternate, c, priorEffects);
-      let newAlternateEffects = ae.shallowCloneWithResult(na);
+      ae.shallowCloneWithResult(na);
       return new PossiblyNormalCompletion(
         c.value,
         pnc.joinCondition,
         pnc.consequent,
-        pnc.consequentEffects,
         na,
-        newAlternateEffects,
         savedPathConditions,
         pnc.savedEffects
       );
@@ -195,23 +191,19 @@ export class JoinImplementation {
           c.value,
           pnc.joinCondition,
           newConsequentEffects.result,
-          newConsequentEffects,
           pnc.alternate,
-          pnc.alternateEffects,
           savedPathConditions,
           pnc.savedEffects
         );
       }
       invariant(pnc.consequent instanceof PossiblyNormalCompletion);
       nc = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
-      let newConsequentEffects = ce.shallowCloneWithResult(nc);
+      ce.shallowCloneWithResult(nc);
       return new PossiblyNormalCompletion(
         c.value,
         pnc.joinCondition,
         nc,
-        newConsequentEffects,
         pnc.alternate,
-        pnc.alternateEffects,
         savedPathConditions,
         pnc.savedEffects
       );
@@ -292,10 +284,10 @@ export class JoinImplementation {
     // effects collected after pnc was constructed
     e: Effects
   ): ForkedAbruptCompletion {
-    let recurse = (xpnc, xe, nac, ne): [ForkedAbruptCompletion, Effects] => {
+    let recurse = (xpnc, xe, nac, ne): ForkedAbruptCompletion => {
       let nx = this.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, xpnc, nac, ne);
-      let nxe = xe.shallowCloneWithResult(nx);
-      return [nx, nxe];
+      xe.shallowCloneWithResult(nx);
+      return nx;
     };
 
     let cloneEffects = () => {
@@ -319,12 +311,11 @@ export class JoinImplementation {
         // todo: simplify with implied path condition
         e = realm.composeEffects(pnc.alternateEffects, e);
         invariant(e.result instanceof AbruptCompletion);
-        ac = e.result;
-        return new ForkedAbruptCompletion(realm, pnc.joinCondition, pncc, pnc.consequentEffects, ac, e);
+        return new ForkedAbruptCompletion(realm, pnc.joinCondition, pncc, e.result);
       }
       invariant(pnca instanceof PossiblyNormalCompletion);
-      let [na, nae] = recurse(pnca, pnc.alternateEffects, ac, e);
-      return new ForkedAbruptCompletion(realm, pnc.joinCondition, pncc, pnc.consequentEffects, na, nae);
+      let na = recurse(pnca, pnc.alternateEffects, ac, e);
+      return new ForkedAbruptCompletion(realm, pnc.joinCondition, pncc, na);
     }
 
     // * case (SimpleNormalCompletion, AbruptCompletion)
@@ -334,12 +325,11 @@ export class JoinImplementation {
         // todo: simplify with implied path condition
         e = realm.composeEffects(pnc.consequentEffects, e);
         invariant(e.result instanceof AbruptCompletion);
-        ac = e.result;
-        return new ForkedAbruptCompletion(realm, pnc.joinCondition, ac, e, pnca, pnc.alternateEffects);
+        return new ForkedAbruptCompletion(realm, pnc.joinCondition, e.result, pnca);
       }
       invariant(pncc instanceof PossiblyNormalCompletion);
-      let [nc, nce] = recurse(pncc, pnc.consequentEffects, ac, e);
-      return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, nce, pnca, pnc.alternateEffects);
+      let nc = recurse(pncc, pnc.consequentEffects, ac, e);
+      return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, pnca);
     }
 
     // * case (SimpleNormalCompletion, SimpleNormalCompletion)
@@ -356,9 +346,9 @@ export class JoinImplementation {
         na = nae.result;
       } else {
         invariant(pnca instanceof PossiblyNormalCompletion);
-        [na, nae] = recurse(pnca, pnc.alternateEffects, ac, e);
+        na = recurse(pnca, pnc.alternateEffects, ac, e);
       }
-      return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, nce, na, nae);
+      return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, na);
     }
 
     // * case (PossibleNormalCompletion, SimpleNormalCompletion)
@@ -368,17 +358,17 @@ export class JoinImplementation {
       let na = nae.result;
       invariant(pncc instanceof PossiblyNormalCompletion);
       [ac, e] = cloneEffects();
-      let [nc, nce] = recurse(pncc, pnc.consequentEffects, ac, e);
-      return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, nce, na, nae);
+      let nc = recurse(pncc, pnc.consequentEffects, ac, e);
+      return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, na);
     }
 
     // * case (PossibleNormalCompletion, PossibleNormalCompletion)
     invariant(pncc instanceof PossiblyNormalCompletion);
     invariant(pnca instanceof PossiblyNormalCompletion);
-    let [nc, nce] = recurse(pncc, pnc.consequentEffects, ac, e);
+    let nc = recurse(pncc, pnc.consequentEffects, ac, e);
     [ac, e] = cloneEffects();
-    let [na, nae] = recurse(pnca, pnc.alternateEffects, ac, e);
-    return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, nce, na, nae);
+    let na = recurse(pnca, pnc.alternateEffects, ac, e);
+    return new ForkedAbruptCompletion(realm, pnc.joinCondition, nc, na);
 
     // Impossible cases:
     // * case (AbruptCompletion, AbruptCompletion)
@@ -400,7 +390,7 @@ export class JoinImplementation {
     let rv = this.joinValues(realm, c.value, a.value, getAbstractValue);
     invariant(rv instanceof Value);
     a.value = rv;
-    return new PossiblyNormalCompletion(rv, joinCondition, c, ce, a, ae, []);
+    return new PossiblyNormalCompletion(rv, joinCondition, c, a, []);
   }
 
   // Join all effects that result in completions of type CompletionType.
@@ -619,7 +609,7 @@ export class JoinImplementation {
       return new SimpleNormalCompletion(val);
     }
     if (result1 instanceof AbruptCompletion && result2 instanceof AbruptCompletion) {
-      return new ForkedAbruptCompletion(realm, joinCondition, result1, e1, result2, e2);
+      return new ForkedAbruptCompletion(realm, joinCondition, result1, result2);
     }
     if (result1 instanceof NormalCompletion && result2 instanceof NormalCompletion) {
       return this.joinNormalCompletions(realm, joinCondition, result1, e1, result2, e2);
@@ -638,9 +628,7 @@ export class JoinImplementation {
         completion.value,
         joinCondition,
         result1,
-        e1,
         result2,
-        e2,
         savedPathConditions,
         savedEffects
       );
@@ -659,9 +647,7 @@ export class JoinImplementation {
         completion.value,
         joinCondition,
         result1,
-        e1,
         result2,
-        e2,
         savedPathConditions,
         savedEffects
       );

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -154,11 +154,11 @@ export class JoinImplementation {
     invariant(c.savedEffects === undefined); // the caller should ensure this
     let savedPathConditions = pnc.savedPathConditions;
     if (pnc.consequent instanceof AbruptCompletion) {
+      let ae = pnc.alternateEffects;
       let na;
       if (pnc.alternate instanceof SimpleNormalCompletion) {
-        let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.alternateEffects;
         na = c.shallowCloneWithoutEffects();
-        let newAlternateEffects = new Effects(na, generator, modifiedBindings, modifiedProperties, createdObjects);
+        let newAlternateEffects = ae.shallowCloneWithResult(na);
         if (priorEffects) newAlternateEffects = realm.composeEffects(priorEffects, newAlternateEffects);
         return new PossiblyNormalCompletion(
           c.value,
@@ -173,8 +173,7 @@ export class JoinImplementation {
       }
       invariant(pnc.alternate instanceof PossiblyNormalCompletion);
       na = this.composePossiblyNormalCompletions(realm, pnc.alternate, c, priorEffects);
-      let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.alternateEffects;
-      let newAlternateEffects = new Effects(na, generator, modifiedBindings, modifiedProperties, createdObjects);
+      let newAlternateEffects = ae.shallowCloneWithResult(na);
       return new PossiblyNormalCompletion(
         c.value,
         pnc.joinCondition,
@@ -186,11 +185,11 @@ export class JoinImplementation {
         pnc.savedEffects
       );
     } else {
+      let ce = pnc.consequentEffects;
       let nc;
       if (pnc.consequent instanceof SimpleNormalCompletion) {
-        let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.consequentEffects;
         nc = c.shallowCloneWithoutEffects();
-        let newConsequentEffects = new Effects(nc, generator, modifiedBindings, modifiedProperties, createdObjects);
+        let newConsequentEffects = ce.shallowCloneWithResult(nc);
         if (priorEffects) newConsequentEffects = realm.composeEffects(priorEffects, newConsequentEffects);
         return new PossiblyNormalCompletion(
           c.value,
@@ -205,8 +204,7 @@ export class JoinImplementation {
       }
       invariant(pnc.consequent instanceof PossiblyNormalCompletion);
       nc = this.composePossiblyNormalCompletions(realm, pnc.consequent, c);
-      let { generator, modifiedBindings, modifiedProperties, createdObjects } = pnc.consequentEffects;
-      let newConsequentEffects = new Effects(nc, generator, modifiedBindings, modifiedProperties, createdObjects);
+      let newConsequentEffects = ce.shallowCloneWithResult(nc);
       return new PossiblyNormalCompletion(
         c.value,
         pnc.joinCondition,
@@ -296,13 +294,13 @@ export class JoinImplementation {
   ): ForkedAbruptCompletion {
     let recurse = (xpnc, xe, nac, ne): [ForkedAbruptCompletion, Effects] => {
       let nx = this.replacePossiblyNormalCompletionWithForkedAbruptCompletion(realm, xpnc, nac, ne);
-      let nxe = new Effects(nx, xe.generator, xe.modifiedBindings, xe.modifiedProperties, xe.createdObjects);
+      let nxe = xe.shallowCloneWithResult(nx);
       return [nx, nxe];
     };
 
     let cloneEffects = () => {
       let nac = ac.shallowCloneWithoutEffects();
-      let ne = new Effects(nac, e.generator, e.modifiedBindings, e.modifiedProperties, e.createdObjects);
+      let ne = e.shallowCloneWithResult(nac);
       return [nac, ne];
     };
 

--- a/src/partial-evaluators/CallExpression.js
+++ b/src/partial-evaluators/CallExpression.js
@@ -11,7 +11,6 @@
 
 import type { BabelNodeCallExpression, BabelNodeExpression, BabelNodeStatement } from "@babel/types";
 import type { Realm } from "../realm.js";
-import { Effects } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 
 import { AbruptCompletion, Completion, PossiblyNormalCompletion, SimpleNormalCompletion } from "../completions.js";
@@ -119,12 +118,7 @@ function callBothFunctionsAndJoinTheirEffects(
   );
   let r2 = e2.result.shallowCloneWithoutEffects();
 
-  let joinedEffects = Join.joinForkOrChoose(
-    realm,
-    cond,
-    new Effects(r1, e1.generator, e1.modifiedBindings, e1.modifiedProperties, e1.createdObjects),
-    new Effects(r2, e2.generator, e2.modifiedBindings, e2.modifiedProperties, e2.createdObjects)
-  );
+  let joinedEffects = Join.joinForkOrChoose(realm, cond, e1.shallowCloneWithResult(r1), e2.shallowCloneWithResult(r2));
   let joinedCompletion = joinedEffects.result;
   if (joinedCompletion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that

--- a/src/partial-evaluators/IfStatement.js
+++ b/src/partial-evaluators/IfStatement.js
@@ -12,7 +12,6 @@
 import type { BabelNodeIfStatement, BabelNodeStatement } from "@babel/types";
 import type { LexicalEnvironment } from "../environment.js";
 import type { Realm } from "../realm.js";
-import { Effects } from "../realm.js";
 
 import { AbruptCompletion, Completion, PossiblyNormalCompletion } from "../completions.js";
 import { Reference } from "../environment.js";
@@ -83,8 +82,8 @@ export default function(
   let joinedEffects = Join.joinForkOrChoose(
     realm,
     exprValue,
-    new Effects(cr, ce.generator, ce.modifiedBindings, ce.modifiedProperties, ce.createdObjects),
-    new Effects(ar, ae.generator, ae.modifiedBindings, ae.modifiedProperties, ae.createdObjects)
+    ce.shallowCloneWithResult(cr),
+    ae.shallowCloneWithResult(ar)
   );
   completion = joinedEffects.result;
   if (completion instanceof PossiblyNormalCompletion) {

--- a/src/realm.js
+++ b/src/realm.js
@@ -128,6 +128,10 @@ export class Effects {
   canBeApplied: boolean;
   _id: number;
 
+  shallowCloneWithResult(result: Completion): Effects {
+    return new Effects(result, this.generator, this.modifiedBindings, this.modifiedProperties, this.createdObjects);
+  }
+
   toDisplayString(): string {
     return Utils.jsonToDisplayString(this, 10);
   }


### PR DESCRIPTION
Release note: Simplified forked completion constructors

Since effects and completions are now 1-1, we can stop passing (completion, effects) argument pairs.