### PR TITLE
Make it possible to materialize without havocing

### DIFF
--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -13,7 +13,7 @@ import * as Singletons from "./singletons.js";
 import { CreateImplementation } from "./methods/create.js";
 import { EnvironmentImplementation } from "./methods/environment.js";
 import { FunctionImplementation } from "./methods/function.js";
-import { HavocImplementation } from "./utils/havoc.js";
+import { HavocImplementation, MaterializeImplementation } from "./utils/havoc.js";
 import { JoinImplementation } from "./methods/join.js";
 import { PathImplementation } from "./utils/paths.js";
 import { PropertiesImplementation } from "./methods/properties.js";
@@ -27,6 +27,7 @@ export default function() {
   Singletons.setEnvironment(new EnvironmentImplementation());
   Singletons.setFunctions(new FunctionImplementation());
   Singletons.setHavoc(new HavocImplementation());
+  Singletons.setMaterialize(new MaterializeImplementation());
   Singletons.setJoin(new JoinImplementation());
   Singletons.setPath(new PathImplementation());
   Singletons.setProperties((new PropertiesImplementation(): any));

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -16,6 +16,7 @@ import type {
   FunctionType,
   HavocType,
   JoinType,
+  MaterializeType,
   PathType,
   PropertiesType,
   ToType,
@@ -27,12 +28,14 @@ export let Create: CreateType = (null: any);
 export let Environment: EnvironmentType = (null: any);
 export let Functions: FunctionType = (null: any);
 export let Havoc: HavocType = (null: any);
+export let Materialize: MaterializeType = (null: any);
 export let Join: JoinType = (null: any);
 export let Path: PathType = (null: any);
 export let Properties: PropertiesType = (null: any);
 export let To: ToType = (null: any);
 export let Widen: WidenType = (null: any);
 export let concretize: ConcretizeType = (null: any);
+
 export let Utils: UtilsType = (null: any);
 
 export function setCreate(singleton: CreateType): void {
@@ -49,6 +52,10 @@ export function setFunctions(singleton: FunctionType): void {
 
 export function setHavoc(singleton: HavocType): void {
   Havoc = singleton;
+}
+
+export function setMaterialize(singleton: MaterializeType): void {
+  Materialize = singleton;
 }
 
 export function setJoin(singleton: JoinType): void {

--- a/src/types.js
+++ b/src/types.js
@@ -374,6 +374,10 @@ export type HavocType = {
   value(realm: Realm, value: Value, loc: ?BabelNodeSourceLocation): void,
 };
 
+export type MaterializeType = {
+  materialize(realm: Realm, object: ObjectValue): void,
+};
+
 export type PropertiesType = {
   // ECMA262 9.1.9.1
   OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value, Receiver: Value): boolean,

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -111,11 +111,7 @@ function getHavocedFunctionInfo(value: FunctionValue) {
   return functionInfo;
 }
 
-function materializeLeakedObject(
-  realm: Realm,
-  object: ObjectValue,
-  getCachingHeapInspector?: () => HeapInspector
-): void {
+function materializeObject(realm: Realm, object: ObjectValue, getCachingHeapInspector?: () => HeapInspector): void {
   let generator = realm.generator;
 
   if (object.symbols.size > 0) {
@@ -240,7 +236,7 @@ class ObjectValueHavocingVisitor {
       // materialization is a common operation and needs to be invoked
       // whenever non-final values need to be made available at intermediate
       // points in a program's control flow. An object can be materialized by
-      // calling materializeLeakedObject(). Sometimes, objects
+      // calling materializeObject(). Sometimes, objects
       // are materialized in cohorts (such as during leaking and havocing).
       // In these cases, we provide a caching mechanism for HeapInspector().
       let makeAndCacheHeapInspector = () => {
@@ -253,7 +249,7 @@ class ObjectValueHavocingVisitor {
         }
       };
       invariant(this.realm.generator !== undefined);
-      materializeLeakedObject(this.realm, obj, makeAndCacheHeapInspector);
+      materializeObject(this.realm, obj, makeAndCacheHeapInspector);
     }
   }
 
@@ -591,6 +587,6 @@ export class HavocImplementation {
 
 export class MaterializeImplementation {
   materialize(realm: Realm, val: ObjectValue) {
-    materializeLeakedObject(realm, val);
+    materializeObject(realm, val);
   }
 }

--- a/src/utils/havoc.js
+++ b/src/utils/havoc.js
@@ -111,6 +111,67 @@ function getHavocedFunctionInfo(value: FunctionValue) {
   return functionInfo;
 }
 
+function materializeLeakedObject(
+  realm: Realm,
+  object: ObjectValue,
+  getCachingHeapInspector?: () => HeapInspector
+): void {
+  let generator = realm.generator;
+
+  if (object.symbols.size > 0) {
+    throw new FatalError("TODO: Support havocing objects with symbols");
+  }
+
+  if (object.unknownProperty !== undefined) {
+    // TODO: Support unknown properties, or throw FatalError.
+    // We have repros, e.g. test/serializer/additional-functions/ArrayConcat.js.
+  }
+
+  let getHeapInspector =
+    getCachingHeapInspector || (() => new HeapInspector(realm, new Logger(realm, /*internalDebug*/ false)));
+
+  // TODO: We should emit current value and then reset value for all *internal slots*; this will require deep serializer support; or throw FatalError when we detect any non-initial values in internal slots.
+  for (let [name, propertyBinding] of object.properties) {
+    // ignore properties with their correct default values
+    if (getHeapInspector().canIgnoreProperty(object, name)) continue;
+
+    let descriptor = propertyBinding.descriptor;
+    if (descriptor === undefined) {
+      // TODO: This happens, e.g. test/serializer/pure-functions/ObjectAssign2.js
+      // If it indeed means deleted binding, should we initialize descriptor with a deleted value?
+      if (generator !== undefined) generator.emitPropertyDelete(object, name);
+    } else {
+      let value = descriptor.value;
+      invariant(
+        value === undefined || value instanceof Value,
+        "cannot be an array because we are not dealing with intrinsics here"
+      );
+      if (value === undefined) {
+        // TODO: Deal with accessor properties
+        // We have repros, e.g. test/serializer/pure-functions/AbstractPropertyObjectKeyAssignment.js
+      } else {
+        invariant(value instanceof Value);
+        if (value instanceof EmptyValue) {
+          if (generator !== undefined) generator.emitPropertyDelete(object, name);
+        } else {
+          if (generator !== undefined) {
+            let targetDescriptor = getHeapInspector().getTargetIntegrityDescriptor(object);
+            if (!isReactElement(object)) {
+              if (
+                descriptor.writable !== targetDescriptor.writable ||
+                descriptor.configurable !== targetDescriptor.configurable
+              ) {
+                generator.emitDefineProperty(object, name, descriptor);
+              } else {
+                generator.emitPropertyAssignment(object, name, value);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
 class ObjectValueHavocingVisitor {
   realm: Realm;
   // ObjectValues to visit if they're reachable.
@@ -123,12 +184,6 @@ class ObjectValueHavocingVisitor {
     this.realm = realm;
     this.objectsTrackedForHavoc = objectsTrackedForHavoc;
     this.visitedValues = new Set();
-  }
-
-  getHeapInspector(): HeapInspector {
-    if (this._heapInspector === undefined)
-      this._heapInspector = new HeapInspector(this.realm, new Logger(this.realm, /*internalDebug*/ false));
-    return this._heapInspector;
   }
 
   mustVisit(val: Value): boolean {
@@ -181,55 +236,24 @@ class ObjectValueHavocingVisitor {
     // so that any mutation and property access get tracked after this.
     if (obj.mightNotBeHavocedObject()) {
       obj.havoc();
-      if (obj.symbols.size > 0) {
-        throw new FatalError("TODO: Support havocing objects with symbols");
-      }
-      if (obj.unknownProperty !== undefined) {
-        // TODO: Support unknown properties, or throw FatalError.
-        // We have repros, e.g. test/serializer/additional-functions/ArrayConcat.js.
-      }
-      // TODO: We should emit current value and then reset value for all *internal slots*; this will require deep serializer support; or throw FatalError when we detect any non-initial values in internal slots.
-      let realmGenerator = this.realm.generator;
-      for (let [name, propertyBinding] of obj.properties) {
-        // ignore properties with their correct default values
-        if (this.getHeapInspector().canIgnoreProperty(obj, name)) continue;
 
-        let descriptor = propertyBinding.descriptor;
-        if (descriptor === undefined) {
-          // TODO: This happens, e.g. test/serializer/pure-functions/ObjectAssign2.js
-          // If it indeed means deleted binding, should we initialize descriptor with a deleted value?
-          if (realmGenerator !== undefined) realmGenerator.emitPropertyDelete(obj, name);
-        } else {
-          let value = descriptor.value;
-          invariant(
-            value === undefined || value instanceof Value,
-            "cannot be an array because we are not dealing with intrinsics here"
-          );
-          if (value === undefined) {
-            // TODO: Deal with accessor properties
-            // We have repros, e.g. test/serializer/pure-functions/AbstractPropertyObjectKeyAssignment.js
-          } else {
-            invariant(value instanceof Value);
-            if (value instanceof EmptyValue) {
-              if (realmGenerator !== undefined) realmGenerator.emitPropertyDelete(obj, name);
-            } else {
-              if (realmGenerator !== undefined) {
-                let targetDescriptor = this.getHeapInspector().getTargetIntegrityDescriptor(obj);
-                if (!isReactElement(obj)) {
-                  if (
-                    descriptor.writable !== targetDescriptor.writable ||
-                    descriptor.configurable !== targetDescriptor.configurable
-                  ) {
-                    realmGenerator.emitDefineProperty(obj, name, descriptor);
-                  } else {
-                    realmGenerator.emitPropertyAssignment(obj, name, value);
-                  }
-                }
-              }
-            }
-          }
+      // materialization is a common operation and needs to be invoked
+      // whenever non-final values need to be made available at intermediate
+      // points in a program's control flow. An object can be materialized by
+      // calling materializeLeakedObject(). Sometimes, objects
+      // are materialized in cohorts (such as during leaking and havocing).
+      // In these cases, we provide a caching mechanism for HeapInspector().
+      let makeAndCacheHeapInspector = () => {
+        let heapInspector = this._heapInspector;
+        if (heapInspector !== undefined) return heapInspector;
+        else {
+          heapInspector = new HeapInspector(this.realm, new Logger(this.realm, /*internalDebug*/ false));
+          this._heapInspector = heapInspector;
+          return heapInspector;
         }
-      }
+      };
+      invariant(this.realm.generator !== undefined);
+      materializeLeakedObject(this.realm, obj, makeAndCacheHeapInspector);
     }
   }
 
@@ -562,5 +586,11 @@ export class HavocImplementation {
       let visitor = new ObjectValueHavocingVisitor(realm, objectsTrackedForHavoc);
       visitor.visitValue(value);
     }
+  }
+}
+
+export class MaterializeImplementation {
+  materialize(realm: Realm, val: ObjectValue) {
+    materializeLeakedObject(realm, val);
   }
 }


### PR DESCRIPTION
This is Part 2/4 of #2185, which is being broken out into focused pieces. This piece separates materialization from the leaking and havocing logic, deals with flow issues and avoids increasing the maximum flow cycle size by adding the materialization routine to singletons.js.

But it does not introduce the possibly problematic pairing of ObjectValues with the generators in which they were leaked. Objects are materialized in the current generator, just as before.

@trueadm needs this for #2321. I suggest he review it before @NTillmann and @hermanventer to check that it meets his needs.

