### PR TITLE
Let the visitor die when it's done

### DIFF
--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -10,36 +10,19 @@
 /* @flow strict-local */
 
 import { Realm } from "../realm.js";
-import { AbstractValue, FunctionValue, Value, ObjectValue } from "../values/index.js";
+import { FunctionValue, Value, ObjectValue } from "../values/index.js";
 import * as t from "@babel/types";
-import type {
-  BabelNodeExpression,
-  BabelNodeStatement,
-  BabelNodeIdentifier,
-  BabelNodeBlockStatement,
-  BabelNodeSwitchCase,
-} from "@babel/types";
-import type {
-  SerializedBody,
-  FunctionInfo,
-  FunctionInstance,
-  AdditionalFunctionInfo,
-  ClassMethodInstance,
-  AdditionalFunctionEffects,
-  ResidualFunctionBinding,
-} from "./types.js";
+import type { BabelNodeExpression, BabelNodeStatement, BabelNodeIdentifier, BabelNodeSwitchCase } from "@babel/types";
+import type { SerializedBody, AdditionalFunctionEffects, ResidualHeapInfo } from "./types.js";
 import type { SerializerOptions } from "../options.js";
 import invariant from "../invariant.js";
 import { Logger } from "../utils/logger.js";
 import { Modules } from "../utils/modules.js";
 import { HeapInspector } from "../utils/HeapInspector.js";
-import type { Scope } from "./ResidualHeapVisitor.js";
 import { ResidualHeapValueIdentifiers } from "./ResidualHeapValueIdentifiers.js";
 import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { getOrDefault } from "./utils.js";
-import type { DeclarativeEnvironmentRecord } from "../environment.js";
 import type { Referentializer } from "./Referentializer.js";
-import { Generator } from "../utils/generator.js";
 import { GeneratorDAG } from "./GeneratorDAG.js";
 
 const LAZY_OBJECTS_SERIALIZER_BODY_TYPE = "LazyObjectInitializer";
@@ -61,20 +44,11 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     modules: Modules,
     residualHeapValueIdentifiers: ResidualHeapValueIdentifiers,
     residualHeapInspector: HeapInspector,
-    residualValues: Map<Value, Set<Scope>>,
-    residualFunctionInstances: Map<FunctionValue, FunctionInstance>,
-    residualClassMethodInstances: Map<FunctionValue, ClassMethodInstance>,
-    residualFunctionInfos: Map<BabelNodeBlockStatement, FunctionInfo>,
+    residualHeapInfo: ResidualHeapInfo,
     options: SerializerOptions,
-    referencedDeclaredValues: Map<Value, void | FunctionValue>,
     additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects> | void,
-    additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
-    declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>,
-    globalBindings: Map<string, ResidualFunctionBinding>,
     referentializer: Referentializer,
-    generatorDAG: GeneratorDAG,
-    conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
-    additionalGeneratorRoots: Map<Generator, Set<ObjectValue>>
+    generatorDAG: GeneratorDAG
   ) {
     super(
       realm,
@@ -82,21 +56,13 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       modules,
       residualHeapValueIdentifiers,
       residualHeapInspector,
-      residualValues,
-      residualFunctionInstances,
-      residualClassMethodInstances,
-      residualFunctionInfos,
+      residualHeapInfo,
       options,
-      referencedDeclaredValues,
       additionalFunctionValuesAndEffects,
-      additionalFunctionValueInfos,
-      declarativeEnvironmentRecordsBindings,
-      globalBindings,
       referentializer,
-      generatorDAG,
-      conditionalFeasibility,
-      additionalGeneratorRoots
+      generatorDAG
     );
+
     this._lazyObjectIdSeed = 1;
     this._valueLazyIds = new Map();
     this._lazyObjectInitializers = new Map();

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -46,6 +46,8 @@ import type {
   FunctionInstance,
   ResidualFunctionBinding,
   ReferentializationScope,
+  Scope,
+  ResidualHeapInfo,
 } from "./types.js";
 import { ClosureRefVisitor } from "./visitors.js";
 import { Logger } from "../utils/logger.js";
@@ -64,8 +66,6 @@ import { Environment, To } from "../singletons.js";
 import { isReactElement, isReactPropsObject, valueIsReactLibraryObject } from "../react/utils.js";
 import { ResidualReactElementVisitor } from "./ResidualReactElementVisitor.js";
 import { GeneratorDAG } from "./GeneratorDAG.js";
-
-export type Scope = FunctionValue | Generator;
 
 type BindingState = {|
   capturedBindings: Set<ResidualFunctionBinding>,
@@ -1371,5 +1371,20 @@ export class ResidualHeapVisitor {
         this.logger.logInformation(`  (${actual} items processed)`);
       }
     }
+  }
+
+  toInfo(): ResidualHeapInfo {
+    return {
+      values: this.values,
+      functionInstances: this.functionInstances,
+      classMethodInstances: this.classMethodInstances,
+      functionInfos: this.functionInfos,
+      referencedDeclaredValues: this.referencedDeclaredValues,
+      additionalFunctionValueInfos: this.additionalFunctionValueInfos,
+      declarativeEnvironmentRecordsBindings: this.declarativeEnvironmentRecordsBindings,
+      globalBindings: this.globalBindings,
+      conditionalFeasibility: this.conditionalFeasibility,
+      additionalGeneratorRoots: this.additionalGeneratorRoots,
+    };
   }
 }

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -190,14 +190,17 @@ export class Serializer {
         if (this.realm.react.verbose) {
           this.logger.logInformation(`Visiting evaluated nodes...`);
         }
-        let residualHeapVisitor = new ResidualHeapVisitor(
-          this.realm,
-          this.logger,
-          this.modules,
-          additionalFunctionValuesAndEffects,
-          referentializer
-        );
-        statistics.deepTraversal.measure(() => residualHeapVisitor.visitRoots());
+        let [residualHeapInfo, generatorDAG, inspector] = (() => {
+          let residualHeapVisitor = new ResidualHeapVisitor(
+            this.realm,
+            this.logger,
+            this.modules,
+            additionalFunctionValuesAndEffects,
+            referentializer
+          );
+          statistics.deepTraversal.measure(() => residualHeapVisitor.visitRoots());
+          return [residualHeapVisitor.toInfo(), residualHeapVisitor.generatorDAG, residualHeapVisitor.inspector];
+        })();
         if (this.logger.hasErrors()) return undefined;
 
         if (this.realm.react.verbose) {
@@ -206,7 +209,7 @@ export class Serializer {
         const realmPreludeGenerator = this.realm.preludeGenerator;
         invariant(realmPreludeGenerator);
         const residualHeapValueIdentifiers = new ResidualHeapValueIdentifiers(
-          residualHeapVisitor.values.keys(),
+          residualHeapInfo.values.keys(),
           realmPreludeGenerator
         );
 
@@ -245,21 +248,12 @@ export class Serializer {
               this.logger,
               this.modules,
               residualHeapValueIdentifiers,
-              residualHeapVisitor.inspector,
-              residualHeapVisitor.values,
-              residualHeapVisitor.functionInstances,
-              residualHeapVisitor.classMethodInstances,
-              residualHeapVisitor.functionInfos,
+              inspector,
+              residualHeapInfo,
               this.options,
-              residualHeapVisitor.referencedDeclaredValues,
               additionalFunctionValuesAndEffects,
-              residualHeapVisitor.additionalFunctionValueInfos,
-              residualHeapVisitor.declarativeEnvironmentRecordsBindings,
-              residualHeapVisitor.globalBindings,
               referentializer,
-              residualHeapVisitor.generatorDAG,
-              residualHeapVisitor.conditionalFeasibility,
-              residualHeapVisitor.additionalGeneratorRoots
+              generatorDAG
             ).serialize();
           });
           if (this.logger.hasErrors()) return undefined;
@@ -276,21 +270,12 @@ export class Serializer {
             this.logger,
             this.modules,
             residualHeapValueIdentifiers,
-            residualHeapVisitor.inspector,
-            residualHeapVisitor.values,
-            residualHeapVisitor.functionInstances,
-            residualHeapVisitor.classMethodInstances,
-            residualHeapVisitor.functionInfos,
+            inspector,
+            residualHeapInfo,
             this.options,
-            residualHeapVisitor.referencedDeclaredValues,
             additionalFunctionValuesAndEffects,
-            residualHeapVisitor.additionalFunctionValueInfos,
-            residualHeapVisitor.declarativeEnvironmentRecordsBindings,
-            residualHeapVisitor.globalBindings,
             referentializer,
-            residualHeapVisitor.generatorDAG,
-            residualHeapVisitor.conditionalFeasibility,
-            residualHeapVisitor.additionalGeneratorRoots
+            generatorDAG
           ).serialize()
         );
       })();

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -12,7 +12,12 @@
 import { DeclarativeEnvironmentRecord, type Binding } from "../environment.js";
 import { AbstractValue, ConcreteValue, ObjectValue, Value } from "../values/index.js";
 import type { ECMAScriptSourceFunctionValue, FunctionValue } from "../values/index.js";
-import type { BabelNodeExpression, BabelNodeStatement, BabelNodeMemberExpression } from "@babel/types";
+import type {
+  BabelNodeExpression,
+  BabelNodeStatement,
+  BabelNodeMemberExpression,
+  BabelNodeBlockStatement,
+} from "@babel/types";
 import { SameValue } from "../methods/abstract.js";
 import { Realm, type Effects } from "../realm.js";
 import invariant from "../invariant.js";
@@ -206,4 +211,22 @@ export type SerializedResult = {
   reactStatistics?: ReactStatistics,
   heapGraph?: string,
   sourceFilePaths?: { sourceMaps: Array<string>, sourceFiles: Array<{ absolute: string, relative: string }> },
+};
+
+export type Scope = FunctionValue | Generator;
+
+export type ResidualHeapInfo = {
+  values: Map<Value, Set<Scope>>,
+  functionInstances: Map<FunctionValue, FunctionInstance>,
+  classMethodInstances: Map<FunctionValue, ClassMethodInstance>,
+  functionInfos: Map<BabelNodeBlockStatement, FunctionInfo>,
+  referencedDeclaredValues: Map<Value, void | FunctionValue>,
+  additionalFunctionValueInfos: Map<FunctionValue, AdditionalFunctionInfo>,
+  // Caches that ensure one ResidualFunctionBinding exists per (record, name) pair
+  declarativeEnvironmentRecordsBindings: Map<DeclarativeEnvironmentRecord, Map<string, ResidualFunctionBinding>>,
+  globalBindings: Map<string, ResidualFunctionBinding>,
+  // For every abstract value of kind "conditional", this map keeps track of whether the consequent and/or alternate is feasible in any scope
+  conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>,
+  // Parents will always be a generator, optimized function value or "GLOBAL"
+  additionalGeneratorRoots: Map<Generator, Set<ObjectValue>>,
 };


### PR DESCRIPTION
Release notes: Reduced memory usage of Prepack

The visitor computes some data structures that live on,
but it also maintains some internal temporary state that
should be released once the visitor is done.

This factors out the resulting data from the stateful visitor.
As a side-effect, we also need to pass less redundant stuff
through various levels of constructors.