### PR TITLE
Don't complain about infeasible paths unless there has been a k-limit

### DIFF
--- a/src/realm.js
+++ b/src/realm.js
@@ -338,6 +338,7 @@ export class Realm {
 
   abstractValueImpliesMax: number;
   abstractValueImpliesCounter: number;
+  impliesCounterOverflowed: boolean;
   inSimplificationPath: boolean;
 
   modifiedBindings: void | Bindings;

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -222,6 +222,7 @@ export default class AbstractValue extends Value {
     // if abstractValueImpliesMax is 0, then the counter is disabled
     if (abstractValueImpliesMax !== 0 && realm.abstractValueImpliesCounter++ > abstractValueImpliesMax) {
       realm.abstractValueImpliesCounter = 0;
+      realm.impliesCounterOverflowed = true;
       let diagnostic = new CompilerDiagnostic(
         `the implies counter has exceeded the maximum value when trying to simplify abstract values`,
         realm.currentLocation,


### PR DESCRIPTION
Release note: Make simplification more robust when complexity limits are reached

Fixes #2361 

Any particular simplification can fail because Prepack has run out of a global limit for allowable implications (set by the abstractValueImpliesMax option). If Prepack then recovers from from the exception and carries on, it may later do the same simplification and succeed. If this happens in a context where the now known result is not expected, there will be an invariant failure, as for example in the issue above.

The invariant useful for finding bugs when reasoning is precise, so I'm keeping it, but only if no limit was exceeded.