### PR TITLE
Refactor AbstractObjectValue to use evaluateWithAbstractConditional

### DIFF
--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -542,9 +542,9 @@ export class CreateImplementation {
   }
 
   // ECMA262 7.3.4
-  CreateDataProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value): boolean {
+  CreateDataProperty(realm: Realm, O: ObjectValue | AbstractObjectValue, P: PropertyKeyValue, V: Value): boolean {
     // 1. Assert: Type(O) is Object.
-    invariant(O instanceof ObjectValue, "Not an object value");
+    invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue, "Not an object value");
 
     // 2. Assert: IsPropertyKey(P) is true.
     invariant(IsPropertyKey(realm, P), "Not a property key");

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -544,7 +544,6 @@ export class CreateImplementation {
   // ECMA262 7.3.4
   CreateDataProperty(realm: Realm, O: ObjectValue | AbstractObjectValue, P: PropertyKeyValue, V: Value): boolean {
     // 1. Assert: Type(O) is Object.
-    invariant(O instanceof ObjectValue || O instanceof AbstractObjectValue, "Not an object value");
 
     // 2. Assert: IsPropertyKey(P) is true.
     invariant(IsPropertyKey(realm, P), "Not a property key");

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -353,7 +353,7 @@ export function OrdinaryGetPartial(
   }
 
   // We assume that simple objects have no getter/setter properties.
-  if (!O.isSimpleObject()) {
+  if (!O.isSimpleObject() || O.mightBeLeakedObject()) {
     if (realm.isInPureScope()) {
       // If we're in pure scope, we can leak the object. Coercion
       // can only have effects on anything reachable from this object.

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -109,13 +109,14 @@ export function OrdinaryGet(
     }
 
     if (val.kind === "widened numeric property") {
-      invariant(Receiver instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(Receiver));
+      invariant(O instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O));
       let propName;
       if (P instanceof StringValue) {
         propName = P.value;
       } else {
         propName = P;
       }
+      invariant(Receiver instanceof ObjectValue || Receiver instanceof AbstractObjectValue);
       return GetFromArrayWithWidenedNumericProperty(realm, Receiver, propName);
     } else if (!propValue) {
       AbstractValue.reportIntrospectionError(val, "abstract computed property name");
@@ -426,7 +427,8 @@ export function OrdinaryGetPartial(
       let val = desc.value;
       invariant(val instanceof AbstractValue);
       if (val.kind === "widened numeric property") {
-        invariant(Receiver instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(Receiver));
+        invariant(O instanceof ArrayValue && ArrayValue.isIntrinsicAndHasWidenedNumericProperty(O));
+        invariant(Receiver instanceof ObjectValue || Receiver instanceof AbstractObjectValue);
         return GetFromArrayWithWidenedNumericProperty(realm, Receiver, P instanceof StringValue ? P.value : P);
       }
       result = specializeJoin(realm, val, P);
@@ -760,7 +762,11 @@ export function GetTemplateObject(realm: Realm, templateLiteral: BabelNodeTempla
   return template;
 }
 
-export function GetFromArrayWithWidenedNumericProperty(realm: Realm, arr: ArrayValue, P: string | Value): Value {
+export function GetFromArrayWithWidenedNumericProperty(
+  realm: Realm,
+  arr: AbstractObjectValue | ObjectValue,
+  P: string | Value
+): Value {
   let proto = arr.$GetPrototypeOf();
   invariant(proto instanceof ObjectValue && proto === realm.intrinsics.ArrayPrototype);
   if (typeof P === "string") {

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -622,6 +622,15 @@ export class PropertiesImplementation {
     // 1. If Desc is undefined, return undefined.
     if (!Desc) return realm.intrinsics.undefined;
 
+    if (Desc.joinCondition) {
+      return AbstractValue.createFromConditionalOp(
+        realm,
+        Desc.joinCondition,
+        this.FromPropertyDescriptor(realm, Desc.descriptor1),
+        this.FromPropertyDescriptor(realm, Desc.descriptor2)
+      );
+    }
+
     // 2. Let obj be ObjectCreate(%ObjectPrototype%).
     let obj = Create.ObjectCreate(realm, realm.intrinsics.ObjectPrototype);
 

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -371,8 +371,8 @@ export class PropertiesImplementation {
         }
 
         // b. If Type(Receiver) is not Object, return false.
-        Receiver = Receiver.throwIfNotConcrete();
-        if (!(Receiver instanceof ObjectValue)) return false;
+        if (!Receiver.mightBeObject()) return false;
+        invariant(Receiver instanceof ObjectValue || Receiver instanceof AbstractObjectValue);
 
         // c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
         let existingDescriptor = Receiver.$GetOwnProperty(P);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -522,7 +522,15 @@ export class PropertiesImplementation {
     // If it was simple, it would've been an assignment to the receiver.
     // The only case the Receiver isn't this, if this was a ToObject
     // coercion from a PrimitiveValue.
-    invariant(O === Receiver || HasCompatibleType(Receiver, PrimitiveValue));
+    let abstractOverO = false;
+    if (Receiver instanceof AbstractObjectValue && !Receiver.values.isTop()) {
+      let elements = Receiver.values.getElements();
+      invariant(elements);
+      if (elements.has(O)) {
+        abstractOverO = true;
+      }
+    }
+    invariant(O === Receiver || HasCompatibleType(Receiver, PrimitiveValue) || abstractOverO);
 
     P = To.ToStringAbstract(realm, P);
 

--- a/src/types.js
+++ b/src/types.js
@@ -723,6 +723,13 @@ export type JoinType = {
 
   joinEffects(joinCondition: Value, e1: Effects, e2: Effects): Effects,
 
+  joinDescriptors(
+    realm: Realm,
+    joinCondition: AbstractValue,
+    d1: void | Descriptor,
+    d2: void | Descriptor
+  ): void | Descriptor,
+
   joinValuesOfSelectedCompletions(selector: (Completion) => boolean, completion: Completion): Value,
 
   mapAndJoin(

--- a/src/types.js
+++ b/src/types.js
@@ -780,7 +780,7 @@ export type CreateType = {
   CopyDataProperties(realm: Realm, target: ObjectValue, source: Value, excluded: Array<PropertyKeyValue>): ObjectValue,
 
   // ECMA262 7.3.4
-  CreateDataProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value): boolean,
+  CreateDataProperty(realm: Realm, O: ObjectValue | AbstractObjectValue, P: PropertyKeyValue, V: Value): boolean,
 
   // ECMA262 7.3.5
   CreateMethodProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, V: Value): boolean,

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -950,8 +950,20 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(oldVal2 instanceof Value);
       let newVal1 = AbstractValue.createFromConditionalOp(this.$Realm, cond, this.$Realm.intrinsics.empty, oldVal1);
       let newVal2 = AbstractValue.createFromConditionalOp(this.$Realm, cond, oldVal2, this.$Realm.intrinsics.empty);
-      let result1 = ob1.$Set(P, newVal1, this);
-      let result2 = ob2.$Set(P, newVal2, this);
+      let result1 = true;
+      let result2 = true;
+      if (d1 !== undefined) {
+        let newDesc1 = cloneDescriptor(d1);
+        invariant(newDesc1);
+        newDesc1.value = newVal1;
+        result1 = ob1.$DefineOwnProperty(P, newDesc1);
+      }
+      if (d2 !== undefined) {
+        let newDesc2 = cloneDescriptor(d2);
+        invariant(newDesc2);
+        newDesc2.value = newVal2;
+        result2 = ob2.$DefineOwnProperty(P, newDesc2);
+      }
       if (result1 !== result2) {
         AbstractValue.reportIntrospectionError(this, P);
         throw new FatalError();
@@ -972,7 +984,10 @@ export default class AbstractObjectValue extends AbstractValue {
         let dval = d.value;
         invariant(dval instanceof Value);
         let v = AbstractValue.createFromConditionalOp(this.$Realm, cond, this.$Realm.intrinsics.empty, dval);
-        if (cv.$Set(P, v, this)) sawTrue = true;
+        let newDesc = cloneDescriptor(d);
+        invariant(newDesc);
+        newDesc.value = v;
+        if (cv.$DefineOwnProperty(P, newDesc)) sawTrue = true;
         else sawFalse = true;
       }
       if (sawTrue && sawFalse) {

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -709,7 +709,7 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        return cv.$GetPartial(P, Receiver === this ? cv : Receiver);
+        return cv.$GetPartial(P, Receiver);
       }
       invariant(false);
     } else if (this.kind === "conditional") {
@@ -719,14 +719,14 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(cond instanceof AbstractValue);
       invariant(ob1 instanceof ObjectValue || ob1 instanceof AbstractObjectValue);
       invariant(ob2 instanceof ObjectValue || ob2 instanceof AbstractObjectValue);
-      let d1val = ob1.$GetPartial(P, Receiver === this ? ob1 : Receiver);
-      let d2val = ob2.$GetPartial(P, Receiver === this ? ob2 : Receiver);
+      let d1val = ob1.$GetPartial(P, Receiver);
+      let d2val = ob2.$GetPartial(P, Receiver);
       return AbstractValue.createFromConditionalOp(this.$Realm, cond, d1val, d2val);
     } else {
       let result;
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        let cvVal = cv.$GetPartial(P, Receiver === this ? cv : Receiver);
+        let cvVal = cv.$GetPartial(P, Receiver);
         if (result === undefined) result = cvVal;
         else {
           let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
@@ -748,7 +748,7 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        return cv.$Set(P, V, Receiver === this ? cv : Receiver);
+        return cv.$Set(P, V, Receiver);
       }
       invariant(false);
     } else if (this.kind === "conditional") {
@@ -772,8 +772,8 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(oldVal2 instanceof Value);
       let newVal1 = AbstractValue.createFromConditionalOp(this.$Realm, cond, V, oldVal1);
       let newVal2 = AbstractValue.createFromConditionalOp(this.$Realm, cond, oldVal2, V);
-      let result1 = ob1.$Set(P, newVal1, ob1);
-      let result2 = ob2.$Set(P, newVal2, ob2);
+      let result1 = ob1.$Set(P, newVal1, Receiver);
+      let result2 = ob2.$Set(P, newVal2, Receiver);
       if (result1 !== result2) {
         AbstractValue.reportIntrospectionError(this, P);
         throw new FatalError();
@@ -793,7 +793,7 @@ export default class AbstractObjectValue extends AbstractValue {
         invariant(oldVal instanceof Value);
         let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
         let v = AbstractValue.createFromConditionalOp(this.$Realm, cond, V, oldVal);
-        if (cv.$Set(P, v, cv)) sawTrue = true;
+        if (cv.$Set(P, v, Receiver)) sawTrue = true;
         else sawFalse = true;
       }
       if (sawTrue && sawFalse) {
@@ -855,7 +855,7 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        return cv.$SetPartial(P, V, Receiver === this ? cv : Receiver);
+        return cv.$SetPartial(P, V, Receiver);
       }
       invariant(false);
     } else if (this.kind === "conditional") {
@@ -865,21 +865,21 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(cond instanceof AbstractValue);
       invariant(ob1 instanceof ObjectValue || ob1 instanceof AbstractObjectValue);
       invariant(ob2 instanceof ObjectValue || ob2 instanceof AbstractObjectValue);
-      let oldVal1 = ob1.$GetPartial(P, Receiver === this ? ob1 : Receiver);
-      let oldVal2 = ob2.$GetPartial(P, Receiver === this ? ob2 : Receiver);
+      let oldVal1 = ob1.$GetPartial(P, Receiver);
+      let oldVal2 = ob2.$GetPartial(P, Receiver);
       let newVal1 = AbstractValue.createFromConditionalOp(this.$Realm, cond, V, oldVal1);
       let newVal2 = AbstractValue.createFromConditionalOp(this.$Realm, cond, oldVal2, V);
-      let result1 = ob1.$SetPartial(P, newVal1, ob1);
-      let result2 = ob2.$SetPartial(P, newVal2, ob2);
+      let result1 = ob1.$SetPartial(P, newVal1, Receiver);
+      let result2 = ob2.$SetPartial(P, newVal2, Receiver);
       invariant(result1 && result2, "a simple object must be writable");
       return result1;
     } else {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        let oldVal = this.$GetPartial(P, Receiver === this ? cv : Receiver);
+        let oldVal = this.$GetPartial(P, Receiver);
         let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
         let v = AbstractValue.createFromConditionalOp(this.$Realm, cond, V, oldVal);
-        cv.$SetPartial(P, v, Receiver === this ? cv : Receiver);
+        cv.$SetPartial(P, v, Receiver);
       }
       return true;
     }
@@ -922,8 +922,8 @@ export default class AbstractObjectValue extends AbstractValue {
       invariant(oldVal2 instanceof Value);
       let newVal1 = AbstractValue.createFromConditionalOp(this.$Realm, cond, this.$Realm.intrinsics.empty, oldVal1);
       let newVal2 = AbstractValue.createFromConditionalOp(this.$Realm, cond, oldVal2, this.$Realm.intrinsics.empty);
-      let result1 = ob1.$Set(P, newVal1, ob1);
-      let result2 = ob2.$Set(P, newVal2, ob2);
+      let result1 = ob1.$Set(P, newVal1, this);
+      let result2 = ob2.$Set(P, newVal2, this);
       if (result1 !== result2) {
         AbstractValue.reportIntrospectionError(this, P);
         throw new FatalError();
@@ -944,7 +944,7 @@ export default class AbstractObjectValue extends AbstractValue {
         let dval = d.value;
         invariant(dval instanceof Value);
         let v = AbstractValue.createFromConditionalOp(this.$Realm, cond, this.$Realm.intrinsics.empty, dval);
-        if (cv.$Set(P, v, cv)) sawTrue = true;
+        if (cv.$Set(P, v, this)) sawTrue = true;
         else sawFalse = true;
       }
       if (sawTrue && sawFalse) {

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -26,7 +26,7 @@ import {
 } from "./index.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import { IsDataDescriptor, cloneDescriptor, equalDescriptors } from "../methods/index.js";
-import { Leak, Properties, Join, Widen } from "../singletons.js";
+import { Leak, Join, Widen } from "../singletons.js";
 import invariant from "../invariant.js";
 import { createOperationDescriptor, type OperationDescriptor } from "../utils/generator.js";
 import { construct_empty_effects } from "../realm.js";
@@ -700,19 +700,6 @@ export default class AbstractObjectValue extends AbstractValue {
 
     let realm = this.$Realm;
     let elements = this.values.getElements();
-
-    if (this.isSimpleObject()) {
-      // If this is a simple object, we know that we won't invoke any special
-      // logic so we can fast path it through the ordinary object model which
-      // will call $GetOwnProperty and $DefineOwnProperty on the Receiver.
-      // These will ensure that all possible values and descriptors are
-      // represented.
-      for (let cv of elements) {
-        invariant(cv instanceof ObjectValue);
-        return Properties.OrdinarySet(realm, cv, P, V, Receiver);
-      }
-      invariant(false, "there is always at least one element in non-top");
-    }
 
     if (elements.size === 1) {
       for (let cv of elements) {

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -243,7 +243,11 @@ export default class AbstractObjectValue extends AbstractValue {
       let p1 = ob1.$GetPrototypeOf();
       let p2 = ob2.$GetPrototypeOf();
       let joinedObject = AbstractValue.createFromConditionalOp(realm, cond, p1, p2);
-      invariant(joinedObject instanceof AbstractObjectValue);
+      invariant(
+        joinedObject instanceof AbstractObjectValue ||
+          joinedObject instanceof ObjectValue ||
+          joinedObject instanceof NullValue
+      );
       return joinedObject;
     } else if (this.kind === "explicit conversion to object") {
       let primitiveValue = this.args[0];
@@ -268,7 +272,11 @@ export default class AbstractObjectValue extends AbstractValue {
           joinedObject = AbstractValue.createFromConditionalOp(realm, cond, p, joinedObject);
         }
       }
-      invariant(joinedObject instanceof AbstractObjectValue);
+      invariant(
+        joinedObject instanceof AbstractObjectValue ||
+          joinedObject instanceof ObjectValue ||
+          joinedObject instanceof NullValue
+      );
       return joinedObject;
     }
   }

--- a/test/serializer/abstract/ConditionalAbstractObjectValueGetOwnProperty.js
+++ b/test/serializer/abstract/ConditionalAbstractObjectValueGetOwnProperty.js
@@ -1,0 +1,14 @@
+(function() {
+  let c = global.__abstract ? __abstract("boolean", "(true)") : true;
+  let o = c
+    ? {}
+    : {
+        get foo() {
+          return 5;
+        },
+      };
+  global.desc = Object.getOwnPropertyDescriptor(o, "foo");
+  inspect = function() {
+    return global.desc;
+  };
+})();

--- a/test/serializer/abstract/DeleteOnConditionalObject.js
+++ b/test/serializer/abstract/DeleteOnConditionalObject.js
@@ -1,0 +1,18 @@
+let c = global.__abstract ? __abstract("boolean", "(true)") : true;
+
+let invokedSetter = false;
+let obj1 = Object.create({
+  set x(v) {
+    invokedSetter = true;
+  },
+});
+let obj2 = { x: 1 };
+
+let conditionalObj = c ? obj1 : obj2;
+
+delete conditionalObj.x;
+
+inspect = function() {
+  let hasProperty = "x" in obj2;
+  return JSON.stringify({ invokedSetter, hasProperty });
+};

--- a/test/serializer/abstract/GetValue4.js
+++ b/test/serializer/abstract/GetValue4.js
@@ -1,10 +1,14 @@
-// throws introspection error
-let x = __abstract("boolean", "true");
+let x = global.__abstract ? __abstract("boolean", "true") : true;
+let calledGetter = false;
 let ob = x
   ? { a: 1 }
   : {
       get a() {
+        calledGetter = true;
         return 2;
       },
     };
 let y = ob.a;
+inspect = function() {
+  return JSON.stringify({ y, calledGetter });
+};

--- a/test/serializer/abstract/PutValue7.js
+++ b/test/serializer/abstract/PutValue7.js
@@ -1,8 +1,10 @@
-// throws introspection error
 let x = global.__abstract ? __abstract("boolean", "true") : true;
 let ob1 = {};
 Object.defineProperty(ob1, "p", { writable: false, value: 1 });
 let ob2 = {};
 Object.defineProperty(ob2, "p", { writable: true, value: 2 });
-ob = x ? ob1 : ob2;
+global.ob = x ? ob1 : ob2;
 ob.p = 3;
+inspect = function() {
+  return global.ob.p;
+};

--- a/test/serializer/abstract/getOwnPropertyDescriptor4.js
+++ b/test/serializer/abstract/getOwnPropertyDescriptor4.js
@@ -1,4 +1,6 @@
-// throws introspection error
-let x = __abstract("boolean", "true");
+let x = global.__abstract ? __abstract("boolean", "true") : true;
 let ob = x ? { a: 1 } : { b: 2 };
 let desc = Object.getOwnPropertyDescriptor(ob, "a");
+inspect = function() {
+  return desc;
+};

--- a/test/serializer/abstract/getOwnPropertyDescriptor9.js
+++ b/test/serializer/abstract/getOwnPropertyDescriptor9.js
@@ -1,5 +1,4 @@
-// throws introspection error
-let x = __abstract("boolean", "true");
+let x = global.__abstract ? __abstract("boolean", "true") : true;
 let nonEnumerableA = { a: 1 };
 Object.defineProperty(nonEnumerableA, "a", { enumerable: false });
 let ob = x ? nonEnumerableA : { a: 2 };

--- a/test/serializer/abstract/getOwnPropertyDescriptor9.js
+++ b/test/serializer/abstract/getOwnPropertyDescriptor9.js
@@ -1,0 +1,9 @@
+// throws introspection error
+let x = __abstract("boolean", "true");
+let nonEnumerableA = { a: 1 };
+Object.defineProperty(nonEnumerableA, "a", { enumerable: false });
+let ob = x ? nonEnumerableA : { a: 2 };
+let desc = Object.getOwnPropertyDescriptor(ob, "a");
+inspect = function() {
+  return desc;
+};

--- a/test/serializer/pure-functions/ConditionalHavocedGet.js
+++ b/test/serializer/pure-functions/ConditionalHavocedGet.js
@@ -1,0 +1,33 @@
+function foo(havoc, condition) {
+  let obj = { x: 1, y: 2 };
+  let havocedObj = { x: 3, y: 4 };
+  let conditionalObj = condition ? havocedObj : obj;
+  havoc(havocedObj);
+  return conditionalObj.x;
+}
+
+if (global.__optimize) __optimize(foo);
+
+inspect = function() {
+  let calls1 = 0;
+  let returnValue1 = foo(obj => {
+    Object.defineProperty(obj, "x", {
+      get() {
+        // Should not be called.
+        calls1++;
+        return 5;
+      },
+    });
+  }, false);
+  let calls2 = 0;
+  let returnValue2 = foo(obj => {
+    Object.defineProperty(obj, "x", {
+      get() {
+        // Should be called.
+        calls2++;
+        return 6;
+      },
+    });
+  }, true);
+  return JSON.stringify({ calls1, returnValue1, calls2, returnValue2 });
+};

--- a/test/serializer/pure-functions/ConditionalHavocedGetPartial.js
+++ b/test/serializer/pure-functions/ConditionalHavocedGetPartial.js
@@ -1,0 +1,41 @@
+function foo(havoc, key, condition) {
+  let obj = { x: 1, y: 2 };
+  let havocedObj = { x: 3, y: 4 };
+  let conditionalObj = condition ? havocedObj : obj;
+  havoc(havocedObj);
+  return conditionalObj[key];
+}
+
+if (global.__optimize) __optimize(foo);
+
+inspect = function() {
+  let calls1 = 0;
+  let returnValue1 = foo(
+    obj => {
+      Object.defineProperty(obj, "x", {
+        get() {
+          // Should not be called.
+          calls1++;
+          return 5;
+        },
+      });
+    },
+    "x",
+    false
+  );
+  let calls2 = 0;
+  let returnValue2 = foo(
+    obj => {
+      Object.defineProperty(obj, "x", {
+        get() {
+          // Should be called.
+          calls2++;
+          return 6;
+        },
+      });
+    },
+    "x",
+    true
+  );
+  return JSON.stringify({ calls1, returnValue1, calls2, returnValue2 });
+};

--- a/test/serializer/pure-functions/ConditionalHavocedSet.js
+++ b/test/serializer/pure-functions/ConditionalHavocedSet.js
@@ -1,0 +1,30 @@
+let c = global.__abstract ? __abstract("boolean", "(false)") : false;
+
+function foo(havoc, key) {
+  let obj = {
+    x(v) {
+      this.y = v;
+    },
+    y: 2,
+  };
+  let havocedObj = { x: 3, y: 4 };
+  let conditionalObj = c ? havocedObj : obj;
+  havoc(havocedObj);
+  conditionalObj.x = 5;
+  return obj.y;
+}
+
+if (global.__optimize) __optimize(foo);
+
+inspect = function() {
+  let called = false;
+  let returnValue = foo(obj => {
+    Object.defineProperty(obj, "x", {
+      set(value) {
+        // Should not be called.
+        called = true;
+      },
+    });
+  }, "x");
+  return JSON.stringify({ called, returnValue });
+};

--- a/test/serializer/pure-functions/ConditionalHavocedSetPartial.js
+++ b/test/serializer/pure-functions/ConditionalHavocedSetPartial.js
@@ -1,0 +1,25 @@
+let c = global.__abstract ? __abstract("boolean", "(false)") : false;
+
+function foo(havoc, key) {
+  let obj = { x: 1, y: 2 };
+  let havocedObj = { x: 3, y: 4 };
+  let conditionalObj = c ? havocedObj : obj;
+  havoc(havocedObj);
+  conditionalObj[key] = 5;
+  return obj.x;
+}
+
+if (global.__optimize) __optimize(foo);
+
+inspect = function() {
+  let called = false;
+  let returnValue = foo(obj => {
+    Object.defineProperty(obj, "x", {
+      set(value) {
+        // Should not be called.
+        called = true;
+      },
+    });
+  }, "x");
+  return JSON.stringify({ called, returnValue });
+};


### PR DESCRIPTION
Release notes: this might increase code size slighty, if the simplifier isn't fully working, in the rare case of conditional objects. I haven't observed any cases of that happening.

_Reviewing the individual commits might be helpful._

The main motivation of these changes is to prepare to avoid leaking the inner object when AbstractObjectValue is wrapping a template which prevents us from modeling templates without true identity.

To do that we need to stop leaking it to the Receiver since the Receiver can be passed to user space. Currently, we unwrap abstract objects [we really need to stop that since it leaks the receiver](https://github.com/facebook/prepack/commit/cf8184904e9a8a147519d3ee373cb33d0ab23654).

It used to be that we special cased simple cases in AbstractObjectValue but since OrdinarySet operations are pretty complex, sometimes it's a simple assignment and sometimes the receiver leaks to a more complex operation.

Additionally, we assume that all these operations in AbstractObjectValue can be expressed as pure operations because they're simple objects. However, that's not the case because in properties.js/get.js we emit generator entries for intrinsic objects, havoced objects, widened properties, etc. These are at the very least unnecessary operations to perform when the AbstractObjectValue is actually representing one of the other branches. However, in the case of havoced objects, we don't really know if it is a simple object so it can actually be observable side-effects.

The simplest way of dealing with all these issues is to simply deal with side-effectful operations. So I do that by evaluating each path for effects and joining the effects using the evaluateWithAbstractConditional helper. This also lets us deal with non-simple abstract objects as a bonus.

This doesn't fully get us all the way to no longer leaking receivers. In a follow up I plan to deal with defIneOwnProperty, getOwnProperty, and a few other operations that also leak the inner object template.