### PR TITLE
Fix issue in isDefinedInsideFunction

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test-residual": "babel-node scripts/test-residual.js",
     "test-residual-with-coverage": "./node_modules/.bin/istanbul cover ./lib/test-residual.js --dir coverage.residual && ./node_modules/.bin/remap-istanbul -i coverage.residual/coverage.json -o coverage-sourcemapped.residual -t html",
     "test-serializer": "babel-node --stack_trace_limit=200 --stack_size=10000 scripts/test-runner.js",
+    "test-serializer-single": "yarn test-serializer --debugNames --verbose --fast --filter",
     "test-serializer-with-coverage": "./node_modules/.bin/istanbul cover ./lib/test-error-handler.js --dir coverage.error && ./node_modules/.bin/istanbul cover ./lib/test-runner.js && ./node_modules/.bin/remap-istanbul -i coverage.error/coverage.json -i coverage/coverage.json -o coverage-sourcemapped -t html",
     "test-sourcemaps": "babel-node scripts/generate-sourcemaps-test.js && bash < scripts/test-sourcemaps.sh",
     "test-test262": "babel-node scripts/test262-runner.js",

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -480,6 +480,9 @@ function runTest(name, code, options: PrepackOptions, args) {
     if (compileJSXWithBabel) {
       expectedCode = transformWithBabel(expectedCode, ["@babel/plugin-transform-react-jsx"]);
     }
+    // For some tests (e.g. nested optimized function definition) there is no way to pass lint due to undefined global
+    // __optimize
+    let runLint = !code.includes("// skip lint");
 
     return execInContext(
       `${addedCode}\n(function () {${expectedCode} // keep newline here as code may end with comment
@@ -603,7 +606,7 @@ function runTest(name, code, options: PrepackOptions, args) {
               );
             }
             // lint output
-            lintCompiledSource(codeToRun);
+            if (runLint) lintCompiledSource(codeToRun);
             let actualPromise;
             if (execSpec) {
               actualPromise = execExternal(execSpec, codeToRun);

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -80,7 +80,7 @@ import { canHoistFunction } from "../react/hoisting.js";
 import { To } from "../singletons.js";
 import { ResidualReactElementSerializer } from "./ResidualReactElementSerializer.js";
 import type { Binding } from "../environment.js";
-import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord, FunctionEnvironmentRecord } from "../environment.js";
+import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../environment.js";
 import type { Referentializer } from "./Referentializer.js";
 import { GeneratorDAG } from "./GeneratorDAG.js";
 import { type Replacement, getReplacement } from "./ResidualFunctionInstantiator.js";
@@ -754,13 +754,10 @@ export class ResidualHeapSerializer {
       if (childFunction === maybeParentFunction) {
         continue;
       }
-      let env = childFunction.$Environment;
-      while (env.parent !== null) {
-        let envRecord = env.environmentRecord;
-        if (envRecord instanceof FunctionEnvironmentRecord && envRecord.$FunctionObject === maybeParentFunction) {
-          return true;
-        }
-        env = env.parent;
+      let additionalFVEffects = this.additionalFunctionValuesAndEffects;
+      if (additionalFVEffects) {
+        let maybeParentFunctionInfo = additionalFVEffects.get(maybeParentFunction);
+        if (maybeParentFunctionInfo && maybeParentFunctionInfo.effects.createdObjects.has(childFunction)) return true;
       }
     }
     return false;

--- a/test/serializer/optimized-functions/DefineOptFuncInsideFuncInsideOptFunc.js
+++ b/test/serializer/optimized-functions/DefineOptFuncInsideFuncInsideOptFunc.js
@@ -1,0 +1,42 @@
+// skip lint
+// The original issue here was that nested is defined inside of fn2 which is a non-optimized function
+// called by fn (an optimized function). That caused Prepack to not detect that nested was nested
+// in optimize.
+
+function fn2(props) {
+  var _ref11;
+  var commentsConnection =
+    (_ref11 = props) != null
+      ? (_ref11 = _ref11.feedback) != null
+        ? _ref11.display_comments
+        : _ref11
+      : _ref11;
+
+  var func = props.func;
+
+  var nested = function() {
+    return func(commentsConnection);
+  };
+  if (global.__optimize) __optimize(nested);
+  return props.items.map(nested);
+}
+
+function fn(props) {
+  var items = Array.from(props.items);
+
+  var func = function(commentsConnection) {
+    return commentsConnection;
+  };
+
+  return fn2({
+    items: items,
+    func: func,
+    feedback: props.feedback,
+  });
+}
+
+inspect = function() {
+  return JSON.stringify(fn({ items: [0, 1, 2], feedback: { display_comments: [1, 2, 3] } }))
+}
+
+if (global.__optimize) __optimize(fn);

--- a/test/serializer/optimized-functions/DefineOptFuncInsideFuncInsideOptFunc.js
+++ b/test/serializer/optimized-functions/DefineOptFuncInsideFuncInsideOptFunc.js
@@ -6,11 +6,7 @@
 function fn2(props) {
   var _ref11;
   var commentsConnection =
-    (_ref11 = props) != null
-      ? (_ref11 = _ref11.feedback) != null
-        ? _ref11.display_comments
-        : _ref11
-      : _ref11;
+    (_ref11 = props) != null ? ((_ref11 = _ref11.feedback) != null ? _ref11.display_comments : _ref11) : _ref11;
 
   var func = props.func;
 
@@ -36,7 +32,7 @@ function fn(props) {
 }
 
 inspect = function() {
-  return JSON.stringify(fn({ items: [0, 1, 2], feedback: { display_comments: [1, 2, 3] } }))
-}
+  return JSON.stringify(fn({ items: [0, 1, 2], feedback: { display_comments: [1, 2, 3] } }));
+};
 
 if (global.__optimize) __optimize(fn);


### PR DESCRIPTION
Release Notes: None

 The original issue here was that `nested` is defined inside of `fn2` which is a non-optimized function called by `fn` (an optimized function). That caused Prepack to not detect that `nested` was nested in `fn2`. 

The fix is to use `CreatedObjects` to test for nesting instead of the environment lookup. The environment lookup fails because `nested` is evaluated with `fn2`'s effects applied but _not in `fn2`'s environment_.

This PR also adds a command I use frequently to test a single failing `test-runner` test as well as a way to skip lint because some tests can't pass lint.

Addresses the first test case of #2337.