### PR TITLE
Add throw-away generator to evaluateWithoutEffects

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1353,7 +1353,6 @@ export class PropertiesImplementation {
         }
       }
 
-      invariant(realm.generator);
       let propName = P;
       if (typeof propName === "string") {
         propName = new StringValue(realm, propName);

--- a/src/realm.js
+++ b/src/realm.js
@@ -789,7 +789,7 @@ export class Realm {
     let savedCreatedObjects = this.createdObjects;
     let saved_completion = this.savedCompletion;
     try {
-      this.generator = undefined;
+      this.generator = new Generator(this, "evaluateIgnoringEffects", this.pathConditions);
       this.modifiedBindings = undefined;
       this.modifiedProperties = undefined;
       this.createdObjects = undefined;

--- a/test/serializer/pure-functions/Issue2418.js
+++ b/test/serializer/pure-functions/Issue2418.js
@@ -1,0 +1,17 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+global.__evaluatePureFunction(function() {
+  function EventSubscriptionVendor() {
+    this._currentSubscription = null;
+  }
+
+  function EventEmitter() {
+    this._subscriber = new EventSubscriptionVendor();
+  }
+
+  var e = new EventEmitter();
+  var havoc = global.__abstract ? global.__abstract("function", "(() => {})") : () => {};
+  havoc(() => e.p);
+
+  new EventEmitter();
+});


### PR DESCRIPTION
Fixes #2432.

`evaluateWithoutEffects` sets the realm generator to `undefined`. However, I found a case in #2432 where a generator is required in `evaluateWithoutEffects`.

What happens is that we build an error stack in `evaluateWithoutEffects`.

https://github.com/facebook/prepack/blob/3eb1e8e8ea91f34b3a7f492b54ca1f029fb35398/src/realm.js#L1607-L1612

As a part of building that error stack we try to get `EventEmitter.name`. However, `EventEmitter` is havoced! So we want to create an abstract temporal value `EventEmitter.name`. But creating a temporal value requires a generator since we need to add a generator entry.

https://github.com/facebook/prepack/blob/3eb1e8e8ea91f34b3a7f492b54ca1f029fb35398/src/methods/properties.js#L1361-L1367

This PR solves the issue by adding a throw-away generator to `evaluateWithoutEffects`. Other strategies might be a bit complicated since `evaluateWithoutEffects` is a very uncommon case. Removing `evaluateWithoutEffects` is also not a great option since in this case we would add a temporal `EventEmitter.name` when we never actually use it.