### PR TITLE
Simplifying / fixing OperationDescriptorData

### DIFF
--- a/flow-typed/npm/babel-types_vx.x.x.js
+++ b/flow-typed/npm/babel-types_vx.x.x.js
@@ -1175,7 +1175,7 @@ declare module "@babel/types" {
   declare function switchStatement(discriminant: BabelNodeExpression, cases: Array<BabelNodeSwitchCase>): BabelNodeSwitchStatement;
   declare function taggedTemplateExpression(tag: BabelNodeExpression, quasi: BabelNodeTemplateLiteral): BabelNodeTaggedTemplateExpression;
   declare function templateElement(value: any, tail?: boolean): BabelNodeTemplateElement;
-  declare function templateLiteral(quasis: Array<BabelNodeTemplateLiteral>, expressions: Array<BabelNodeExpression>): BabelNodeTemplateLiteral;
+  declare function templateLiteral(quasis: Array<BabelNodeTemplateElement>, expressions: Array<BabelNodeExpression>): BabelNodeTemplateLiteral;
   declare function thisExpression(): BabelNodeThisExpression;
   declare function thisTypeAnnotation(): BabelNodeThisTypeAnnotation;
   declare function throwStatement(argument: BabelNodeExpression): BabelNodeThrowStatement;

--- a/src/intrinsics/dom/global.js
+++ b/src/intrinsics/dom/global.js
@@ -58,12 +58,7 @@ export default function(realm: Realm): void {
       if (!realm.useAbstractInterpretation) throw new FatalError("TODO #1003: implement global.setTimeout");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
-      return generator.emitCallAndCaptureResult(
-        TypesDomain.topVal,
-        ValuesDomain.topVal,
-        () => generator.preludeGenerator.memoizeReference("global.setTimeout"),
-        args
-      );
+      return generator.emitCallAndCaptureResult(TypesDomain.topVal, ValuesDomain.topVal, "global.setTimeout", args);
     }),
     writable: true,
     enumerable: true,
@@ -75,7 +70,7 @@ export default function(realm: Realm): void {
       if (!realm.useAbstractInterpretation) throw new FatalError("TODO #1003: implement global.clearTimeout");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
-      generator.emitCall(() => generator.preludeGenerator.memoizeReference("global.clearTimeout"), args);
+      generator.emitCall("global.clearTimeout", args);
       return realm.intrinsics.undefined;
     }),
     writable: true,
@@ -91,12 +86,7 @@ export default function(realm: Realm): void {
         throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "callback arguments must be function");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
-      return generator.emitCallAndCaptureResult(
-        TypesDomain.topVal,
-        ValuesDomain.topVal,
-        () => generator.preludeGenerator.memoizeReference("global.setInterval"),
-        args
-      );
+      return generator.emitCallAndCaptureResult(TypesDomain.topVal, ValuesDomain.topVal, "global.setInterval", args);
     }),
     writable: true,
     enumerable: true,
@@ -108,7 +98,7 @@ export default function(realm: Realm): void {
       if (!realm.useAbstractInterpretation) throw new FatalError("TODO #1003: implement global.clearInterval");
       invariant(realm.generator !== undefined);
       let generator = realm.generator;
-      generator.emitCall(() => generator.preludeGenerator.memoizeReference("global.clearInterval"), args);
+      generator.emitCall("global.clearInterval", args);
       return realm.intrinsics.undefined;
     }),
     writable: true,

--- a/src/serializer/ResidualOperationSerializer.js
+++ b/src/serializer/ResidualOperationSerializer.js
@@ -870,7 +870,7 @@ export class ResidualOperationSerializer {
     valueNodes: Array<BabelNodeExpression>
   ): BabelNodeExpression {
     invariant(quasis !== undefined);
-    return t.templateLiteral(((quasis: any): Array<any>), valueNodes);
+    return t.templateLiteral(quasis, valueNodes);
   }
 
   _serializeReactRenderValueHelper(
@@ -913,17 +913,22 @@ export class ResidualOperationSerializer {
     return t.newExpression(constructorNode, argListNodes);
   }
 
-  _serializeEmitCall({ callTemplate }: OperationDescriptorData, nodes: Array<BabelNodeExpression>): BabelNodeStatement {
-    invariant(typeof callTemplate === "function");
-    return t.expressionStatement(t.callExpression(callTemplate(), [...nodes]));
+  _serializeEmitCall(
+    { callFunctionRef }: OperationDescriptorData,
+    nodes: Array<BabelNodeExpression>
+  ): BabelNodeStatement {
+    invariant(callFunctionRef !== undefined);
+    let callFunction = this.preludeGenerator.memoizeReference(callFunctionRef);
+    return t.expressionStatement(t.callExpression(callFunction, [...nodes]));
   }
 
   _serializeEmitCallAndCaptureResults(
-    { callTemplate }: OperationDescriptorData,
+    { callFunctionRef }: OperationDescriptorData,
     nodes: Array<BabelNodeExpression>
   ): BabelNodeExpression {
-    invariant(typeof callTemplate === "function");
-    return t.callExpression(callTemplate(), ((nodes: any): Array<BabelNodeExpression | BabelNodeSpreadElement>));
+    invariant(callFunctionRef !== undefined);
+    let callFunction = this.preludeGenerator.memoizeReference(callFunctionRef);
+    return t.callExpression(callFunction, ((nodes: any): Array<BabelNodeExpression | BabelNodeSpreadElement>));
   }
 
   _serializeObjectProtoGetOwnPropertyDescriptor(

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -50,6 +50,7 @@ import type {
   BabelUnaryOperator,
   BabelBinaryOperator,
   BabelLogicalOperator,
+  BabelNodeTemplateElement,
 } from "@babel/types";
 import { concretize, Join, Utils } from "../singletons.js";
 import type { SerializerOptions } from "../options.js";
@@ -144,7 +145,7 @@ export type OperationDescriptorData = {
   binding?: Binding, // used by GET_BINDING
   propertyBinding?: PropertyBinding, // used by LOGICAL_PROPERTY_ASSIGNMENT
   boundName?: BabelNodeIdentifier, // used by FOR_IN
-  callTemplate?: () => BabelNodeExpression, // used by EMIT_CALL and EMIT_CALL_AND_CAPTURE_RESULT
+  callFunctionRef?: string, // used by EMIT_CALL and EMIT_CALL_AND_CAPTURE_RESULT
   concreteComparisons?: Array<Value>, // used by FULL_INVARIANT_ABSTRACT
   desc?: Descriptor, // used by DEFINE_PROPERTY
   generator?: Generator, // used by DO_WHILE
@@ -160,7 +161,7 @@ export type OperationDescriptorData = {
   propertyGetter?: SupportedGraphQLGetters, // used by ABSTRACT_OBJECT_GET
   propRef?: ReferenceName | AbstractValue, // used by CALL_BAILOUT, and then only if string
   object?: ObjectValue, // used by DEFINE_PROPERTY
-  quasis?: Array<any>, // used by REACT_SSR_TEMPLATE_LITERAL
+  quasis?: Array<BabelNodeTemplateElement>, // used by REACT_SSR_TEMPLATE_LITERAL
   state?: "MISSING" | "PRESENT" | "DEFINED", // used by PROPERTY_INVARIANT
   thisArg?: BaseValue | Value, // used by CALL_BAILOUT
   template?: PreludeGenerator => ({}) => BabelNodeExpression, // used by ABSTRACT_FROM_TEMPLATE
@@ -755,10 +756,10 @@ export class Generator {
     });
   }
 
-  emitCall(callTemplate: () => BabelNodeExpression, args: Array<Value>): void {
+  emitCall(callFunctionRef: string, args: Array<Value>): void {
     this._addEntry({
       args,
-      operationDescriptor: createOperationDescriptor("EMIT_CALL", { callTemplate }),
+      operationDescriptor: createOperationDescriptor("EMIT_CALL", { callFunctionRef }),
     });
   }
 
@@ -900,7 +901,7 @@ export class Generator {
   emitCallAndCaptureResult(
     types: TypesDomain,
     values: ValuesDomain,
-    callTemplate: () => BabelNodeExpression,
+    callFunctionRef: string,
     args: Array<Value>,
     kind?: AbstractValueKind
   ): AbstractValue {
@@ -908,7 +909,7 @@ export class Generator {
       types,
       values,
       args,
-      createOperationDescriptor("EMIT_CALL_AND_CAPTURE_RESULT", { callTemplate }),
+      createOperationDescriptor("EMIT_CALL_AND_CAPTURE_RESULT", { callFunctionRef }),
       { kind }
     );
   }


### PR DESCRIPTION
Release notes: None

- Fixing type of `quasis` in Babel and as field
- Instead of storing callTemplate as a derived function, store instead the source string (working towards having a human-readable generator intermediate format)