### PR TITLE
Keep key on inlined component

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1184,6 +1184,21 @@ export class Reconciler {
       );
       return reactElement;
     }
+
+    // If we have a new result and we might have a key value then wrap our inlined result in a
+    // `<React.Fragment key={keyValue}>` so that we may maintain the key.
+    if (needsKey && keyValue.mightNotBeNull()) {
+      const react = this.realm.fbLibraries.react;
+      invariant(react instanceof ObjectValue);
+      const reactFragment = getProperty(this.realm, react, "Fragment");
+      const fragmentConfigValue = Create.ObjectCreate(this.realm, this.realm.intrinsics.ObjectPrototype);
+      Create.CreateDataPropertyOrThrow(this.realm, fragmentConfigValue, "key", keyValue);
+      const fragmentChildrenValue = Create.ArrayCreate(this.realm, 1);
+      Create.CreateDataPropertyOrThrow(this.realm, fragmentChildrenValue, "0", reactElement);
+      const fragmentElement = createReactElement(this.realm, reactFragment, fragmentConfigValue, fragmentChildrenValue);
+      return this._resolveFragmentComponent(reactFragment, fragmentElement, context, branchStatus, evaluatedNode);
+    }
+
     let componentResolutionStrategy = this._getComponentResolutionStrategy(typeValue);
 
     // We do not support "ref" on <Component /> ReactElements, unless it's a forwarded ref
@@ -1269,19 +1284,6 @@ export class Reconciler {
 
       if (result instanceof UndefinedValue) {
         return this._resolveReactElementUndefinedRender(reactElement, evaluatedNode, branchStatus);
-      }
-
-      // If we have a new result and we might have a key value then wrap our inlined result in a
-      // `<React.Fragment key={keyValue}>` so that we may maintain the key.
-      if (needsKey && result !== reactElement && keyValue.mightNotBeNull()) {
-        const react = this.realm.fbLibraries.react;
-        invariant(react instanceof ObjectValue);
-        const reactFragment = getProperty(this.realm, react, "Fragment");
-        const fragmentConfigValue = Create.ObjectCreate(this.realm, this.realm.intrinsics.ObjectPrototype);
-        Create.CreateDataPropertyOrThrow(this.realm, fragmentConfigValue, "key", keyValue);
-        const fragmentChildrenValue = Create.ArrayCreate(this.realm, 1);
-        Create.CreateDataPropertyOrThrow(this.realm, fragmentChildrenValue, "0", result);
-        result = createReactElement(this.realm, reactFragment, fragmentConfigValue, fragmentChildrenValue);
       }
 
       return result;

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -335,3 +335,7 @@ it("Inline keys", () => {
 it("Inline unnecessary keys", () => {
   runTest(__dirname + "/FunctionalComponents/keyed-unnecessarily.js");
 });
+
+it("Inline key on component that does not return element", () => {
+  runTest(__dirname + "/FunctionalComponents/keyed-non-element.js");
+});

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -331,3 +331,7 @@ it("Model props", () => {
 it("Inline keys", () => {
   runTest(__dirname + "/FunctionalComponents/keyed.js");
 });
+
+it("Inline unnecessary keys", () => {
+  runTest(__dirname + "/FunctionalComponents/keyed-unnecessarily.js");
+});

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -327,3 +327,7 @@ it("Pathological case", () => {
 it("Model props", () => {
   runTest(__dirname + "/FunctionalComponents/model-props.js");
 });
+
+it("Inline keys", () => {
+  runTest(__dirname + "/FunctionalComponents/keyed.js");
+});

--- a/test/react/FunctionalComponents/keyed-non-element.js
+++ b/test/react/FunctionalComponents/keyed-non-element.js
@@ -1,0 +1,18 @@
+const React = require("react");
+
+function Upsilon(props) {
+  return [<Delta key="0" />, <Delta key="1" />];
+}
+
+function Delta(props) {
+  return [];
+}
+
+if (this.__optimizeReactComponentTree) __optimizeReactComponentTree(Upsilon);
+
+Upsilon.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [["render", renderer.toJSON()]];
+};
+
+module.exports = Upsilon;

--- a/test/react/FunctionalComponents/keyed-unnecessarily.js
+++ b/test/react/FunctionalComponents/keyed-unnecessarily.js
@@ -1,0 +1,27 @@
+const React = require("react");
+
+function Lambda(props) {
+  return (
+    <div>
+      <div key="0" />
+      {this.__optimizeReactComponentTree ? <Omega key="1" /> : <Omega />}
+      {this.__optimizeReactComponentTree ? <Omega key="2" /> : <Omega />}
+    </div>
+  );
+}
+
+function Omega(props) {
+  return <div />;
+}
+
+if (this.__optimizeReactComponentTree) __optimizeReactComponentTree(Lambda);
+
+Lambda.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [
+    ["render", renderer.toJSON()],
+    ["keys are not added", JSON.stringify(Lambda().props.children.map(element => element.key))],
+  ];
+};
+
+module.exports = Lambda;

--- a/test/react/FunctionalComponents/keyed.js
+++ b/test/react/FunctionalComponents/keyed.js
@@ -1,0 +1,18 @@
+const React = require("react");
+
+function Lambda(props) {
+  return [<div key="0" />, <Omega key="1" />, <Omega key="2" />];
+}
+
+function Omega(props) {
+  return <div />;
+}
+
+if (this.__optimizeReactComponentTree) __optimizeReactComponentTree(Lambda);
+
+Lambda.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [["render", renderer.toJSON()], ["keys are maintained", JSON.stringify(Lambda().map(element => element.key))]];
+};
+
+module.exports = Lambda;

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -3160,6 +3160,126 @@ ReactStatistics {
 }
 `;
 
+exports[`Inline unnecessary keys: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline unnecessary keys: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline unnecessary keys: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline unnecessary keys: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Model props: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -3040,6 +3040,126 @@ ReactStatistics {
 }
 `;
 
+exports[`Inline keys: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline keys: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline keys: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline keys: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 3,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Omega",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "Lambda",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Model props: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 1,

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -3040,23 +3040,213 @@ ReactStatistics {
 }
 `;
 
-exports[`Inline keys: (JSX => JSX) 1`] = `
+exports[`Inline key on component that does not return element: (JSX => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Upsilon",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline key on component that does not return element: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Upsilon",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline key on component that does not return element: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Upsilon",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline key on component that does not return element: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Delta",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+      ],
+      "message": "",
+      "name": "Upsilon",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 2,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Inline keys: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 5,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
+          "message": "",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",
@@ -3072,21 +3262,35 @@ ReactStatistics {
 
 exports[`Inline keys: (JSX => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",
@@ -3102,21 +3306,35 @@ ReactStatistics {
 
 exports[`Inline keys: (createElement => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",
@@ -3132,21 +3350,35 @@ ReactStatistics {
 
 exports[`Inline keys: (createElement => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "Omega",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "Omega",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",
@@ -8970,21 +9202,35 @@ ReactStatistics {
 
 exports[`Return text: (JSX => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "A",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "B",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "B",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",
@@ -9000,21 +9246,35 @@ ReactStatistics {
 
 exports[`Return text: (JSX => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "A",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "B",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "B",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",
@@ -9030,21 +9290,35 @@ ReactStatistics {
 
 exports[`Return text: (createElement => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "A",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "B",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "B",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",
@@ -9060,21 +9334,35 @@ ReactStatistics {
 
 exports[`Return text: (createElement => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 3,
+  "componentsEvaluated": 5,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "A",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "A",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
         Object {
-          "children": Array [],
+          "children": Array [
+            Object {
+              "children": Array [],
+              "message": "",
+              "name": "B",
+              "status": "INLINED",
+            },
+          ],
           "message": "",
-          "name": "B",
-          "status": "INLINED",
+          "name": "React.Fragment",
+          "status": "NORMAL",
         },
       ],
       "message": "",

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -3042,35 +3042,21 @@ ReactStatistics {
 
 exports[`Inline key on component that does not return element: (JSX => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -3086,35 +3072,21 @@ ReactStatistics {
 
 exports[`Inline key on component that does not return element: (JSX => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -3130,35 +3102,21 @@ ReactStatistics {
 
 exports[`Inline key on component that does not return element: (createElement => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -3174,35 +3132,21 @@ ReactStatistics {
 
 exports[`Inline key on component that does not return element: (createElement => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Delta",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Delta",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -3218,35 +3162,21 @@ ReactStatistics {
 
 exports[`Inline keys: (JSX => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -3262,35 +3192,21 @@ ReactStatistics {
 
 exports[`Inline keys: (JSX => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -3306,35 +3222,21 @@ ReactStatistics {
 
 exports[`Inline keys: (createElement => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -3350,35 +3252,21 @@ ReactStatistics {
 
 exports[`Inline keys: (createElement => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "Omega",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "Omega",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -9202,35 +9090,21 @@ ReactStatistics {
 
 exports[`Return text: (JSX => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "A",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "A",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "B",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "B",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -9246,35 +9120,21 @@ ReactStatistics {
 
 exports[`Return text: (JSX => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "A",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "A",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "B",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "B",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -9290,35 +9150,21 @@ ReactStatistics {
 
 exports[`Return text: (createElement => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "A",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "A",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "B",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "B",
+          "status": "INLINED",
         },
       ],
       "message": "",
@@ -9334,35 +9180,21 @@ ReactStatistics {
 
 exports[`Return text: (createElement => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 5,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "A",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "A",
+          "status": "INLINED",
         },
         Object {
-          "children": Array [
-            Object {
-              "children": Array [],
-              "message": "",
-              "name": "B",
-              "status": "INLINED",
-            },
-          ],
+          "children": Array [],
           "message": "",
-          "name": "React.Fragment",
-          "status": "NORMAL",
+          "name": "B",
+          "status": "INLINED",
         },
       ],
       "message": "",


### PR DESCRIPTION
Fixes #2322. The React Compiler was discarding keys for components that were inlined.

Consider:

## Input

```jsx
const React = require("react");

__evaluatePureFunction(() => {
  function Lambda(props) {
    return [<div key="0" />, <Omega key="1" />, <Omega key="2" />];
  }

  function Omega(props) {
    return <div />;
  }

  __optimizeReactComponentTree(Lambda);

  module.exports = Lambda;
});
```

## Output

```jsx
(function() {
  var _2 = function(props, context) {
    _4 === void 0 && $f_0();
    return [_4, _7, _7]; // <------------------------- `_7` has no `key`!
  };

  var $f_0 = function() {
    _4 = <div key="0" />;
    _7 = <div />;
  };

  var _4;

  var _7;

  module.exports = _2;
})();
```

---

Cases where this can be an issue:

- First render mode and we need to hydrate instances based on keys (will this be a thing?)
- Compiled component is re-rendered and a list has a different order. List item components are expensive.
- We inline components with state.

Of course, it’s possible this may be a non-issue.

My solution for this was to wrap the inlined React Element in a `<React.Fragment>` with a key. So my input above becomes:

```jsx
[
  <div key="0" />,
  <React.Fragment key="1"><div /></React.Fragment>,
  <React.Fragment key="2"><div /></React.Fragment>,
]
```

Cloning inlined elements and adding keys is a fragile operation since the element may already have a key or the element may be some other React node like a portal. I opted for wrapping in `<React.Fragment>`. Note that this also means we can hoist `<div />`  in the example above.

Thoughts on adding an optimization which clones the element and adds `key={x}` in cases where this is possible? `<React.Fragment>` seems correct in all cases, but cloning with `key={x}` when possible seems like it might be faster.

Also happy to hear other suggestions for maintaining the key on inlined elements.

This has no impact on our internal bundle.