### PR TITLE
Add ReactSharedInternals to React mocks

### DIFF
--- a/src/intrinsics/fb-www/react-mocks.js
+++ b/src/intrinsics/fb-www/react-mocks.js
@@ -371,6 +371,10 @@ let reactCode = `
     ReactPropTypes.checkPropTypes = shim;
     ReactPropTypes.PropTypes = ReactPropTypes;
 
+    var ReactSharedInternals = {
+      ReactCurrentOwner,
+    };
+
     return {
       Children: {
         forEach: forEachChildren,
@@ -386,6 +390,7 @@ let reactCode = `
       isValidElement,
       version: "16.2.0",
       PropTypes: ReactPropTypes,
+      __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: ReactSharedInternals,
     };
   }
 `;


### PR DESCRIPTION
In the React Native internal bundle I’m working on the React Native renderer needs access to `ReactSharedInternals`. Specifically it needs a reference to `ReactCurrentOwner`. This PR exposes that in our Prepack React mocks.

- `ReactSharedInternals`: https://github.com/facebook/react/blob/659a29cecf74301532354261369e9048aac6e20f/packages/react/src/ReactSharedInternals.js
- Use of `ReactSharedInternals` in `react-native-renderer`: https://github.com/facebook/react/blob/4b32f525e1233df1bd90cbd1df7da1cd329ca44a/packages/react-native-renderer/src/ReactNativeRenderer.js#L33