### PR TITLE
Refactor Get/Set Partial

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -404,7 +404,15 @@ export class ObjectEnvironmentRecord extends EnvironmentRecord {
     let bindings = this.object;
 
     // 3. Let foundBinding be ? HasProperty(bindings, N).
-    let foundBinding = HasProperty(realm, bindings, N);
+    let foundBinding;
+    if (bindings.isPartialObject()) {
+      // If a partial object is used we have already issued an error in WithStatement.
+      // If we recovered from that, we assume that all bindings match against the
+      // partial object.
+      foundBinding = true;
+    } else {
+      foundBinding = HasProperty(realm, bindings, N);
+    }
 
     // 4. If foundBinding is false, return false.
     if (!foundBinding) return false;

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -29,7 +29,7 @@ import {
   Value,
 } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { FatalError } from "../errors.js";
+import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { SetIntegrityLevel } from "./integrity.js";
 import {
   Call,
@@ -39,10 +39,11 @@ import {
   IsDataDescriptor,
   IsPropertyKey,
 } from "./index.js";
-import { Create, Environment, Join, Path, To } from "../singletons.js";
+import { Create, Environment, Join, Havoc, Path, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeTemplateLiteral } from "@babel/types";
 import { createOperationDescriptor } from "../utils/generator.js";
+import buildExpressionTemplate from "../utils/builder.js";
 
 // ECMA262 7.3.22
 export function GetFunctionRealm(realm: Realm, obj: ObjectValue): Realm {
@@ -94,6 +95,36 @@ export function OrdinaryGet(
   Receiver: Value,
   dataOnly?: boolean
 ): Value {
+  // First deal with potential unknown properties.
+  let prop = O.unknownProperty;
+  if (prop !== undefined && prop.descriptor !== undefined && O.$GetOwnProperty(P) === undefined) {
+    let desc = prop.descriptor;
+    invariant(desc !== undefined);
+    let val = desc.value;
+    invariant(val instanceof AbstractValue);
+    let propValue;
+    if (P instanceof StringValue) {
+      propValue = P;
+    } else if (typeof P === "string") {
+      propValue = new StringValue(realm, P);
+    }
+
+    if (val.kind === "widened numeric property") {
+      invariant(Receiver instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(Receiver));
+      let propName;
+      if (P instanceof StringValue) {
+        propName = P.value;
+      } else {
+        propName = P;
+      }
+      return GetFromArrayWithWidenedNumericProperty(realm, Receiver, propName);
+    } else if (!propValue) {
+      AbstractValue.reportIntrospectionError(val, "abstract computed property name");
+      throw new FatalError();
+    }
+    return specializeJoin(realm, val, propValue);
+  }
+
   // 1. Assert: IsPropertyKey(P) is true.
   invariant(IsPropertyKey(realm, P), "expected property key");
 
@@ -246,6 +277,199 @@ export function OrdinaryGet(
     // 8. Return ? Call(getter, Receiver).
     return Call(realm, getter, Receiver);
   }
+}
+
+function isWidenedValue(v: void | Value) {
+  if (!(v instanceof AbstractValue)) return false;
+  if (v.kind === "widened" || v.kind === "widened property") return true;
+  for (let a of v.args) {
+    if (isWidenedValue(a)) return true;
+  }
+  return false;
+}
+
+const lengthTemplateSrc = "(A).length";
+const lengthTemplate = buildExpressionTemplate(lengthTemplateSrc);
+
+function specializeJoin(realm: Realm, absVal: AbstractValue, propName: Value): Value {
+  if (absVal.kind === "widened property") {
+    let ob = absVal.args[0];
+    if (propName instanceof StringValue) {
+      let pName = propName.value;
+      let pNumber = +pName;
+      if (pName === pNumber + "") propName = new NumberValue(realm, pNumber);
+    }
+    return AbstractValue.createTemporalFromBuildFunction(
+      realm,
+      absVal.getType(),
+      [ob, propName],
+      createOperationDescriptor("OBJECT_GET_PARTIAL"),
+      { skipInvariant: true, isPure: true }
+    );
+  }
+  invariant(absVal.args.length === 3 && absVal.kind === "conditional");
+  let generic_cond = absVal.args[0];
+  invariant(generic_cond instanceof AbstractValue);
+  let cond = specializeCond(realm, generic_cond, propName);
+  let arg1 = absVal.args[1];
+  if (arg1 instanceof AbstractValue && arg1.args.length === 3) arg1 = specializeJoin(realm, arg1, propName);
+  let arg2 = absVal.args[2];
+  if (arg2 instanceof AbstractValue) {
+    if (arg2.kind === "template for prototype member expression") {
+      let ob = arg2.args[0];
+      arg2 = AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        absVal.getType(),
+        [ob, propName],
+        createOperationDescriptor("OBJECT_GET_PARTIAL"),
+        { skipInvariant: true, isPure: true }
+      );
+    } else if (arg2.args.length === 3) {
+      arg2 = specializeJoin(realm, arg2, propName);
+    }
+  }
+  return AbstractValue.createFromConditionalOp(realm, cond, arg1, arg2, absVal.expressionLocation);
+}
+
+function specializeCond(realm: Realm, absVal: AbstractValue, propName: Value): Value {
+  if (absVal.kind === "template for property name condition")
+    return AbstractValue.createFromBinaryOp(realm, "===", absVal.args[0], propName);
+  return absVal;
+}
+
+export function OrdinaryGetPartial(
+  realm: Realm,
+  O: ObjectValue,
+  P: AbstractValue | PropertyKeyValue,
+  Receiver: Value,
+  dataOnly?: boolean
+): Value {
+  if (Receiver instanceof AbstractValue && Receiver.getType() === StringValue && P === "length") {
+    return AbstractValue.createFromTemplate(realm, lengthTemplate, NumberValue, [Receiver], lengthTemplateSrc);
+  }
+
+  if (!(P instanceof AbstractValue)) return OrdinaryGet(realm, O, P, Receiver);
+
+  // A string coercion might have side-effects.
+  // TODO #1682: We assume that simple objects mean that they don't have a
+  // side-effectful valueOf and toString but that's not enforced.
+  if (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject()) {
+    if (realm.isInPureScope()) {
+      // If we're in pure scope, we can havoc the key and keep going.
+      // Coercion can only have effects on anything reachable from the key.
+      Havoc.value(realm, P);
+    } else {
+      let error = new CompilerDiagnostic(
+        "property key might not have a well behaved toString or be a symbol",
+        realm.currentLocation,
+        "PP0002",
+        "RecoverableError"
+      );
+      if (realm.handleError(error) !== "Recover") {
+        throw new FatalError();
+      }
+    }
+  }
+
+  // We assume that simple objects have no getter/setter properties.
+  if (!O.isSimpleObject()) {
+    if (realm.isInPureScope()) {
+      // If we're in pure scope, we can havoc the object. Coercion
+      // can only have effects on anything reachable from this object.
+      // We assume that if the receiver is different than this object,
+      // then we only got here because there were no other keys with
+      // this name on other parts of the prototype chain.
+      // TODO #1675: A fix to 1675 needs to take this into account.
+      Havoc.value(realm, Receiver);
+      return AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        Value,
+        [Receiver, P],
+        createOperationDescriptor("OBJECT_GET_PARTIAL"),
+        { skipInvariant: true, isPure: true }
+      );
+    } else {
+      let error = new CompilerDiagnostic(
+        "unknown property access might need to invoke a getter",
+        realm.currentLocation,
+        "PP0030",
+        "RecoverableError"
+      );
+      if (realm.handleError(error) !== "Recover") {
+        throw new FatalError();
+      }
+    }
+  }
+
+  P = To.ToStringAbstract(realm, P);
+
+  // If all else fails, use this expression
+  // TODO #1675: Check the prototype chain for known properties too.
+  let result;
+  if (O.isPartialObject()) {
+    if (isWidenedValue(P)) {
+      // TODO #1678: Use a snapshot or havoc this object.
+      return AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        Value,
+        [O, P],
+        createOperationDescriptor("OBJECT_GET_PARTIAL"),
+        { skipInvariant: true, isPure: true }
+      );
+    }
+    result = AbstractValue.createFromType(realm, Value, "sentinel member expression", [O, P]);
+  } else {
+    // This is simple and not partial. Any access that isn't covered by checking against
+    // all its properties, is covered by reading from the prototype.
+    if (O.$Prototype === realm.intrinsics.null) {
+      // If the prototype is null, then the fallback value is undefined.
+      result = realm.intrinsics.undefined;
+    } else {
+      // Otherwise, we read the value dynamically from the prototype chain.
+      result = AbstractValue.createTemporalFromBuildFunction(
+        realm,
+        Value,
+        [O.$Prototype, P],
+        createOperationDescriptor("OBJECT_GET_PARTIAL"),
+        { skipInvariant: true, isPure: true }
+      );
+    }
+  }
+
+  // Get a specialization of the join of all values written to the object
+  // with abstract property names.
+  let prop = O.unknownProperty;
+  if (prop !== undefined) {
+    let desc = prop.descriptor;
+    if (desc !== undefined) {
+      let val = desc.value;
+      invariant(val instanceof AbstractValue);
+      if (val.kind === "widened numeric property") {
+        invariant(Receiver instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(Receiver));
+        return GetFromArrayWithWidenedNumericProperty(realm, Receiver, P instanceof StringValue ? P.value : P);
+      }
+      result = specializeJoin(realm, val, P);
+    }
+  }
+  // Join in all of the other values that were written to the object with
+  // concrete property names.
+  for (let [key, propertyBinding] of O.properties) {
+    let desc = propertyBinding.descriptor;
+    if (desc === undefined) continue; // deleted
+    invariant(desc.value !== undefined); // otherwise this is not simple
+    let val = desc.value;
+    invariant(val instanceof Value);
+    let cond = AbstractValue.createFromBinaryOp(
+      realm,
+      "===",
+      P,
+      new StringValue(realm, key),
+      undefined,
+      "check for known property"
+    );
+    result = AbstractValue.createFromConditionalOp(realm, cond, val, result);
+  }
+  return result;
 }
 
 // ECMA262 8.3.6

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -24,6 +24,7 @@ import {
   StringValue,
   SymbolValue,
   UndefinedValue,
+  PrimitiveValue,
   Value,
 } from "../values/index.js";
 import { EvalPropertyName } from "../evaluators/ObjectExpression.js";
@@ -37,6 +38,7 @@ import {
   Get,
   GetGlobalObject,
   GetThisValue,
+  HasCompatibleType,
   HasSomeCompatibleType,
   IsAccessorDescriptor,
   IsDataDescriptor,
@@ -51,6 +53,7 @@ import type { LexicalEnvironment } from "../environment.js";
 import { Create, Environment, Functions, Havoc, Join, Path, To } from "../singletons.js";
 import IsStrict from "../utils/strict.js";
 import { createOperationDescriptor } from "../utils/generator.js";
+import { TypesDomain, ValuesDomain } from "../domains/index.js";
 
 function StringKey(key: PropertyKeyValue): string {
   if (key instanceof StringValue) key = key.value;
@@ -233,6 +236,15 @@ function ensureIsNotFinal(realm: Realm, O: ObjectValue, P: void | PropertyKeyVal
   );
   realm.handleError(error);
   throw new FatalError();
+}
+
+function isWidenedValue(v: void | Value) {
+  if (!(v instanceof AbstractValue)) return false;
+  if (v.kind === "widened" || v.kind === "widened property") return true;
+  for (let a of v.args) {
+    if (isWidenedValue(a)) return true;
+  }
+  return false;
 }
 
 export class PropertiesImplementation {
@@ -451,6 +463,167 @@ export class PropertiesImplementation {
       // 9. Return true.
       return true;
     }
+  }
+
+  OrdinarySetPartial(
+    realm: Realm,
+    O: ObjectValue,
+    P: AbstractValue | PropertyKeyValue,
+    V: Value,
+    Receiver: Value
+  ): boolean {
+    if (!(P instanceof AbstractValue)) return this.OrdinarySet(realm, O, P, V, Receiver);
+    let pIsLoopVar = isWidenedValue(P);
+    let pIsNumeric = Value.isTypeCompatibleWith(P.getType(), NumberValue);
+
+    // A string coercion might have side-effects.
+    // TODO #1682: We assume that simple objects mean that they don't have a
+    // side-effectful valueOf and toString but that's not enforced.
+    if (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject()) {
+      if (realm.isInPureScope()) {
+        // If we're in pure scope, we can havoc the key and keep going.
+        // Coercion can only have effects on anything reachable from the key.
+        Havoc.value(realm, P);
+      } else {
+        let error = new CompilerDiagnostic(
+          "property key might not have a well behaved toString or be a symbol",
+          realm.currentLocation,
+          "PP0002",
+          "RecoverableError"
+        );
+        if (realm.handleError(error) !== "Recover") {
+          throw new FatalError();
+        }
+      }
+    }
+
+    // We assume that simple objects have no getter/setter properties and
+    // that all properties are writable.
+    if (!O.isSimpleObject()) {
+      if (realm.isInPureScope()) {
+        // If we're in pure scope, we can havoc the object and leave an
+        // assignment in place.
+        Havoc.value(realm, Receiver);
+        // We also need to havoc the value since it might leak to a setter.
+        Havoc.value(realm, V);
+        realm.evaluateWithPossibleThrowCompletion(
+          () => {
+            let generator = realm.generator;
+            invariant(generator);
+            invariant(P instanceof AbstractValue);
+            generator.emitPropertyAssignment(Receiver, P, V);
+            return realm.intrinsics.undefined;
+          },
+          TypesDomain.topVal,
+          ValuesDomain.topVal
+        );
+        // The emitted assignment might throw at runtime but if it does, that
+        // is handled by evaluateWithPossibleThrowCompletion. Anything that
+        // happens after this, can assume we didn't throw and therefore,
+        // we return true here.
+        return true;
+      } else {
+        let error = new CompilerDiagnostic(
+          "unknown property access might need to invoke a setter",
+          realm.currentLocation,
+          "PP0030",
+          "RecoverableError"
+        );
+        if (realm.handleError(error) !== "Recover") {
+          throw new FatalError();
+        }
+      }
+    }
+
+    // We should never consult the prototype chain for unknown properties.
+    // If it was simple, it would've been an assignment to the receiver.
+    // The only case the Receiver isn't this, if this was a ToObject
+    // coercion from a PrimitiveValue.
+    invariant(O === Receiver || HasCompatibleType(Receiver, PrimitiveValue));
+
+    P = To.ToStringAbstract(realm, P);
+
+    function createTemplate(propName: AbstractValue) {
+      return AbstractValue.createFromBinaryOp(
+        realm,
+        "===",
+        propName,
+        new StringValue(realm, ""),
+        undefined,
+        "template for property name condition"
+      );
+    }
+
+    let prop;
+    if (O.unknownProperty === undefined) {
+      prop = {
+        descriptor: undefined,
+        object: O,
+        key: P,
+      };
+      O.unknownProperty = prop;
+    } else {
+      prop = O.unknownProperty;
+    }
+    realm.recordModifiedProperty(prop);
+    let desc = prop.descriptor;
+    if (desc === undefined) {
+      let newVal = V;
+      if (!(V instanceof UndefinedValue) && !isWidenedValue(P)) {
+        // join V with sentinel, using a property name test as the condition
+        let cond = createTemplate(P);
+        let sentinel = AbstractValue.createFromType(realm, Value, "template for prototype member expression", [
+          Receiver,
+          P,
+        ]);
+        newVal = AbstractValue.createFromConditionalOp(realm, cond, V, sentinel);
+      }
+      prop.descriptor = {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value: newVal,
+      };
+    } else {
+      // join V with current value of O.unknownProperty. I.e. weak update.
+      let oldVal = desc.value;
+      invariant(oldVal instanceof Value);
+      let newVal = oldVal;
+      if (!(V instanceof UndefinedValue)) {
+        if (isWidenedValue(P)) {
+          newVal = V; // It will be widened later on
+        } else {
+          let cond = createTemplate(P);
+          newVal = AbstractValue.createFromConditionalOp(realm, cond, V, oldVal);
+        }
+      }
+      desc.value = newVal;
+    }
+
+    // Since we don't know the name of the property we are writing to, we also need
+    // to perform weak updates of all of the known properties.
+    // First clear out O.unknownProperty so that helper routines know its OK to update the properties
+    let savedUnknownProperty = O.unknownProperty;
+    O.unknownProperty = undefined;
+    for (let [key, propertyBinding] of O.properties) {
+      if (pIsLoopVar && pIsNumeric) {
+        // Delete numeric properties and don't do weak updates on other properties.
+        if (key !== +key + "") continue;
+        O.properties.delete(key);
+        continue;
+      }
+      let oldVal = realm.intrinsics.empty;
+      if (propertyBinding.descriptor && propertyBinding.descriptor.value) {
+        oldVal = propertyBinding.descriptor.value;
+        invariant(oldVal instanceof Value); // otherwise this is not simple
+      }
+      let cond = AbstractValue.createFromBinaryOp(realm, "===", P, new StringValue(realm, key));
+      let newVal = AbstractValue.createFromConditionalOp(realm, cond, V, oldVal);
+      this.OrdinarySet(realm, O, key, newVal, Receiver);
+    }
+    O.unknownProperty = savedUnknownProperty;
+
+    return true;
   }
 
   // ECMA262 6.2.4.4

--- a/src/types.js
+++ b/src/types.js
@@ -382,6 +382,13 @@ export type MaterializeType = {
 export type PropertiesType = {
   // ECMA262 9.1.9.1
   OrdinarySet(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value, Receiver: Value): boolean,
+  OrdinarySetPartial(
+    realm: Realm,
+    O: ObjectValue,
+    P: AbstractValue | PropertyKeyValue,
+    V: Value,
+    Receiver: Value
+  ): boolean,
 
   // ECMA262 6.2.4.4
   FromPropertyDescriptor(realm: Realm, Desc: ?Descriptor): Value,

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -416,6 +416,7 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   isSimpleObject(): boolean {
+    if (this === this.$Realm.intrinsics.ObjectPrototype) return true;
     if (!this._isSimple.mightNotBeTrue()) return true;
     if (this.isPartialObject()) return false;
     if (this.symbols.size > 0) return false;
@@ -426,7 +427,6 @@ export default class ObjectValue extends ConcreteValue {
       if (!desc.writable) return false;
     }
     if (this.$Prototype instanceof NullValue) return true;
-    if (this.$Prototype === this.$Realm.intrinsics.ObjectPrototype) return true;
     invariant(this.$Prototype);
     return this.$Prototype.isSimpleObject();
   }


### PR DESCRIPTION
This is part of a larger set of features for the object model to fully model the Set/Get phases for partial and abstract objects. I wanted to break it down into smaller steps. This has two changes.

[The first commit](https://github.com/facebook/prepack/commit/93a252643dce61c23a44d0588a52105e3183aa36) changes the way we model OrdinaryGetOwnProperty for partial objects. It was not correct to model it as a known value of a particular type since it might not exist. Instead I model this as mightBeEmpty. I recommend reviewing that commit separately.

This lets us get rid of the special case introduced by #1183. This special case caused trouble for me trying to generalize these paths. Instead we can know that a property might not exist in a partial object by checking mightBeEmpty.

The second two commits is just a plain move of GetPartial and SetPartial to get.js/properties.js. All other property modeling for concrete keys are already there. You can tell that a lot of imports and logic becomes duplicated because they do similar things.

An alternative could be to move all the logic into ObjectValue but that's not how the spec is structured.
This also causes trouble for me trying to generalize these operations for abstract object values which may not consult the ObjectValue's virtual dispatch.