### PR TITLE
Set on havoced object should target the receiver, not the own object

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -235,8 +235,10 @@ export class PropertiesImplementation {
     if (!realm.ignoreLeakLogic && O.mightBeHavocedObject()) {
       // Writing a value to a havoced (because leaked) object leaks the value, so havoc it.
       Havoc.value(realm, V);
+      // The receiver might leak to a getter so if it's not already havoced, we need to havoc it.
+      Havoc.value(realm, Receiver);
       if (realm.generator) {
-        realm.generator.emitPropertyAssignment(O, StringKey(P), V);
+        realm.generator.emitPropertyAssignment(Receiver, StringKey(P), V);
       }
       return true;
     }

--- a/src/serializer/ResidualOperationSerializer.js
+++ b/src/serializer/ResidualOperationSerializer.js
@@ -199,9 +199,6 @@ export class ResidualOperationSerializer {
       case "ABSTRACT_OBJECT_GET_PARTIAL":
         babelNode = this._serializeAbstractObjectGetPartial(data, nodes);
         break;
-      case "ABSTRACT_OBJECT_SET_PARTIAL":
-        babelNode = this._serializeAbstractObjectSetPartial(data, nodes);
-        break;
       case "ABSTRACT_OBJECT_GET_PROTO_OF":
         babelNode = this._serializeAbstractObjectGetProtoOf(data, nodes);
         break;
@@ -711,13 +708,6 @@ export class ResidualOperationSerializer {
       t.memberExpression(t.identifier("Bootloader"), t.identifier("loadModules")),
       ((args: any): Array<any>)
     );
-  }
-
-  _serializeAbstractObjectSetPartial(
-    data: OperationDescriptorData,
-    [objectNode, keyNode, valueNode]: Array<BabelNodeExpression>
-  ) {
-    return t.expressionStatement(t.assignmentExpression("=", memberExpressionHelper(objectNode, keyNode), valueNode));
   }
 
   _serializeUnknownArrayGetPartial(data: OperationDescriptorData, [o, p]: Array<BabelNodeExpression>) {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -64,7 +64,6 @@ export type OperationDescriptorType =
   | "ABSTRACT_OBJECT_GET"
   | "ABSTRACT_OBJECT_GET_PARTIAL"
   | "ABSTRACT_OBJECT_GET_PROTO_OF"
-  | "ABSTRACT_OBJECT_SET_PARTIAL"
   | "ABSTRACT_PROPERTY"
   | "APPEND_GENERATOR"
   | "ASSUME_CALL"
@@ -769,10 +768,15 @@ export class Generator {
     this._entries.push(new BindingAssignmentEntry(this.realm, binding, value));
   }
 
-  emitPropertyAssignment(object: ObjectValue, key: string, value: Value): void {
-    if (object.refuseSerialization) return;
+  emitPropertyAssignment(object: Value, key: string | Value, value: Value): void {
+    if (object instanceof ObjectValue && object.refuseSerialization) {
+      return;
+    }
+    if (typeof key === "string") {
+      key = new StringValue(this.realm, key);
+    }
     this._addEntry({
-      args: [object, value, new StringValue(this.realm, key)],
+      args: [object, value, key],
       operationDescriptor: createOperationDescriptor("EMIT_PROPERTY_ASSIGNMENT", { value }),
     });
   }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -768,16 +768,11 @@ export default class AbstractObjectValue extends AbstractValue {
             let generator = this.$Realm.generator;
             invariant(generator);
 
-            if (typeof P === "string") {
-              generator.emitStatement(
-                [Receiver, new StringValue(this.$Realm, P), V],
-                createOperationDescriptor("ABSTRACT_OBJECT_SET_PARTIAL")
-              );
-            } else {
+            if (typeof P !== "string" && !(P instanceof StringValue)) {
               // Coercion can only have effects on anything reachable from the key.
               Havoc.value(this.$Realm, P);
-              generator.emitStatement([Receiver, P, V], createOperationDescriptor("ABSTRACT_OBJECT_SET_PARTIAL"));
             }
+            generator.emitPropertyAssignment(Receiver, P, V);
             return this.$Realm.intrinsics.undefined;
           },
           TypesDomain.topVal,

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -944,7 +944,7 @@ export default class ObjectValue extends ConcreteValue {
             let generator = this.$Realm.generator;
             invariant(generator);
             invariant(P instanceof AbstractValue);
-            generator.emitStatement([Receiver, P, V], createOperationDescriptor("OBJECT_SET_PARTIAL"));
+            generator.emitPropertyAssignment(Receiver, P, V);
             return this.$Realm.intrinsics.undefined;
           },
           TypesDomain.topVal,

--- a/test/serializer/pure-functions/SetterOnHavocedPrototype.js
+++ b/test/serializer/pure-functions/SetterOnHavocedPrototype.js
@@ -1,0 +1,22 @@
+var obj = global.__abstract && global.__makePartial ? __makePartial(__abstract({}, "({foo:1})")) : { foo: 1 };
+
+function fn(cb) {
+  var foo = {
+    set x(v) {
+      this.y = 1;
+    },
+  };
+  var bar = Object.create(foo);
+  bar.y = 2;
+  cb(foo);
+  bar.x = 3;
+  return bar.y;
+}
+
+if (global.__optimize) {
+  __optimize(fn);
+}
+
+inspect = function() {
+  return fn(o => o);
+};


### PR DESCRIPTION
In case the havoced object has a setter on it.

This is fixes this particular bug but it's also useful to be able to pass the correct receiver to properties.js rather than unwrapping it like we do now. This will be evident in a follow up PR.

This also lets emitPropertyAssignment deal with abstract values which is a common pattern and will become more common with widened objects.