### PR TITLE
Add failing test cases for modified bindings before a fatal error and add a __fatal utility function

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -274,6 +274,7 @@ function tryToEvaluateCallOrLeaveAsAbstract(
     );
   } catch (error) {
     if (error instanceof FatalError) {
+      if (func instanceof NativeFunctionValue && func.name === "__fatal") throw error;
       realm.suppressDiagnostics = savedSuppressDiagnostics;
       return realm.evaluateWithPossibleThrowCompletion(
         () => generateRuntimeCall(ref, func, ast, strictCode, env, realm),

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -507,4 +507,13 @@ export default function(realm: Realm): void {
     enumerable: false,
     configurable: true,
   });
+
+  global.$DefineOwnProperty("__fatal", {
+    value: new NativeFunctionValue(realm, "global.__fatal", "__fatal", 0, (context, []) => {
+      throw new FatalError();
+    }),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 }

--- a/src/realm.js
+++ b/src/realm.js
@@ -1255,15 +1255,13 @@ export class Realm {
     this.restoreProperties(this.modifiedProperties);
 
     // Restore saved state
-    if (completion.savedEffects !== undefined) {
+    if (completion.savedEffects) {
       const savedEffects = completion.savedEffects;
       completion.savedEffects = undefined;
       this.generator = savedEffects.generator;
       this.modifiedBindings = savedEffects.modifiedBindings;
       this.modifiedProperties = savedEffects.modifiedProperties;
       this.createdObjects = savedEffects.createdObjects;
-    } else {
-      invariant(false);
     }
 
     // Undo the effects from completions we are composed with

--- a/src/realm.js
+++ b/src/realm.js
@@ -1255,18 +1255,15 @@ export class Realm {
     this.restoreProperties(this.modifiedProperties);
 
     // Restore saved state
-    if (completion.savedEffects) {
+    if (completion.savedEffects !== undefined) {
       const savedEffects = completion.savedEffects;
       completion.savedEffects = undefined;
       this.generator = savedEffects.generator;
       this.modifiedBindings = savedEffects.modifiedBindings;
       this.modifiedProperties = savedEffects.modifiedProperties;
       this.createdObjects = savedEffects.createdObjects;
-    }
-
-    // Undo the effects from completions we are composed with
-    if (completion.composedWith) {
-      this.stopEffectCaptureAndUndoEffects(completion.composedWith);
+    } else {
+      invariant(false);
     }
   }
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -1265,6 +1265,11 @@ export class Realm {
     } else {
       invariant(false);
     }
+
+    // Undo the effects from completions we are composed with
+    if (completion.composedWith) {
+      this.stopEffectCaptureAndUndoEffects(completion.composedWith);
+    }
   }
 
   // Apply the given effects to the global state

--- a/test/serializer/pure-functions/FatalErrorAfterJoins.js
+++ b/test/serializer/pure-functions/FatalErrorAfterJoins.js
@@ -1,0 +1,20 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+global.__evaluatePureFunction(() => {
+  let x, y;
+
+  function f() {
+    const getNumber = global.__abstract ? global.__abstract("function", "(() => 1)") : () => 1;
+    const b1 = global.__abstract ? global.__abstract("boolean", "true") : true;
+    const b2 = global.__abstract ? global.__abstract("boolean", "!false") : true;
+
+    x = getNumber();
+    if (!b1) throw new Error("abrupt");
+    y = getNumber();
+    if (!b2) throw new Error("abrupt");
+    if (global.__fatal) global.__fatal();
+    return x + y;
+  }
+
+  f();
+});

--- a/test/serializer/pure-functions/FatalErrorAfterModifiedBinding.js
+++ b/test/serializer/pure-functions/FatalErrorAfterModifiedBinding.js
@@ -1,0 +1,20 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+const result = global.__evaluatePureFunction(() => {
+  let x, y;
+
+  function f() {
+    const getNumber = global.__abstract ? global.__abstract("function", "(() => 1)") : () => 1;
+    const b1 = global.__abstract ? global.__abstract("boolean", "true") : true;
+
+    x = getNumber();
+    if (!b1) throw new Error("abrupt");
+    if (global.__fatal) global.__fatal();
+  }
+
+  f();
+
+  return x;
+});
+
+global.inspect = () => result;


### PR DESCRIPTION
Fixes #2458.

The `modifiedBindings` and `modifiedProperties` of a completion in `composedWith` were not correctly undone when a fatal error is thrown and Prepack chooses to bail out instead of surfacing the fatal error to the user.

This fixes the invariant.