### PR TITLE
Fixing fixup of source locations, mostly.

### DIFF
--- a/flow-typed/npm/source-map_vx.x.x.js
+++ b/flow-typed/npm/source-map_vx.x.x.js
@@ -14,7 +14,161 @@
  */
 
 declare module 'source-map' {
-  declare module.exports: any;
+  // Adapted from https://raw.githubusercontent.com/mozilla/source-map/c73baa52dedcbb77af97d90390d9def4d594c75f/source-map.d.ts
+
+  // Type definitions for source-map
+  // Project: https://github.com/mozilla/source-map
+  // Definitions by: Morten Houston Ludvigsen <https://github.com/MortenHoustonLudvigsen>,
+  //                 Ron Buckton <https://github.com/rbuckton>,
+  //                 John Vilk <https://github.com/jvilk>
+  // Definitions: https://github.com/mozilla/source-map
+  declare type SourceMapUrl = string;
+
+  declare interface Position {
+      line: number;
+      column: number;
+  }
+
+  declare interface NullablePosition {
+      line: number | null;
+      column: number | null;
+      lastColumn: number | null;
+  }
+
+  declare interface MappedPosition {
+      source: string;
+      line: number;
+      column: number;
+      name?: string;
+  }
+
+  declare interface NullableMappedPosition {
+      source: string | null;
+      line: number | null;
+      column: number | null;
+      name: string | null;
+  }
+
+  declare interface MappingItem {
+      source: string;
+      generatedLine: number;
+      generatedColumn: number;
+      originalLine: number;
+      originalColumn: number;
+      name: string;
+  }
+
+  declare interface Mapping {
+      generated: Position;
+      original: Position;
+      source: string;
+      name?: string;
+  }
+
+  declare class SourceMapConsumer {
+      constructor (rawSourceMap: string, sourceMapUrl?: SourceMapUrl): void;
+
+      /**
+       * Compute the last column for each generated mapping. The last column is
+       * inclusive.
+       */
+      computeColumnSpans(): void;
+
+      /**
+       * Returns the original source, line, and column information for the generated
+       * source's line and column positions provided. The only argument is an object
+       * with the following properties:
+       *
+       *   - line: The line number in the generated source.
+       *   - column: The column number in the generated source.
+       *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
+       *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
+       *     closest element that is smaller than or greater than the one we are
+       *     searching for, respectively, if the exact element cannot be found.
+       *     Defaults to 'SourceMapConsumer.GREATEST_LOWER_BOUND'.
+       *
+       * and an object is returned with the following properties:
+       *
+       *   - source: The original source file, or null.
+       *   - line: The line number in the original source, or null.
+       *   - column: The column number in the original source, or null.
+       *   - name: The original identifier, or null.
+       */
+      originalPositionFor(generatedPosition: Position & { bias?: number }): NullableMappedPosition;
+
+      /**
+       * Returns the generated line and column information for the original source,
+       * line, and column positions provided. The only argument is an object with
+       * the following properties:
+       *
+       *   - source: The filename of the original source.
+       *   - line: The line number in the original source.
+       *   - column: The column number in the original source.
+       *   - bias: Either 'SourceMapConsumer.GREATEST_LOWER_BOUND' or
+       *     'SourceMapConsumer.LEAST_UPPER_BOUND'. Specifies whether to return the
+       *     closest element that is smaller than or greater than the one we are
+       *     searching for, respectively, if the exact element cannot be found.
+       *     Defaults to 'SourceMapConsumer.GREATEST_LOWER_BOUND'.
+       *
+       * and an object is returned with the following properties:
+       *
+       *   - line: The line number in the generated source, or null.
+       *   - column: The column number in the generated source, or null.
+       */
+      generatedPositionFor(originalPosition: MappedPosition & { bias?: number }): NullablePosition;
+
+      /**
+       * Returns all generated line and column information for the original source,
+       * line, and column provided. If no column is provided, returns all mappings
+       * corresponding to a either the line we are searching for or the next
+       * closest line that has any mappings. Otherwise, returns all mappings
+       * corresponding to the given line and either the column we are searching for
+       * or the next closest column that has any offsets.
+       *
+       * The only argument is an object with the following properties:
+       *
+       *   - source: The filename of the original source.
+       *   - line: The line number in the original source.
+       *   - column: Optional. the column number in the original source.
+       *
+       * and an array of objects is returned, each with the following properties:
+       *
+       *   - line: The line number in the generated source, or null.
+       *   - column: The column number in the generated source, or null.
+       */
+      allGeneratedPositionsFor(originalPosition: MappedPosition): NullablePosition[];
+
+      /**
+       * Return true if we have the source content for every source in the source
+       * map, false otherwise.
+       */
+      hasContentsOfAllSources(): boolean;
+
+      /**
+       * Returns the original source content. The only argument is the url of the
+       * original source file. Returns null if no original source content is
+       * available.
+       */
+      sourceContentFor(source: string, returnNullOnMissing?: boolean): string | null;
+
+      /**
+       * Iterate over each mapping between an original source/line/column and a
+       * generated line/column in this source map.
+       *
+       * @param callback
+       *        The function that is called with each mapping.
+       * @param context
+       *        Optional. If specified, this object will be the value of `this` every
+       *        time that `aCallback` is called.
+       * @param order
+       *        Either `SourceMapConsumer.GENERATED_ORDER` or
+       *        `SourceMapConsumer.ORIGINAL_ORDER`. Specifies whether you want to
+       *        iterate over the mappings sorted by the generated file's line/column
+       *        order or the original's source/line/column order, respectively. Defaults to
+       *        `SourceMapConsumer.GENERATED_ORDER`.
+       */
+      eachMapping(callback: (mapping: MappingItem) => void, context?: any, order?: number): void;
+  }
 }
 
 /**

--- a/src/environment.js
+++ b/src/environment.js
@@ -1329,7 +1329,7 @@ export class LexicalEnvironment {
         invariant(otherInfo.originalPosition.source != null);
 
         let deltaLine = posInfo.newLine - otherInfo.newLine;
-        pos.line = Math.max(0, otherInfo.originalPosition.line + deltaLine);
+        pos.line = Math.max(1, otherInfo.originalPosition.line + deltaLine);
 
         let deltaColumn = posInfo.newColumn - otherInfo.newColumn;
         pos.column = Math.max(0, otherInfo.originalPosition.column + deltaColumn);

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -35,7 +35,6 @@ import {
   hardModifyReactObjectPropertyBinding,
   getComponentName,
   getComponentTypeFromRootValue,
-  getLocationFromValue,
   getProperty,
   getReactSymbol,
   getValueFromFunctionCall,
@@ -78,6 +77,7 @@ import { Logger } from "../utils/logger.js";
 import type { ClassComponentMetadata, ReactComponentTreeConfig, ReactHint } from "../types.js";
 import { handleReportedSideEffect } from "../serializer/utils.js";
 import { createOperationDescriptor } from "../utils/generator.js";
+import { optionalStringOfLocation } from "../utils/babelhelpers.js";
 
 type ComponentResolutionStrategy =
   | "NORMAL"
@@ -1388,7 +1388,7 @@ export class Reconciler {
     } else if (value instanceof ObjectValue && isReactElement(value)) {
       return this._resolveReactElement(componentType, value, context, branchStatus, evaluatedNode, needsKey);
     } else {
-      let location = getLocationFromValue(value.expressionLocation);
+      let location = optionalStringOfLocation(value.expressionLocation);
       throw new ExpectedBailOut(`invalid return value from render${location}`);
     }
   }

--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -825,15 +825,6 @@ function isEventProp(name: string): boolean {
   return name.length > 2 && name[0].toLowerCase() === "o" && name[1].toLowerCase() === "n";
 }
 
-export function getLocationFromValue(expressionLocation: any): string {
-  // if we can't get a value, then it's likely that the source file was not given
-  // (this happens in React tests) so instead don't print any location
-  return expressionLocation
-    ? ` at location: ${expressionLocation.start.line}:${expressionLocation.start.column} ` +
-        `- ${expressionLocation.end.line}:${expressionLocation.end.line}`
-    : "";
-}
-
 export function createNoopFunction(realm: Realm): ECMAScriptSourceFunctionValue {
   if (realm.react.noopFunction !== undefined) {
     return realm.react.noopFunction;

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -28,7 +28,7 @@ import { Logger } from "../utils/logger.js";
 import { Generator } from "../utils/generator.js";
 import type { AdditionalFunctionEffects } from "./types";
 import type { Binding } from "../environment.js";
-import { getLocationFromValue } from "../react/utils.js";
+import { optionalStringOfLocation } from "../utils/babelHelpers.js";
 
 /**
  * Get index property list length by searching array properties list for the max index key value plus 1.
@@ -210,7 +210,7 @@ export function handleReportedSideEffect(
 ): void {
   // This causes an infinite recursion because creating a callstack causes internal-only side effects
   if (binding && binding.object && binding.object.intrinsicName === "__checkedBindings") return;
-  let location = getLocationFromValue(expressionLocation);
+  let location = optionalStringOfLocation(expressionLocation);
 
   if (sideEffectType === "MODIFIED_BINDING") {
     let name = binding ? `"${((binding: any): Binding).name}"` : "unknown";

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -28,7 +28,7 @@ import { Logger } from "../utils/logger.js";
 import { Generator } from "../utils/generator.js";
 import type { AdditionalFunctionEffects } from "./types";
 import type { Binding } from "../environment.js";
-import { optionalStringOfLocation } from "../utils/babelHelpers.js";
+import { optionalStringOfLocation } from "../utils/babelhelpers.js";
 
 /**
  * Get index property list length by searching array properties list for the max index key value plus 1.

--- a/src/utils/babelhelpers.js
+++ b/src/utils/babelhelpers.js
@@ -59,8 +59,11 @@ export function memberExpressionHelper(
   return t.memberExpression(object, propertyExpression, computed);
 }
 
+export function optionalStringOfLocation(location: ?BabelNodeSourceLocation): string {
+  // if we can't get a value, then it's likely that the source file was not given
+  return location ? ` at location ${stringOfLocation(location)}` : "";
+}
+
 export function stringOfLocation(location: BabelNodeSourceLocation): string {
-  return `${location.source || "(unknown source file)"}(${location.start.line}:${location.start.column} ${
-    location.end.line
-  }:${location.end.column})`;
+  return `${location.source || "(unknown source file)"}[${location.start.line}:${location.start.column}]`;
 }


### PR DESCRIPTION
Release notes: Fixing source map support.

I kept getting seemingly garbage source locations in error messages, and looked into that.
I found various issues:
- We in-place update positions, but they are actually shared between locations, and thus we may revisit positions. When we do, we map them again, and so on...
- Locations are also shared between nodes, so we kept revisiting and rewriting yet again.
- The actual mapping doesn't pay attention to the filename, so we apply the wrong mapping altogether, especially in the presence of multiple input files. I am not fixing this, but added a TODO, and opened #2353.
- Another remaining but not blocking issue is that something goes wrong with end-positions: They are sometimes mapped to some seemingly random position in the right line. If anyone knows anything about this, please let me know...