### PR TITLE
Remove React pathCondition resetting

### DIFF
--- a/src/react/experimental-server-rendering/rendering.js
+++ b/src/react/experimental-server-rendering/rendering.js
@@ -359,17 +359,11 @@ class ReactDOMServerRenderer {
             });
 
           let resolvedEffects;
-          let saved_pathConditions = this.realm.pathConditions;
-          this.realm.pathConditions = [];
-          try {
-            resolvedEffects = this.realm.evaluateForEffects(
-              pureFuncCall,
-              /*state*/ null,
-              `react SSR resolve nested optimized closure`
-            );
-          } finally {
-            this.realm.pathConditions = saved_pathConditions;
-          }
+          resolvedEffects = this.realm.evaluateForEffects(
+            pureFuncCall,
+            /*state*/ null,
+            `react SSR resolve nested optimized closure`
+          );
           nestedOptimizedFunctionEffects.set(func, resolvedEffects);
           this.realm.collectedNestedOptimizedFunctionEffects.set(func, resolvedEffects);
         }

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1433,17 +1433,11 @@ export class Reconciler {
             );
 
           let resolvedEffects;
-          let saved_pathConditions = this.realm.pathConditions;
-          this.realm.pathConditions = [];
-          try {
-            resolvedEffects = this.realm.evaluateForEffects(
-              pureFuncCall,
-              /*state*/ null,
-              `react resolve nested optimized closure`
-            );
-          } finally {
-            this.realm.pathConditions = saved_pathConditions;
-          }
+          resolvedEffects = this.realm.evaluateForEffects(
+            pureFuncCall,
+            /*state*/ null,
+            `react resolve nested optimized closure`
+          );
           this.statistics.optimizedNestedClosures++;
           nestedOptimizedFunctionEffects.set(func, resolvedEffects);
           this.realm.collectedNestedOptimizedFunctionEffects.set(func, resolvedEffects);
@@ -1551,8 +1545,6 @@ export class Reconciler {
         throw new NestedOptimizedFunctionSideEffect();
       });
     let effects;
-    let saved_pathConditions = this.realm.pathConditions;
-    this.realm.pathConditions = [];
     try {
       effects = this.realm.evaluateForEffects(
         () => {
@@ -1571,8 +1563,6 @@ export class Reconciler {
         return;
       }
       throw e;
-    } finally {
-      this.realm.pathConditions = saved_pathConditions;
     }
     this.statistics.optimizedNestedClosures++;
     this.realm.collectedNestedOptimizedFunctionEffects.set(funcToModel, effects);

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -51,8 +51,6 @@ function evaluatePossibleNestedOptimizedFunctionsAndStoreEffects(
         throw new NestedOptimizedFunctionSideEffect();
       });
     let effects;
-    let saved_pathConditions = realm.pathConditions;
-    realm.pathConditions = [];
     try {
       effects = realm.evaluateForEffects(pureFuncCall, null, "temporalArray nestedOptimizedFunction");
     } catch (e) {
@@ -64,8 +62,6 @@ function evaluatePossibleNestedOptimizedFunctionsAndStoreEffects(
         return;
       }
       throw e;
-    } finally {
-      realm.pathConditions = saved_pathConditions;
     }
     // Check if effects were pure then add them
     if (abstractArrayValue.nestedOptimizedFunctionEffects === undefined) {


### PR DESCRIPTION
Release notes: none

During React reconciliation we wrongly reset `pathConditions`. This was done originally because of a pushing false invariant, that I incorrectly thought was a bug because of React specific code.

However, today, I re-worked the original test code to remove all React logic and I found that the invariant occurs even without React specific logic. This strongly suggests that this is still an existing bug in Prepack and adding `pathConditions` logic, which gets around it, was the wrong strategy and should be reverted.