### PR TITLE
Don’t record modified bindings for immutable bindings when havocing

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -60,7 +60,11 @@ export function havocBinding(binding: Binding): void {
   let realm = binding.environment.realm;
   let value = binding.value;
   if (!binding.hasLeaked) {
-    if (binding.mutable) realm.recordModifiedBinding(binding).hasLeaked = true;
+    if (binding.mutable) {
+      realm.recordModifiedBinding(binding).hasLeaked = true;
+    } else {
+      binding.hasLeaked = true;
+    }
     if (value !== undefined) {
       let realmGenerator = realm.generator;
       if (realmGenerator !== undefined && value !== realm.intrinsics.undefined)

--- a/src/environment.js
+++ b/src/environment.js
@@ -60,7 +60,7 @@ export function havocBinding(binding: Binding): void {
   let realm = binding.environment.realm;
   let value = binding.value;
   if (!binding.hasLeaked) {
-    if (binding.mutable) realm.recordModifiedBinding(binding).hasLeaked = true;
+    realm.recordModifiedBinding(binding).hasLeaked = true;
     if (value !== undefined) {
       let realmGenerator = realm.generator;
       if (realmGenerator !== undefined && value !== realm.intrinsics.undefined)

--- a/src/environment.js
+++ b/src/environment.js
@@ -60,7 +60,7 @@ export function havocBinding(binding: Binding): void {
   let realm = binding.environment.realm;
   let value = binding.value;
   if (!binding.hasLeaked) {
-    realm.recordModifiedBinding(binding).hasLeaked = true;
+    if (binding.mutable) realm.recordModifiedBinding(binding).hasLeaked = true;
     if (value !== undefined) {
       let realmGenerator = realm.generator;
       if (realmGenerator !== undefined && value !== realm.intrinsics.undefined)

--- a/src/realm.js
+++ b/src/realm.js
@@ -1343,6 +1343,9 @@ export class Realm {
   // Record the current value of binding in this.modifiedBindings unless
   // there is already an entry for binding.
   recordModifiedBinding(binding: Binding, value?: Value): Binding {
+    // If the binding is immutable, don’t record it as a modified binding.
+    if (!binding.mutable) return binding;
+
     const isDefinedInsidePureFn = root => {
       let context = this.getRunningContext();
       let { lexicalEnvironment: env } = context;

--- a/src/realm.js
+++ b/src/realm.js
@@ -1343,9 +1343,6 @@ export class Realm {
   // Record the current value of binding in this.modifiedBindings unless
   // there is already an entry for binding.
   recordModifiedBinding(binding: Binding, value?: Value): Binding {
-    // If the binding is immutable, don’t record it as a modified binding.
-    if (!binding.mutable) return binding;
-
     const isDefinedInsidePureFn = root => {
       let context = this.getRunningContext();
       let { lexicalEnvironment: env } = context;

--- a/test/serializer/pure-functions/HavocBindingImmutable.js
+++ b/test/serializer/pure-functions/HavocBindingImmutable.js
@@ -1,0 +1,20 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+const havoc = global.__abstract ? global.__abstract("function", "(() => {})") : () => {};
+
+const result = global.__evaluatePureFunction(() => {
+  const b = global.__abstract ? global.__abstract("boolean", "true") : true;
+
+  if (b) {
+    var g = function f(i) {
+      return i === 0 ? 0 : f(i - 1) + 1;
+    };
+    havoc(g);
+  } else {
+    return;
+  }
+
+  return g(5);
+});
+
+global.inspect = () => result;


### PR DESCRIPTION
Fixes #2442 by not marking immutable bindings as modified. Its very possible that my fix is incorrect. There’s a bunch of related logic for `binding.hasLeaked`/`binding.mutable`/`modifiedBindings` and I certainly didn’t find them all to get a holistic view of what’s happening. From the code I did look at, this fix seems to be safe since there’s no way for a havoced function to change an immutable binding.

I ran into this issue while trying to compile our internal React Native bundle with the React Compiler.

Let me walk through this repro to the invariant.

```js
const havoc = __abstract("function", "(() => {})");

global.result = __evaluatePureFunction(() => {
  const b = __abstract("boolean", "true");

  if (b) {
    var g = function f(i) {
      return i === 0 ? 0 : f(i - 1) + 1;
    };
    havoc(g);
  } else {
    return;
  }

  return g(5);
});
```

1. Create a function expression that refers to itself inside a construct that wraps the evaluation in `evaluateForEffects()`. (I used an if-statement.)
2. Havoc the function expression. This will add the function’s reference to itself to `modifiedBindings`. However, the original [function expression skipped (3rd arg)](https://github.com/facebook/prepack/blob/3eb1e8e8ea91f34b3a7f492b54ca1f029fb35398/src/evaluators/FunctionExpression.js#L108) adding its binding to `modifiedBindings`.
3. Outside of `evaluateForEffects()` call the function.
4. Observe the invariant firing:

https://github.com/facebook/prepack/blob/3eb1e8e8ea91f34b3a7f492b54ca1f029fb35398/src/environment.js#L339

According to `modifiedBindings`, we only initialize the function expression _after_ its definition. So if the function expression wants to recursively refer to itself, it can’t since the effects we’ve recorded/applied puts us in a state where the binding is not available.