### PR TITLE
Fix havoced binding not in optimized function

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -69,7 +69,7 @@ import { GeneratorDAG } from "./GeneratorDAG.js";
 
 type BindingState = {|
   capturedBindings: Set<ResidualFunctionBinding>,
-  capturingFunctions: Set<FunctionValue>,
+  capturingScopes: Set<Scope>,
 |};
 
 /* This class visits all values that are reachable in the residual heap.
@@ -648,10 +648,10 @@ export class ResidualHeapVisitor {
   // function c() { return x.length + y.length; }
   // Here we need to make sure that a and b both initialize x and y because x and y will be in the same
   // captured scope because c captures both x and y.
-  visitBinding(val: FunctionValue, residualFunctionBinding: ResidualFunctionBinding): void {
+  visitBinding(scope: Scope, residualFunctionBinding: ResidualFunctionBinding): void {
     let environment = residualFunctionBinding.declarativeEnvironmentRecord;
     if (environment === null) return;
-    invariant(this.scope === val);
+    invariant(this.scope === scope);
 
     let refScope = this._getAdditionalFunctionOfScope() || "GLOBAL";
     residualFunctionBinding.potentialReferentializationScopes.add(refScope);
@@ -661,20 +661,20 @@ export class ResidualHeapVisitor {
     invariant(envRec !== null);
     let bindingState = getOrDefault(funcToScopes, envRec, () => ({
       capturedBindings: new Set(),
-      capturingFunctions: new Set(),
+      capturingScopes: new Set(),
     }));
     // If the binding is new for this bindingState, have all functions capturing bindings from that scope visit it
     if (!bindingState.capturedBindings.has(residualFunctionBinding)) {
-      for (let functionValue of bindingState.capturingFunctions) {
-        this._enqueueWithUnrelatedScope(functionValue, () => this._visitBindingHelper(residualFunctionBinding));
+      for (let capturingScope of bindingState.capturingScopes) {
+        this._enqueueWithUnrelatedScope(capturingScope, () => this._visitBindingHelper(residualFunctionBinding));
       }
       bindingState.capturedBindings.add(residualFunctionBinding);
     }
     // If the function is new for this bindingState, visit all existent bindings in this scope
-    if (!bindingState.capturingFunctions.has(val)) {
-      invariant(this.scope === val);
+    if (!bindingState.capturingScopes.has(scope)) {
+      invariant(this.scope === scope);
       for (let residualBinding of bindingState.capturedBindings) this._visitBindingHelper(residualBinding);
-      bindingState.capturingFunctions.add(val);
+      bindingState.capturingScopes.add(scope);
     }
   }
 
@@ -1210,14 +1210,15 @@ export class ResidualHeapVisitor {
         residualBinding.hasLeaked = true;
         // This may not have been referentialized if the binding is a local of an optimized function.
         // in that case, we need to figure out which optimized function it is, and referentialize it in that scope.
-        let optimizedFunctionScope = this._getAdditionalFunctionOfScope();
-        if (residualBinding.potentialReferentializationScopes.size === 0 && optimizedFunctionScope !== undefined) {
-          this._enqueueWithUnrelatedScope(optimizedFunctionScope, () => {
-            invariant(additionalFunctionInfo !== undefined);
-            let funcInstance = additionalFunctionInfo.instance;
-            invariant(funcInstance !== undefined);
-            funcInstance.residualFunctionBindings.set(residualBinding.name, residualBinding);
-            this.visitBinding(optimizedFunctionScope, residualBinding);
+        let commonScope = this._getCommonScope();
+        if (residualBinding.potentialReferentializationScopes.size === 0) {
+          this._enqueueWithUnrelatedScope(commonScope, () => {
+            if (additionalFunctionInfo !== undefined) {
+              let funcInstance = additionalFunctionInfo.instance;
+              invariant(funcInstance !== undefined);
+              funcInstance.residualFunctionBindings.set(residualBinding.name, residualBinding);
+            }
+            this.visitBinding(commonScope, residualBinding);
           });
         }
         return this.visitEquivalentValue(value);

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1211,8 +1211,7 @@ export class ResidualHeapVisitor {
         // This may not have been referentialized if the binding is a local of an optimized function.
         // in that case, we need to figure out which optimized function it is, and referentialize it in that scope.
         let optimizedFunctionScope = this._getAdditionalFunctionOfScope();
-        if (residualBinding.potentialReferentializationScopes.size === 0) {
-          invariant(optimizedFunctionScope !== undefined);
+        if (residualBinding.potentialReferentializationScopes.size === 0 && optimizedFunctionScope !== undefined) {
           this._enqueueWithUnrelatedScope(optimizedFunctionScope, () => {
             invariant(additionalFunctionInfo !== undefined);
             let funcInstance = additionalFunctionInfo.instance;

--- a/test/serializer/optimized-functions/HavocBindings11.js
+++ b/test/serializer/optimized-functions/HavocBindings11.js
@@ -1,0 +1,15 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+const havoc = global.__abstract ? global.__abstract("function", "(() => {})") : () => {};
+
+const result = global.__evaluatePureFunction(() => {
+  let x = 23;
+  function incrementX() {
+    x = x + 42;
+  }
+  if (global.__optimize) __optimize(incrementX);
+  havoc(incrementX);
+  return x;
+});
+
+global.inspect = () => result;

--- a/test/serializer/pure-functions/HavocBinding.js
+++ b/test/serializer/pure-functions/HavocBinding.js
@@ -1,0 +1,14 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+const x = global.__evaluatePureFunction(() => {
+  const x = { p: 42 };
+
+  const havoc = global.__abstract ? __abstract("function", "(() => {})") : () => {};
+  havoc(() => x);
+
+  return x;
+});
+
+global.inspect = () => {
+  return JSON.stringify(x);
+};


### PR DESCRIPTION
Fixes #2419 and #2386. I ran into this issue while testing an internal React Native bundle. This invariant assumes that all property bindings emitted in a pure scope are also in an optimized function. This is not true for `__evaluatePureFunction` which the React Compiler wraps around initialization code so that globals outside of the closure are not havoced.