### PR TITLE
Ensure createdObjects is not broken

### DIFF
--- a/src/react/utils.js
+++ b/src/react/utils.js
@@ -793,6 +793,7 @@ export function getValueFromFunctionCall(
   let funcCall = func.$Call;
   let newCall = func.$Construct;
   let completion;
+  let createdObjects = realm.createdObjects;
   try {
     if (isConstructor) {
       invariant(newCall);
@@ -806,6 +807,8 @@ export function getValueFromFunctionCall(
     } else {
       throw error;
     }
+  } finally {
+    invariant(createdObjects === realm.createdObjects, "realm.createdObjects was not correctly restored");
   }
   if (completion instanceof PossiblyNormalCompletion) {
     // in this case one of the branches may complete abruptly, which means that

--- a/src/realm.js
+++ b/src/realm.js
@@ -888,6 +888,7 @@ export class Realm {
 
   evaluateForEffects(f: () => Completion | Value, state: any, generatorName: string): Effects {
     // Save old state and set up empty state
+    invariant(this.createdObjects !== undefined, "created objects should never be undefined");
     let [savedBindings, savedProperties] = this.getAndResetModifiedMaps();
     let saved_generator = this.generator;
     let saved_createdObjects = this.createdObjects;
@@ -966,6 +967,13 @@ export class Realm {
       }
     } finally {
       for (let t2 of this.tracers) t2.endEvaluateForEffects(state, result);
+      if (saved_createdObjects) {
+        for (let obj of saved_createdObjects) {
+          if (!this.createdObjects.has(obj)) {
+            debugger;
+          }
+        }
+      }
     }
   }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -888,7 +888,6 @@ export class Realm {
 
   evaluateForEffects(f: () => Completion | Value, state: any, generatorName: string): Effects {
     // Save old state and set up empty state
-    invariant(this.createdObjects !== undefined, "created objects should never be undefined");
     let [savedBindings, savedProperties] = this.getAndResetModifiedMaps();
     let saved_generator = this.generator;
     let saved_createdObjects = this.createdObjects;

--- a/src/realm.js
+++ b/src/realm.js
@@ -967,13 +967,6 @@ export class Realm {
       }
     } finally {
       for (let t2 of this.tracers) t2.endEvaluateForEffects(state, result);
-      if (saved_createdObjects) {
-        for (let obj of saved_createdObjects) {
-          if (!this.createdObjects.has(obj)) {
-            debugger;
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
Release notes: none

This adds a check in the React utils component function caller to ensure that the `createObjects` are correct at evaluation time.