### PR TITLE
Refactoring of Generator DAG to Generator Tree.

### DIFF
--- a/src/serializer/LazyObjectsSerializer.js
+++ b/src/serializer/LazyObjectsSerializer.js
@@ -24,7 +24,7 @@ import { ResidualHeapSerializer } from "./ResidualHeapSerializer.js";
 import { getOrDefault } from "./utils.js";
 import type { ResidualOptimizedFunctions } from "./ResidualOptimizedFunctions";
 import type { Referentializer } from "./Referentializer.js";
-import { GeneratorDAG } from "./GeneratorDAG.js";
+import { GeneratorTree } from "./GeneratorTree.js";
 
 const LAZY_OBJECTS_SERIALIZER_BODY_TYPE = "LazyObjectInitializer";
 
@@ -49,7 +49,7 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
     options: SerializerOptions,
     additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
     referentializer: Referentializer,
-    generatorDAG: GeneratorDAG,
+    generatorTree: GeneratorTree,
     residualOptimizedFunctions: ResidualOptimizedFunctions
   ) {
     super(
@@ -62,7 +62,7 @@ export class LazyObjectsSerializer extends ResidualHeapSerializer {
       options,
       additionalFunctionValuesAndEffects,
       referentializer,
-      generatorDAG,
+      generatorTree,
       residualOptimizedFunctions
     );
 

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -81,7 +81,7 @@ import { ResidualReactElementSerializer } from "./ResidualReactElementSerializer
 import type { Binding } from "../environment.js";
 import { GlobalEnvironmentRecord, DeclarativeEnvironmentRecord } from "../environment.js";
 import type { Referentializer } from "./Referentializer.js";
-import { GeneratorDAG } from "./GeneratorDAG.js";
+import { GeneratorTree } from "./GeneratorTree.js";
 import { type Replacement, getReplacement } from "./ResidualFunctionInstantiator.js";
 import { describeValue } from "../utils.js";
 import { getAsPropertyNameExpression } from "../utils/babelhelpers.js";
@@ -123,7 +123,7 @@ export class ResidualHeapSerializer {
     options: SerializerOptions,
     additionalFunctionValuesAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
     referentializer: Referentializer,
-    generatorDAG: GeneratorDAG,
+    generatorTree: GeneratorTree,
     residualOptimizedFunctions: ResidualOptimizedFunctions
   ) {
     this.realm = realm;
@@ -215,7 +215,7 @@ export class ResidualHeapSerializer {
     this.rewrittenAdditionalFunctions = new Map();
     this.declarativeEnvironmentRecordsBindings = residualHeapInfo.declarativeEnvironmentRecordsBindings;
     this.globalBindings = residualHeapInfo.globalBindings;
-    this.generatorDAG = generatorDAG;
+    this.generatorTree = generatorTree;
     this.conditionalFeasibility = residualHeapInfo.conditionalFeasibility;
     this.additionalFunctionGenerators = new Map();
     this.declaredGlobalLets = new Map();
@@ -274,7 +274,7 @@ export class ResidualHeapSerializer {
   // TODO: revisit this and fix additional functions to be capable of delaying initializations
   additionalFunctionValueNestedFunctions: Set<FunctionValue>;
 
-  generatorDAG: GeneratorDAG;
+  generatorTree: GeneratorTree;
   conditionalFeasibility: Map<AbstractValue, { t: boolean, f: boolean }>;
   additionalGeneratorRoots: Map<Generator, Set<ObjectValue>>;
 
@@ -888,7 +888,7 @@ export class ResidualHeapSerializer {
       generators = generators.filter(generator => {
         let s = generator;
         while (s instanceof Generator) {
-          s = this.generatorDAG.getParent(s);
+          s = this.generatorTree.getParent(s);
         }
         return s === "GLOBAL";
       });
@@ -904,7 +904,7 @@ export class ResidualHeapSerializer {
     }
 
     const getGeneratorParent = g => {
-      let s = this.generatorDAG.getParent(g);
+      let s = this.generatorTree.getParent(g);
       return s instanceof Generator ? s : undefined;
     };
     // This value is referenced from more than one generator.
@@ -2132,7 +2132,7 @@ export class ResidualHeapSerializer {
 
   _annotateGeneratorStatements(generator: Generator, statements: Array<BabelNodeStatement>): void {
     let comment = `generator "${generator.getName()}"`;
-    let parent = this.generatorDAG.getParent(generator);
+    let parent = this.generatorTree.getParent(generator);
     if (parent instanceof Generator) {
       comment = `${comment} with parent "${parent.getName()}"`;
     } else if (parent instanceof FunctionValue) {
@@ -2574,7 +2574,7 @@ export class ResidualHeapSerializer {
     for (let s of scopes)
       if (s instanceof Generator) {
         let text = "";
-        for (; s instanceof Generator; s = this.generatorDAG.getParent(s)) text += "=>" + s.getName();
+        for (; s instanceof Generator; s = this.generatorTree.getParent(s)) text += "=>" + s.getName();
         console.log(`      ${text}`);
       } else {
         invariant(s instanceof FunctionValue);

--- a/src/serializer/ResidualOptimizedFunctions.js
+++ b/src/serializer/ResidualOptimizedFunctions.js
@@ -12,7 +12,7 @@
 import { FunctionValue } from "../values/index.js";
 import type { AdditionalFunctionEffects } from "./types";
 import invariant from "../invariant.js";
-import { GeneratorDAG } from "./GeneratorDAG";
+import { GeneratorTree } from "./GeneratorTree";
 import type { Scope } from "./types.js";
 import { FunctionEnvironmentRecord } from "../environment";
 import type { Value } from "../values/index";
@@ -20,16 +20,16 @@ import { Generator } from "../utils/generator";
 
 export class ResidualOptimizedFunctions {
   constructor(
-    generatorDAG: GeneratorDAG,
+    generatorTree: GeneratorTree,
     optimizedFunctionsAndEffects: Map<FunctionValue, AdditionalFunctionEffects>,
     residualValues: Map<Value, Set<Scope>>
   ) {
-    this._generatorDAG = generatorDAG;
+    this._generatorTree = generatorTree;
     this._optimizedFunctionsAndEffects = optimizedFunctionsAndEffects;
     this._residualValues = residualValues;
   }
 
-  _generatorDAG: GeneratorDAG;
+  _generatorTree: GeneratorTree;
   _optimizedFunctionsAndEffects: Map<FunctionValue, AdditionalFunctionEffects>;
   _residualValues: Map<Value, Set<Scope>>;
 
@@ -80,7 +80,7 @@ export class ResidualOptimizedFunctions {
     for (let scope of scopes) {
       let s = scope;
       while (s instanceof Generator) {
-        s = this._generatorDAG.getParent(s);
+        s = this._generatorTree.getParent(s);
       }
       if (s === "GLOBAL") return undefined;
       invariant(s instanceof FunctionValue);

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -193,7 +193,7 @@ export class Serializer {
         if (this.realm.react.verbose) {
           this.logger.logInformation(`Visiting evaluated nodes...`);
         }
-        let [residualHeapInfo, generatorDAG, inspector] = (() => {
+        let [residualHeapInfo, generatorTree, inspector] = (() => {
           let residualHeapVisitor = new ResidualHeapVisitor(
             this.realm,
             this.logger,
@@ -201,12 +201,12 @@ export class Serializer {
             additionalFunctionValuesAndEffects
           );
           statistics.deepTraversal.measure(() => residualHeapVisitor.visitRoots());
-          return [residualHeapVisitor.toInfo(), residualHeapVisitor.generatorDAG, residualHeapVisitor.inspector];
+          return [residualHeapVisitor.toInfo(), residualHeapVisitor.generatorTree, residualHeapVisitor.inspector];
         })();
         if (this.logger.hasErrors()) return undefined;
 
         let residualOptimizedFunctions = new ResidualOptimizedFunctions(
-          generatorDAG,
+          generatorTree,
           additionalFunctionValuesAndEffects,
           residualHeapInfo.values
         );
@@ -270,7 +270,7 @@ export class Serializer {
               this.options,
               additionalFunctionValuesAndEffects,
               referentializer,
-              generatorDAG,
+              generatorTree,
               residualOptimizedFunctions
             ).serialize();
           });
@@ -293,7 +293,7 @@ export class Serializer {
             this.options,
             additionalFunctionValuesAndEffects,
             referentializer,
-            generatorDAG,
+            generatorTree,
             residualOptimizedFunctions
           ).serialize()
         );


### PR DESCRIPTION
Release notes: None

To avoid all kinds of serialization issues, generators should form
a tree, and not a DAG. This is an attempt to establish that.