### PR TITLE
Accounts for P in AbstractObjectValue being a SymbolValue

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -509,8 +509,13 @@ export default class AbstractObjectValue extends AbstractValue {
         let realm = this.$Realm;
         let shape = shapeContainer.shape;
         let propertyShape, propertyGetter;
-        if ((realm.instantRender.enabled || realm.react.enabled) && shape !== undefined && typeof P === "string") {
-          propertyShape = shape.getPropertyShape(P);
+        // propertyShape expects only a string value
+        if (
+          (realm.instantRender.enabled || realm.react.enabled) &&
+          shape !== undefined &&
+          (typeof P === "string" || P instanceof StringValue)
+        ) {
+          propertyShape = shape.getPropertyShape(P instanceof StringValue ? P.value : P);
           if (propertyShape !== undefined) {
             type = propertyShape.getAbstractType();
             propertyGetter = propertyShape.getGetter();

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -506,21 +506,24 @@ export default class AbstractObjectValue extends AbstractValue {
         // shape logic
         let shapeContainer = this.kind === "explicit conversion to object" ? this.args[0] : this;
         invariant(shapeContainer instanceof AbstractValue);
-        invariant(typeof P === "string");
         let realm = this.$Realm;
         let shape = shapeContainer.shape;
         let propertyShape, propertyGetter;
-        if ((realm.instantRender.enabled || realm.react.enabled) && shape !== undefined) {
+        if ((realm.instantRender.enabled || realm.react.enabled) && shape !== undefined && typeof P === "string") {
           propertyShape = shape.getPropertyShape(P);
           if (propertyShape !== undefined) {
             type = propertyShape.getAbstractType();
             propertyGetter = propertyShape.getGetter();
           }
         }
+        // P can also be a SymbolValue
+        if (typeof P === "string") {
+          P = new StringValue(this.$Realm, P);
+        }
         let propAbsVal = AbstractValue.createTemporalFromBuildFunction(
           realm,
           type,
-          [ob, new StringValue(this.$Realm, P)],
+          [ob, P],
           createOperationDescriptor("ABSTRACT_OBJECT_GET", { propertyGetter }),
           {
             skipInvariant: true,

--- a/test/serializer/optimized-functions/SymbolGet.js
+++ b/test/serializer/optimized-functions/SymbolGet.js
@@ -1,0 +1,15 @@
+function fn(x) {
+  return x[Symbol.hasInstance];
+}
+
+this.__optimize && __optimize(fn);
+
+inspect = function() {
+  class Array1 {
+    static [Symbol.hasInstance](instance) {
+      return Array.isArray(instance);
+    }
+  }
+
+  return fn(Array1)([]);
+};


### PR DESCRIPTION
Release notes: none

Changes invariant to accept SymbolValue as well as strings. I found to be hitting this invariant in the internal bundle. I'll put up a regression test next week as this is a tricky one to repro it seems.