### PR TITLE
Clarify terminology for Leaked Value Analysis

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -58,9 +58,9 @@ function deriveGetBinding(realm: Realm, binding: Binding) {
 
 export function materializeBinding(realm: Realm, binding: Binding): void {
   let realmGenerator = realm.generator;
+  invariant(realmGenerator !== undefined);
   let value = binding.value;
-  if (value !== undefined && realmGenerator !== undefined && value !== realm.intrinsics.undefined)
-    realmGenerator.emitBindingAssignment(binding, value);
+  if (value !== undefined && value !== realm.intrinsics.undefined) realmGenerator.emitBindingAssignment(binding, value);
 }
 export function leakBinding(binding: Binding): void {
   let realm = binding.environment.realm;

--- a/src/environment.js
+++ b/src/environment.js
@@ -42,7 +42,7 @@ import parse from "./utils/parse.js";
 import invariant from "./invariant.js";
 import traverseFast from "./utils/traverse-fast.js";
 import { HasProperty, Get, IsExtensible, HasOwnProperty, IsDataDescriptor } from "./methods/index.js";
-import { Environment, Havoc, Properties, To } from "./singletons.js";
+import { Environment, Leak, Properties, To } from "./singletons.js";
 import { TypesDomain, ValuesDomain } from "./domains/index.js";
 import PrimitiveValue from "./values/PrimitiveValue.js";
 import { createOperationDescriptor } from "./utils/generator.js";
@@ -56,21 +56,24 @@ function deriveGetBinding(realm: Realm, binding: Binding) {
   return realm.generator.deriveAbstract(types, values, [], createOperationDescriptor("GET_BINDING", { binding }));
 }
 
-export function havocBinding(binding: Binding): void {
-  let realm = binding.environment.realm;
+export function materializeBinding(realm: Realm, binding: Binding): void {
+  let realmGenerator = realm.generator;
   let value = binding.value;
+  if (value !== undefined && realmGenerator !== undefined && value !== realm.intrinsics.undefined)
+    realmGenerator.emitBindingAssignment(binding, value);
+}
+export function leakBinding(binding: Binding): void {
+  let realm = binding.environment.realm;
   if (!binding.hasLeaked) {
     realm.recordModifiedBinding(binding).hasLeaked = true;
-    if (value !== undefined) {
-      let realmGenerator = realm.generator;
-      if (realmGenerator !== undefined && value !== realm.intrinsics.undefined)
-        realmGenerator.emitBindingAssignment(binding, value);
-      if (binding.mutable === true) {
-        // For mutable, i.e. non-const bindings, the actual value is no longer directly available.
-        // Thus, we reset the value to undefined to prevent any use of the last known value.
-        binding.value = undefined;
-      }
-    }
+    materializeBinding(realm, binding);
+  }
+
+  // Havoc the binding
+  if (binding.mutable === true) {
+    // For mutable, i.e. non-const bindings, the actual value is no longer directly available.
+    // Thus, we reset the value to undefined to prevent any use of the last known value.
+    binding.value = undefined;
   }
 }
 
@@ -295,7 +298,7 @@ export class DeclarativeEnvironmentRecord extends EnvironmentRecord {
     } else if (binding.mutable) {
       // 5. Else if the binding for N in envRec is a mutable binding, change its bound value to V.
       if (binding.hasLeaked) {
-        Havoc.value(realm, V);
+        Leak.value(realm, V);
         invariant(realm.generator);
         realm.generator.emitBindingAssignment(binding, V);
       } else {

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -26,7 +26,7 @@ import {
   UndefinedValue,
   Value,
 } from "../values/index.js";
-import { Environment, Havoc, To } from "../singletons.js";
+import { Environment, Leak, To } from "../singletons.js";
 import type { BabelBinaryOperator, BabelNodeBinaryExpression, BabelNodeSourceLocation } from "@babel/types";
 import { createOperationDescriptor } from "../utils/generator.js";
 import invariant from "../invariant.js";
@@ -290,11 +290,11 @@ export function computeBinary(
     // If this ended up reporting an error, it might not be pure, so we'll leave it in
     // as a temporal operation with a known return type.
     // Some of these values may trigger side-effectful user code such as valueOf.
-    // To be safe, we have to Havoc them.
-    Havoc.value(realm, lval, loc);
+    // To be safe, we have to leak them.
+    Leak.value(realm, lval, loc);
     if (op !== "in") {
       // The "in" operator have side-effects on its right val other than throw.
-      Havoc.value(realm, rval, loc);
+      Leak.value(realm, rval, loc);
     }
     return realm.evaluateWithPossibleThrowCompletion(
       () =>

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -29,7 +29,7 @@ import {
   Value,
 } from "../values/index.js";
 import { Reference } from "../environment.js";
-import { Environment, Functions, Havoc, Join } from "../singletons.js";
+import { Environment, Functions, Leak, Join } from "../singletons.js";
 import {
   ArgumentListEvaluation,
   EvaluateDirectCall,
@@ -237,11 +237,10 @@ function generateRuntimeCall(
   for (let arg of args) {
     if (arg !== func) {
       // Since we don't know which function we are calling, we assume that any unfrozen object
-      // passed as an argument has leaked to the environment and is henceforth in an unknown (havoced) state,
-      // as is any other object that is known to be reachable from this object.
+      // passed as an argument has leaked to the environment as is any other object that is known to be reachable from this object.
       // NB: Note that this is still optimistic, particularly if the environment exposes the same object
       // to Prepack via alternative means, thus creating aliasing that is not tracked by Prepack.
-      Havoc.value(realm, arg, ast.loc);
+      Leak.value(realm, arg, ast.loc);
     }
   }
   let resultType = (func instanceof AbstractObjectValue ? func.functionResultType : undefined) || Value;

--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -35,7 +35,7 @@ import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { UpdateEmpty } from "../methods/index.js";
 import { LoopContinues, InternalGetResultValue } from "./ForOfStatement.js";
-import { Environment, Functions, Havoc, To } from "../singletons.js";
+import { Environment, Functions, Leak, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import * as t from "@babel/types";
 import type { BabelNodeExpression, BabelNodeForStatement, BabelNodeBlockStatement } from "@babel/types";
@@ -322,15 +322,15 @@ function generateRuntimeForStatement(
   if (usesThis) {
     let thisRef = env.evaluate(t.thisExpression(), strictCode);
     let thisVal = Environment.GetValue(realm, thisRef);
-    Havoc.value(realm, thisVal);
+    Leak.value(realm, thisVal);
     args.push(thisVal);
   }
 
-  // We havoc the wrapping function value, which in turn invokes the havocing
-  // logic which is transitive. The havocing logic should recursively visit
+  // We leak the wrapping function value, which in turn invokes the leak
+  // logic which is transitive. The leaking logic should recursively visit
   // all bindings/objects in the loop and its body and mark the associated
-  // bindings/objects that do havoc appropiately.
-  Havoc.value(realm, wrapperFunction);
+  // bindings/objects as leaked
+  Leak.value(realm, wrapperFunction);
 
   let wrapperValue = AbstractValue.createTemporalFromBuildFunction(
     realm,

--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -13,7 +13,7 @@ import type { Realm } from "../realm.js";
 import type { LexicalEnvironment } from "../environment.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { ObjectValue, Value, AbstractObjectValue, AbstractValue } from "../values/index.js";
-import { Environment, Havoc } from "../singletons.js";
+import { Environment, Leak } from "../singletons.js";
 import { IsConstructor, ArgumentListEvaluation } from "../methods/index.js";
 import { Construct } from "../methods/index.js";
 import invariant from "../invariant.js";
@@ -90,10 +90,10 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
     // if a FatalError occurs when constructing the constructor
     // then try and recover and create an abstract for this construct
     if (error instanceof FatalError) {
-      // we need to havoc all the arguments and the constructor
-      Havoc.value(realm, constructor);
+      // we need to leak all the arguments and the constructor
+      Leak.value(realm, constructor);
       for (let arg of argsList) {
-        Havoc.value(realm, arg);
+        Leak.value(realm, arg);
       }
       let abstractValue = realm.evaluateWithPossibleThrowCompletion(
         () =>

--- a/src/evaluators/UpdateExpression.js
+++ b/src/evaluators/UpdateExpression.js
@@ -16,7 +16,7 @@ import { CompilerDiagnostic, FatalError } from "../errors.js";
 import { Add } from "../methods/index.js";
 import { AbstractValue, NumberValue, IntegralValue } from "../values/index.js";
 import type { BabelNodeUpdateExpression } from "@babel/types";
-import { Environment, Havoc, Properties, To } from "../singletons.js";
+import { Environment, Leak, Properties, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import { ValuesDomain, TypesDomain } from "../domains/index.js";
 import { createOperationDescriptor } from "../utils/generator.js";
@@ -41,9 +41,9 @@ export default function(
     if (!To.IsToNumberPure(realm, oldExpr)) {
       if (realm.isInPureScope()) {
         // In pure scope we have to treat the ToNumber operation as temporal since it
-        // might throw or mutate something. We also need to havoc the argument due to the
+        // might throw or mutate something. We also need to leak the argument due to the
         // possible mutations.
-        Havoc.value(realm, oldExpr);
+        Leak.value(realm, oldExpr);
         newAbstractValue = realm.evaluateWithPossibleThrowCompletion(
           () =>
             AbstractValue.createTemporalFromBuildFunction(

--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -13,7 +13,7 @@ import * as Singletons from "./singletons.js";
 import { CreateImplementation } from "./methods/create.js";
 import { EnvironmentImplementation } from "./methods/environment.js";
 import { FunctionImplementation } from "./methods/function.js";
-import { HavocImplementation, MaterializeImplementation } from "./utils/havoc.js";
+import { LeakImplementation, MaterializeImplementation } from "./utils/leak.js";
 import { JoinImplementation } from "./methods/join.js";
 import { PathImplementation } from "./utils/paths.js";
 import { PropertiesImplementation } from "./methods/properties.js";
@@ -27,7 +27,7 @@ export default function() {
   Singletons.setCreate(new CreateImplementation());
   Singletons.setEnvironment(new EnvironmentImplementation());
   Singletons.setFunctions(new FunctionImplementation());
-  Singletons.setHavoc(new HavocImplementation());
+  Singletons.setLeak(new LeakImplementation());
   Singletons.setMaterialize(new MaterializeImplementation());
   Singletons.setJoin(new JoinImplementation());
   Singletons.setPath(new PathImplementation());

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -32,7 +32,7 @@ import {
   IsCallable,
 } from "../../methods/index.js";
 import { GetIterator, IteratorClose, IteratorStep, IteratorValue } from "../../methods/iterator.js";
-import { Create, Havoc, Properties, To } from "../../singletons.js";
+import { Create, Leak, Properties, To } from "../../singletons.js";
 import invariant from "../../invariant.js";
 import { createOperationDescriptor } from "../../utils/generator.js";
 
@@ -245,7 +245,7 @@ export default function(realm: Realm): NativeFunctionValue {
           }
           possibleNestedOptimizedFunctions = [{ func: mapfn, thisValue: thisArg || realm.intrinsics.undefined }];
         }
-        Havoc.value(realm, items);
+        Leak.value(realm, items);
         return ArrayValue.createTemporalWithWidenedNumericProperty(
           realm,
           args,

--- a/src/intrinsics/ecma262/Object.js
+++ b/src/intrinsics/ecma262/Object.js
@@ -37,7 +37,7 @@ import {
   SetIntegrityLevel,
   HasSomeCompatibleType,
 } from "../../methods/index.js";
-import { Create, Havoc, Properties as Props, To } from "../../singletons.js";
+import { Create, Leak, Properties as Props, To } from "../../singletons.js";
 import { createOperationDescriptor } from "../../utils/generator.js";
 import invariant from "../../invariant.js";
 
@@ -63,8 +63,8 @@ function handleObjectAssignSnapshot(
     AbstractValue.reportIntrospectionError(to);
     throw new FatalError();
   } else {
-    if (frm instanceof ObjectValue && frm.mightBeHavocedObject()) {
-      // "frm" is havoced, so it might contain properties that potentially overwrite
+    if (frm instanceof ObjectValue && frm.mightBeLeakedObject()) {
+      // "frm" is leaked, so it might contain properties that potentially overwrite
       // properties already on the "to" object.
       snapshotToObjectAndRemoveProperties(to, delayedSources);
       // it's not safe to trust any of its values
@@ -182,8 +182,8 @@ function tryAndApplySourceOrRecover(
       if (!didSnapshot) {
         delayedSources.push(frm);
       }
-      // Havoc the frm value because it can have getters on it
-      Havoc.value(realm, frm);
+      // Leak the frm value because it can have getters on it
+      Leak.value(realm, frm);
       return to_must_be_partial;
     }
     throw e;

--- a/src/intrinsics/ecma262/ObjectPrototype.js
+++ b/src/intrinsics/ecma262/ObjectPrototype.js
@@ -44,7 +44,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
       if (realm.isInPureScope() && x instanceof FatalError) {
         // If we're in pure scope we can try to recover from any fatals by
         // leaving the call in place which we do by default, but we don't
-        // have to havoc the state of any arguments since this function is pure.
+        // have to leak the state of any arguments since this function is pure.
         // This also lets us define the return type properly.
         const key = typeof P === "string" ? new StringValue(realm, P) : P;
         return realm.evaluateWithPossibleThrowCompletion(

--- a/src/methods/call.js
+++ b/src/methods/call.js
@@ -43,7 +43,7 @@ import {
   ThrowCompletion,
 } from "../completions.js";
 import { GetTemplateObject, GetV, GetThisValue } from "./get.js";
-import { Create, Environment, Functions, Havoc, Join, To, Widen } from "../singletons.js";
+import { Create, Environment, Functions, Leak, Join, To, Widen } from "../singletons.js";
 import invariant from "../invariant.js";
 import { createOperationDescriptor } from "../utils/generator.js";
 import type { BabelNodeExpression, BabelNodeSpreadElement, BabelNodeTemplateLiteral } from "@babel/types";
@@ -587,9 +587,9 @@ export function Call(realm: Realm, F: Value, V: Value, argsList?: Array<Value>):
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
   }
   if (F instanceof AbstractValue && Value.isTypeCompatibleWith(F.getType(), FunctionValue)) {
-    Havoc.value(realm, V);
+    Leak.value(realm, V);
     for (let arg of argsList) {
-      Havoc.value(realm, arg);
+      Leak.value(realm, arg);
     }
     if (V === realm.intrinsics.undefined) {
       let fullArgs = [F].concat(argsList);

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -38,7 +38,7 @@ import {
   IsDataDescriptor,
   IsPropertyKey,
 } from "./index.js";
-import { Create, Environment, Join, Havoc, Path, To } from "../singletons.js";
+import { Create, Environment, Join, Leak, Path, To } from "../singletons.js";
 import invariant from "../invariant.js";
 import type { BabelNodeTemplateLiteral } from "@babel/types";
 import { createOperationDescriptor } from "../utils/generator.js";
@@ -336,9 +336,9 @@ export function OrdinaryGetPartial(
   // side-effectful valueOf and toString but that's not enforced.
   if (P.mightNotBeString() && P.mightNotBeNumber() && !P.isSimpleObject()) {
     if (realm.isInPureScope()) {
-      // If we're in pure scope, we can havoc the key and keep going.
+      // If we're in pure scope, we can leak the key and keep going.
       // Coercion can only have effects on anything reachable from the key.
-      Havoc.value(realm, P);
+      Leak.value(realm, P);
     } else {
       let error = new CompilerDiagnostic(
         "property key might not have a well behaved toString or be a symbol",
@@ -355,13 +355,13 @@ export function OrdinaryGetPartial(
   // We assume that simple objects have no getter/setter properties.
   if (!O.isSimpleObject()) {
     if (realm.isInPureScope()) {
-      // If we're in pure scope, we can havoc the object. Coercion
+      // If we're in pure scope, we can leak the object. Coercion
       // can only have effects on anything reachable from this object.
       // We assume that if the receiver is different than this object,
       // then we only got here because there were no other keys with
       // this name on other parts of the prototype chain.
       // TODO #1675: A fix to 1675 needs to take this into account.
-      Havoc.value(realm, Receiver);
+      Leak.value(realm, Receiver);
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,
@@ -389,7 +389,7 @@ export function OrdinaryGetPartial(
   let result;
   if (O.isPartialObject()) {
     if (isWidenedValue(P)) {
-      // TODO #1678: Use a snapshot or havoc this object.
+      // TODO #1678: Use a snapshot or leak this object.
       return AbstractValue.createTemporalFromBuildFunction(
         realm,
         Value,

--- a/src/methods/integrity.js
+++ b/src/methods/integrity.js
@@ -20,7 +20,7 @@ type IntegrityLevels = "sealed" | "frozen";
 
 // ECMA262 9.1.4.1
 export function OrdinaryPreventExtensions(realm: Realm, O: ObjectValue): boolean {
-  if (O.mightBeHavocedObject() && O.getExtensible()) {
+  if (O.mightBeLeakedObject() && O.getExtensible()) {
     // todo: emit a diagnostic messsage
     throw new FatalError();
   }

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -292,7 +292,7 @@ export class JoinImplementation {
     let rewritten1 = false;
     let rewritten2 = false;
     let leak = (b: Binding, g: Generator, v: void | Value, rewritten: boolean) => {
-      // just like to what happens in havocBinding, we are going to append a
+      // just like to what happens in leakBinding, we are going to append a
       // binding-assignment generator entry; however, we play it safe and don't
       // mutate the generator; instead, we create a new one that wraps around the old one.
       if (!rewritten) {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -47,7 +47,7 @@ import {
 } from "./utils.js";
 import { Get } from "../methods/index.js";
 import invariant from "../invariant.js";
-import { Havoc, Properties, Utils } from "../singletons.js";
+import { Leak, Properties, Utils } from "../singletons.js";
 import { FatalError, NestedOptimizedFunctionSideEffect } from "../errors.js";
 import {
   type BranchStatusEnum,
@@ -1556,10 +1556,10 @@ export class Reconciler {
       );
     } catch (e) {
       // If the nested optimized function had side-effects, we need to fallback to
-      // the default behaviour and havoc the nested functions so any bindings
+      // the default behaviour and leak the nested functions so any bindings
       // within the function properly leak and materialize.
       if (e instanceof NestedOptimizedFunctionSideEffect) {
-        Havoc.value(this.realm, func);
+        Leak.value(this.realm, func);
         return;
       }
       throw e;

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -315,7 +315,7 @@ export class ResidualHeapSerializer {
     }
 
     // TODO #2259: Make deduplication in the face of leaking work for custom accessors
-    let isCertainlyLeaked = !obj.mightNotBeHavocedObject();
+    let isCertainlyLeaked = !obj.mightNotBeLeakedObject();
     let shouldDropAsAssignedProp = (descriptor: Descriptor | void) =>
       isCertainlyLeaked && (descriptor !== undefined && (descriptor.get === undefined && descriptor.set === undefined));
 
@@ -1299,7 +1299,7 @@ export class ResidualHeapSerializer {
   ): void {
     const realm = this.realm;
     let lenProperty;
-    if (val.mightBeHavocedObject()) {
+    if (val.mightBeLeakedObject()) {
       lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
     } else {
       lenProperty = Get(realm, val, "length");
@@ -1740,7 +1740,7 @@ export class ResidualHeapSerializer {
     let remainingProperties = new Map(val.properties);
     const dummyProperties = new Set();
     let props = [];
-    let isCertainlyLeaked = !val.mightNotBeHavocedObject();
+    let isCertainlyLeaked = !val.mightNotBeLeakedObject();
 
     // TODO #2259: Make deduplication in the face of leaking work for custom accessors
     let shouldDropAsAssignedProp = (descriptor: Descriptor | void) =>

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -318,7 +318,7 @@ export class ResidualHeapVisitor {
       // Leaked object. Properties are set via assignments
       // TODO #2259: Make deduplication in the face of leaking work for custom accessors
       if (
-        !obj.mightNotBeHavocedObject() &&
+        !obj.mightNotBeLeakedObject() &&
         (descriptor !== undefined && (descriptor.get === undefined && descriptor.set === undefined))
       )
         continue;
@@ -424,7 +424,7 @@ export class ResidualHeapVisitor {
     this.visitObjectProperties(val);
     const realm = this.realm;
     let lenProperty;
-    if (val.mightBeHavocedObject()) {
+    if (val.mightBeLeakedObject()) {
       lenProperty = this.realm.evaluateWithoutLeakLogic(() => Get(realm, val, "length"));
     } else {
       lenProperty = Get(realm, val, "length");

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -14,7 +14,7 @@ import type {
   CreateType,
   EnvironmentType,
   FunctionType,
-  HavocType,
+  LeakType,
   JoinType,
   MaterializeType,
   PathType,
@@ -28,7 +28,7 @@ import type {
 export let Create: CreateType = (null: any);
 export let Environment: EnvironmentType = (null: any);
 export let Functions: FunctionType = (null: any);
-export let Havoc: HavocType = (null: any);
+export let Leak: LeakType = (null: any);
 export let Materialize: MaterializeType = (null: any);
 export let Join: JoinType = (null: any);
 export let Path: PathType = (null: any);
@@ -52,8 +52,8 @@ export function setFunctions(singleton: FunctionType): void {
   Functions = singleton;
 }
 
-export function setHavoc(singleton: HavocType): void {
-  Havoc = singleton;
+export function setLeak(singleton: LeakType): void {
+  Leak = singleton;
 }
 
 export function setMaterialize(singleton: MaterializeType): void {

--- a/src/types.js
+++ b/src/types.js
@@ -380,7 +380,7 @@ export type PathType = {
   pushInverseAndRefine(condition: Value): void,
 };
 
-export type HavocType = {
+export type LeakType = {
   value(realm: Realm, value: Value, loc: ?BabelNodeSourceLocation): void,
 };
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1164,8 +1164,8 @@ export function attemptToMergeEquivalentObjectAssigns(
       let otherArgsToUse = [];
       for (let x = 1; x < otherArgs.length; x++) {
         let arg = otherArgs[x];
-        // The arg might have been havoced, so ensure we do not continue in this case
-        if (arg instanceof ObjectValue && arg.mightBeHavocedObject()) {
+        // The arg might have been leaked, so ensure we do not continue in this case
+        if (arg instanceof ObjectValue && arg.mightBeLeakedObject()) {
           continue loopThroughArgs;
         }
         if (arg instanceof ObjectValue || arg instanceof AbstractValue) {

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -21,7 +21,7 @@ import {
   Value,
 } from "./index.js";
 import { IsAccessorDescriptor, IsPropertyKey, IsArrayIndex } from "../methods/is.js";
-import { Havoc, Properties, To, Utils } from "../singletons.js";
+import { Leak, Properties, To, Utils } from "../singletons.js";
 import { type OperationDescriptor } from "../utils/generator.js";
 import invariant from "../invariant.js";
 import { NestedOptimizedFunctionSideEffect } from "../errors.js";
@@ -55,10 +55,10 @@ function evaluatePossibleNestedOptimizedFunctionsAndStoreEffects(
       effects = realm.evaluateForEffects(pureFuncCall, null, "temporalArray nestedOptimizedFunction");
     } catch (e) {
       // If the nested optimized function had side-effects, we need to fallback to
-      // the default behaviour and havoc the nested functions so any bindings
+      // the default behaviour and leaked the nested functions so any bindings
       // within the function properly leak and materialize.
       if (e instanceof NestedOptimizedFunctionSideEffect) {
-        Havoc.value(realm, func);
+        Leak.value(realm, func);
         return;
       }
       throw e;
@@ -88,10 +88,10 @@ function createArrayWithWidenedNumericProperty(
       );
     } else {
       // If nested optimized functions are disabled, we need to fallback to
-      // the default behaviour and havoc the nested functions so any bindings
+      // the default behaviour and leaked the nested functions so any bindings
       // within the function properly leak and materialize.
       for (let { func } of possibleNestedOptimizedFunctions) {
-        Havoc.value(realm, func);
+        Leak.value(realm, func);
       }
     }
   }

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -65,7 +65,7 @@ export default class ObjectValue extends ConcreteValue {
     this.$Prototype = proto || realm.intrinsics.null;
     this.$Extensible = realm.intrinsics.true;
     this._isPartial = realm.intrinsics.false;
-    this._isHavoced = realm.intrinsics.false;
+    this._isLeaked = realm.intrinsics.false;
     this._isSimple = realm.intrinsics.false;
     this._simplicityIsTransitive = realm.intrinsics.false;
     this._isFinal = realm.intrinsics.false;
@@ -81,7 +81,7 @@ export default class ObjectValue extends ConcreteValue {
 
   static trackedPropertyNames = [
     "_isPartial",
-    "_isHavoced",
+    "_isLeaked",
     "_isSimple",
     "_isFinal",
     "_simplicityIsTransitive",
@@ -129,24 +129,24 @@ export default class ObjectValue extends ConcreteValue {
           return binding === undefined ? undefined : binding.descriptor.value;
         },
         set: function(v) {
-          // Let's make sure that the object is not havoced.
-          // To that end, we'd like to call this.isHavocedObject().
+          // Let's make sure that the object is not leaked.
+          // To that end, we'd like to call this.isLeakedObject().
           // However, while the object is still being initialized,
-          // properties may be set, but this.isHavocedObject() may not be called yet.
+          // properties may be set, but this.isLeakedObject() may not be called yet.
           // To check if we are still initializing, guard the call by looking at
           // whether this.$IsClassPrototype has been initialized as a proxy for
           // object initialization in general.
           invariant(
             // We're still initializing so we can set a property.
             this.$IsClassPrototype === undefined ||
-              // It's not havoced so we can set a property.
-              this.mightNotBeHavocedObject() ||
+              // It's not leaked so we can set a property.
+              this.mightNotBeLeakedObject() ||
               // Object.assign() implementation needs to temporarily
-              // make potentially havoced objects non-partial and back.
-              // We don't gain anything from checking whether it's havoced
+              // make potentially leaked objects non-partial and back.
+              // We don't gain anything from checking whether it's leaked
               // before calling makePartial() so we'll whitelist this property.
               propBindingName === "_isPartial_binding",
-            "cannot mutate a havoced object"
+            "cannot mutate a leaked object"
           );
           let binding = this[propBindingName];
           if (binding === undefined) {
@@ -266,7 +266,7 @@ export default class ObjectValue extends ConcreteValue {
   _isPartial: AbstractValue | BooleanValue;
 
   // tainted objects
-  _isHavoced: AbstractValue | BooleanValue;
+  _isLeaked: AbstractValue | BooleanValue;
 
   // If true, the object has no property getters or setters and it is safe
   // to return AbstractValue for unknown properties.
@@ -390,16 +390,16 @@ export default class ObjectValue extends ConcreteValue {
     return this._isFinal.mightNotBeTrue();
   }
 
-  havoc(): void {
-    this._isHavoced = this.$Realm.intrinsics.true;
+  leak(): void {
+    this._isLeaked = this.$Realm.intrinsics.true;
   }
 
-  mightBeHavocedObject(): boolean {
-    return this._isHavoced.mightBeTrue();
+  mightBeLeakedObject(): boolean {
+    return this._isLeaked.mightBeTrue();
   }
 
-  mightNotBeHavocedObject(): boolean {
-    return this._isHavoced.mightNotBeTrue();
+  mightNotBeLeakedObject(): boolean {
+    return this._isLeaked.mightNotBeTrue();
   }
 
   isSimpleObject(): boolean {


### PR DESCRIPTION
This PR continues the break up of #2185 into smaller pieces, and makes the use of Leaking, Havocing and Materialization consistent with agreed upon terminology.

*Leaking* transitively adds mutable locations to the environment. Accessing such leaked locations is equivalent to accessing to the environment.

*Havocing* takes on its usual meaning in static analysis: to set an abstract value to "unknown" i.e. topVal.

*Materialization* snapshots locations into runtime assignments for the purpose of outlining functions.

Presently, leaking always leads to havocing, and materialization. But in addition, it also marks a location or an object as "leaked" implying that it may be aliased and/or no longer be "well behaved" (for example, a leaked object may leak any object passed to one of its methods).
