### PR TITLE
Reduce possibleInfiniteLoopIterations constant to 6

### DIFF
--- a/src/evaluators/ForStatement.js
+++ b/src/evaluators/ForStatement.js
@@ -169,14 +169,14 @@ function ForBodyEvaluation(
       // ii. Perform ? GetValue(incRef).
       Environment.GetValue(realm, incRef);
     } else if (realm.useAbstractInterpretation) {
-      // If we have no increment and we've hit 12 iterations of trying to evaluate
+      // If we have no increment and we've hit 6 iterations of trying to evaluate
       // this loop body, then see if we have a break, return or throw completion in a
       // guarded condition and fail if it does. We already have logic to guard
       // against loops that are actually infinite. However, because there may be so
       // many forked execution paths, and they're non linear, then it might
       // computationally lead to a something that seems like an infinite loop.
       possibleInfiniteLoopIterations++;
-      if (possibleInfiniteLoopIterations > 12) {
+      if (possibleInfiniteLoopIterations > 6) {
         failIfContainsBreakOrReturnOrThrowCompletion(realm.savedCompletion);
       }
     }


### PR DESCRIPTION
Release notes: reduces loop iteration counter to 6 before bailing out

With our internal bundle, it takes far too long to hit the current limit of 12 with production code (gave up after 2 hours). This now takes a few minutes.

https://en.wikipedia.org/wiki/The_Magical_Number_Seven,_Plus_or_Minus_Two