### PR TITLE
Compose without tail duplication

### DIFF
--- a/src/evaluators/SwitchStatement.js
+++ b/src/evaluators/SwitchStatement.js
@@ -247,7 +247,7 @@ function CaseBlockEvaluation(
 
   // Abstract interpretation of case blocks is a significantly different process
   // from regular interpretation, so we fork off early to keep things tidily separated.
-  if (input instanceof AbstractValue) {
+  if (input instanceof AbstractValue && cases.length < 6) {
     return AbstractCaseBlockEvaluation(cases, default_case_num, input, strictCode, env, realm);
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -752,7 +752,11 @@ export type JoinType = {
     d2: void | Descriptor
   ): void | Descriptor,
 
-  joinValuesOfSelectedCompletions(selector: (Completion) => boolean, completion: Completion): Value,
+  joinValuesOfSelectedCompletions(
+    selector: (Completion) => boolean,
+    completion: Completion,
+    keepInfeasiblePaths?: boolean
+  ): Value,
 
   mapAndJoin(
     realm: Realm,

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -258,6 +258,7 @@ function pushInversePathCondition(condition: Value): void {
     let right = condition.args[1];
     invariant(left instanceof AbstractValue); // it is a mistake to create an abstract value when concrete value will do
     pushInversePathCondition(left);
+    if (right instanceof AbstractValue) right = realm.simplifyAndRefineAbstractCondition(right);
     if (right.mightNotBeTrue()) pushInversePathCondition(right);
   } else {
     if (condition.kind === "!=" || condition.kind === "==") {


### PR DESCRIPTION
Release note: none

Closes #2435
Closes #1829

Join.composeWithEffects composes a forked completion with subsequent effects. When two or more forks could end normally, this could result in shallow copies of the subsequent effects. These were then joined together and applied, so it was mostly OK. The generator of the subsequent effects, however, ended up being joined with itself and thus transformed the generator tree to a DAG, which is not desirable for the serializer.

The new approach is to extract a join condition from the forked completion and using it to join the subsequent effects with a newly constructed empty effects. The condition ensures that the subsequent effects are applied only in situations where the forked completion is not abrupt.

Extracting this condition makes for complicated abstract expressions and this uncovered some existing bugs and limitations that are also addressed in this pull request. As a side effect, path conditions are now longer and the time to compile unrolled loops with conditional abrupt completions inside their bodies has gone up so much that the unroll limit had to be lowered.

Please note that the expected output React tests has changed because of re-ordering. I'm none too sure that this re-ordering is necessarily benign, so please review carefully.