### PR TITLE
Don't wait for identifiers declared in other optimized functions

### DIFF
--- a/src/serializer/Emitter.js
+++ b/src/serializer/Emitter.js
@@ -78,6 +78,14 @@ export class Emitter {
     this._activeValues = new Set();
     this._activeGeneratorStack = [this._mainBody];
     this._finalized = false;
+    let mustWaitForValue = (val: AbstractValue | ArrayValue) => {
+      if (this.cannotDeclare()) return false;
+      if (this.hasBeenDeclared(val)) return false;
+      let activeOptimizedFunction = this.getActiveOptimizedFunction();
+      if (activeOptimizedFunction === undefined) return true;
+      let optimizedFunctionWhereValueWasDeclared = referencedDeclaredValues.get(val);
+      return optimizedFunctionWhereValueWasDeclared === activeOptimizedFunction;
+    };
     this._getReasonToWaitForDependenciesCallbacks = {
       onActive: val => val, // cyclic dependency; we need to wait until this value has finished emitting
       onFunction: val => {
@@ -85,29 +93,9 @@ export class Emitter {
         this._residualFunctions.addFunctionUsage(val, this.getBodyReference());
         return undefined;
       },
-      onAbstractValueWithIdentifier: val => {
-        // If the value hasn't been declared yet, then we should wait for it.
-        if (
-          derivedIds.has(val.getIdentifier()) &&
-          !this.cannotDeclare() &&
-          !this.hasBeenDeclared(val) &&
-          (!this.emittingToAdditionalFunction() || referencedDeclaredValues.get(val) !== undefined)
-        ) {
-          return val;
-        }
-        return undefined;
-      },
-      onArrayWithWidenedNumericProperty: val => {
-        // If the value hasn't been declared yet, then we should wait for it.
-        if (
-          !this.cannotDeclare() &&
-          !this.hasBeenDeclared(val) &&
-          (!this.emittingToAdditionalFunction() || referencedDeclaredValues.get(val) !== undefined)
-        ) {
-          return val;
-        }
-        return undefined;
-      },
+      onAbstractValueWithIdentifier: val =>
+        derivedIds.has(val.getIdentifier()) && mustWaitForValue(val) ? val : undefined,
+      onArrayWithWidenedNumericProperty: val => (mustWaitForValue(val) ? val : undefined),
     };
     this._conditionalFeasibility = conditionalFeasibility;
   }
@@ -134,6 +122,7 @@ export class Emitter {
     isChild: boolean = false
   ): SerializedBody {
     invariant(!this._finalized);
+    invariant((targetBody.type === "OptimizedFunction") === !!targetBody.optimizedFunction);
     this._activeStack.push(dependency);
     if (dependency instanceof Value) {
       invariant(!this._activeValues.has(dependency));
@@ -238,7 +227,7 @@ export class Emitter {
     return this._activeGeneratorStack[this._activeGeneratorStack.length - 1] === this._body;
   }
   _isGeneratorBody(body: SerializedBody): boolean {
-    return body.type === "MainGenerator" || body.type === "Generator" || body.type === "AdditionalFunction";
+    return body.type === "MainGenerator" || body.type === "Generator" || body.type === "OptimizedFunction";
   }
   _processCurrentBody(): void {
     if (!this._isEmittingActiveGenerator() || this._body.processing) {
@@ -487,10 +476,11 @@ export class Emitter {
     this._body.declaredValues.set(value, this._body);
     this._processValue(value);
   }
-  emittingToAdditionalFunction(): boolean {
-    // Whether we are directly or indirectly emitting to an additional function
-    for (let b = this._body; b !== undefined; b = b.parentBody) if (b.type === "AdditionalFunction") return true;
-    return false;
+  getActiveOptimizedFunction(): void | FunctionValue {
+    // Whether we are directly or indirectly emitting to an optimized function
+    for (let b = this._body; b !== undefined; b = b.parentBody)
+      if (b.type === "OptimizedFunction") return b.optimizedFunction;
+    return undefined;
   }
   cannotDeclare(): boolean {
     // Bodies of the following types will never contain any (temporal) abstract value declarations.

--- a/src/serializer/types.js
+++ b/src/serializer/types.js
@@ -26,11 +26,10 @@ import { type SerializerStatistics } from "./statistics.js";
 
 export type TryQuery<T> = (f: () => T, defaultValue: T) => T;
 
-// TODO: add type for additional functions.
 export type SerializedBodyType =
   | "MainGenerator"
   | "Generator"
-  | "AdditionalFunction"
+  | "OptimizedFunction"
   | "DelayInitializations"
   | "ConditionalAssignmentBranch"
   | "LazyObjectInitializer";
@@ -43,6 +42,7 @@ export type SerializedBody = {
   parentBody?: SerializedBody,
   nestingLevel?: number,
   processing?: boolean,
+  optimizedFunction?: FunctionValue, // defined if any only if type is OptimizedFunction
 };
 
 export type AdditionalFunctionEffects = {

--- a/test/serializer/optimized-functions/Issue2392-1.js
+++ b/test/serializer/optimized-functions/Issue2392-1.js
@@ -1,0 +1,15 @@
+function fn(x, obj, cond, cond4) {
+    var arr = Array.from(x);
+
+    var f = function(item) { return cond4 ? a : 5; };
+    if (cond) {
+        var a = obj.a;
+        return arr.map(f);
+    }
+}
+
+global.__optimize && __optimize(fn);
+
+global.inspect = function() {
+    return true;
+}

--- a/test/serializer/optimized-functions/Issue2392-1.js
+++ b/test/serializer/optimized-functions/Issue2392-1.js
@@ -1,15 +1,17 @@
 function fn(x, obj, cond, cond4) {
-    var arr = Array.from(x);
+  var arr = Array.from(x);
 
-    var f = function(item) { return cond4 ? a : 5; };
-    if (cond) {
-        var a = obj.a;
-        return arr.map(f);
-    }
+  var f = function(item) {
+    return cond4 ? a : 5;
+  };
+  if (cond) {
+    var a = obj.a;
+    return arr.map(f);
+  }
 }
 
 global.__optimize && __optimize(fn);
 
 global.inspect = function() {
-    return true;
-}
+  return true;
+};

--- a/test/serializer/optimized-functions/Issue2392-2.js
+++ b/test/serializer/optimized-functions/Issue2392-2.js
@@ -1,0 +1,25 @@
+function fn(x, obj, cond, cond2, cond3, cond4) {
+    var arr = Array.from(x);
+    var a;
+    var b;
+    var res;
+
+    if (cond) {
+        a = obj.a;
+        if (cond2) {
+            b = obj.b;
+            if (cond3) {
+                res = arr.map(function(item) {
+                        return cond4 ? a : b;
+                    });
+            }
+        }
+    }
+    return res;
+}
+
+global.__optimize && __optimize(fn);
+
+global.inspect = function() {
+    return true;
+}

--- a/test/serializer/optimized-functions/Issue2392-2.js
+++ b/test/serializer/optimized-functions/Issue2392-2.js
@@ -1,25 +1,25 @@
 function fn(x, obj, cond, cond2, cond3, cond4) {
-    var arr = Array.from(x);
-    var a;
-    var b;
-    var res;
+  var arr = Array.from(x);
+  var a;
+  var b;
+  var res;
 
-    if (cond) {
-        a = obj.a;
-        if (cond2) {
-            b = obj.b;
-            if (cond3) {
-                res = arr.map(function(item) {
-                        return cond4 ? a : b;
-                    });
-            }
-        }
+  if (cond) {
+    a = obj.a;
+    if (cond2) {
+      b = obj.b;
+      if (cond3) {
+        res = arr.map(function(item) {
+          return cond4 ? a : b;
+        });
+      }
     }
-    return res;
+  }
+  return res;
 }
 
 global.__optimize && __optimize(fn);
 
 global.inspect = function() {
-    return true;
-}
+  return true;
+};


### PR DESCRIPTION
Release notes: Progress in support for nested optimized functions

This fixes #2392.
Control flow of nested optimized functions is independent of
their parents. This change reflects that.

Added regression tests.