### PR TITLE
Try conditional branches separately if binary expression fails

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -181,38 +181,38 @@ export function computeBinary(
           // If this failed and one of the arguments was conditional, try each value
           // and join the effects based on the condition.
           if (lval instanceof AbstractValue && lval.kind === "conditional") {
-            let condition = lval.args[0];
+            let [condition, consequentL, alternateL] = lval.args;
             invariant(condition instanceof AbstractValue);
             return realm.evaluateWithAbstractConditional(
               condition,
               () =>
                 realm.evaluateForEffects(
-                  () => computeBinary(realm, op, lval.args[1], rval, lloc, rloc, loc),
+                  () => computeBinary(realm, op, consequentL, rval, lloc, rloc, loc),
                   undefined,
                   "ConditionalBinaryExpression/1"
                 ),
               () =>
                 realm.evaluateForEffects(
-                  () => computeBinary(realm, op, lval.args[2], rval, lloc, rloc, loc),
+                  () => computeBinary(realm, op, alternateL, rval, lloc, rloc, loc),
                   undefined,
                   "ConditionalBinaryExpression/2"
                 )
             );
           }
           if (rval instanceof AbstractValue && rval.kind === "conditional") {
-            let condition = rval.args[0];
+            let [condition, consequentR, alternateR] = rval.args;
             invariant(condition instanceof AbstractValue);
             return realm.evaluateWithAbstractConditional(
               condition,
               () =>
                 realm.evaluateForEffects(
-                  () => computeBinary(realm, op, lval, rval.args[1], lloc, rloc, loc),
+                  () => computeBinary(realm, op, lval, consequentR, lloc, rloc, loc),
                   undefined,
                   "ConditionalBinaryExpression/3"
                 ),
               () =>
                 realm.evaluateForEffects(
-                  () => computeBinary(realm, op, lval, rval.args[2], lloc, rloc, loc),
+                  () => computeBinary(realm, op, lval, alternateR, lloc, rloc, loc),
                   undefined,
                   "ConditionalBinaryExpression/4"
                 )

--- a/test/serializer/abstract/BinaryExpression3.js
+++ b/test/serializer/abstract/BinaryExpression3.js
@@ -1,0 +1,19 @@
+var b = global.__abstract ? __abstract("boolean", "true") : true;
+var x = global.__abstract ? __abstract("number", "123") : 123;
+var ob = {
+  valueOf: function() {
+    throw 13;
+  },
+};
+var y = b ? ob : x;
+
+var z;
+try {
+  z = 100 + y;
+} catch (err) {
+  z = 200 + err;
+}
+
+inspect = function() {
+  return "" + z;
+};


### PR DESCRIPTION
This solves the remaining issues in #2300.

If a binary expression can't be resolved as pure (such as when applied to values of two different types), we can instead try conditions separately and join the effects.

If the left value is conditional, we try each possible value separately until we hit a non-conditional value. Then we try any conditional right values.