### PR TITLE
Leak function in call bailout

### DIFF
--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -274,6 +274,7 @@ function tryToEvaluateCallOrLeaveAsAbstract(
     );
   } catch (error) {
     if (error instanceof FatalError) {
+      if (func instanceof NativeFunctionValue && func.name === "__fatal") throw error;
       realm.suppressDiagnostics = savedSuppressDiagnostics;
       return realm.evaluateWithPossibleThrowCompletion(
         () => generateRuntimeCall(ref, func, ast, strictCode, env, realm),

--- a/src/evaluators/CallExpression.js
+++ b/src/evaluators/CallExpression.js
@@ -276,6 +276,7 @@ function tryToEvaluateCallOrLeaveAsAbstract(
     if (error instanceof FatalError) {
       if (func instanceof NativeFunctionValue && func.name === "__fatal") throw error;
       realm.suppressDiagnostics = savedSuppressDiagnostics;
+      Leak.value(realm, func, ast.loc);
       return realm.evaluateWithPossibleThrowCompletion(
         () => generateRuntimeCall(ref, func, ast, strictCode, env, realm),
         TypesDomain.topVal,

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -507,4 +507,13 @@ export default function(realm: Realm): void {
     enumerable: false,
     configurable: true,
   });
+
+  global.$DefineOwnProperty("__fatal", {
+    value: new NativeFunctionValue(realm, "global.__fatal", "__fatal", 0, (context, []) => {
+      throw new FatalError();
+    }),
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
 }

--- a/test/serializer/pure-functions/FatalErrorAfterModifiedBinding.js
+++ b/test/serializer/pure-functions/FatalErrorAfterModifiedBinding.js
@@ -1,0 +1,20 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+const result = global.__evaluatePureFunction(() => {
+  let x, y;
+
+  function f() {
+    const getNumber = global.__abstract ? global.__abstract("function", "(() => 1)") : () => 1;
+    const b1 = global.__abstract ? global.__abstract("boolean", "true") : true;
+
+    x = getNumber();
+    if (!b1) throw new Error("abrupt");
+    if (global.__fatal) global.__fatal();
+  }
+
+  f();
+
+  return x;
+});
+
+global.inspect = () => result;

--- a/test/serializer/pure-functions/FatalErrorAfterModifiedBinding.js
+++ b/test/serializer/pure-functions/FatalErrorAfterModifiedBinding.js
@@ -1,7 +1,7 @@
 if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
 
 const result = global.__evaluatePureFunction(() => {
-  let x, y;
+  let x;
 
   function f() {
     const getNumber = global.__abstract ? global.__abstract("function", "(() => 1)") : () => 1;


### PR DESCRIPTION
Fixes #2464.

When we bail out of a function call because of a `FatalError` we did not leak the function we called. This means modified bindings were not appropriately leaked. See issue #2464 where the result is `undefined` instead of a reference to the leaked value.

This PR also adds a utility `__fatal` function for throwing a fatal error. Allowing us to more clearly express issues involving `FatalError`s. Used in the test.