### PR TITLE
Fix issue #2359

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1944,7 +1944,7 @@ export class ResidualHeapSerializer {
       let id = ((serializedValue: any): BabelNodeIdentifier);
       invariant(
         !this.realm.derivedIds.has(id.name) ||
-          this.emitter.cannotDeclare(val) ||
+          this.emitter.cannotDeclare() ||
           this.emitter.hasBeenDeclared(val) ||
           this.emitter.emittingToAdditionalFunction(),
         `an abstract value with an identifier "${id.name}" was referenced before being declared`

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1944,8 +1944,9 @@ export class ResidualHeapSerializer {
       let id = ((serializedValue: any): BabelNodeIdentifier);
       invariant(
         !this.realm.derivedIds.has(id.name) ||
+          this.emitter.cannotDeclare(val) ||
           this.emitter.hasBeenDeclared(val) ||
-          (this.emitter.emittingToAdditionalFunction() && this.referencedDeclaredValues.get(val) !== undefined),
+          this.emitter.emittingToAdditionalFunction(),
         `an abstract value with an identifier "${id.name}" was referenced before being declared`
       );
     }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1944,9 +1944,8 @@ export class ResidualHeapSerializer {
       let id = ((serializedValue: any): BabelNodeIdentifier);
       invariant(
         !this.realm.derivedIds.has(id.name) ||
-          this.emitter.cannotDeclare() ||
           this.emitter.hasBeenDeclared(val) ||
-          (this.emitter.emittingToAdditionalFunction() && this.referencedDeclaredValues.get(val) === undefined),
+          (this.emitter.emittingToAdditionalFunction() && this.referencedDeclaredValues.get(val) !== undefined),
         `an abstract value with an identifier "${id.name}" was referenced before being declared`
       );
     }

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1211,9 +1211,13 @@ export class ResidualHeapVisitor {
         let optimizedFunctionScope = this._getAdditionalFunctionOfScope();
         if (residualBinding.potentialReferentializationScopes.size === 0) {
           invariant(optimizedFunctionScope !== undefined);
-          this._enqueueWithUnrelatedScope(optimizedFunctionScope, () =>
-            this.visitBinding(optimizedFunctionScope, residualBinding)
-          );
+          this._enqueueWithUnrelatedScope(optimizedFunctionScope, () => {
+            let funcInstance = additionalFunctionInfo.instance;
+            invariant(funcInstance !== undefined);
+            funcInstance.residualFunctionBindings.set(residualBinding.name, residualBinding);
+            this.visitBinding(optimizedFunctionScope, residualBinding);
+            return true; // ??
+          });
         }
         return this.visitEquivalentValue(value);
       },

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1216,7 +1216,6 @@ export class ResidualHeapVisitor {
             invariant(funcInstance !== undefined);
             funcInstance.residualFunctionBindings.set(residualBinding.name, residualBinding);
             this.visitBinding(optimizedFunctionScope, residualBinding);
-            return true; // ??
           });
         }
         return this.visitEquivalentValue(value);

--- a/test/serializer/optimized-functions/Issue2359-1.js
+++ b/test/serializer/optimized-functions/Issue2359-1.js
@@ -1,0 +1,25 @@
+function fn(x, cond, abstractFunc) {
+  var arr = Array.from(x);
+
+  var a = {};
+
+  if (cond) {
+    abstractFunc(function() {
+      a = 1;
+    });
+
+    var z = a.x;
+
+    var res = arr.map(function() {
+      return z;
+    });
+  }
+
+  return res;
+}
+
+global.__optimize && __optimize(fn);
+
+global.inspect = function() {
+  return true;
+};

--- a/test/serializer/optimized-functions/Issue2359-1.js
+++ b/test/serializer/optimized-functions/Issue2359-1.js
@@ -21,5 +21,7 @@ function fn(x, cond, abstractFunc) {
 global.__optimize && __optimize(fn);
 
 global.inspect = function() {
-  return fn([1, 2], true, function(argF) { argF(); });
+  return fn([1, 2], true, function(argF) {
+    argF();
+  });
 };

--- a/test/serializer/optimized-functions/Issue2359-1.js
+++ b/test/serializer/optimized-functions/Issue2359-1.js
@@ -21,5 +21,5 @@ function fn(x, cond, abstractFunc) {
 global.__optimize && __optimize(fn);
 
 global.inspect = function() {
-  return true;
+  return fn([1, 2], true, function(argF) { argF(); });
 };

--- a/test/serializer/optimized-functions/Issue2359-2.js
+++ b/test/serializer/optimized-functions/Issue2359-2.js
@@ -1,0 +1,24 @@
+function fn(arr, abstractFunc) {
+  var a = {};
+
+  abstractFunc(function() {
+    a = 1;
+  });
+
+  var z = a.x;
+
+  var mapper = function(item) {
+    return z;
+  };
+
+  __optimize(mapper);
+  var res = arr.map(mapper);
+
+  return res;
+}
+
+global.__optimize && __optimize(fn);
+
+global.inspect = function() {
+  return true;
+};

--- a/test/serializer/optimized-functions/Issue2359-2.js
+++ b/test/serializer/optimized-functions/Issue2359-2.js
@@ -11,7 +11,7 @@ function fn(arr, abstractFunc) {
     return z;
   };
 
-  __optimize(mapper);
+  global.__optimize && __optimize(mapper);
   var res = arr.map(mapper);
 
   return res;
@@ -20,5 +20,5 @@ function fn(arr, abstractFunc) {
 global.__optimize && __optimize(fn);
 
 global.inspect = function() {
-  return true;
+  return fn([1, 2], function(argF) { argF(); });
 };

--- a/test/serializer/optimized-functions/Issue2359-2.js
+++ b/test/serializer/optimized-functions/Issue2359-2.js
@@ -20,5 +20,7 @@ function fn(arr, abstractFunc) {
 global.__optimize && __optimize(fn);
 
 global.inspect = function() {
-  return fn([1, 2], function(argF) { argF(); });
+  return fn([1, 2], function(argF) {
+    argF();
+  });
 };


### PR DESCRIPTION
Release Notes: None

We weren't properly adding leaked bindings to the optimized function's FunctionInstance, so state didn't get cleaned up properly between passes of the serializer.

There was also a bug in emitter invariants. Loosening the invariant causes the test cases to pass. 

Also the invariant seems to have been incorrect in the first place. I suspect it is just the direct negation of [this line](https://github.com/facebook/prepack/blob/393624f00f7ad5291622ee28bf90ea0470becbcf/src/serializer/Emitter.js#L103). 

Added slightly minimized repros from the issue.

I am not quite sure what we are trying to test with the last line of this invariant. I think what we're trying to test with the last line of this invariant is: If we're emitting to an additional function, it must be the case that referencedDeclaredValues has `val`. Here the test also passes when `referencedDeclaredValues.has(val)` is `false` which seems wrong to me.

I'm also dubious that top level optimized functions don't consider the MainGenerator as their parent generator, as this means that any derived ids declared in the MainGenerator shouldn't be considered declared in optimized functions (was able to repro that in conditions2 test after tightening invariants). For the sake of unblocking React Compiler, I'll look into that in a future PR.

Solves #2359. 
