### PR TITLE
Adds a bunch of test utility helpers

### DIFF
--- a/src/intrinsics/fb-www/fb-mocks.js
+++ b/src/intrinsics/fb-www/fb-mocks.js
@@ -24,8 +24,7 @@ import {
 import { Create } from "../../singletons.js";
 import { Get } from "../../methods/index.js";
 import invariant from "../../invariant.js";
-import { Properties } from "../../singletons.js";
-import { forEachArrayValue } from "../../react/utils.js";
+import { Properties, Utils } from "../../singletons.js";
 import { createOperationDescriptor } from "../../utils/generator.js";
 
 const fbMagicGlobalFunctions = [
@@ -84,7 +83,7 @@ function createBabelHelpers(realm: Realm, global: ObjectValue | AbstractObjectVa
 
   const createObjectWithoutProperties = (obj: ObjectValue, keys: ArrayValue) => {
     let removeKeys = new Set();
-    forEachArrayValue(realm, keys, key => {
+    Utils.forEachArrayValue(realm, keys, key => {
       if (key instanceof StringValue || key instanceof NumberValue) {
         removeKeys.add(key.value);
       }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -562,7 +562,7 @@ export function GetFromArrayWithWidenedNumericProperty(realm: Realm, arr: ArrayV
     if (P === "length") {
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
-        NumberValue,
+        Value,
         [arr],
         createOperationDescriptor("UNKNOWN_ARRAY_LENGTH"),
         { skipInvariant: true, isPure: true }

--- a/src/react/branching.js
+++ b/src/react/branching.js
@@ -24,15 +24,9 @@ import {
 } from "../values/index.js";
 import invariant from "../invariant.js";
 import { ValuesDomain } from "../domains/index.js";
-import {
-  cloneReactElement,
-  isReactElement,
-  addKeyToReactElement,
-  forEachArrayValue,
-  getProperty,
-  mapArrayValue,
-} from "./utils.js";
+import { cloneReactElement, isReactElement, addKeyToReactElement, getProperty, mapArrayValue } from "./utils.js";
 import { ExpectedBailOut } from "./errors.js";
+import { Utils } from "../singletons.js";
 import { createOperationDescriptor } from "../utils/generator.js";
 
 // Branch status is used for when Prepack returns an abstract value from a render
@@ -77,7 +71,7 @@ export function getValueWithBranchingLogicApplied(
     } else if (x instanceof ArrayValue) {
       // If we have x: []
       // Go  through the elements of array x
-      forEachArrayValue(realm, x, (xElem, index) => {
+      Utils.forEachArrayValue(realm, x, (xElem, index) => {
         let yElem = y;
         // And if we also have y: [], with a given element from x
         // search element of y at the same index from x.
@@ -90,7 +84,7 @@ export function getValueWithBranchingLogicApplied(
     } else if (y instanceof ArrayValue) {
       // If we have y: []
       // Go  through the elements of array y
-      forEachArrayValue(realm, y, (yElem, index) => {
+      Utils.forEachArrayValue(realm, y, (yElem, index) => {
         let xElem = x;
         // And if we also have x: [], with a given element from y
         // search element of x at the same index from y.
@@ -145,7 +139,7 @@ export function getValueWithBranchingLogicApplied(
       // If either case is an unknown array, we do not know
       // the contents of the array, so we cannot add keys
     } else if (x instanceof ArrayValue && arrayDepth === 0) {
-      forEachArrayValue(realm, x, (xElem, index) => {
+      Utils.forEachArrayValue(realm, x, (xElem, index) => {
         let yElem;
         if (y instanceof ArrayValue) {
           // handle the case of [x].equals([y])
@@ -160,7 +154,7 @@ export function getValueWithBranchingLogicApplied(
         }
       });
     } else if (y instanceof ArrayValue && arrayDepth === 0) {
-      forEachArrayValue(realm, y, (yElem, index) => {
+      Utils.forEachArrayValue(realm, y, (yElem, index) => {
         let xElem;
         if (x instanceof ArrayValue) {
           // handle the case of [y].equals([x]

--- a/src/react/experimental-server-rendering/rendering.js
+++ b/src/react/experimental-server-rendering/rendering.js
@@ -31,14 +31,7 @@ import {
   UndefinedValue,
 } from "../../values/index.js";
 import { Reconciler } from "../reconcilation.js";
-import {
-  createReactEvaluatedNode,
-  forEachArrayValue,
-  getComponentName,
-  getProperty,
-  getReactSymbol,
-  isReactElement,
-} from "../utils.js";
+import { createReactEvaluatedNode, getComponentName, getProperty, getReactSymbol, isReactElement } from "../utils.js";
 import * as t from "@babel/types";
 import invariant from "../../invariant.js";
 import {
@@ -67,7 +60,7 @@ import {
 } from "./dom-config.js";
 // $FlowFixMe: flow complains that this isn't a module but it is, and it seems to load fine
 import hyphenateStyleName from "fbjs/lib/hyphenateStyleName";
-import { To } from "../../singletons.js";
+import { To, Utils } from "../../singletons.js";
 import { createOperationDescriptor } from "../../utils/generator.js";
 
 export type ReactNode = Array<ReactNode> | string | AbstractValue | ArrayValue;
@@ -347,7 +340,7 @@ class ReactDOMServerRenderer {
       }
     }
     let elements = [];
-    forEachArrayValue(this.realm, value, elementValue => {
+    Utils.forEachArrayValue(this.realm, value, elementValue => {
       let renderedElement = this._renderValue(elementValue, namespace, depth);
       if (Array.isArray(renderedElement)) {
         elements.push(...renderedElement);

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -41,7 +41,7 @@ import { Get, cloneDescriptor } from "../methods/index.js";
 import { computeBinary } from "../evaluators/BinaryExpression.js";
 import type { AdditionalFunctionEffects, ReactEvaluatedNode } from "../serializer/types.js";
 import invariant from "../invariant.js";
-import { Create, Properties, To } from "../singletons.js";
+import { Create, Properties, To, Utils } from "../singletons.js";
 import traverse from "@babel/traverse";
 import * as t from "@babel/types";
 import type { BabelNodeStatement } from "@babel/types";
@@ -233,27 +233,6 @@ export function getUniqueReactElementKey(index?: string, usedReactElementKeys: S
     return `${key}${index}`;
   }
   return key;
-}
-
-// a helper function to loop over ArrayValues
-export function forEachArrayValue(
-  realm: Realm,
-  array: ArrayValue,
-  mapFunc: (element: Value, index: number) => void
-): void {
-  let lengthValue = Get(realm, array, "length");
-  invariant(lengthValue instanceof NumberValue, "TODO: support non-numeric length on forEachArrayValue");
-  let length = lengthValue.value;
-  for (let i = 0; i < length; i++) {
-    let elementProperty = array.properties.get("" + i);
-    let elementPropertyDescriptor = elementProperty && elementProperty.descriptor;
-    if (elementPropertyDescriptor) {
-      let elementValue = elementPropertyDescriptor.value;
-      if (elementValue instanceof Value) {
-        mapFunc(elementValue, i);
-      }
-    }
-  }
 }
 
 export function mapArrayValue(
@@ -591,7 +570,7 @@ export function hasNoPartialKeyOrRef(realm: Realm, props: ObjectValue | Abstract
 }
 
 function recursivelyFlattenArray(realm: Realm, array, targetArray): void {
-  forEachArrayValue(realm, array, item => {
+  Utils.forEachArrayValue(realm, array, item => {
     if (item instanceof ArrayValue && !item.intrinsicName) {
       recursivelyFlattenArray(realm, item, targetArray);
     } else {

--- a/src/types.js
+++ b/src/types.js
@@ -1041,6 +1041,7 @@ export type ConcretizeType = (realm: Realm, val: Value) => ConcreteValue;
 export type DisplayResult = {} | string;
 
 export type UtilsType = {|
+  forEachArrayValue: (Realm, ArrayValue, (element: Value, index: number) => void) => void,
   typeToString: (typeof Value) => void | string,
   getTypeFromName: string => void | typeof Value,
   describeValue: Value => string,

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@
 
 /* @flow strict-local */
 
+import { Realm } from "./realm.js";
 import {
   AbstractValue,
   ArrayValue,
@@ -26,6 +27,7 @@ import {
   Value,
 } from "./values/index.js";
 import invariant from "./invariant.js";
+import { Get } from "./methods/index.js";
 
 export function typeToString(type: typeof Value): void | string {
   function isInstance(proto, Constructor): boolean {
@@ -143,4 +145,25 @@ export function verboseToDisplayJson(obj: {}, depth: number): DisplayResult {
     if (value && value !== "[object Object]") result[key] = value;
   }
   return result;
+}
+
+// a helper function to loop over ArrayValues
+export function forEachArrayValue(
+  realm: Realm,
+  array: ArrayValue,
+  mapFunc: (element: Value, index: number) => void
+): void {
+  let lengthValue = Get(realm, array, "length");
+  invariant(lengthValue instanceof NumberValue, "TODO: support non-numeric length on forEachArrayValue");
+  let length = lengthValue.value;
+  for (let i = 0; i < length; i++) {
+    let elementProperty = array.properties.get("" + i);
+    let elementPropertyDescriptor = elementProperty && elementProperty.descriptor;
+    if (elementPropertyDescriptor) {
+      let elementValue = elementPropertyDescriptor.value;
+      if (elementValue instanceof Value) {
+        mapFunc(elementValue, i);
+      }
+    }
+  }
 }

--- a/test/serializer/optimized-functions/ChangeType.js
+++ b/test/serializer/optimized-functions/ChangeType.js
@@ -1,0 +1,29 @@
+function fn2(cond, arr) {
+  if (cond) {
+    var length = arr.length;
+    global.__changeType && __changeType(length, "number");
+    return length;
+  }
+  return 0;
+}
+
+function fn(cond, arr1, arr2) {
+  var len = fn2(cond, arr1);
+  var len2 = fn2(cond, arr2);
+
+  if (len > 0) {
+    var toString = __abstract("string", "template:(A).toString()", { args: [len] })
+    return toString;
+  }
+  if (len2 > 0) {
+    var toString = __abstract("string", "template:(A).toString()", { args: [len] })
+    return toString;
+  }
+  return "Should not hit this!";
+}
+
+this.__optimize && __optimize(fn);
+
+inspect = function() {
+  return fn(true, [], []);
+}

--- a/test/serializer/optimized-functions/ChangeType.js
+++ b/test/serializer/optimized-functions/ChangeType.js
@@ -1,7 +1,7 @@
 function fn2(cond, arr) {
   if (cond) {
     var length = arr.length;
-    global.__changeType && __changeType(length, "number");
+    global.__changeType ? global.__changeType(length, "number") : 5;
     return length;
   }
   return 0;
@@ -12,11 +12,11 @@ function fn(cond, arr1, arr2) {
   var len2 = fn2(cond, arr2);
 
   if (len > 0) {
-    var toString = __abstract("string", "template:(A).toString()", { args: [len] })
+    var toString = global.__abstract ? __abstract("string", "template:(A).toString()", { args: [len] }) : len.toString();
     return toString;
   }
   if (len2 > 0) {
-    var toString = __abstract("string", "template:(A).toString()", { args: [len] })
+    var toString = global.__abstract ? __abstract("string", "template:(A).toString()", { args: [len] }) : len.toString();
     return toString;
   }
   return "Should not hit this!";


### PR DESCRIPTION
Release notes: adds `__changeType` Prepack global and allows for `args` to be passed to `__abstract`

When working on some tricky to reproduce bugs, it occurred to me that we could do with some internal shortcuts to build up models quickly without pulling in specific concepts relating to IR or React – so this PR adds a bunch of useful additions to the Prepack globals and also pulls out React util's array mapping help function and put it's in Prepack's `utils` singleton.

You can now do `__changeType(someAbstractValue, "string")` for example. Furthermore, you can construct abstract values with specific arguments `__abstract("string", "template:(A).toString()`, { args: [someValue] })`. This should really help us make test cases and regression tests for hard to reproduce issues without leaking too much of Prepack's internals into the API.