### PR TITLE
Fixing source map support with multiple source files

### DIFF
--- a/scripts/generate-sourcemaps-test.js
+++ b/scripts/generate-sourcemaps-test.js
@@ -67,7 +67,7 @@ function generateTest(name: string, test_path: string, code: string): boolean {
     fs.writeFileSync(name + ".new1.js.map", JSON.stringify(newMap1));
     s = prepackFileSync([name + ".new1.js"], {
       compatibility: "node-source-maps",
-      inputSourceMapFilename: name + ".new1.js.map",
+      inputSourceMapFilenames: [name + ".new1.js.map"],
       internalDebug: true,
       errorHandler: errorHandler,
       sourceMaps: true,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -92,7 +92,7 @@ function run(
   let check: void | Array<number>;
   let compatibility: Compatibility;
   let mathRandomSeed;
-  let inputSourceMap;
+  let inputSourceMapFilenames = [];
   let outputSourceMap;
   let statsFileName;
   let maxStackDepth: number;
@@ -166,7 +166,8 @@ function run(
           reproArguments.push("--mathRandomSeed", mathRandomSeed);
           break;
         case "srcmapIn":
-          inputSourceMap = args.shift();
+          let inputSourceMap = args.shift();
+          inputSourceMapFilenames.push(inputSourceMap);
           reproArguments.push("--srcmapIn", inputFile(inputSourceMap));
           break;
         case "srcmapOut":
@@ -344,7 +345,7 @@ function run(
     {
       compatibility,
       mathRandomSeed,
-      inputSourceMapFilename: inputSourceMap,
+      inputSourceMapFilenames,
       errorHandler,
       sourceMaps: !!outputSourceMap,
       maxStackDepth,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -24,7 +24,7 @@ export type PrepackOptions = {|
   delayInitializations?: boolean,
   delayUnsupportedRequires?: boolean,
   accelerateUnsupportedRequires?: boolean,
-  inputSourceMapFilename?: string,
+  inputSourceMapFilenames?: Array<string>,
   internalDebug?: boolean,
   debugScopes?: boolean,
   debugIdentifiers?: Array<string>,


### PR DESCRIPTION
Release notes: Fixing source map support with multiple source files

This fixes issue #2353: We now track multiple --srcmapIn arguments,
and match which one applies by comparing the basenames:
The convention is that sourcemaps share the same basename with an appended .map.