### PR TITLE
Remove makeNotPartial and pass around explicit boolean instead

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -692,6 +692,7 @@ function runTest(name, code, options: PrepackOptions, args) {
         });
       })
       .catch(function(err) {
+        console.log(name);
         console.error(err);
         console.error(err.stack);
       });

--- a/src/evaluators/ForInStatement.js
+++ b/src/evaluators/ForInStatement.js
@@ -210,10 +210,8 @@ function emitResidualLoopIfSafe(
         if (sourceObject === o) {
           // Known enumerable properties of sourceObject can become known properties of targetObject.
           invariant(sourceObject.isPartialObject());
-          sourceObject.makeNotPartial();
           // EnumerableOwnProperties is sufficient because sourceObject is simple
-          let keyValPairs = EnumerableOwnProperties(realm, sourceObject, "key+value");
-          sourceObject.makePartial();
+          let keyValPairs = EnumerableOwnProperties(realm, sourceObject, "key+value", true);
           for (let keyVal of keyValPairs) {
             invariant(keyVal instanceof ArrayValue);
             let key = keyVal.$Get("0", keyVal);

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -349,13 +349,7 @@ function InternalJSONClone(realm: Realm, val: Value): Value {
       }
     } else {
       clonedObj = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
-      let valIsPartial = false;
-      if (val.isPartialObject()) {
-        valIsPartial = true;
-        val.makeNotPartial();
-      }
-      let keys = EnumerableOwnProperties(realm, val, "key");
-      if (valIsPartial) val.makePartial();
+      let keys = EnumerableOwnProperties(realm, val, "key", true);
       for (let P of keys) {
         invariant(P instanceof StringValue);
         let newElement = Get(realm, val, P);

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -77,7 +77,7 @@ function handleObjectAssignSnapshot(
         // Make it implicit again since it is getting delayed into an Object.assign call.
         delayedSources.push(frm.args[0]);
       } else {
-        let frmSnapshot = frm.getSnapshot({ getOwnPropertyKeysEvenIfPartial: true });
+        let frmSnapshot = frm.getSnapshot();
         frm.temporalAlias = frmSnapshot;
         frm.makePartial();
         delayedSources.push(frmSnapshot);

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -77,7 +77,7 @@ function handleObjectAssignSnapshot(
         // Make it implicit again since it is getting delayed into an Object.assign call.
         delayedSources.push(frm.args[0]);
       } else {
-        let frmSnapshot = frm.getSnapshot();
+        let frmSnapshot = frm.getSnapshot({ getOwnPropertyKeysEvenIfPartial: true });
         frm.temporalAlias = frmSnapshot;
         frm.makePartial();
         delayedSources.push(frmSnapshot);
@@ -137,20 +137,11 @@ function applyObjectAssignSource(
     }
 
     to_must_be_partial = true;
-    // Make this temporarily not partial
-    // so that we can call frm.$OwnPropertyKeys below.
-    frm.makeNotPartial();
   }
 
-  try {
-    keys = frm.$OwnPropertyKeys();
-    if (to_must_be_partial) {
-      handleObjectAssignSnapshot(to, frm, frm_was_partial, delayedSources);
-    }
-  } finally {
-    if (frm_was_partial) {
-      frm.makePartial();
-    }
+  keys = frm.$OwnPropertyKeys(true);
+  if (to_must_be_partial) {
+    handleObjectAssignSnapshot(to, frm, frm_was_partial, delayedSources);
   }
 
   // c. Repeat for each element nextKey of keys in List order,

--- a/src/methods/own.js
+++ b/src/methods/own.js
@@ -81,7 +81,7 @@ export function EnumerableOwnProperties(
   realm: Realm,
   O: ObjectValue,
   kind: string,
-  getOwnPropertyKeysEvenIfPartial: boolean
+  getOwnPropertyKeysEvenIfPartial?: boolean = false
 ): Array<Value> {
   // 1. Assert: Type(O) is Object.
   invariant(O instanceof ObjectValue, "expected object");

--- a/src/methods/own.js
+++ b/src/methods/own.js
@@ -42,12 +42,16 @@ export function GetOwnPropertyKeys(realm: Realm, O: Value, Type: Function): Arra
 }
 
 // ECMA262 9.1.11.1
-export function OrdinaryOwnPropertyKeys(realm: Realm, o: ObjectValue): Array<PropertyKeyValue> {
+export function OrdinaryOwnPropertyKeys(
+  realm: Realm,
+  o: ObjectValue,
+  getOwnPropertyKeysEvenIfPartial?: boolean = false
+): Array<PropertyKeyValue> {
   // 1. Let keys be a new empty List.
   let keys = [];
 
   // 2. For each own property key P of O that is an integer index, in ascending numeric index order
-  let properties = o.getOwnPropertyKeysArray();
+  let properties = o.getOwnPropertyKeysArray(undefined, getOwnPropertyKeysEvenIfPartial);
   for (let key of properties
     .filter(x => IsArrayIndex(realm, x))
     .map(x => parseInt(x, 10))
@@ -73,12 +77,17 @@ export function OrdinaryOwnPropertyKeys(realm: Realm, o: ObjectValue): Array<Pro
 }
 
 // ECMA262 7.3.21
-export function EnumerableOwnProperties(realm: Realm, O: ObjectValue, kind: string): Array<Value> {
+export function EnumerableOwnProperties(
+  realm: Realm,
+  O: ObjectValue,
+  kind: string,
+  getOwnPropertyKeysEvenIfPartial: boolean
+): Array<Value> {
   // 1. Assert: Type(O) is Object.
   invariant(O instanceof ObjectValue, "expected object");
 
   // 2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
-  let ownKeys = O.$OwnPropertyKeys();
+  let ownKeys = O.$OwnPropertyKeys(getOwnPropertyKeysEvenIfPartial);
 
   // 3. Let properties be a new empty List.
   let properties = [];

--- a/src/utils/ConcreteModelConverter.js
+++ b/src/utils/ConcreteModelConverter.js
@@ -108,23 +108,12 @@ export function concretize(realm: Realm, val: Value): ConcreteValue {
       return new ObjectValue(realm);
     } else {
       let template = val.getTemplate();
-      let valIsPartial = false;
-      if (val.isPartialObject()) {
-        valIsPartial = true;
-        val.makeNotPartial();
-      }
       let concreteObj = Create.ObjectCreate(realm, template.$GetPrototypeOf());
-      try {
-        let keys = EnumerableOwnProperties(realm, template, "key");
-        for (let P of keys) {
-          invariant(P instanceof StringValue);
-          let newElement = Get(realm, template, P);
-          Create.CreateDataProperty(realm, concreteObj, P, concretize(realm, newElement));
-        }
-      } finally {
-        if (valIsPartial) {
-          val.makePartial();
-        }
+      let keys = EnumerableOwnProperties(realm, template, "key", true);
+      for (let P of keys) {
+        invariant(P instanceof StringValue);
+        let newElement = Get(realm, template, P);
+        Create.CreateDataProperty(realm, concreteObj, P, concretize(realm, newElement));
       }
       return concreteObj;
     }

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -145,17 +145,6 @@ export default class AbstractObjectValue extends AbstractValue {
     return true;
   }
 
-  makeNotPartial(): void {
-    if (this.values.isTop()) {
-      AbstractValue.reportIntrospectionError(this);
-      throw new FatalError();
-    }
-    for (let element of this.values.getElements()) {
-      invariant(element instanceof ObjectValue);
-      element.makeNotPartial();
-    }
-  }
-
   makePartial(): void {
     if (this.values.isTop()) {
       AbstractValue.reportIntrospectionError(this);
@@ -955,7 +944,7 @@ export default class AbstractObjectValue extends AbstractValue {
     }
   }
 
-  $OwnPropertyKeys(): Array<PropertyKeyValue> {
+  $OwnPropertyKeys(getOwnPropertyKeysEvenIfPartial?: boolean = false): Array<PropertyKeyValue> {
     if (this.values.isTop()) {
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();
@@ -964,7 +953,7 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        return cv.$OwnPropertyKeys();
+        return cv.$OwnPropertyKeys(getOwnPropertyKeysEvenIfPartial);
       }
       invariant(false);
     } else {

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -515,7 +515,6 @@ export default class ObjectValue extends ConcreteValue {
       this.mightBeHavocedObject() ||
       this.unknownProperty !== undefined
     ) {
-      debugger;
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();
     }
@@ -542,10 +541,9 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   // Note that internal properties will not be copied to the snapshot, nor will they be removed.
-  getSnapshot(options?: { removeProperties: boolean, getOwnPropertyKeysEvenIfPartial: boolean }): AbstractObjectValue {
+  getSnapshot(options?: { removeProperties: boolean }): AbstractObjectValue {
     try {
       if (this.temporalAlias !== undefined) return this.temporalAlias;
-      invariant(!this.isPartialObject() || options.getOwnPropertyKeysEvenIfPartial);
       let template = new ObjectValue(this.$Realm, this.$Realm.intrinsics.ObjectPrototype);
       this.copyKeys(this.$OwnPropertyKeys(true), this, template);
       let realm = this.$Realm;

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -509,7 +509,10 @@ export default class ObjectValue extends ConcreteValue {
     });
   }
 
-  getOwnPropertyKeysArray(allowAbstractKeys: boolean = false, getOwnPropertyKeysEvenIfPartial? = false): Array<string> {
+  getOwnPropertyKeysArray(
+    allowAbstractKeys: boolean = false,
+    getOwnPropertyKeysEvenIfPartial?: boolean = false
+  ): Array<string> {
     if (
       (this.isPartialObject() && !getOwnPropertyKeysEvenIfPartial) ||
       this.mightBeHavocedObject() ||

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -351,10 +351,6 @@ export default class ObjectValue extends ConcreteValue {
     return this;
   }
 
-  makeNotPartial(): void {
-    this._isPartial = this.$Realm.intrinsics.false;
-  }
-
   makePartial(): void {
     this._isPartial = this.$Realm.intrinsics.true;
   }
@@ -513,8 +509,13 @@ export default class ObjectValue extends ConcreteValue {
     });
   }
 
-  getOwnPropertyKeysArray(allowAbstractKeys: boolean = false): Array<string> {
-    if (this.isPartialObject() || this.mightBeHavocedObject() || this.unknownProperty !== undefined) {
+  getOwnPropertyKeysArray(allowAbstractKeys: boolean = false, getOwnPropertyKeysEvenIfPartial? = false): Array<string> {
+    if (
+      (this.isPartialObject() && !getOwnPropertyKeysEvenIfPartial) ||
+      this.mightBeHavocedObject() ||
+      this.unknownProperty !== undefined
+    ) {
+      debugger;
       AbstractValue.reportIntrospectionError(this);
       throw new FatalError();
     }
@@ -541,12 +542,12 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   // Note that internal properties will not be copied to the snapshot, nor will they be removed.
-  getSnapshot(options?: { removeProperties: boolean }): AbstractObjectValue {
+  getSnapshot(options?: { removeProperties: boolean, getOwnPropertyKeysEvenIfPartial: boolean }): AbstractObjectValue {
     try {
       if (this.temporalAlias !== undefined) return this.temporalAlias;
-      invariant(!this.isPartialObject());
+      invariant(!this.isPartialObject() || options.getOwnPropertyKeysEvenIfPartial);
       let template = new ObjectValue(this.$Realm, this.$Realm.intrinsics.ObjectPrototype);
-      this.copyKeys(this.$OwnPropertyKeys(), this, template);
+      this.copyKeys(this.$OwnPropertyKeys(true), this, template);
       let realm = this.$Realm;
       // The snapshot is an immutable object snapshot
       template.makeFinal();
@@ -713,8 +714,8 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   // ECMA262 9.1.11
-  $OwnPropertyKeys(): Array<PropertyKeyValue> {
-    return OrdinaryOwnPropertyKeys(this.$Realm, this);
+  $OwnPropertyKeys(getOwnPropertyKeysEvenIfPartial?: boolean = false): Array<PropertyKeyValue> {
+    return OrdinaryOwnPropertyKeys(this.$Realm, this, getOwnPropertyKeysEvenIfPartial);
   }
 
   static refuseSerializationOnPropertyBinding(pb: PropertyBinding): boolean {


### PR DESCRIPTION
Release notes: none

This PR removes the `makeNotPartial` method and all its call-sites in favour of explicitly telling execution paths that we want own properties even if partial. This stops the mutation of objects where we set the partial boolean flag, which actually is a very common cause of side-effects in pure functions. Furthermore, the whole `makeNotPartial` before and after was potentially error-prone if the `try/catch` was omitted by mistake and it was generally a code smell.

I also made it test-runner log the failing test name upon error, which helps with debugging.