### PR TITLE
Fix FatalErrors that are actually Recoverable

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -153,7 +153,8 @@ export default function(realm: Realm): void {
             realm.currentLocation,
             "PP0033",
             "Warning"
-          ));
+          )
+        );
         if (result !== "Recover") throw new FatalError();
         else return;
       }

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -118,6 +118,7 @@ export default function(realm: Realm): void {
   // NB: If we interpret one of these calls in an evaluateForEffects context
   //     that is not subsequently applied, the function will not be registered
   //     (because prepack won't have a correct value for the FunctionValue itself)
+  // If we encounter an invalid input, we will emit a warning and not optimize the function
   global.$DefineOwnProperty("__optimize", {
     value: new NativeFunctionValue(realm, "global.__optimize", "__optimize", 1, (context, [value, argModelString]) => {
       let argModel;
@@ -134,9 +135,10 @@ export default function(realm: Realm): void {
               "__optimize called twice with different argModelStrings",
               realm.currentLocation,
               "PP1008",
-              "FatalError"
+              "Warning"
             );
             if (realm.handleError(argModelError) !== "Recover") throw new FatalError();
+            else return;
           }
         }
         realm.optimizedFunctions.set(value, argModel);
@@ -150,10 +152,10 @@ export default function(realm: Realm): void {
             `Optimized Function Value ${location} is an not a function or react element`,
             realm.currentLocation,
             "PP0033",
-            "FatalError"
-          )
-        );
+            "Warning"
+          );
         if (result !== "Recover") throw new FatalError();
+        else return;
       }
       return value;
     }),

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -153,7 +153,7 @@ export default function(realm: Realm): void {
             realm.currentLocation,
             "PP0033",
             "Warning"
-          );
+          ));
         if (result !== "Recover") throw new FatalError();
         else return;
       }

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -138,7 +138,7 @@ export default function(realm: Realm): void {
               "Warning"
             );
             if (realm.handleError(argModelError) !== "Recover") throw new FatalError();
-            else return;
+            else return realm.intrinsics.undefined;
           }
         }
         realm.optimizedFunctions.set(value, argModel);
@@ -156,7 +156,7 @@ export default function(realm: Realm): void {
           )
         );
         if (result !== "Recover") throw new FatalError();
-        else return;
+        else return realm.intrinsics.undefined;
       }
       return value;
     }),

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -304,8 +304,7 @@ export class Functions {
           "RecoverableError"
         );
         // We generate correct code in this case, but the user probably doesn't want us to emit an unconditional throw
-        this.realm.handleError(error);
-        throw new FatalError();
+        if (this.realm.handleError(error) !== "Recover") throw new FatalError();
       }
       for (let fun2 of additionalFunctions) {
         if (fun1 === fun2) continue;
@@ -335,8 +334,8 @@ export class Functions {
       }
     }
     if (conflicts.size > 0) {
-      for (let diagnostic of conflicts.values()) this.realm.handleError(diagnostic);
-      throw new FatalError();
+      for (let diagnostic of conflicts.values())
+        if (this.realm.handleError(diagnostic) !== "Recover") throw new FatalError();
     }
   }
 

--- a/test/serializer/optimized-functions/NestedOptimizeSameFunction.js
+++ b/test/serializer/optimized-functions/NestedOptimizeSameFunction.js
@@ -1,4 +1,4 @@
-// expected FatalError: PP1009
+// expected RecoverableError: PP1009
 // does not contain: = 5
 
 function fn() {


### PR DESCRIPTION
Release Notes: None

When optimizing a function fails, we can usually continue to emit a correct program while ignoring that call to `__optimize`, thus most of these errors should be `Warning`s and not `FatalError`s.

A few times (like when we have multiple sets of `Effects` for one optimized function), we can sensibly continue Prepacking code, but our output may be incorrect. In these cases, we can issue a `RecoverableError` instead of a `FatalError`