### PR TITLE
typeof React.forwardRef is not function

### DIFF
--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -265,7 +265,7 @@ function evaluateOperation(
       return new StringValue(realm, "number");
     } else if (isInstance(proto, SymbolValue)) {
       return new StringValue(realm, "symbol");
-    } else if (isInstance(proto, ObjectValue) && !(val instanceof AbstractValue)) {
+    } else if (isInstance(proto, ObjectValue)) {
       if (IsCallable(realm, val)) {
         return new StringValue(realm, "function");
       }

--- a/src/evaluators/UnaryExpression.js
+++ b/src/evaluators/UnaryExpression.js
@@ -265,7 +265,7 @@ function evaluateOperation(
       return new StringValue(realm, "number");
     } else if (isInstance(proto, SymbolValue)) {
       return new StringValue(realm, "symbol");
-    } else if (isInstance(proto, ObjectValue)) {
+    } else if (isInstance(proto, ObjectValue) && !(val instanceof AbstractValue)) {
       if (IsCallable(realm, val)) {
         return new StringValue(realm, "function");
       }

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -540,6 +540,7 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
       { skipInvariant: true, isPure: true }
     );
     invariant(forwardedRef instanceof AbstractObjectValue);
+    forwardedRef.makeSimple();
     realm.react.abstractHints.set(
       forwardedRef,
       createReactHintObject(reactValue, "forwardRef", [func], realm.intrinsics.undefined)

--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -32,14 +32,14 @@ import { createOperationDescriptor } from "../../utils/generator.js";
 
 // most of the code here was taken from https://github.com/facebook/react/blob/master/packages/react/src/ReactElement.js
 let reactCode = `
-  function createReact(REACT_ELEMENT_TYPE, REACT_FRAGMENT_TYPE, REACT_PORTAL_TYPE, ReactCurrentOwner, create) {
+  function createReact(REACT_ELEMENT_TYPE, REACT_FRAGMENT_TYPE, REACT_PORTAL_TYPE, ReactCurrentOwner) {
     function makeEmptyFunction(arg) {
       return function() {
         return arg;
       };
     }
     var emptyFunction = function() {};
-    
+
     emptyFunction.thatReturns = makeEmptyFunction;
     emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
     emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
@@ -58,7 +58,7 @@ let reactCode = `
     function hasValidRef(config) {
       return config.ref !== undefined;
     }
-    
+
     function hasValidKey(config) {
       return config.key !== undefined;
     }
@@ -70,7 +70,7 @@ let reactCode = `
       this.setState = function () {}; // NO-OP
       this.setState.__PREPACK_MOCK__ = true;
     }
-    
+
     Component.prototype.isReactComponent = {};
 
     function PureComponent(props, context) {
@@ -99,7 +99,7 @@ let reactCode = `
       const escapedString = ('' + key).replace(escapeRegex, function(match) {
         return escaperLookup[match];
       });
-    
+
       return '$' + escapedString;
     }
 
@@ -147,7 +147,7 @@ let reactCode = `
       if (children == null) {
         return 0;
       }
-    
+
       return traverseAllChildrenImpl(children, '', callback, traverseContext);
     }
 
@@ -173,14 +173,14 @@ let reactCode = `
       traverseContext,
     ) {
       const type = typeof children;
-    
+
       if (type === 'undefined' || type === 'boolean') {
         // All of the above are perceived as null.
         children = null;
       }
-    
+
       let invokeCallback = false;
-    
+
       if (children === null) {
         invokeCallback = true;
       } else {
@@ -197,7 +197,7 @@ let reactCode = `
             }
         }
       }
-    
+
       if (invokeCallback) {
         callback(
           traverseContext,
@@ -208,13 +208,13 @@ let reactCode = `
         );
         return 1;
       }
-    
+
       let child;
       let nextName;
       let subtreeCount = 0; // Count of children found in the current subtree.
       const nextNamePrefix =
         nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
-    
+
       if (Array.isArray(children)) {
         for (let i = 0; i < children.length; i++) {
           child = children[i];
@@ -228,7 +228,7 @@ let reactCode = `
         }
       } else {
         const iteratorFn = getIteratorFn(children);
-        if (typeof iteratorFn === 'function') {    
+        if (typeof iteratorFn === 'function') {
           var iterator = iteratorFn.call(children);
           let step;
           let ii = 0;
@@ -247,7 +247,7 @@ let reactCode = `
           var childrenString = '' + children;
         }
       }
-    
+
       return subtreeCount;
     }
 
@@ -338,7 +338,7 @@ let reactCode = `
       object: shim,
       string: shim,
       symbol: shim,
-  
+
       any: shim,
       arrayOf: getShim,
       element: shim,
@@ -534,7 +534,7 @@ export function createMockReact(realm: Realm, reactRequireName: string): ObjectV
   addMockFunctionToObject(realm, reactValue, reactRequireName, "forwardRef", (funcVal, [func]) => {
     let forwardedRef = AbstractValue.createTemporalFromBuildFunction(
       realm,
-      FunctionValue,
+      ObjectValue,
       [funcVal, func],
       createOperationDescriptor("REACT_TEMPORAL_FUNC"),
       { skipInvariant: true, isPure: true }

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -206,6 +206,10 @@ it("16.3 refs 3", () => {
   runTest(__dirname + "/FunctionalComponents/refs3.js");
 });
 
+it("refs typeof", () => {
+  runTest(__dirname + "/FunctionalComponents/refs-typeof.js");
+});
+
 it("defaultProps", () => {
   runTest(__dirname + "/FunctionalComponents/default-props.js");
 });

--- a/test/react/FunctionalComponents/refs-typeof.js
+++ b/test/react/FunctionalComponents/refs-typeof.js
@@ -1,0 +1,19 @@
+const React = require("react");
+
+function Text(props, forwardedRef) {
+  return <div forwardedRef={forwardedRef}>{props.children}</div>;
+}
+
+const TextForwardRef = React.forwardRef(Text);
+
+// This condition has relevance as it cannot be `function` for the invariant in React Native’s
+// `Animated.createAnimatedComponent`.
+//
+// https://github.com/facebook/react-native/blob/22cf5dc5660f19b16de3592ccae4c42cc16ace69/Libraries/Animated/src/createAnimatedComponent.js#L20-L25
+
+const type = typeof TextForwardRef;
+
+module.exports = {
+  independent: true,
+  getTrials: () => [["typeof `React.forwardRef`", type]],
+};

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -11783,3 +11783,43 @@ ReactStatistics {
   "optimizedTrees": 1,
 }
 `;
+
+exports[`refs typeof: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
+exports[`refs typeof: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
+exports[`refs typeof: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;
+
+exports[`refs typeof: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 0,
+  "evaluatedRootNodes": Array [],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 0,
+}
+`;

--- a/test/react/setupReactTests.js
+++ b/test/react/setupReactTests.js
@@ -269,7 +269,7 @@ ${source}
       let B = runSource(compiledSource);
 
       expect(typeof A).toBe(typeof B);
-      if (typeof A !== "function") {
+      if (A == null || B == null) {
         // Test without exports just verifies that the file compiles.
         return;
       }
@@ -281,9 +281,6 @@ ${source}
       };
       let rendererA = ReactTestRenderer.create(null, config);
       let rendererB = ReactTestRenderer.create(null, config);
-      if (A == null || B == null) {
-        throw new Error("React test runner issue");
-      }
 
       // Use the original version of the test in case transforming messes it up.
       let { getTrials: getTrialsA, independent } = A;


### PR DESCRIPTION
`typeof React.forwardRef(...)` is `object` but Prepack was returning `function`. This is particularly important since React Native’s `Animated.createAnimatedComponent` crashes with an invariant if `typeof` is `function`. We can’t compile our React Native internal bundle without this fix.

https://github.com/facebook/react-native/blob/22cf5dc5660f19b16de3592ccae4c42cc16ace69/Libraries/Animated/src/createAnimatedComponent.js#L20-L25

https://github.com/facebook/react/blob/f9358c51c8de93abe3cdd0f4720b489befad8c48/packages/react/src/forwardRef.js#L12-L43

Small Prepack core change in `src/evaluators/UnaryExpression.js`.