### PR TITLE
Support constructors that return an object but also throw

### DIFF
--- a/src/evaluators/NewExpression.js
+++ b/src/evaluators/NewExpression.js
@@ -26,7 +26,7 @@ export default function(
   strictCode: boolean,
   env: LexicalEnvironment,
   realm: Realm
-): ObjectValue | AbstractObjectValue {
+): Value {
   // ECMA262 12.3.3.1 We just implement this method inline since it's only called here.
   // 1. Return ? EvaluateNew(NewExpression, empty).
 
@@ -78,7 +78,7 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
   argsList: Array<Value>,
   strictCode: boolean,
   realm: Realm
-): ObjectValue | AbstractObjectValue {
+): Value {
   let effects;
   try {
     effects = realm.evaluateForEffects(
@@ -118,7 +118,7 @@ function tryToEvaluateConstructOrLeaveAsAbstract(
   return completion;
 }
 
-function createConstruct(constructor: Value, argsList: Array<Value>, realm: Realm): ObjectValue {
+function createConstruct(constructor: Value, argsList: Array<Value>, realm: Realm): Value {
   // 7. If IsConstructor(constructor) is false, throw a TypeError exception.
   if (IsConstructor(realm, constructor) === false) {
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError);

--- a/src/evaluators/SuperCall.js
+++ b/src/evaluators/SuperCall.js
@@ -69,7 +69,7 @@ export default function SuperCall(
   // 6. ReturnIfAbrupt(argList).
 
   // 7. Let result be Construct(func, argList, newTarget).
-  let result = Construct(realm, func, argList, newTarget);
+  let result = Construct(realm, func, argList, newTarget).throwIfNotConcreteObject();
 
   // 8. ReturnIfAbrupt(result).
 

--- a/src/intrinsics/ecma262/Array.js
+++ b/src/intrinsics/ecma262/Array.js
@@ -20,6 +20,7 @@ import {
   ObjectValue,
   StringValue,
   UndefinedValue,
+  AbstractObjectValue,
 } from "../../values/index.js";
 import {
   Construct,
@@ -175,6 +176,7 @@ export default function(realm: Realm): NativeFunctionValue {
         invariant(C instanceof ObjectValue);
         // a. Let A be ? Construct(C, « len »).
         A = Construct(realm, C, [new NumberValue(realm, len)]);
+        invariant(A instanceof ObjectValue || A instanceof AbstractObjectValue);
       } else {
         // 5. Else,
         // a. Let A be ? ArrayCreate(len).
@@ -265,6 +267,7 @@ export default function(realm: Realm): NativeFunctionValue {
           invariant(C instanceof ObjectValue);
           // i. Let A be ? Construct(C).
           A = Construct(realm, C);
+          invariant(A instanceof ObjectValue || A instanceof AbstractObjectValue);
         } else {
           // b. Else,
           // i. Let A be ArrayCreate(0).
@@ -360,6 +363,7 @@ export default function(realm: Realm): NativeFunctionValue {
         invariant(C instanceof ObjectValue);
         // a. Let A be ? Construct(C, « len »).
         A = Construct(realm, C, [new NumberValue(realm, len)]);
+        invariant(A instanceof ObjectValue || A instanceof AbstractObjectValue);
       } else {
         // 10. Else,
         // a. Let A be ? ArrayCreate(len).

--- a/src/intrinsics/ecma262/ArrayBufferPrototype.js
+++ b/src/intrinsics/ecma262/ArrayBufferPrototype.js
@@ -93,7 +93,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     let ctor = SpeciesConstructor(realm, O, realm.intrinsics.ArrayBuffer);
 
     // 12. Let New be ? Construct(ctor, « newLen »).
-    let New = Construct(realm, ctor, [new NumberValue(realm, newLen)]);
+    let New = Construct(realm, ctor, [new NumberValue(realm, newLen)]).throwIfNotConcreteObject();
 
     // 13. If New does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
     if (!("$ArrayBufferData" in New)) {

--- a/src/intrinsics/ecma262/RegExpPrototype.js
+++ b/src/intrinsics/ecma262/RegExpPrototype.js
@@ -525,7 +525,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 10. Let splitter be ? Construct(C, « rx, newFlags »).
-    let splitter = Construct(realm, C, [rx, new StringValue(realm, newFlags)]);
+    let splitter = Construct(realm, C, [rx, new StringValue(realm, newFlags)]).throwIfNotConcreteObject();
 
     // 11. Let A be ArrayCreate(0).
     let A = Create.ArrayCreate(realm, 0);

--- a/src/methods/construct.js
+++ b/src/methods/construct.js
@@ -82,7 +82,7 @@ export function Construct(
   F: ObjectValue,
   _argumentsList?: Array<Value>,
   _newTarget?: ObjectValue
-): ObjectValue {
+): Value {
   let argumentsList = _argumentsList;
   let newTarget = _newTarget;
   // If newTarget was not passed, let newTarget be F.

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -231,7 +231,7 @@ export class CreateImplementation {
     }
 
     // 8. Return ? Construct(C, « length »).
-    return Construct(realm, C.throwIfNotConcreteObject(), [new NumberValue(realm, length)]);
+    return Construct(realm, C.throwIfNotConcreteObject(), [new NumberValue(realm, length)]).throwIfNotConcreteObject();
   }
 
   // ECMA262 7.4.7

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -161,7 +161,7 @@ function $BoundConstruct(
   F: BoundFunctionValue,
   argumentsList: Array<Value>,
   newTarget: ObjectValue
-): ObjectValue {
+): Value {
   // 1. Let target be the value of F's [[BoundTargetFunction]] internal slot.
   let target = F.$BoundTargetFunction;
 
@@ -189,7 +189,7 @@ function InternalConstruct(
   newTarget: ObjectValue,
   thisArgument: void | ObjectValue,
   tracerIndex: number
-): ObjectValue {
+): Value {
   // 1. Assert: F is an ECMAScript function object.
   invariant(F instanceof FunctionValue, "expected function");
 
@@ -261,21 +261,31 @@ function InternalConstruct(
 
   // 13. If result.[[Type]] is return, then
   if (result instanceof ReturnCompletion) {
-    // a. If Type(result.[[Value]]) is Object, return NormalCompletion(result.[[Value]]).
-    if (result.value.mightBeObject()) {
-      return result.value.throwIfNotConcreteObject();
-    }
+    return map(result.value);
 
-    // b. If kind is "base", return NormalCompletion(thisArgument).
-    if (kind === "base") {
-      invariant(thisArgument, "this wasn't initialized for some reason");
-      return thisArgument;
-    }
+    function map(value: Value) {
+      if (value === realm.intrinsics.__bottomValue) return value;
 
-    // c. If result.[[Value]] is not undefined, throw a TypeError exception.
-    if (!result.value.mightBeUndefined())
-      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "constructor must return Object");
-    result.value.throwIfNotConcrete();
+      if (value instanceof AbstractValue && value.kind === "conditional") {
+        const [condition, consequent, alternate] = value.args;
+        return AbstractValue.createFromConditionalOp(realm, condition, map(consequent), map(alternate));
+      }
+
+      // a. If Type(result.[[Value]]) is Object, return NormalCompletion(result.[[Value]]).
+      if (value.mightBeObject()) return value.throwIfNotConcreteObject();
+
+      // c. If result.[[Value]] is not undefined, throw a TypeError exception.
+      if (!value.mightBeUndefined()) {
+        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "constructor must return Object");
+      }
+
+      value.throwIfNotConcrete();
+
+      // 15. Return ? envRec.GetThisBinding().
+      let envRecThisBinding = envRec.GetThisBinding();
+      invariant(envRecThisBinding instanceof ObjectValue);
+      return envRecThisBinding;
+    }
   } else if (result instanceof AbruptCompletion) {
     // 14. Else, ReturnIfAbrupt(result).
     throw result;
@@ -856,12 +866,7 @@ export class FunctionImplementation {
   }
 
   // ECMA262 9.2.2
-  $Construct(
-    realm: Realm,
-    F: ECMAScriptFunctionValue,
-    argumentsList: Array<Value>,
-    newTarget: ObjectValue
-  ): ObjectValue {
+  $Construct(realm: Realm, F: ECMAScriptFunctionValue, argumentsList: Array<Value>, newTarget: ObjectValue): Value {
     return InternalConstruct(realm, F, argumentsList, newTarget, undefined, 0);
   }
 

--- a/src/methods/promise.js
+++ b/src/methods/promise.js
@@ -96,7 +96,7 @@ export function NewPromiseCapability(realm: Realm, C: Value): PromiseCapability 
   executor.$Capability = promiseCapability;
 
   // 6. Let promise be ? Construct(C, « executor »).
-  let promise = Construct(realm, C, [executor]);
+  let promise = Construct(realm, C, [executor]).throwIfNotConcreteObject();
 
   // 7. If IsCallable(promiseCapability.[[Resolve]]) is false, throw a TypeError exception.
   if (IsCallable(realm, promiseCapability.resolve) === false) {

--- a/src/methods/proxy.js
+++ b/src/methods/proxy.js
@@ -81,7 +81,7 @@ export function ProxyConstruct(
     invariant(target.$Construct, "expected construct method");
 
     // b. Return ? Construct(target, argumentsList, newTarget).
-    return Construct(realm, target, argumentsList, newTarget);
+    return Construct(realm, target, argumentsList, newTarget).throwIfNotConcreteObject();
   }
 
   // 7. Let argArray be CreateArrayFromList(argumentsList).

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -332,7 +332,7 @@ export function AllocateTypedArrayBuffer(realm: Realm, O: ObjectValue, length: n
 // ECMA262 22.2.4.6
 export function TypedArrayCreate(realm: Realm, constructor: ObjectValue, argumentList: Array<Value>): ObjectValue {
   // 1. Let newTypedArray be ? Construct(constructor, argumentList).
-  let newTypedArray = Construct(realm, constructor, argumentList);
+  let newTypedArray = Construct(realm, constructor, argumentList).throwIfNotConcreteObject();
 
   // 2. Perform ? ValidateTypedArray(newTypedArray).
   ValidateTypedArray(realm, newTypedArray);

--- a/src/realm.js
+++ b/src/realm.js
@@ -1615,7 +1615,7 @@ export class Realm {
   // Return value indicates whether the caller should try to recover from the error or not.
   handleError(diagnostic: CompilerDiagnostic): ErrorHandlerResult {
     if (!diagnostic.callStack && this.contextStack.length > 0) {
-      let error = this.evaluateWithoutEffects(() => Construct(this, this.intrinsics.Error));
+      let error = this.evaluateWithoutEffects(() => Construct(this, this.intrinsics.Error).throwIfNotConcreteObject());
       let stack = error._SafeGetDataPropertyValue("stack");
       if (stack instanceof StringValue) diagnostic.callStack = stack.value;
     }

--- a/src/types.js
+++ b/src/types.js
@@ -520,12 +520,7 @@ export type FunctionType = {
   $Call(realm: Realm, F: ECMAScriptFunctionValue, thisArgument: Value, argsList: Array<Value>): Value,
 
   // ECMA262 9.2.2
-  $Construct(
-    realm: Realm,
-    F: ECMAScriptFunctionValue,
-    argumentsList: Array<Value>,
-    newTarget: ObjectValue
-  ): ObjectValue,
+  $Construct(realm: Realm, F: ECMAScriptFunctionValue, argumentsList: Array<Value>, newTarget: ObjectValue): Value,
 
   // ECMA262 9.2.3
   FunctionAllocate(

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -57,6 +57,7 @@ export default function(
       } else {
         error = Construct(realm, realm.intrinsics.SyntaxError, [new StringValue(realm, e.message)]);
       }
+      error = error.throwIfNotConcreteObject();
       // These constructors are currently guaranteed to produce an object with
       // built-in error data. Append location information about the syntax error
       // and the source code to it so that we can use it to print nicer errors.

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -188,7 +188,7 @@ export default class ObjectValue extends ConcreteValue {
 
   // function
   $Call: void | ((thisArgument: Value, argumentsList: Array<Value>) => Value);
-  $Construct: void | ((argumentsList: Array<Value>, newTarget: ObjectValue) => ObjectValue);
+  $Construct: void | ((argumentsList: Array<Value>, newTarget: ObjectValue) => Value);
 
   // promise
   $PromiseState: void | "pending" | "fulfilled" | "rejected";

--- a/test/serializer/abstract/ThrowInConstructor.js
+++ b/test/serializer/abstract/ThrowInConstructor.js
@@ -1,0 +1,9 @@
+function F() {
+  const b = global.__abstract ? global.__abstract("boolean", "false") : false;
+  if (b) throw new Error("abrupt");
+  return { p: 42 };
+}
+
+const result = new F();
+
+global.inspect = () => JSON.stringify(result);


### PR DESCRIPTION
The following example currently fails with a `FatalError`.

```js
function F() {
  const b = global.__abstract ? global.__abstract("boolean", "false") : false;
  if (b) throw new Error("abrupt");
  return { p: 42 };
}

const result = new F();

global.inspect = () => JSON.stringify(result);
```

This is where the `FatalError` is thrown:

https://github.com/facebook/prepack/blob/f59798b19678b52fe11ae77def2dfe551e374c1e/src/methods/function.js#L264-L267

The majority of this PR is refactoring the type of construction functions to return a `Value` (which includes `AbstractValue`) instead of a concrete `ObjectValue`. I updated call sites to include a `throwIfNotConcreteObject()` instead of handling abstract values in many cases.

Would it be useful to add some general `Value.prototype.map` utility function? Which would provide `ConcreteValue`s to a mapper function and abstract over conditional values, `__bottomValue`, and more.

## Motivation

[Babel return an object from constructors for classes that call `super()`](https://babeljs.io/repl#?babili=false&browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=MYGwhgzhAEAa0G8C-AoFpIwJrQKYA8AXXAOwBMZ4EVppgB7EiQgJwFdhD6WAKASkQ1a0CGwAOuXnwDcQ2gEsAZtB4AjAYQAWLegHdoJXPoCiLHbwDkYVezGELMoalRA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=true&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=es2015%2Creact%2Cstage-1%2Cstage-2&prettier=false&targets=&version=6.26.0&envVersion=) to follow the spec. This means we hit an invariant on all React class components which might throw. Which happens to be quite a few given the prevalent use of `nullthrows()` or `invariant()` in Facebook codebases.