### PR TITLE
Improve defaultProps handling

### DIFF
--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -318,7 +318,8 @@ export function computeBinary(
           realm,
           resultType,
           [lval, rval],
-          createOperationDescriptor("BINARY_EXPRESSION", { op })
+          createOperationDescriptor("BINARY_EXPRESSION", { op }),
+          { isPure: true }
         ),
       TypesDomain.topVal,
       ValuesDomain.topVal

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -169,6 +169,7 @@ function createPropsObject(
         // exist
         for (let [propName, binding] of props.properties) {
           if (binding.descriptor !== undefined && binding.descriptor.value === realm.intrinsics.undefined) {
+            invariant(defaultProps instanceof AbstractObjectValue || defaultProps instanceof ObjectValue);
             hardModifyReactObjectPropertyBinding(realm, props, propName, Get(realm, defaultProps, propName));
           }
         }

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -206,6 +206,10 @@ it("defaultProps", () => {
   runTest(__dirname + "/FunctionalComponents/default-props.js");
 });
 
+it("defaultProps 2", () => {
+  runTest(__dirname + "/FunctionalComponents/default-props2.js");
+});
+
 it("Simple with abstract props", () => {
   runTest(__dirname + "/FunctionalComponents/simple-with-abstract-props.js");
 });

--- a/test/react/FunctionalComponents/default-props2.js
+++ b/test/react/FunctionalComponents/default-props2.js
@@ -4,22 +4,23 @@ function Child(props) {
   return <span>{props.children}</span>;
 }
 
-Child.defaultProps = {
+var defaultProps = {
   children: "default text",
 };
 
+this.__makePartial && __makePartial(defaultProps);
+
+Child.defaultProps = defaultProps;
+
 function App(props) {
-  return <Child {...props.foo}>{props.bar}</Child>;
+  var newProps = Object.assign({}, props, { children: undefined });
+  return <Child {...newProps} />;
 }
 
 App.getTrials = function(renderer, Root) {
   let results = [];
-  renderer.update(<Root foo={{ children: undefined }} bar={undefined} />);
-  results.push(["defaultProps", renderer.toJSON()]);
-  renderer.update(<Root foo={{ children: "prop children text" }} bar={undefined} />);
-  results.push(["defaultProps", renderer.toJSON()]);
   renderer.update(<Root foo={{ children: undefined }} bar={"children prop text"} />);
-  results.push(["defaultProps", renderer.toJSON()]);
+  results.push(["defaultProps 2", renderer.toJSON()]);
   return results;
 };
 

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -11584,6 +11584,102 @@ ReactStatistics {
 }
 `;
 
+exports[`defaultProps 2: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`defaultProps 2: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`defaultProps 2: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`defaultProps 2: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`defaultProps: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 2,


### PR DESCRIPTION
Release notes: none

Fixes a `defaultProps` bug and also improves bloat slightly by ensuring we state that the default props helper can be omitted if the value it mutates is never used. Furthermore, added `isPure` to the binary expression temporal, so if the value created from it never gets used, then we don't emit the action.