### PR TITLE
Allow arrays with widened numeric properties to update index properties

### DIFF
--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -132,6 +132,12 @@ export default class ArrayValue extends ObjectValue {
       // a. Return ? ArraySetLength(A, Desc).
       return Properties.ArraySetLength(this.$Realm, A, Desc);
     } else if (IsArrayIndex(this.$Realm, P)) {
+      if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(this)) {
+        // The length of an array with widenend numeric properties is always abstract
+        let succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
+        if (succeeded === false) return false;
+        return true;
+      }
       // 3. Else if P is an array index, then
 
       // a. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").

--- a/test/serializer/optimized-functions/ArrayFrom10.js
+++ b/test/serializer/optimized-functions/ArrayFrom10.js
@@ -1,0 +1,21 @@
+// arrayNestedOptimizedFunctionsEnabled
+
+function f(c) {
+  var arr = Array.from(c);
+
+  let a = { foo: 1 };
+  function op(o) {
+    return a;
+  }
+
+  let mapped = arr.map(op);
+  mapped[0] = 2;
+  let x = a.foo;
+  return x;
+}
+
+global.__optimize && __optimize(f);
+
+inspect = () => {
+  return f([{ foo: 42 }]);
+};


### PR DESCRIPTION
Fixes #2447 by adding a separate codepath for when we encounter arrays with widened numeric properties, otherwise we hit an invariant when trying to deal the `length` property (which always remains abstract for arrays with widened numeric properties).