### PR TITLE
Work on modules: deleting dead code, adding helper to disable lazy module initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test-all-coverage": "./node_modules/.bin/istanbul --stack_size=10000 --max_old_space_size=16384 cover ./lib/multi-runner.js --dir coverage.most && ./node_modules/.bin/istanbul --stack_size=10000 --max_old_space_size=16384 cover ./lib/test262-runner.js --timeout 50 --singleThreaded && ./node_modules/.bin/remap-istanbul -i coverage/coverage.json -i coverage.most/coverage.json -o coverage-sourcemapped -t html",
     "repl": "node lib/repl-cli.js",
     "precheck": "yarn prepack-cli --check",
-    "prepack-cli": "node --stack_size=10000 --stack_trace_limit=200 --max_old_space_size=16384 lib/prepack-cli.js --accelerateUnsupportedRequires --compatibility jsc-600-1-4-17 --mathRandomSeed 0",
+    "prepack-cli": "node --stack_size=10000 --stack_trace_limit=200 --max_old_space_size=16384 lib/prepack-cli.js --compatibility jsc-600-1-4-17 --mathRandomSeed 0",
     "validate": "yarn install --frozen-lockfile && yarn build && yarn build-scripts && yarn lint && yarn depcheck && yarn flow && yarn test",
     "prepublishOnly": "yarn build",
     "depcheck": "babel-node scripts/detect_bad_deps.js",

--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -68,7 +68,6 @@ function runTest(name: string, code: string): boolean {
     let options = {
       internalDebug: true,
       compatibility: "jsc-600-1-4-17",
-      accelerateUnsupportedRequires: true,
       mathRandomSeed: "0",
       errorHandler,
       serialize: true,

--- a/src/options.js
+++ b/src/options.js
@@ -65,7 +65,6 @@ export type RealmOptions = {
 export type SerializerOptions = {
   lazyObjectsRuntime?: string,
   delayInitializations?: boolean,
-  accelerateUnsupportedRequires?: boolean,
   initializeMoreModules?: boolean,
   internalDebug?: boolean,
   debugScopes?: boolean,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -118,7 +118,6 @@ function run(
     logStatistics: false,
     logModules: false,
     delayInitializations: false,
-    accelerateUnsupportedRequires: true,
     internalDebug: false,
     debugScopes: false,
     serialize: false,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -22,7 +22,6 @@ export type PrepackOptions = {|
   compatibility?: Compatibility,
   debugNames?: boolean,
   delayInitializations?: boolean,
-  accelerateUnsupportedRequires?: boolean,
   inputSourceMapFilenames?: Array<string>,
   internalDebug?: boolean,
   debugScopes?: boolean,
@@ -121,7 +120,6 @@ export function getSerializerOptions({
   lazyObjectsRuntime,
   heapGraphFormat,
   delayInitializations = false,
-  accelerateUnsupportedRequires = true,
   internalDebug = false,
   debugScopes = false,
   debugIdentifiers,
@@ -134,7 +132,6 @@ export function getSerializerOptions({
 }: PrepackOptions): SerializerOptions {
   let result: SerializerOptions = {
     delayInitializations,
-    accelerateUnsupportedRequires,
     initializeMoreModules,
     internalDebug,
     debugScopes,

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -54,7 +54,7 @@ export function prepackSources(
   if (options.check) {
     realm.generator = new Generator(realm, "main", realm.pathConditions);
     let logger = new Logger(realm, !!options.internalDebug);
-    let modules = new Modules(realm, logger, !!options.logModules, !!options.accelerateUnsupportedRequires);
+    let modules = new Modules(realm, logger, !!options.logModules);
     let [result] = realm.$GlobalEnv.executeSources(sourceFileCollection.toArray());
     if (result instanceof AbruptCompletion) throw result;
     invariant(options.check);

--- a/src/realm.js
+++ b/src/realm.js
@@ -457,6 +457,8 @@ export class Realm {
   optimizedFunctions: Map<FunctionValue | AbstractValue, ArgModel | void>;
   arrayNestedOptimizedFunctionsEnabled: boolean;
 
+  eagerlyRequireModuleDependencies: void | boolean;
+
   // to force flow to type the annotations
   isCompatibleWith(compatibility: Compatibility): boolean {
     return compatibility === this.compatibility;

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -47,12 +47,7 @@ export class Serializer {
 
     this.realm = realm;
     this.logger = new Logger(this.realm, !!serializerOptions.internalDebug);
-    this.modules = new Modules(
-      this.realm,
-      this.logger,
-      !!serializerOptions.logModules,
-      !!serializerOptions.accelerateUnsupportedRequires
-    );
+    this.modules = new Modules(this.realm, this.logger, !!serializerOptions.logModules);
     this.functions = new Functions(this.realm, this.modules.moduleTracer);
     if (serializerOptions.trace) {
       let loggingTracer = new LoggingTracer(this.realm);

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -14,7 +14,6 @@ import { FatalError } from "../errors.js";
 import { Realm, Tracer } from "../realm.js";
 import type { Effects } from "../realm.js";
 import { Get } from "../methods/index.js";
-import { AbruptCompletion, SimpleNormalCompletion } from "../completions.js";
 import { Environment } from "../singletons.js";
 import {
   Value,
@@ -103,8 +102,6 @@ export class ModuleTracer extends Tracer {
     }
   }
 
-  // If we don't delay unsupported requires, we simply want to record here
-  // when a module gets initialized, and then we return.
   _callRequireAndRecord(moduleIdValue: number | string, performCall: () => Value): void | Value {
     if (this.requireStack.length === 0 || this.requireStack[this.requireStack.length - 1] !== moduleIdValue) {
       this.requireStack.push(moduleIdValue);
@@ -117,67 +114,6 @@ export class ModuleTracer extends Tracer {
       }
     }
     return undefined;
-  }
-
-  _callRequireAndAccelerate(
-    isTopLevelRequire: boolean,
-    moduleIdValue: number | string,
-    performCall: () => Value
-  ): void | Effects {
-    let realm = this.modules.realm;
-    let acceleratedModuleIds, effects;
-    do {
-      try {
-        effects = realm.evaluateForEffects(() => performCall(), this, "_callRequireAndAccelerate");
-      } catch (e) {
-        e;
-      }
-
-      acceleratedModuleIds = [];
-      if (isTopLevelRequire && effects !== undefined && !(effects.result instanceof AbruptCompletion)) {
-        // We gathered all effects, but didn't apply them yet.
-        // Let's check if there was any call to `require` in a
-        // evaluate-for-effects context. If so, try to initialize
-        // that module right now. Acceleration module initialization in this
-        // way might not actually be desirable, but it works around
-        // general prepack-limitations around joined abstract values involving
-        // conditionals. Long term, Prepack needs to implement a notion of refinement
-        // of conditional abstract values under the known path condition.
-        // Example:
-        //   if (*) require(1); else require(2);
-        //   let x = require(1).X;
-        // =>
-        //   require(1);
-        //   require(2);
-        //   if (*) require(1); else require(2);
-        //   let x = require(1).X;
-
-        for (let nestedModuleId of this.uninitializedModuleIdsRequiredInEvaluateForEffects) {
-          let nestedEffects = this.modules.tryInitializeModule(
-            nestedModuleId,
-            `accelerated initialization of conditional module ${nestedModuleId} as it's required in an evaluate-for-effects context by module ${moduleIdValue}`
-          );
-          if (
-            this.modules.accelerateUnsupportedRequires &&
-            nestedEffects !== undefined &&
-            nestedEffects.result instanceof Value &&
-            this.modules.isModuleInitialized(nestedModuleId)
-          ) {
-            acceleratedModuleIds.push(nestedModuleId);
-          }
-        }
-        this.uninitializedModuleIdsRequiredInEvaluateForEffects.clear();
-        // Keep restarting for as long as we find additional modules to accelerate.
-        if (acceleratedModuleIds.length > 0) {
-          console.log(
-            `restarting require(${moduleIdValue}) after accelerating conditional require calls for ${acceleratedModuleIds.join()}`
-          );
-          this.getStatistics().acceleratedModules += acceleratedModuleIds.length;
-        }
-      }
-    } while (acceleratedModuleIds.length > 0);
-
-    return effects;
   }
 
   _tryExtractDependencies(value: void | Value): void | Array<Value> {
@@ -208,95 +144,85 @@ export class ModuleTracer extends Tracer {
     newTarget: void | ObjectValue,
     performCall: () => Value
   ): void | Value {
-    if (
-      F === this.modules.getRequire() &&
-      !this.modules.disallowDelayingRequiresOverride &&
-      argumentsList.length === 1
-    ) {
+    let requireInfo = this.modules.getRequireInfo();
+    if (requireInfo !== undefined && F === requireInfo.value && argumentsList.length === 1) {
       // Here, we handle calls of the form
       //   require(42)
 
       let moduleId = argumentsList[0];
       let moduleIdValue;
       // Do some sanity checks and request require(...) calls with bad arguments
-      if (moduleId instanceof NumberValue || moduleId instanceof StringValue) {
-        moduleIdValue = moduleId.value;
-      } else {
-        return undefined;
+      if (moduleId instanceof NumberValue || moduleId instanceof StringValue) moduleIdValue = moduleId.value;
+      else return performCall();
+      // call require(...); this might cause calls to the define function
+      let res = this._callRequireAndRecord(moduleIdValue, performCall);
+      if (F.$Realm.eagerlyRequireModuleDependencies) {
+        // all dependencies of the required module should now be known
+        let dependencies = this.modules.moduleDependencies.get(moduleIdValue);
+        if (dependencies === undefined)
+          this.modules.logger.logError(moduleId, `Cannot resolve module dependencies for ${moduleIdValue.toString()}.`);
+        else
+          for (let dependency of dependencies)
+            if (dependency instanceof NumberValue || dependency instanceof StringValue)
+              this.modules.tryInitializeModule(dependency.value, `Eager initialization of module ${dependency.value}`);
       }
-      return this._callRequireAndRecord(moduleIdValue, performCall);
+      return res;
     } else if (F === this.modules.getDefine()) {
       // Here, we handle calls of the form
       //   __d(factoryFunction, moduleId, dependencyArray)
 
-      let factoryFunction = argumentsList[0];
-      if (factoryFunction instanceof FunctionValue) {
-        let dependencies = this._tryExtractDependencies(argumentsList[2]);
-        if (dependencies !== undefined) {
-          let previousDependencies = this.modules.factoryFunctionDependencies.get(factoryFunction);
-          if (previousDependencies) {
-            // Verify that they are the same
-            let logError = () => {
-              let moduleId = argumentsList[1];
-              let moduleString =
-                moduleId instanceof StringValue || moduleId instanceof NumberValue ? moduleId.value : "unknown";
-              this.modules.logger.logError(
-                factoryFunction,
-                `Called define on the same module ${moduleString} twice with different dependencies each time.`
-              );
-            };
-            if (previousDependencies.length !== dependencies.length) {
-              logError();
-            } else {
-              let previousDependenciesSet = new Set(previousDependencies);
-              dependencies.forEach(dependency => {
-                if (!previousDependenciesSet.has(dependency)) logError();
-              });
-            }
-          } else {
-            this.modules.factoryFunctionDependencies.set(factoryFunction, dependencies);
-          }
-        } else
-          this.modules.logger.logError(
-            argumentsList[2],
-            "Third argument to define function is present but not a concrete array."
-          );
-      } else
-        this.modules.logger.logError(factoryFunction, "First argument to define function is not a function value.");
       let moduleId = argumentsList[1];
-      if (moduleId instanceof NumberValue || moduleId instanceof StringValue)
-        this.modules.moduleIds.add(moduleId.value);
-      else
+      if (moduleId instanceof NumberValue || moduleId instanceof StringValue) {
+        let moduleIdValue = moduleId.value;
+        let factoryFunction = argumentsList[0];
+        if (factoryFunction instanceof FunctionValue) {
+          let dependencies = this._tryExtractDependencies(argumentsList[2]);
+          if (dependencies !== undefined) {
+            this.modules.moduleDependencies.set(moduleIdValue, dependencies);
+            this.modules.factoryFunctionDependencies.set(factoryFunction, dependencies);
+          } else
+            this.modules.logger.logError(
+              argumentsList[2],
+              "Third argument to define function is present but not a concrete array."
+            );
+        } else
+          this.modules.logger.logError(factoryFunction, "First argument to define function is not a function value.");
+
+        this.modules.moduleIds.add(moduleIdValue);
+      } else
         this.modules.logger.logError(moduleId, "Second argument to define function is not a number or string value.");
     }
     return undefined;
   }
 }
 
+export type RequireInfo = {
+  value: FunctionValue,
+  globalName: string,
+};
+
 export class Modules {
-  constructor(realm: Realm, logger: Logger, logModules: boolean, accelerateUnsupportedRequires: boolean) {
+  constructor(realm: Realm, logger: Logger, logModules: boolean) {
     this.realm = realm;
     this.logger = logger;
-    this._require = realm.intrinsics.undefined;
+    this._requireInfo = undefined;
     this._define = realm.intrinsics.undefined;
     this.factoryFunctionDependencies = new Map();
+    this.moduleDependencies = new Map();
     this.moduleIds = new Set();
     this.initializedModules = new Map();
     realm.tracers.push((this.moduleTracer = new ModuleTracer(this, logModules)));
-    this.accelerateUnsupportedRequires = accelerateUnsupportedRequires;
-    this.disallowDelayingRequiresOverride = false;
   }
 
   realm: Realm;
   logger: Logger;
-  _require: Value;
+  _requireInfo: void | RequireInfo;
   _define: Value;
   factoryFunctionDependencies: Map<FunctionValue, Array<Value>>;
+  moduleDependencies: Map<number | string, Array<Value>>;
   moduleIds: Set<number | string>;
   initializedModules: Map<number | string, Value>;
   active: boolean;
-  accelerateUnsupportedRequires: boolean;
-  disallowDelayingRequiresOverride: boolean;
   moduleTracer: ModuleTracer;
 
   getStatistics(): SerializerStatistics {
@@ -330,12 +256,16 @@ export class Modules {
     }
   }
 
-  getRequire(): Value {
-    if (!(this._require instanceof FunctionValue)) {
-      this._require = this._getGlobalProperty("require");
-      if (!(this._require instanceof FunctionValue)) this._require = this._getGlobalProperty("__r");
-    }
-    return this._require;
+  getRequireInfo(): void | RequireInfo {
+    if (this._requireInfo === undefined)
+      for (let globalName of ["require", "__r"]) {
+        let value = this._getGlobalProperty(globalName);
+        if (value instanceof FunctionValue) {
+          this._requireInfo = { value, globalName };
+          break;
+        }
+      }
+    return this._requireInfo;
   }
 
   getDefine(): Value {
@@ -457,7 +387,8 @@ export class Modules {
           if (!binding.initialized) return undefined;
           value = binding.value;
         }
-        if (value !== modules.getRequire()) return undefined;
+        let requireInfo = modules.getRequireInfo();
+        if (requireInfo === undefined || value !== requireInfo.value) return undefined;
         const newModuleId = getModuleId();
         invariant(newModuleId !== undefined);
         if (!updateModuleId(newModuleId)) return undefined;
@@ -479,11 +410,11 @@ export class Modules {
 
   tryInitializeModule(moduleId: number | string, message: string): void | Effects {
     let realm = this.realm;
-    let previousDisallowDelayingRequiresOverride = this.disallowDelayingRequiresOverride;
-    this.disallowDelayingRequiresOverride = true;
+    let requireInfo = this.getRequireInfo();
+    if (requireInfo === undefined) return undefined;
     return downgradeErrorsToWarnings(realm, () => {
       try {
-        let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
+        let node = t.callExpression(t.identifier(requireInfo.globalName), [t.valueToNode(moduleId)]);
 
         let effects = realm.evaluateNodeForEffectsInGlobalEnv(node);
         realm.applyEffects(effects, message);
@@ -491,8 +422,6 @@ export class Modules {
       } catch (err) {
         if (err instanceof FatalError) return undefined;
         else throw err;
-      } finally {
-        this.disallowDelayingRequiresOverride = previousDisallowDelayingRequiresOverride;
       }
     });
   }
@@ -510,47 +439,5 @@ export class Modules {
       this.initializedModules.set(moduleId, result);
     }
     if (count > 0) console.log(`=== speculatively initialized ${count} additional modules`);
-  }
-
-  isModuleInitialized(moduleId: number | string): void | Value {
-    let realm = this.realm;
-    let oldReadOnly = realm.setReadOnly(true);
-    let oldDisallowDelayingRequiresOverride = this.disallowDelayingRequiresOverride;
-    this.disallowDelayingRequiresOverride = true;
-    try {
-      let node = t.callExpression(t.identifier("require"), [t.valueToNode(moduleId)]);
-
-      let {
-        result,
-        generator,
-        modifiedBindings,
-        modifiedProperties,
-        createdObjects,
-      } = realm.evaluateNodeForEffectsInGlobalEnv(node);
-      // for lint unused
-      invariant(modifiedBindings);
-
-      if (result instanceof AbruptCompletion) return undefined;
-      if (result instanceof SimpleNormalCompletion) result = result.value;
-      invariant(result instanceof Value);
-
-      if (!generator.empty() || (result instanceof ObjectValue && createdObjects.has(result))) return undefined;
-      // Check for escaping property assignments, if none escape, we got an existing object
-      let escapes = false;
-      for (let [binding] of modifiedProperties) {
-        let object = binding.object;
-        invariant(object instanceof ObjectValue);
-        if (!createdObjects.has(object)) escapes = true;
-      }
-      if (escapes) return undefined;
-
-      return result;
-    } catch (err) {
-      if (err instanceof FatalError) return undefined;
-      throw err;
-    } finally {
-      realm.setReadOnly(oldReadOnly);
-      this.disallowDelayingRequiresOverride = oldDisallowDelayingRequiresOverride;
-    }
   }
 }

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -162,9 +162,12 @@ export class ModuleTracer extends Tracer {
         if (dependencies === undefined)
           this.modules.logger.logError(moduleId, `Cannot resolve module dependencies for ${moduleIdValue.toString()}.`);
         else
-          for (let dependency of dependencies)
+          for (let dependency of dependencies) {
+            // We'll try to initialize module dependency on a best-effort basis,
+            // ignoring any errors. Note that tryInitializeModule applies effects on success.
             if (dependency instanceof NumberValue || dependency instanceof StringValue)
               this.modules.tryInitializeModule(dependency.value, `Eager initialization of module ${dependency.value}`);
+          }
       }
       return res;
     } else if (F === this.modules.getDefine()) {
@@ -205,7 +208,6 @@ export class Modules {
   constructor(realm: Realm, logger: Logger, logModules: boolean) {
     this.realm = realm;
     this.logger = logger;
-    this._requireInfo = undefined;
     this._define = realm.intrinsics.undefined;
     this.factoryFunctionDependencies = new Map();
     this.moduleDependencies = new Map();

--- a/test/serializer/optimizations/eagerlyRequireModuleDependencies.js
+++ b/test/serializer/optimizations/eagerlyRequireModuleDependencies.js
@@ -1,10 +1,17 @@
 let c = 0;
 function __d(f, id, deps) {}
-function __r(id) { __d(function(){}, id, id === 0 ? [1] : []); c++; }
+function __r(id) {
+  __d(function() {}, id, id === 0 ? [1] : []);
+  c++;
+}
 if (global.__abstract) {
   // prepacking
-  global.__eagerlyRequireModuleDependencies(() => { __r(0); });
+  global.__eagerlyRequireModuleDependencies(() => {
+    __r(0);
+  });
 } else {
   c = 2;
 }
-inspect = function() { return c; }
+inspect = function() {
+  return c;
+};

--- a/test/serializer/optimizations/eagerlyRequireModuleDependencies.js
+++ b/test/serializer/optimizations/eagerlyRequireModuleDependencies.js
@@ -1,0 +1,10 @@
+let c = 0;
+function __d(f, id, deps) {}
+function __r(id) { __d(function(){}, id, id === 0 ? [1] : []); c++; }
+if (global.__abstract) {
+  // prepacking
+  global.__eagerlyRequireModuleDependencies(() => { __r(0); });
+} else {
+  c = 2;
+}
+inspect = function() { return c; }


### PR DESCRIPTION
Release notes: None

Remove dead _callRequireAndAccelerate function
Remove dead isModuleInitialized function
Remove dead --accelerateUnsupportedRequires option
Deleting dead code around checking uniqueness of previousDependencies
Add global.__eagerlyRequireModuleDependencies helper to effectively disable lazy module initialization in a code block (needed for InstantRender, to avoid having to deal with conditionally defined modules when prepacking nested callbacks)