### PR TITLE
Making sure ThrowTypeError intrinsic has intrinsic name

### DIFF
--- a/src/intrinsics/ecma262/ThrowTypeError.js
+++ b/src/intrinsics/ecma262/ThrowTypeError.js
@@ -14,7 +14,7 @@ import { NativeFunctionValue } from "../../values/index.js";
 
 export default function(realm: Realm): NativeFunctionValue {
   // ECMA262 9.2.7.1
-  let func = new NativeFunctionValue(realm, "", "", 0, context => {
+  let func = new NativeFunctionValue(realm, "(function() { throw new TypeError(); })", "", 0, context => {
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);
   });
 


### PR DESCRIPTION
Release notes: None

Every native function value needs an intrinsic name,
otherwise the serializer will fail with an invariant violation.

This gives an intrinsic "name" to `ThrowTypeError`
that meets the requirements of the ECMAScript spec.