### PR TITLE
Ensure abstract value has kind

### DIFF
--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -170,7 +170,13 @@ function createPropsObject(
         // exist
         for (let [propName, binding] of props.properties) {
           if (binding.descriptor !== undefined && binding.descriptor.value === realm.intrinsics.undefined) {
-            hardModifyReactObjectPropertyBinding(realm, props, propName, AbstractValue.createFromType(realm, Value));
+            let kind = AbstractValue.makeKind("abstractCounted", (realm.objectCount++).toString()); // need not be an object, but must be unique
+            hardModifyReactObjectPropertyBinding(
+              realm,
+              props,
+              propName,
+              AbstractValue.createFromType(realm, Value, kind)
+            );
           }
         }
         // if we have children and they are abstract, they might be undefined at runtime


### PR DESCRIPTION
Release notes: none

This gives a unique kind to the abstract value created by the React elements logic. Otherwise we hit this invariant, https://github.com/facebook/prepack/blob/master/src/utils/havoc.js#L493-L500 with our internal bundle. The abstract value in this case should have always had a kind given it has no args, values or types.