### PR TITLE
Release source code and source map data after parsing and source map fixup.

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -30,6 +30,7 @@ function SerialPromises(promises: Array<() => Promise<void>>) {
 }
 
 let Serializer = require("../lib/serializer/index.js").default;
+let SourceFileCollection = require("../lib/types.js").SourceFileCollection;
 let SerializerStatistics = require("../lib/serializer/statistics.js").SerializerStatistics;
 let construct_realm = require("../lib/construct_realm.js").default;
 let initializeGlobals = require("../lib/globals.js").default;
@@ -381,8 +382,8 @@ function runTest(name, code, options: PrepackOptions, args) {
         lazyObjectsRuntime: options.lazyObjectsRuntime,
       };
       let serializer = new Serializer(realm, serializerOptions);
-      let sources = [{ filePath: name, fileContents: code }];
-      let serialized = serializer.init(sources, false);
+      let sourceFileCollection = new SourceFileCollection([{ filePath: name, fileContents: code }]);
+      let serialized = serializer.init(sourceFileCollection, false);
       if (!serialized) {
         console.error(chalk.red("Error during serialization"));
       } else {

--- a/src/benchmarker.js
+++ b/src/benchmarker.js
@@ -10,6 +10,7 @@
 /* @flow strict-local */
 
 import type { Compatibility } from "./options.js";
+import { SourceFileCollection } from "./types.js";
 import Serializer from "./serializer/index.js";
 import construct_realm from "./construct_realm.js";
 import initializeGlobals from "./globals.js";
@@ -161,8 +162,8 @@ function dump(
   let realm = construct_realm({ serialize: true, compatibility });
   initializeGlobals(realm);
   let serializer = new Serializer(realm);
-  let sources = [{ filePath: name, fileContents: raw }];
-  let serialized = serializer.init(sources);
+  let sourceFileCollection = new SourceFileCollection([{ filePath: name, fileContents: raw }]);
+  let serialized = serializer.init(sourceFileCollection);
   if (!serialized) {
     process.exit(1);
     invariant(false);

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -151,12 +151,14 @@ function getSourceFileCollection(filenames: Array<string>, options: PrepackOptio
     };
   });
 
-  // Don't include sourcemaps that weren't found
-  return new SourceFileCollection(sourceFiles.filter(sf => sf.sourceMapContents !== ""));
+  return new SourceFileCollection(sourceFiles);
 }
 
 export function prepackFileSync(filenames: Array<string>, options: PrepackOptions = defaultOptions): SerializedResult {
   let sourceFileCollection = getSourceFileCollection(filenames, options);
+
+  // Filter to not include sourcemaps that weren't found
+  let filterValidSourceMaps = a => a.filter(sf => sf.sourceMapContents !== "");
 
   // The existence of debug[In/Out]FilePath represents the desire to use the debugger.
   if (options.debugInFilePath !== undefined && options.debugOutFilePath !== undefined) {
@@ -165,11 +167,11 @@ export function prepackFileSync(filenames: Array<string>, options: PrepackOption
 
     let ioWrapper = new FileIOWrapper(false, options.debugInFilePath, options.debugOutFilePath);
     debuggerConfigArgs.debugChannel = new DebugChannel(ioWrapper);
-    debuggerConfigArgs.sourcemaps = sourceFileCollection.toArray();
+    debuggerConfigArgs.sourcemaps = filterValidSourceMaps(sourceFileCollection.toArray());
   }
 
   let debugReproArgs = options.debugReproArgs;
-  if (debugReproArgs) debugReproArgs.sourcemaps = sourceFileCollection.toArray();
+  if (debugReproArgs) debugReproArgs.sourcemaps = filterValidSourceMaps(sourceFileCollection.toArray());
 
   return prepackSources(sourceFileCollection, options, createStatistics(options));
 }

--- a/src/prepack-node.js
+++ b/src/prepack-node.js
@@ -16,7 +16,7 @@ import { defaultOptions } from "./options";
 import { FatalError } from "./errors.js";
 import { type PrepackOptions } from "./prepack-options";
 import { prepackSources } from "./prepack-standalone.js";
-import { type SourceMap } from "./types.js";
+import { type SourceMap, SourceFileCollection } from "./types.js";
 import { DebugChannel } from "./debugger/server/channel/DebugChannel.js";
 import { FileIOWrapper } from "./debugger/common/channel/FileIOWrapper.js";
 import { type SerializedResult } from "./serializer/types.js";
@@ -131,7 +131,7 @@ export function prepackFile(
   });
 }
 
-export function prepackFileSync(filenames: Array<string>, options: PrepackOptions = defaultOptions): SerializedResult {
+function getSourceFileCollection(filenames: Array<string>, options: PrepackOptions) {
   const sourceFiles = filenames.map(filename => {
     let code = fs.readFileSync(filename, "utf8");
     let sourceMap = "";
@@ -152,18 +152,24 @@ export function prepackFileSync(filenames: Array<string>, options: PrepackOption
   });
 
   // Don't include sourcemaps that weren't found
-  let validSourceFiles = sourceFiles.filter(sf => sf.sourceMapContents !== "");
+  return new SourceFileCollection(sourceFiles.filter(sf => sf.sourceMapContents !== ""));
+}
+
+export function prepackFileSync(filenames: Array<string>, options: PrepackOptions = defaultOptions): SerializedResult {
+  let sourceFileCollection = getSourceFileCollection(filenames, options);
 
   // The existence of debug[In/Out]FilePath represents the desire to use the debugger.
   if (options.debugInFilePath !== undefined && options.debugOutFilePath !== undefined) {
     if (options.debuggerConfigArgs === undefined) options.debuggerConfigArgs = {};
+    let debuggerConfigArgs = options.debuggerConfigArgs;
 
     let ioWrapper = new FileIOWrapper(false, options.debugInFilePath, options.debugOutFilePath);
-    options.debuggerConfigArgs.debugChannel = new DebugChannel(ioWrapper);
-    options.debuggerConfigArgs.sourcemaps = validSourceFiles;
+    debuggerConfigArgs.debugChannel = new DebugChannel(ioWrapper);
+    debuggerConfigArgs.sourcemaps = sourceFileCollection.toArray();
   }
 
-  if (options.debugReproArgs) options.debugReproArgs.sourcemaps = validSourceFiles;
+  let debugReproArgs = options.debugReproArgs;
+  if (debugReproArgs) debugReproArgs.sourcemaps = sourceFileCollection.toArray();
 
-  return prepackSources(sourceFiles, options, createStatistics(options));
+  return prepackSources(sourceFileCollection, options, createStatistics(options));
 }

--- a/src/types.js
+++ b/src/types.js
@@ -52,6 +52,7 @@ import type { Bindings, Effects, EvaluationResult, PropertyBindings, CreatedObje
 import { CompilerDiagnostic } from "./errors.js";
 import type { Severity } from "./errors.js";
 import type { DebugChannel } from "./debugger/server/channel/DebugChannel.js";
+import invariant from "./invariant.js";
 
 export const ElementSize = {
   Float32: 4,
@@ -94,6 +95,19 @@ export type SourceFile = {
   sourceMapFilename?: string,
 };
 
+export class SourceFileCollection {
+  constructor(sourceFiles: Array<SourceFile>) {
+    this._sourceFiles = sourceFiles;
+  }
+  _sourceFiles: void | Array<SourceFile>;
+  toArray(): Array<SourceFile> {
+    invariant(this._sourceFiles !== undefined);
+    return this._sourceFiles;
+  }
+  destroy(): void {
+    this._sourceFiles = undefined;
+  }
+}
 export type SourceMap = {
   sources: Array<string>,
   names: Array<string>,


### PR DESCRIPTION
Release notes: Reduce memory usage of running Prepack by 3% in some scenarios

This fixes #2365.

This is realized via a stateful SourceFileCollection.
On a small internal benchmark, this saved around 3% of total node memory usage
(the parsed AST that we keep around uses an order of magnitude more memory
than the original source file and source map,
11MB of source files + source map vs 88MB of parsed AST).