### PR TITLE
Remove numeric widened property special case in abstract get

### DIFF
--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -24,12 +24,7 @@ import {
   Value,
 } from "./index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
-import {
-  GetFromArrayWithWidenedNumericProperty,
-  IsDataDescriptor,
-  cloneDescriptor,
-  equalDescriptors,
-} from "../methods/index.js";
+import { IsDataDescriptor, cloneDescriptor, equalDescriptors } from "../methods/index.js";
 import { Leak, Widen } from "../singletons.js";
 import invariant from "../invariant.js";
 import { createOperationDescriptor, type OperationDescriptor } from "../utils/generator.js";
@@ -598,13 +593,6 @@ export default class AbstractObjectValue extends AbstractValue {
     }
 
     let $GetHelper = ob => {
-      if (ob instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(ob) && typeof P === "string") {
-        return {
-          object: ob,
-          key: P,
-          value: GetFromArrayWithWidenedNumericProperty(this.$Realm, ob, P),
-        };
-      }
       let d = ob.$GetOwnProperty(P);
       if (d !== undefined) return d;
       let proto = ob.$GetPrototypeOf();


### PR DESCRIPTION
I'm refactoring these parts in a different diff and stumble upon this.

I don't really get (pun intended) why this is here. It is also returning a property binding instead of a descriptor which doesn't make sense.

Removing it doesn't fail any tests so at the very least we need to add test coverage to this if it is needed.