### PR TITLE
Fix default attributes in joined descriptor

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -410,11 +410,21 @@ export default class AbstractObjectValue extends AbstractValue {
         AbstractValue.reportIntrospectionError(this, P);
         throw new FatalError();
       }
+      // Extract the first existing descriptor to get its existing attributes as defaults.
+      let firstExistingDesc;
+      for (let cv of elements) {
+        invariant(cv instanceof ObjectValue);
+        firstExistingDesc = cv.$GetOwnProperty(P);
+        if (firstExistingDesc) {
+          break;
+        }
+      }
       let desc = {
         value: "value" in Desc ? Desc.value : this.$Realm.intrinsics.undefined,
-        writable: "writable" in Desc ? Desc.writable : false,
-        enumerable: "enumerable" in Desc ? Desc.enumerable : false,
-        configurable: "configurable" in Desc ? Desc.configurable : false,
+        writable: "writable" in Desc ? Desc.writable : firstExistingDesc ? firstExistingDesc.writable : false,
+        enumerable: "enumerable" in Desc ? Desc.enumerable : firstExistingDesc ? firstExistingDesc.enumerable : false,
+        configurable:
+          "configurable" in Desc ? Desc.configurable : firstExistingDesc ? firstExistingDesc.configurable : false,
       };
       let newVal = desc.value;
       if (this.kind === "conditional") {

--- a/test/serializer/abstract/ConditionalAbstractObjectValueDefineProperty2.js
+++ b/test/serializer/abstract/ConditionalAbstractObjectValueDefineProperty2.js
@@ -1,0 +1,13 @@
+(function() {
+  let c = global.__abstract ? __abstract("boolean", "(true)") : true;
+  var a = { enumerableProp: 1 };
+  var b = { enumerableProp: 2 };
+  var obj = c ? a : b;
+  Object.defineProperty(obj, "enumerableProp", {
+    value: 3,
+  });
+  global.result = Object.getOwnPropertyDescriptor(a, "enumerableProp");
+  inspect = function() {
+    return global.result;
+  };
+})();


### PR DESCRIPTION
When we create a joined descriptor in an abstract object we need to preserve any attributes of that property that were already there. To do that, we just need to read the first descriptor of the elements since all elements must have the same attributes (or we fatal).