### PR TITLE
Nested optimized function with residual functions

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -782,6 +782,9 @@ export class ResidualHeapSerializer {
       } else {
         let f = this.tryGetOptimizedFunctionRoot(functionValue);
         if (f === undefined) return undefined;
+        if (this.isDefinedInsideFunction(f, functionValues)) {
+          continue;
+        }
         if (additionalFunction !== undefined && additionalFunction !== f) return undefined;
         additionalFunction = f;
       }

--- a/test/serializer/additional-functions/NestedOptimizedFunction17.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction17.js
@@ -1,0 +1,31 @@
+function fn(props, cond, cond2, cond3) {
+  var arr = Array.from(props.x);
+  var newObj;
+  var value;
+
+  if (cond) {
+    var _ref8;
+    value =
+      (_ref8 = props.feedback) != null
+        ? (_ref8 = _ref8.display_comments) != null
+          ? _ref8.ordering_mode
+          : _ref8
+        : _ref8;
+
+    var res = arr.map(function(item) {
+      var fn2 = function() {
+        return value;
+      };
+
+      return [item[value], fn2];
+    });
+  }
+
+  return res;
+}
+
+global.__optimize && __optimize(fn);
+
+global.inspect = function() {
+  return true;
+};


### PR DESCRIPTION
Release notes: none

This fixes a bug with nested optimized functions referencing nested residual functions and makes our internal bundle compile.

The issue was that we weren't checking if the function we get from `tryGetOptimizedFunctionRoot` was defined inside another optimized function, like we do already 5-6 lines up in the other if statement. This is an important thing, as the next line will result in `undefined` being returned. When `undefined` is returned, we use the `MainGenerator` rather than the `OptimizedFunction` generator, which means all declared values look at the wrong body.