### PR TITLE
Fix visiting of leaked bindings of nested optimized functions

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1210,6 +1210,7 @@ export class ResidualHeapVisitor {
         // in that case, we need to figure out which optimized function it is, and referentialize it in that scope.
         let optimizedFunctionScope = this._getAdditionalFunctionOfScope();
         if (residualBinding.potentialReferentializationScopes.size === 0) {
+          invariant(optimizedFunctionScope !== undefined);
           this._enqueueWithUnrelatedScope(optimizedFunctionScope, () =>
             this.visitBinding(optimizedFunctionScope, residualBinding)
           );

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -9,11 +9,7 @@
 
 /* @flow */
 
-import {
-  GlobalEnvironmentRecord,
-  DeclarativeEnvironmentRecord,
-  EnvironmentRecord,
-} from "../environment.js";
+import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord, EnvironmentRecord } from "../environment.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { type Effects, Realm } from "../realm.js";
 import { Path } from "../singletons.js";
@@ -1213,22 +1209,11 @@ export class ResidualHeapVisitor {
         // This may not have been referentialized if the binding is a local of an optimized function.
         // in that case, we need to figure out which optimized function it is, and referentialize it in that scope.
         let optimizedFunctionScope = this._getAdditionalFunctionOfScope();
-        invariant(optimizedFunctionScope);
-        let fixpoint_rerun = () => {
-          // NB: we wait out the first iteration to make sure that any residual functions that would add a
-          // referentialization scope, it has done so.
-          this._enqueueWithUnrelatedScope(this.scope, () => {
-            if (residualBinding.potentialReferentializationScopes.size === 0) {
-              this._enqueueWithUnrelatedScope(optimizedFunctionScope, () =>
-                this.visitBinding(optimizedFunctionScope, residualBinding)
-              );
-              return true;
-            }
-            return false;
-          });
-          return true;
-        };
-        this._enqueueWithUnrelatedScope(this.scope, fixpoint_rerun);
+        if (residualBinding.potentialReferentializationScopes.size === 0) {
+          this._enqueueWithUnrelatedScope(optimizedFunctionScope, () =>
+            this.visitBinding(optimizedFunctionScope, residualBinding)
+          );
+        }
         return this.visitEquivalentValue(value);
       },
     };

--- a/test/serializer/additional-functions/OptimizedResidualOptimized.js
+++ b/test/serializer/additional-functions/OptimizedResidualOptimized.js
@@ -1,0 +1,21 @@
+// does not contain:1 + 2
+(function() {
+  function f() {
+    function residual() {
+      let z = 3;
+      function g() {
+        return 1 + 2 + z;
+      }
+
+      global.__optimize && __optimize(g);
+      return g;
+    }
+    let g = residual();
+
+    return g;
+  }
+  if (global.__optimize) __optimize(f);
+  global.inspect = function() {
+    return f()();
+  };
+})();

--- a/test/serializer/optimized-functions/HavocNestedBindings1.js
+++ b/test/serializer/optimized-functions/HavocNestedBindings1.js
@@ -4,7 +4,7 @@
     function incrementX() {
       x = x + 42;
     }
-    __optimize(incrementX);
+    global.__optimize && __optimize(incrementX);
 
     g(incrementX);
     return x;

--- a/test/serializer/optimized-functions/HavocNestedBindings1.js
+++ b/test/serializer/optimized-functions/HavocNestedBindings1.js
@@ -1,0 +1,16 @@
+(function() {
+  function f(g) {
+    let x = 23;
+    function incrementX() {
+      x = x + 42;
+    }
+    __optimize(incrementX);
+
+    g(incrementX);
+    return x;
+  }
+  global.__optimize && __optimize(f);
+  global.inspect = function() {
+    return f(g => g());
+  };
+})();

--- a/test/serializer/optimized-functions/HavocNestedBindings2.js
+++ b/test/serializer/optimized-functions/HavocNestedBindings2.js
@@ -1,0 +1,20 @@
+(function() {
+  function f(g) {
+    function definesX() {
+      let x = 23;
+      function incrementX() {
+        x = x + 42;
+      }
+
+      __optimize(incrementX);
+      return [incrementX, x];
+    }
+    let [f1, x1] = definesX();
+    g(f1);
+    return x1;
+  }
+  global.__optimize && __optimize(f);
+  global.inspect = function() {
+    return f(g => g());
+  };
+})();

--- a/test/serializer/optimized-functions/HavocNestedBindings2.js
+++ b/test/serializer/optimized-functions/HavocNestedBindings2.js
@@ -6,7 +6,7 @@
         x = x + 42;
       }
 
-      __optimize(incrementX);
+      global.__optimize && __optimize(incrementX);
       return [incrementX, x];
     }
     let [f1, x1] = definesX();

--- a/test/serializer/optimized-functions/issue-2252-3.js
+++ b/test/serializer/optimized-functions/issue-2252-3.js
@@ -1,0 +1,25 @@
+// skip lint because __optimize isn't defined
+function fn2(props) {
+  var _ref11;
+  var commentsConnection =
+    (_ref11 = props) != null ? ((_ref11 = _ref11.feedback) != null ? _ref11.display_comments : _ref11) : _ref11;
+
+  var nested = function() {
+    return commentsConnection;
+  };
+  global.__optimize && __optimize(nested);
+  return props.items.map(nested);
+}
+
+function fn(props) {
+  return fn2({
+    items: props.items,
+    feedback: props.feedback,
+  });
+}
+
+inspect = function() {
+  return JSON.stringify(fn({ items: [0, 1, 2], feedback: { display_comments: [1, 2, 3] } }));
+};
+
+global.__optimize && __optimize(fn);


### PR DESCRIPTION
Release Notes: None

Now bindingAssignments will have their containing optimized function visit them.

Fixes #2335 and test case 3 of #2252

Test output currently fails lint, once #2339 lands and I rebase past it, that'll go away.