### PR TITLE
Fix React branch serialization issues

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -2300,7 +2300,7 @@ export class ResidualHeapSerializer {
         invariant(effectsGenerator === generator);
         effectsGenerator.serialize(this._getContext());
         this.realm.withEffectsAppliedInGlobalEnv(() => {
-          const lazyHoistedReactNodes = this.residualReactElementSerializer.serializeLazyHoistedNodes();
+          const lazyHoistedReactNodes = this.residualReactElementSerializer.serializeLazyHoistedNodes(functionValue);
           this.mainBody.entries.push(...lazyHoistedReactNodes);
           return null;
         }, additionalEffects.effects);

--- a/test/react/ClassComponents-test.js
+++ b/test/react/ClassComponents-test.js
@@ -66,3 +66,11 @@ it("Complex class components folding into functional root component #4", () => {
 it("Complex class components folding into functional root component #5", () => {
   runTest(__dirname + "/ClassComponents/complex-class-into-functional-root5.js");
 });
+
+it("Complex class component rendering equivalent node to functional root component", () => {
+  runTest(__dirname + "/ClassComponents/complex-class-with-equivalent-node.js");
+});
+
+it("Complex class component hoists nodes independently of functional root component", () => {
+  runTest(__dirname + "/ClassComponents/complex-class-proper-hoisting.js");
+});

--- a/test/react/ClassComponents/complex-class-proper-hoisting.js
+++ b/test/react/ClassComponents/complex-class-proper-hoisting.js
@@ -1,0 +1,43 @@
+const React = require("react");
+
+function Tau(props) {
+  return React.createElement(
+    "a",
+    null,
+    React.createElement("b", null),
+    React.createElement(Epsilon, null),
+    React.createElement("c", null)
+  );
+}
+
+class Epsilon extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return React.createElement(React.Fragment, null, React.createElement("d", null), React.createElement("b", null));
+  }
+}
+
+if (this.__optimizeReactComponentTree) __optimizeReactComponentTree(Tau);
+
+Tau.getTrials = renderer => {
+  const trials = [];
+
+  renderer.update(<Epsilon />);
+  trials.push(["render Epsilon", renderer.toJSON()]);
+
+  renderer.update(<Tau />);
+  trials.push(["render Tau", renderer.toJSON()]);
+
+  const a = Tau().props.children[0];
+  const b = Epsilon.prototype.render.call(undefined).props.children[1];
+  if (a.type !== "b" || b.type !== "b") throw new Error("Expected <b>s");
+  trials.push(["different React elements", JSON.stringify(a !== b)]);
+
+  return trials;
+};
+
+module.exports = Tau;

--- a/test/react/ClassComponents/complex-class-with-equivalent-node.js
+++ b/test/react/ClassComponents/complex-class-with-equivalent-node.js
@@ -1,0 +1,51 @@
+const React = require("react");
+
+function Tau(props) {
+  return React.createElement(
+    "div",
+    null,
+    React.createElement(Epsilon, {
+      a: props.z,
+    }),
+    React.createElement(Zeta, {
+      p: props.h,
+    })
+  );
+}
+
+class Epsilon extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return React.createElement(Zeta, { p: this.props.a });
+  }
+}
+
+function Zeta(props) {
+  return props.p ? null : React.createElement("foobar", null);
+}
+
+if (this.__optimizeReactComponentTree) __optimizeReactComponentTree(Tau);
+
+Tau.getTrials = function(renderer, Root) {
+  const trials = [];
+
+  renderer.update(<Root z={false} p={false} />);
+  trials.push(["render 1", renderer.toJSON()]);
+
+  renderer.update(<Root z={true} p={false} />);
+  trials.push(["render 2", renderer.toJSON()]);
+
+  renderer.update(<Root z={false} p={true} />);
+  trials.push(["render 3", renderer.toJSON()]);
+
+  renderer.update(<Root z={true} p={true} />);
+  trials.push(["render 4", renderer.toJSON()]);
+
+  return trials;
+};
+
+module.exports = Tau;

--- a/test/react/__snapshots__/ClassComponents-test.js.snap
+++ b/test/react/__snapshots__/ClassComponents-test.js.snap
@@ -68,6 +68,278 @@ ReactStatistics {
 }
 `;
 
+exports[`Complex class component hoists nodes independently of functional root component: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
+exports[`Complex class component hoists nodes independently of functional root component: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
+exports[`Complex class component hoists nodes independently of functional root component: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
+exports[`Complex class component hoists nodes independently of functional root component: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 4,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "React.Fragment",
+              "status": "NORMAL",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
+exports[`Complex class component rendering equivalent node to functional root component: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Zeta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Zeta",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
+exports[`Complex class component rendering equivalent node to functional root component: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Zeta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Zeta",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
+exports[`Complex class component rendering equivalent node to functional root component: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Zeta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Zeta",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
+exports[`Complex class component rendering equivalent node to functional root component: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Zeta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "Epsilon",
+          "status": "NEW_TREE",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Zeta",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Tau",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 2,
+}
+`;
+
 exports[`Complex class components folding into functional root component #2: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 4,


### PR DESCRIPTION
After adding classes to my fuzzer (which does not use first render mode) I found #2316. This PR fixes #2316 and a related issue I found while working on that. (Each fix is in a separate commit.) The second issue I found is scarier since the compiler passes but we get invalid output.

## Invariant violation from equivalent React element in different trees

In the following example I observed an invariant violation:

```js
const React = require("react");

__evaluatePureFunction(() => {
  function Tau(props) {
    return React.createElement(
      "div",
      null,
      React.createElement(Epsilon, {
        a: props.z,
      }),
      React.createElement(Zeta, {
        p: props.h,
      })
    );
  }

  class Epsilon extends React.Component {
    constructor(props) {
      super(props);
      this.state = {};
    }

    render() {
      return React.createElement(Zeta, { p: this.props.a });
    }
  }

  function Zeta(props) {
    return props.p ? null : React.createElement("foobar", null);
  }

  __optimizeReactComponentTree(Tau);

  module.exports = Tau;
});
```

```
=== serialized but not visited values
=== visited but not serialized values
undefined, hash: 792057514635681
  referenced by 1 scopes
      =>_resolveAbstractConditionalValue alternate(#75)=>ReactAdditionalFunctionEffects(#80)

Invariant Violation: serialized 26 of 27
This is likely a bug in Prepack, not your code. Feel free to open an issue on GitHub.
    at invariant (/Users/calebmer/prepack/src/invariant.js:18:15)
    at ResidualHeapSerializer.serialize (/Users/calebmer/prepack/src/serializer/ResidualHeapSerializer.js:2465:17)
    at statistics.referenceCounts.measure (/Users/calebmer/prepack/src/serializer/serializer.js:259:15)
    at PerformanceTracker.measure (/Users/calebmer/prepack/src/statistics.js:100:14)
    at ast (/Users/calebmer/prepack/src/serializer/serializer.js:238:38)
    at statistics.total.measure (/Users/calebmer/prepack/src/serializer/serializer.js:169:17)
    at PerformanceTracker.measure (/Users/calebmer/prepack/src/statistics.js:100:14)
    at Serializer.init (/Users/calebmer/prepack/src/serializer/serializer.js:136:35)
    at prepackSources (/Users/calebmer/prepack/src/prepack-standalone.js:66:33)
    at compileSource (/Users/calebmer/prepack/scripts/debug-fb-www.js:92:18)
```

Somehow we were visiting `undefined`, but clearly we weren’t serializing it given the source code. Here’s what was happening:

- We’d visit an additional function calling `withCleanEquivalenceSet`.
- The additional function would enqueue an action which visited `<foobar>`.
- Later, we’d execute the `<foobar>` visiting action outside our `withCleanEquivalenceSet` with our default equivalence set.
- The same thing happens with our new root from our `Epsilon` class.
- Except now some effects have been applied that set the `type` for our `<foobar>` React element in our React equivalence set to `undefined`. Since when we created `<foobar>` we modified its `type` property. (Recorded in `modifiedProperties`.)
- Now our `<Zeta>` in `<Tau>` and our `<Zeta>` in `<Epsilon>` share the _exact same_ `<foobar>` thanks to our equivalence set.
- But `<foobar>` has a `type` of `undefined` thanks to the effects we applied. We should be creating a new `<foobar>` since we are in a new optimized function.
- ***Boom!*** We visit `undefined`, but don’t serialize it since the same effects aren’t applied when we serialize.

This test case caught an important flaw in our visiting logic, but it only manifested as an invariant under these very specific conditions. Which is a little scary. In a large example, like our internal bundle, we would of course serialize some `undefined` value but we would have still visited `undefined` instead of the proper type, _and_ we may consider two elements to be equivalent when we shouldn’t since their components may render independently. This issue (I presume) can also affect we bail out on since they create new trees inside the root tree.

## Hoisted nodes improperly placed

While debugging and fixing this issue, I found another with incorrect/suboptimal output that passes Prepack and passes eslint. Given the following input:

```js
require("react");

__evaluatePureFunction(() => {
  const React = require("react");

  function Tau(props) {
    return React.createElement(
      "a",
      null,
      React.createElement("b", null),
      React.createElement(Epsilon, null),
      React.createElement("c", null)
    );
  }

  class Epsilon extends React.Component {
    constructor(props) {
      super(props);
      this.state = {};
    }

    render() {
      return React.createElement("d", null);
    }
  }

  __optimizeReactComponentTree(Tau);

  module.exports = { Tau, Epsilon };
});
```

We get this output:

```js
(function () {
  var _$0 = require("react").Component;

  var _3 = function (props, context) {
    _6 === void 0 && $f_0();
    _9 === void 0 && $f_1();

    var _8 = <_B />;

    var _4 = <a>{_6}{_8}{_9}</a>;

    return _4;
  };

  var _B = class extends _$0 {
    constructor(props) {
      super(props);
      this.state = {};
    }

    render() {
      return _E; // <--------------------------- Incorrect. `_B` may be rendered outside of `_3`.
    }
  };

  var $f_0 = function () {
    _6 = <b />;
    _E = <d />;
  };

  var _6;

  var _E;

  var $f_1 = function () {
    _9 = <c />;
  };

  var _9;

  var _0 = {
    Tau: _3,
    Epsilon: _B
  };
  module.exports = _0;
})();
```

This happened because the React serializer’s `_lazilyHoistedNodes` logic was implemented in a way that doesn’t play well with the interleaving almost random order of the serializer invocation of React lazily hoisted nodes logic.