### PR TITLE
Fix nested for statement bailout with nested for-in

### DIFF
--- a/src/serializer/visitors.js
+++ b/src/serializer/visitors.js
@@ -97,4 +97,15 @@ export let ClosureRefVisitor = {
       visitName(path, state, ids[name], true);
     }
   },
+
+  "ForInStatement|ForOfStatement"(path: BabelTraversePath, state: ClosureRefVisitorState) {
+    if (path.node.left !== "VariableDeclaration") {
+      // `LeftHandSideExpression`s in a for-in/for-of statement perform `DestructuringAssignment` on the current loop
+      // value so we need to make sure we visit these bindings and mark them as modified.
+      const ids = path.get("left").getBindingIdentifiers();
+      for (const name in ids) {
+        visitName(path, state, ids[name], true);
+      }
+    }
+  },
 };

--- a/test/serializer/pure-functions/ForInBailout.js
+++ b/test/serializer/pure-functions/ForInBailout.js
@@ -1,0 +1,20 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+const result = global.__evaluatePureFunction(() => {
+  const ks = [];
+
+  const n = global.__abstract ? __abstract("number", "5") : 5;
+  const o = { a: 1, b: 2, c: 3 };
+
+  for (let i = 0; i < n; i++) {
+    for (var k in o) {
+      ks.push(k);
+    }
+    ks.push(k);
+  }
+  ks.push(k);
+
+  return ks;
+});
+
+global.inspect = () => JSON.stringify(result);


### PR DESCRIPTION
Fixes #2437.

The code to handle for-statement bailouts was failing on nested for-in/for-out statements since while they had a variable declaration node in their AST the variable declaration behaves very differently. Notably there must be exactly one declaration, the declaration may not have an initializer, and the declaration may only be replaced by a `LeftHandSideExpression` not a expression or statement.

This PR does two things:

1. Replace the variable declarations in for-in/for-of statements with a `LeftHandSideExpression` which will then perform `DestructuringAssignment` with loop values in the evaluator.
2. Recognize that a `LeftHandSideExpression` in a for-in/for-of expression modifies bindings in the serializer residual function visitor.