### PR TITLE
[New invariant finds bug] Add invariant that path conditions of nested generators are related

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -659,7 +659,11 @@ export class JoinImplementation {
     // TODO #2222: The path condition of the resulting generator should really just be generator2.pathConditions,
     // and we shouldn't have to bring in generator1.pathConditions. We have observed that this causes an issue
     // in InstantRender.
-    let result = new Generator(realm, "composed", generator1.pathConditions.concat(generator2.pathConditions));
+    let result = new Generator(
+      realm,
+      "composed",
+      Array.from(new Set(generator1.pathConditions.concat(generator2.pathConditions)))
+    );
     // We copy the entries here because actually composing the generators breaks the serializer
     if (!generator1.empty()) result.appendGenerator(generator1, "");
     if (!generator2.empty()) result.appendGenerator(generator2, "");

--- a/src/serializer/GeneratorDAG.js
+++ b/src/serializer/GeneratorDAG.js
@@ -76,6 +76,22 @@ export class GeneratorDAG {
         this.createdObjects.set(createdObject, generator);
       }
 
+    if (parent instanceof Generator) {
+      // We'd like to ensure at this point that the path conditions
+      // of a nested generator imply the path conditions of its parent
+      // generator.
+      // Without a fancy solver, we simply rely on a very simple check
+      // whether the conditions of the parent generator are all
+      // present in the nested generator.
+      // TODO: This relies on path conditions not being simplified, which seems to be the case so far.
+      function isSubset(parentPathConditions, currentPathConditions) {
+        let set = new Set(currentPathConditions);
+        for (let parentPathCondition of parentPathConditions) if (!set.has(parentPathCondition)) return false;
+        return true;
+      }
+      invariant(isSubset(parent.pathConditions, generator.pathConditions), generator.getName());
+    }
+
     for (let dependency of generator.getDependencies()) this._add(generator, dependency);
   }
 }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -2085,11 +2085,11 @@ export class ResidualHeapSerializer {
     }
     let beginComments = [commentStatement("begin " + comment)];
     let effects = generator.effectsToApply;
+    let valueToString = value =>
+      this.residualHeapValueIdentifiers.hasIdentifier(value)
+        ? this.residualHeapValueIdentifiers.getIdentifier(value).name
+        : "?";
     if (effects) {
-      let valueToString = value =>
-        this.residualHeapValueIdentifiers.hasIdentifier(value)
-          ? this.residualHeapValueIdentifiers.getIdentifier(value).name
-          : "?";
       let keyToString = key => (typeof key === "string" ? key : key instanceof Value ? valueToString(key) : "?");
 
       beginComments.push(
@@ -2123,6 +2123,13 @@ export class ResidualHeapSerializer {
               .join(", ")}`
           )
         );
+    }
+    if (generator.pathConditions.length > 0) {
+      beginComments.push(commentStatement(`    path conditions: ${generator.pathConditions.length}`));
+      for (let pc of generator.pathConditions) {
+        for (let line of describeValue(pc, valueToString).split("\n"))
+          beginComments.push(commentStatement(`    * ${line}`));
+      }
     }
     statements.unshift(...beginComments);
     statements.push(commentStatement("end " + comment));

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,7 +83,7 @@ export function getTypeFromName(typeName: string): void | typeof Value {
   }
 }
 
-export function describeValue(value: Value): string {
+export function describeValue(value: Value, valueToString?: Value => string): string {
   let title;
   let suffix = "";
   if (value instanceof PrimitiveValue) title = value.toDisplayString();
@@ -100,6 +100,9 @@ export function describeValue(value: Value): string {
           .map(u => "  " + u)
           .join("\n") + "\n";
     }
+  }
+  if (valueToString !== undefined) {
+    title += `, id: ${valueToString(value)}`;
   }
   title += `, hash: ${value.getHash()}`;
   if (value.intrinsicName !== undefined) title += `, intrinsic name: ${value.intrinsicName}`;


### PR DESCRIPTION
Release notes: None

This adds a check that a nested generator's path conditions should imply its parent's path conditions.

However, this is not actually currently the case, as
test/serializer/additional-functions/EmitPropertyRegressionTest.js
fails the new invariant (need to run with --invariantLevel 99).

Also added path conditions to logging output when running with --debugScopes.

This is tracked in #2331.