### PR TITLE
Fixed multiple ordering bugs involving unsafe a-temporal abstract values

### DIFF
--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -317,8 +317,17 @@ const JSONParse = buildExpressionTemplate(JSONParseStr);
 function InternalJSONClone(realm: Realm, val: Value): Value {
   if (val instanceof AbstractValue) {
     if (val instanceof AbstractObjectValue) {
-      let strVal = AbstractValue.createFromTemplate(realm, JSONStringify, StringValue, [val], JSONStringifyStr);
-      let obVal = AbstractValue.createFromTemplate(realm, JSONParse, ObjectValue, [strVal], JSONParseStr);
+      let strVal;
+      let obVal;
+
+      // If val is temporal, then this operation is also temporal. See #2327.
+      if (val.isTemporal()) {
+        strVal = AbstractValue.createFromTemplate(realm, JSONStringify, StringValue, [val], JSONStringifyStr);
+        obVal = AbstractValue.createFromTemplate(realm, JSONParse, ObjectValue, [strVal], JSONParseStr);
+      } else {
+        strVal = AbstractValue.createTemporalFromTemplate(realm, JSONStringify, StringValue, [val]);
+        obVal = AbstractValue.createTemporalFromTemplate(realm, JSONParse, ObjectValue, [strVal]);
+      }
       obVal.values = new ValuesDomain(new Set([InternalCloneObject(realm, val.getTemplate())]));
       return obVal;
     }

--- a/src/intrinsics/ecma262/JSON.js
+++ b/src/intrinsics/ecma262/JSON.js
@@ -320,14 +320,8 @@ function InternalJSONClone(realm: Realm, val: Value): Value {
       let strVal;
       let obVal;
 
-      // If val is temporal, then this operation is also temporal. See #2327.
-      if (val.isTemporal()) {
-        strVal = AbstractValue.createFromTemplate(realm, JSONStringify, StringValue, [val], JSONStringifyStr);
-        obVal = AbstractValue.createFromTemplate(realm, JSONParse, ObjectValue, [strVal], JSONParseStr);
-      } else {
-        strVal = AbstractValue.createTemporalFromTemplate(realm, JSONStringify, StringValue, [val]);
-        obVal = AbstractValue.createTemporalFromTemplate(realm, JSONParse, ObjectValue, [strVal]);
-      }
+      strVal = AbstractValue.createFromTemplate(realm, JSONStringify, StringValue, [val], JSONStringifyStr);
+      obVal = AbstractValue.createFromTemplate(realm, JSONParse, ObjectValue, [strVal], JSONParseStr);
       obVal.values = new ValuesDomain(new Set([InternalCloneObject(realm, val.getTemplate())]));
       return obVal;
     }

--- a/src/intrinsics/ecma262/Math.js
+++ b/src/intrinsics/ecma262/Math.js
@@ -167,6 +167,9 @@ export default function(realm: Realm): ObjectValue {
           let template = buildExpressionTemplate(templateSource);
           buildMathTemplates.set(name, (r = { template, templateSource }));
         }
+        /* Functions in the Math module cannot throw, so if we ever end up supporting these calls on AbstractValues,
+        using createFromTemplate instead of createTemporalFromTemplate should be safe.
+        This makes the function amenable to CSE, which is a good thing for Math.* */
         return AbstractValue.createFromTemplate(realm, r.template, NumberValue, args, r.templateSource);
       }
 

--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -577,7 +577,14 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     if (O instanceof AbstractValue && O.getType() === StringValue) {
-      return AbstractValue.createFromTemplate(realm, sliceTemplate, StringValue, [O, start, end], sliceTemplateSrc);
+      // If O is temporal, this operation is also temporal. See #2327.
+      if (O.isTemporal())
+        return AbstractValue.createTemporalFromTemplate(realm, sliceTemplate, StringValue, [O, start, end], {
+          isPure: true,
+          skipInvariant: true,
+        });
+      else
+        return AbstractValue.createFromTemplate(realm, sliceTemplate, StringValue, [O, start, end], sliceTemplateSrc);
     }
 
     // 2. Let S be ? ToString(O).
@@ -611,13 +618,20 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     if (O instanceof AbstractValue && O.getType() === StringValue) {
-      return AbstractValue.createFromTemplate(
-        realm,
-        splitTemplate,
-        ObjectValue,
-        [O, separator, limit],
-        splitTemplateSrc
-      );
+      // If O is temporal, this operation is also temporal. See #2327.
+      if (O.isTemporal())
+        return AbstractValue.createTemporalFromTemplate(realm, splitTemplate, ObjectValue, [O, separator, limit], {
+          isPure: true,
+          skipInvariant: true,
+        });
+      else
+        return AbstractValue.createFromTemplate(
+          realm,
+          splitTemplate,
+          ObjectValue,
+          [O, separator, limit],
+          splitTemplateSrc
+        );
     }
 
     // 2. If separator is neither undefined nor null, then

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -327,7 +327,14 @@ export function OrdinaryGetPartial(
   Receiver: Value
 ): Value {
   if (Receiver instanceof AbstractValue && Receiver.getType() === StringValue && P === "length") {
-    return AbstractValue.createFromTemplate(realm, lengthTemplate, NumberValue, [Receiver], lengthTemplateSrc);
+    if (Receiver.isTemporal()) {
+      return AbstractValue.createTemporalFromTemplate(realm, lengthTemplate, NumberValue, [Receiver], {
+        isPure: true,
+        skipInvariant: true,
+      });
+    } else {
+      return AbstractValue.createFromTemplate(realm, lengthTemplate, NumberValue, [Receiver], lengthTemplateSrc);
+    }
   }
 
   if (!(P instanceof AbstractValue)) return O.$Get(P, Receiver);

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -234,6 +234,8 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       }
       if (remainingConcreteValues.length === 0) return abstractValue;
       if (remainingConcreteValues.length === concreteValues.length) return value;
+
+      // This abstractValue was extracted from an abstract concrete union, and must be temporal
       return AbstractValue.createAbstractConcreteUnion(realm, abstractValue, ...remainingConcreteValues);
     }
     default:

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -888,10 +888,6 @@ export default class AbstractValue extends Value {
     let abstractValue = elements.find(e => e instanceof AbstractValue);
     invariant(abstractValue instanceof AbstractValue);
 
-    // Abstract values in an abstract concrete union are temporal, as they are predicated
-    // on the conditions that preclude the concrete values in the union.
-    // invariant(abstractValue.isTemporal());
-
     let values;
     if (!abstractValue.values.isTop()) {
       abstractValue.values.getElements().forEach(v => concreteSet.add(v));

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -355,6 +355,9 @@ export default class AbstractValue extends Value {
     return false;
   }
 
+  isTemporal(): boolean {
+    return this.$Realm.getTemporalOperationEntryFromDerivedValue(this) !== undefined;
+  }
   // todo: abstract values should never be of type UndefinedValue or NullValue, assert this
   mightBeFalse(): boolean {
     let valueType = this.getType();
@@ -756,7 +759,13 @@ export default class AbstractValue extends Value {
   /* Note that the template is parameterized by the names A, B, C and so on.
      When the abstract value is serialized, the serialized operations are substituted
      for the corresponding parameters and the resulting template is parsed into an AST subtree
-     that is incorporated into the AST produced by the serializer. */
+     that is incorporated into the AST produced by the serializer.
+
+     NOTE: Only call this function if you can guarantee that the template you pass to it will not
+     generate code that is a-temporal. Code is a-temporal if it cannot throw or cause side effects.
+     If there is a possibility that it might exhibit this behavior, then use the safer
+     createTemporalFromTemplate call instead. */
+
   static createFromTemplate(
     realm: Realm,
     template: PreludeGenerator => ({}) => BabelNodeExpression,
@@ -878,6 +887,11 @@ export default class AbstractValue extends Value {
     let concreteSet = new Set(concreteValues);
     let abstractValue = elements.find(e => e instanceof AbstractValue);
     invariant(abstractValue instanceof AbstractValue);
+
+    // Abstract values in an abstract concrete union are temporal, as they are predicated
+    // on the conditions that preclude the concrete values in the union.
+    // invariant(abstractValue.isTemporal());
+
     let values;
     if (!abstractValue.values.isTop()) {
       abstractValue.values.getElements().forEach(v => concreteSet.add(v));

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -30,6 +30,9 @@ export default class ConcreteValue extends Value {
     super(realm, intrinsicName);
   }
 
+  isTemporal(): boolean {
+    return false;
+  }
   mightNotBeFalse(): boolean {
     return !this.mightBeFalse();
   }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -73,6 +73,10 @@ export default class Value {
     return !!this.intrinsicName;
   }
 
+  isTemporal() {
+    invariant(false, "abstract method; please override");
+  }
+
   isPartialObject(): boolean {
     return false;
   }

--- a/test/serializer/abstract/Issue2327InBinop.js
+++ b/test/serializer/abstract/Issue2327InBinop.js
@@ -1,0 +1,11 @@
+// expected RecoverableError: PP0004
+
+let o = global.__abstractOrNull ? __abstractOrNull("object", "undefined") : undefined;
+let s = true;
+
+if (o != undefined) s = "foobar" in o;
+if (o != undefined) s = "foobar" in o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327InBinopUnconditional.js
+++ b/test/serializer/abstract/Issue2327InBinopUnconditional.js
@@ -1,0 +1,12 @@
+// Copies of "foobar" in:1
+// expected RecoverableError: PP0004
+
+let o = global.__abstract ? __abstract("object", "('foobar42')") : "foobar42";
+let s = true;
+
+if (o != undefined) s = "foobar" in o;
+if (o != undefined) s = "foobar" in o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327InstanceOfBinop.js
+++ b/test/serializer/abstract/Issue2327InstanceOfBinop.js
@@ -1,0 +1,11 @@
+// expected RecoverableError: PP0004
+
+let o = global.__abstractOrNull ? __abstractOrNull("object", "undefined") : undefined;
+let s = true;
+
+if (o != undefined) s = "foobar" instanceof o;
+if (o != undefined) s = "foobar" instanceof o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327InstanceOfBinopUnconditional.js
+++ b/test/serializer/abstract/Issue2327InstanceOfBinopUnconditional.js
@@ -1,0 +1,12 @@
+// Copies of "foobar" instanceof:1
+// expected RecoverableError: PP0004
+
+let o = global.__abstract ? __abstract("object", "({})") : {};
+let s = true;
+
+if (o != undefined) s = "foobar" instanceof o;
+if (o != undefined) s = "foobar" instanceof o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327StringLength.js
+++ b/test/serializer/abstract/Issue2327StringLength.js
@@ -1,0 +1,9 @@
+let o = global.__abstractOrNull ? __abstractOrNull("string", "undefined") : undefined;
+let s;
+
+if (o != undefined) s = 5 + o.length;
+if (o != undefined) s = 7 + o.length;
+
+global.s = s;
+
+inspect = () => s;

--- a/test/serializer/abstract/Issue2327StringLengthUnconditional.js
+++ b/test/serializer/abstract/Issue2327StringLengthUnconditional.js
@@ -1,0 +1,11 @@
+// Copies of length:1
+
+let o = global.__abstract ? __abstract("string", "('xyz')") : "xyz";
+let s;
+
+if (o != undefined) s = 5 + o.length;
+if (o != undefined) s = 7 + o.length;
+
+global.s = s;
+
+inspect = () => s;

--- a/test/serializer/abstract/Issue2327StringSlice.js
+++ b/test/serializer/abstract/Issue2327StringSlice.js
@@ -1,0 +1,9 @@
+let o = global.__abstractOrNull ? __abstractOrNull("string", "undefined") : undefined;
+let s = "ok";
+
+if (o != undefined) s = "X" + o.slice(3);
+if (o != undefined) s = "Y" + o.slice(3);
+
+global.s = s;
+
+inspect = () => s;

--- a/test/serializer/abstract/Issue2327StringSliceUnconditional.js
+++ b/test/serializer/abstract/Issue2327StringSliceUnconditional.js
@@ -1,0 +1,13 @@
+// Copies of slice\(:1
+
+(function() {
+  let o = global.__abstract ? __abstract("string", "('x y z')") : "x y z";
+  let c = global.__abstract ? __abstract("boolean", "true") : true;
+  let s = "ok";
+
+  if (c) s = "X" + o.slice(3);
+  if (c) s = "Y" + o.slice(3);
+
+  global.s = s;
+  inspect = () => s;
+})();

--- a/test/serializer/abstract/Issue2327StringSplit.js
+++ b/test/serializer/abstract/Issue2327StringSplit.js
@@ -1,0 +1,9 @@
+let o = global.__abstractOrNull ? __abstractOrNull("string", "undefined") : undefined;
+let s = "ok";
+
+if (o != undefined) s = o.split();
+if (o != undefined) s = o.split();
+
+global.s = s;
+
+inspect = () => s;


### PR DESCRIPTION
Release notes: Fixed multiple ordering bugs

Fixes #2327 and #2406. The discussion around this set of issues can be found in #2327. To summarize, sometimes the serializer's CSE algorithm would relocate simplified values out of the path along which they were simplified. This relocation is unsafe for values that can cause side effects and ones that can throw. Otherwise, it may be wasteful but safe.

This PR helps improves the situation by making all potentially unsafe abstract values temporal. The cases I found came out of a code audit. Calls to `createFromTemplate` should have been covered comprehensively. Most unsafe operations still don't accept abstract values and throw introspection errors, so they are not a problem yet.