### PR TITLE
Fix composed completion undo

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -867,9 +867,10 @@ export class Realm {
           this.restoreProperties(this.modifiedProperties);
           let completion = this.savedCompletion;
           while (completion !== undefined) {
-            if (completion.savedEffects !== undefined) {
-              this.restoreBindings(completion.savedEffects.modifiedBindings);
-              this.restoreProperties(completion.savedEffects.modifiedProperties);
+            const { savedEffects } = completion;
+            if (savedEffects !== undefined) {
+              this.restoreBindings(savedEffects.modifiedBindings);
+              this.restoreProperties(savedEffects.modifiedProperties);
             }
             completion = completion.composedWith;
           }

--- a/src/realm.js
+++ b/src/realm.js
@@ -863,11 +863,16 @@ export class Realm {
           this.restoreBindings(result.modifiedBindings);
           this.restoreProperties(result.modifiedProperties);
         } else {
-          if (this.savedCompletion !== undefined) {
-            this.stopEffectCaptureAndUndoEffects(this.savedCompletion);
-          }
           this.restoreBindings(this.modifiedBindings);
           this.restoreProperties(this.modifiedProperties);
+          let completion = this.savedCompletion;
+          while (completion !== undefined) {
+            if (completion.savedEffects !== undefined) {
+              this.restoreBindings(completion.savedEffects.modifiedBindings);
+              this.restoreProperties(completion.savedEffects.modifiedProperties);
+            }
+            completion = completion.composedWith;
+          }
         }
         this.generator = saved_generator;
         this.modifiedBindings = savedBindings;

--- a/test/serializer/pure-functions/FatalErrorAfterJoins.js
+++ b/test/serializer/pure-functions/FatalErrorAfterJoins.js
@@ -1,0 +1,29 @@
+if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();
+
+const result = global.__evaluatePureFunction(() => {
+  let x, y, z;
+
+  function f() {
+    const getNumber = global.__abstract ? global.__abstract("function", "(() => 1)") : () => 1;
+    const b1 = global.__abstract ? global.__abstract("boolean", "true") : true;
+    const b2 = global.__abstract ? global.__abstract("boolean", "!false") : true;
+    const b3 = global.__abstract ? global.__abstract("boolean", "!!true") : true;
+
+    x = getNumber();
+    if (!b1) throw new Error("abrupt");
+    y = getNumber();
+    if (!b2) throw new Error("abrupt");
+    z = getNumber();
+    if (!b3) throw new Error("abrupt");
+
+    if (global.__fatal) global.__fatal();
+
+    return x + y + z;
+  }
+
+  f();
+
+  return x + y + z;
+});
+
+global.inspect = () => result;


### PR DESCRIPTION
Fixes #2458.

This is a new version of my change in #2459. I closed that PR since @hermanventer had doubts which I confirmed after discovering my “fix” crashed my React Native internal bundle in a different way demonstrating its incorrectness.

After thinking about how to workaround this issue (since I was blocked on this) and fixing related issue #2466 I think I have a proper fix and I’m ready to defend it.

Note that this PR is based on top of #2466. The changes in [this commit](https://github.com/calebmer/prepack/commit/4896087869a05f9e2a3d71ed307bf1bbcb4cca27) are the ones to look at.

The failing test case is the following. Annotated with some comments to help demonstrate the issue:

```js
if (!global.__evaluatePureFunction) global.__evaluatePureFunction = f => f();

const result = global.__evaluatePureFunction(() => {
  let x, y, z;

  function f() {
    const getNumber = global.__abstract ? global.__abstract("function", "(() => 1)") : () => 1;
    const b1 = global.__abstract ? global.__abstract("boolean", "true") : true;
    const b2 = global.__abstract ? global.__abstract("boolean", "!false") : true;
    const b3 = global.__abstract ? global.__abstract("boolean", "!!true") : true;

    x = getNumber();                        // Modify binding
    if (!b1) throw new Error("abrupt");     // Compose JoinedNormalAndAbruptCompletions
    y = getNumber();                        // Modify binding
    if (!b2) throw new Error("abrupt");     // Compose JoinedNormalAndAbruptCompletions
    z = getNumber();                        // Modify binding
    if (!b3) throw new Error("abrupt");     // Compose JoinedNormalAndAbruptCompletions

    if (global.__fatal) global.__fatal();

    return x + y + z;
  }

  f();

  return x + y + z;
});

global.inspect = () => result;
```

What is happening is that we modify three bindings in `f` before we throw a `FatalError`. `x`, `y`, and `z`. We also have three `JoinedNormalAndAbruptCompletions` since we’re using abstract booleans and throwing if the boolean is false. Our realm when we throw the `FatalError` ends up looking like:

```
Realm {
  savedCompletion: JoinedNormalAndAbruptCompletions {
    savedEffects: { modifiedBindings: { z } },
    composedWith: JoinedNormalAndAbruptCompletions {
      savedEffects: { modifiedBindings: { y } },
      composedWith: JoinedNormalAndAbruptCompletions {
        savedEffects: { modifiedBindings: { x } },
      }
    }
  }
}
```

When we throw the `FatalError` we want to restore all our bindings to a state before we started the `evaluateForEffects()` call so that we can leave a residual call in pure scope. However, the way the code is currently written we _don’t look into `savedCompletion.composedWith`_ even though there may be more bindings there. Instead we only look at `savedCompletion` so we only restore the `z` binding.

My previous fix modified `stopEffectCaptureAndUndoEffects()` to chase `composedWith`, but that broke the contract of `stopEffectCaptureAndUndoEffects()` as @hermanventer mentioned. So instead I updated the `finally` block in `evaluateForEffects()` which cleans up modified bindings of a `savedCompletion` (in case we throw in the middle of evaluation) to more explicitly clean up the bindings of the saved completion and all composed completions. This preserves and fixes our effect cleanup behavior without changing the meaning of `stopEffectCaptureAndUndoEffects()`.

@hermanventer I know you mentioned you wanted to look at this issue, sorry if I’m stepping on your toes. Since I was blocked I thought a bit more about this issue and figured I was directionally correct, but the specific fix in #2459 was wrong. Also sorry for the PR churn. Thought I wasn’t going to come back to this issue.