### PR TITLE
Better simplify [strict] equals when types differ.

### DIFF
--- a/test/serializer/optimizations/simplifyEqNull.js
+++ b/test/serializer/optimizations/simplifyEqNull.js
@@ -1,0 +1,17 @@
+// does not contain: ==
+function abstract(t, n) {
+  if (global.__abstract) return __abstract(t, n);
+  return eval(n);
+}
+var n = abstract("number", "1");
+var numberIsNull = n == null;
+var b = abstract("boolean", "false");
+var booleanIsNull = b == null;
+var s = abstract("string", "'foo'");
+var stringIsNull = s == null;
+var o = abstract("object", "({})");
+var objectIsNull = o == null;
+
+inspect = function() {
+  return [numberIsNull, booleanIsNull, stringIsNull, objectIsNull].join(" ");
+};

--- a/test/serializer/optimizations/simplifyEqUndefined.js
+++ b/test/serializer/optimizations/simplifyEqUndefined.js
@@ -1,0 +1,17 @@
+// does not contain: ==
+function abstract(t, n) {
+  if (global.__abstract) return __abstract(t, n);
+  return eval(n);
+}
+var n = abstract("number", "1");
+var numberIsUndefined = n == undefined;
+var b = abstract("boolean", "false");
+var booleanIsUndefined = b == undefined;
+var s = abstract("string", "'foo'");
+var stringIsUndefined = s == undefined;
+var o = abstract("object", "({})");
+var stringIsUndefined = o == undefined;
+
+inspect = function() {
+  return [numberIsUndefined, booleanIsUndefined, stringIsUndefined, stringIsUndefined].join(" ");
+};

--- a/test/serializer/optimizations/simplifyStrictEq.js
+++ b/test/serializer/optimizations/simplifyStrictEq.js
@@ -1,0 +1,19 @@
+// does not contain: ===
+function abstract(t, n) {
+  if (global.__abstract) return __abstract(t, n);
+  return eval(n);
+}
+var n = abstract("number", "1");
+var numberIsNull = n === null;
+var b = abstract("boolean", "false");
+var booleanIsNull = n === null;
+var s = abstract("string", "'foo'");
+var stringIsNull = n === null;
+var o = abstract("object", "({})");
+var objectIsNull = o === null;
+var stringIsNumber = n === s;
+var stringIsUndefined = s === undefined;
+
+inspect = function() {
+  return [numberIsNull, booleanIsNull, stringIsNull, objectIsNull, stringIsNumber, stringIsUndefined].join(" ");
+};


### PR DESCRIPTION
Release note: Simplify equality expressions where types are known

Fixes: #2317

If the types or the arguments are known we can simplify equality expressions involving different typed arguments to false in some cases.