### PR TITLE
Dumping an intermediate representation

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -47,6 +47,7 @@ let execSpec;
 let JSONTokenizer = require("../lib/utils/JSONTokenizer.js").default;
 let { Linter } = require("eslint");
 let lintConfig = require("./lint-config");
+let TextPrinter = require("../lib/utils/TextPrinter.js").TextPrinter;
 
 function transformWithBabel(code, plugins, presets) {
   return babel.transform(code, {
@@ -432,6 +433,7 @@ function runTest(name, code, options: PrepackOptions, args) {
     return Promise.resolve(false);
   } else {
     let codeIterations = [];
+    let irIterations = [];
     let markersToFind = [];
     for (let [positive, marker] of [[true, "// does contain:"], [false, "// does not contain:"]]) {
       for (let i = code.indexOf(marker); i >= 0; i = code.indexOf(marker, i + 1)) {
@@ -510,6 +512,18 @@ function runTest(name, code, options: PrepackOptions, args) {
                 options.errorHandler = getErrorHandlerWithWarningCapture(diagnosticOutput, args.verbose);
             }
 
+            let ir = "";
+            if (args.ir)
+              options.onExecute = realm => {
+                let generator = realm.generator;
+                if (generator !== undefined) {
+                  let textPrinter = new TextPrinter(line => {
+                    ir += line + "\n";
+                  });
+                  textPrinter.printGenerator(generator);
+                }
+              };
+
             let serialized = prepackSources([{ filePath: name, fileContents: code, sourceMapContents: "" }], options);
             if (serialized.statistics && serialized.statistics.delayedValues > 0) anyDelayedValues = true;
             if (!serialized) {
@@ -586,7 +600,11 @@ function runTest(name, code, options: PrepackOptions, args) {
             if (!execSpec && options.lazyObjectsRuntime !== undefined) {
               codeToRun = augmentCodeWithLazyObjectSupport(codeToRun, args.lazyObjectsRuntime);
             }
-            if (args.verbose) console.log(codeToRun);
+            if (args.verbose) {
+              if (args.ir) console.log(`=== ir\n${ir}\n`);
+              console.log(`=== generated code\n${codeToRun}\n`);
+            }
+            irIterations.push(unescapeUniqueSuffix(ir, options.uniqueSuffix));
             codeIterations.push(unescapeUniqueSuffix(codeToRun, options.uniqueSuffix));
             if (args.es5) {
               codeToRun = transformWithBabel(
@@ -663,6 +681,10 @@ function runTest(name, code, options: PrepackOptions, args) {
             console.error(chalk.underline("output of inspect() on original code"));
             console.error(expected);
             for (let ii = 0; ii < codeIterations.length; ii++) {
+              if (args.ir) {
+                console.error(chalk.underline(`ir in iteration ${ii}`));
+                console.error(irIterations[ii]);
+              }
               console.error(chalk.underline(`generated code in iteration ${ii}`));
               console.error(codeIterations[ii]);
             }
@@ -834,6 +856,7 @@ class ProgramArgs {
   fast: boolean;
   residual: boolean;
   cpuprofilePath: string;
+  ir: boolean;
   constructor(
     debugNames: boolean,
     debugScopes: boolean,
@@ -845,7 +868,8 @@ class ProgramArgs {
     noLazySupport: boolean,
     fast: boolean,
     residual: boolean,
-    cpuProfilePath: string
+    cpuProfilePath: string,
+    ir: boolean
   ) {
     this.debugNames = debugNames;
     this.debugScopes = debugScopes;
@@ -858,6 +882,7 @@ class ProgramArgs {
     this.fast = fast;
     this.residual = residual;
     this.cpuprofilePath = cpuProfilePath;
+    this.ir = ir;
   }
 }
 
@@ -892,7 +917,7 @@ function usage(): string {
   return (
     `Usage: ${process.argv[0]} ${process.argv[1]} ` +
     EOL +
-    `[--debugNames] [--debugScopes] [--es5] [--fast] [--noLazySupport] [--verbose] [--filter <string>] [--outOfProcessRuntime <path>] `
+    `[--debugNames] [--debugScopes] [--es5] [--fast] [--noLazySupport] [--verbose] [--ir] [--filter <string>] [--outOfProcessRuntime <path>] `
   );
 }
 
@@ -920,6 +945,7 @@ function argsParse(): ProgramArgs {
       // to run tests. If not a separate node context used.
       lazyObjectsRuntime: LAZY_OBJECTS_RUNTIME_NAME,
       noLazySupport: false,
+      ir: false,
       fast: false,
       residual: false,
       cpuprofilePath: "",
@@ -954,6 +980,9 @@ function argsParse(): ProgramArgs {
   if (typeof parsedArgs.noLazySupport !== "boolean") {
     throw new ArgsParseError("noLazySupport must be a boolean (either --noLazySupport or not)");
   }
+  if (typeof parsedArgs.ir !== "boolean") {
+    throw new ArgsParseError("ir must be a boolean (either --ir or not)");
+  }
   if (typeof parsedArgs.residual !== "boolean") {
     throw new ArgsParseError("residual must be a boolean (either --residual or not)");
   }
@@ -971,7 +1000,8 @@ function argsParse(): ProgramArgs {
     parsedArgs.noLazySupport,
     parsedArgs.fast,
     parsedArgs.residual,
-    parsedArgs.cpuprofilePath
+    parsedArgs.cpuprofilePath,
+    parsedArgs.ir
   );
   return programArgs;
 }

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -514,14 +514,10 @@ function runTest(name, code, options: PrepackOptions, args) {
 
             let ir = "";
             if (args.ir)
-              options.onExecute = realm => {
-                let generator = realm.generator;
-                if (generator !== undefined) {
-                  let textPrinter = new TextPrinter(line => {
-                    ir += line + "\n";
-                  });
-                  textPrinter.printGenerator(generator);
-                }
+              options.onExecute = (realm, optimizedFunctions) => {
+                new TextPrinter(line => {
+                  ir += line + "\n";
+                }).print(realm, optimizedFunctions);
               };
 
             let serialized = prepackSources([{ filePath: name, fileContents: code, sourceMapContents: "" }], options);

--- a/src/options.js
+++ b/src/options.js
@@ -77,8 +77,4 @@ export type SerializerOptions = {
   heapGraphFormat?: "DotLanguage" | "VISJS",
 };
 
-export type PartialEvaluatorOptions = {
-  sourceMaps?: boolean,
-};
-
 export const defaultOptions = {};

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -374,17 +374,13 @@ function run(
   );
   if (heapGraphFilePath !== undefined) resolvedOptions.heapGraphFormat = "DotLanguage";
   if (dumpIRFilePath !== undefined) {
-    resolvedOptions.onExecute = realm => {
-      let generator = realm.generator;
-      if (generator !== undefined) {
-        let text = "";
-        let textPrinter = new TextPrinter(line => {
-          text += line + "\n";
-        });
-        textPrinter.printGenerator(generator);
-        invariant(dumpIRFilePath !== undefined);
-        fs.writeFileSync(dumpIRFilePath, text);
-      }
+    resolvedOptions.onExecute = (realm, optimizedFunctions) => {
+      let text = "";
+      new TextPrinter(line => {
+        text += line + "\n";
+      }).print(realm, optimizedFunctions);
+      invariant(dumpIRFilePath !== undefined);
+      fs.writeFileSync(dumpIRFilePath, text);
     };
   }
   if (lazyObjectsRuntime !== undefined && (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)) {

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -21,6 +21,7 @@ import {
   InvariantModeValues,
 } from "./options.js";
 import { type SerializedResult } from "./serializer/types.js";
+import { TextPrinter } from "./utils/TextPrinter.js";
 import { prepackStdin, prepackFileSync } from "./prepack-node.js";
 import type { BabelNodeSourceLocation } from "@babel/types";
 import fs from "fs";
@@ -70,6 +71,7 @@ function run(
     --logStatistics          Log statistics to console
     --statsFile              The name of the output file where statistics will be written to.
     --heapGraphFilePath      The name of the output file where heap graph will be written to.
+    --dumpIRFilePath         The name of the output file where the intermediate representation will be written to.
     --inlineExpressions      When generating code, tells prepack to avoid naming expressions when they are only used once,
                              and instead inline them where they are used.
     --invariantLevel         0: no invariants (default); 1: checks for abstract values; 2: checks for accessed built-ins; 3: internal consistency
@@ -97,6 +99,7 @@ function run(
   let debugIdentifiers: void | Array<string>;
   let lazyObjectsRuntime: string;
   let heapGraphFilePath: void | string;
+  let dumpIRFilePath: void | string;
   let debugInFilePath: string;
   let debugOutFilePath: string;
   let reactOutput: ReactOutputTypes = "create-element";
@@ -235,6 +238,10 @@ function run(
           heapGraphFilePath = args.shift();
           // do not include this in reproArguments needed by --repro[OnFatalError/Unconditionally], as path is likely not portable between environments
           break;
+        case "dumpIRFilePath":
+          dumpIRFilePath = args.shift();
+          // do not include this in reproArguments needed by --repro[OnFatalError/Unconditionally], as path is likely not portable between environments
+          break;
         case "reactOutput":
           arg = args.shift();
           if (!ReactOutputValues.includes(arg)) {
@@ -311,6 +318,7 @@ function run(
             "--check [start[, number]]",
             "--lazyObjectsRuntime lazyObjectsRuntimeName",
             "--heapGraphFilePath heapGraphFilePath",
+            "--dumpIRFilePath dumpIRFilePath",
             "--reactOutput " + ReactOutputValues.join(" | "),
             "--repro reprofile.zip",
             "--cpuprofile name.cpuprofile",
@@ -365,6 +373,20 @@ function run(
     flags
   );
   if (heapGraphFilePath !== undefined) resolvedOptions.heapGraphFormat = "DotLanguage";
+  if (dumpIRFilePath !== undefined) {
+    resolvedOptions.onExecute = realm => {
+      let generator = realm.generator;
+      if (generator !== undefined) {
+        let text = "";
+        let textPrinter = new TextPrinter(line => {
+          text += line + "\n";
+        });
+        textPrinter.printGenerator(generator);
+        invariant(dumpIRFilePath !== undefined);
+        fs.writeFileSync(dumpIRFilePath, text);
+      }
+    };
+  }
   if (lazyObjectsRuntime !== undefined && (resolvedOptions.delayInitializations || resolvedOptions.inlineExpressions)) {
     console.error("lazy objects feature is incompatible with delayInitializations and inlineExpressions options");
     process.exit(1);

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -59,6 +59,7 @@ export type PrepackOptions = {|
   debuggerConfigArgs?: DebuggerConfigArguments,
   debugReproArgs?: DebugReproArguments,
   onParse?: BabelNodeFile => void,
+  onExecute?: Realm => void,
   arrayNestedOptimizedFunctionsEnabled?: boolean,
 |};
 

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -11,7 +11,9 @@
 
 import type { ErrorHandler } from "./errors.js";
 import type { SerializerOptions, RealmOptions, Compatibility, ReactOutputTypes, InvariantModeTypes } from "./options";
-import { Realm } from "./realm.js";
+import { type Realm } from "./realm.js";
+import { type Generator } from "./utils/generator.js";
+import { type FunctionValue } from "./values/index.js";
 import type { DebuggerConfigArguments, DebugReproArguments } from "./types";
 import type { BabelNodeFile } from "@babel/types";
 
@@ -59,7 +61,7 @@ export type PrepackOptions = {|
   debuggerConfigArgs?: DebuggerConfigArguments,
   debugReproArgs?: DebugReproArguments,
   onParse?: BabelNodeFile => void,
-  onExecute?: Realm => void,
+  onExecute?: (Realm, Map<FunctionValue, Generator>) => void,
   arrayNestedOptimizedFunctionsEnabled?: boolean,
 |};
 

--- a/src/prepack-standalone.js
+++ b/src/prepack-standalone.js
@@ -62,7 +62,7 @@ export function prepackSources(
     return { code: "", map: undefined };
   } else {
     let serializer = new Serializer(realm, getSerializerOptions(options));
-    let serialized = serializer.init(sourceFileCollection, options.sourceMaps, options.onParse);
+    let serialized = serializer.init(sourceFileCollection, options.sourceMaps, options.onParse, options.onExecute);
 
     //Turn off the debugger if there is one
     if (realm.debuggerInstance) {

--- a/src/serializer/LoggingTracer.js
+++ b/src/serializer/LoggingTracer.js
@@ -33,7 +33,7 @@ function describeValue(realm: Realm, v: Value): string {
   if (v instanceof NumberValue || v instanceof BooleanValue) return v.value.toString();
   if (v instanceof UndefinedValue) return "undefined";
   if (v instanceof NullValue) return "null";
-  if (v instanceof StringValue) return `"${v.value}"`; // TODO: proper escaping
+  if (v instanceof StringValue) return JSON.stringify(v.value);
   if (v instanceof FunctionValue) return To.ToStringPartial(realm, Get(realm, v, "name")) || "(anonymous function)";
   if (v instanceof ObjectValue) return "(some object)";
   if (v instanceof AbstractValue) return "(some abstract value)";

--- a/src/serializer/ResidualOperationSerializer.js
+++ b/src/serializer/ResidualOperationSerializer.js
@@ -739,15 +739,15 @@ export class ResidualOperationSerializer {
   }
 
   _serializeDefineProperty(
-    { object, desc }: OperationDescriptorData,
+    { object, descriptor }: OperationDescriptorData,
     [propName]: Array<BabelNodeExpression>,
     context?: SerializationContext
   ): BabelNodeStatement {
     let propString = ((propName: any): BabelNodeStringLiteral).value;
     invariant(object !== undefined);
-    invariant(desc !== undefined);
+    invariant(descriptor !== undefined);
     invariant(context !== undefined);
-    return context.emitDefinePropertyBody(object, propString, desc);
+    return context.emitDefinePropertyBody(object, propString, descriptor);
   }
 
   _serializeFBMocksMagicGlobalFunction(

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -55,7 +55,6 @@ export class Functions {
   }
 
   realm: Realm;
-  // maps back from FunctionValue to the expression string
   moduleTracer: ModuleTracer;
   writeEffects: WriteEffects;
   _noopFunction: void | ECMAScriptSourceFunctionValue;
@@ -176,7 +175,7 @@ export class Functions {
     }
   }
 
-  getDeclaringOptimizedFunction(functionValue: ECMAScriptSourceFunctionValue) {
+  getDeclaringOptimizedFunction(functionValue: ECMAScriptSourceFunctionValue): void | FunctionValue {
     for (let [optimizedFunctionValue, additionalEffects] of this.writeEffects) {
       // CreatedObjects is all objects created by this optimized function but not
       // nested optimized functions.

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -126,7 +126,8 @@ export class Serializer {
   init(
     sourceFileCollection: SourceFileCollection,
     sourceMaps?: boolean = false,
-    onParse?: BabelNodeFile => void
+    onParse?: BabelNodeFile => void,
+    onExecute?: Realm => void
   ): void | SerializedResult {
     let realmStatistics = this.realm.statistics;
     invariant(realmStatistics instanceof SerializerStatistics, "serialization requires SerializerStatistics");
@@ -150,6 +151,10 @@ export class Serializer {
       statistics.checkThatFunctionsAreIndependent.measure(() =>
         this.functions.checkThatFunctionsAreIndependent(environmentRecordIdAfterGlobalCode)
       );
+
+      statistics.dumpIR.measure(() => {
+        if (onExecute !== undefined) onExecute(this.realm);
+      });
 
       let reactStatistics;
       if (this.realm.react.enabled) {

--- a/src/serializer/statistics.js
+++ b/src/serializer/statistics.js
@@ -34,6 +34,7 @@ export class SerializerStatistics extends RealmStatistics {
     this.referenceCounts = new PerformanceTracker(getTime, getMemory);
     this.serializePass = new PerformanceTracker(getTime, getMemory);
     this.babelGenerate = new PerformanceTracker(getTime, getMemory);
+    this.dumpIR = new PerformanceTracker(getTime, getMemory);
   }
 
   resetBeforePass(): void {
@@ -100,6 +101,7 @@ export class SerializerStatistics extends RealmStatistics {
   referenceCounts: PerformanceTracker;
   serializePass: PerformanceTracker;
   babelGenerate: PerformanceTracker;
+  dumpIR: PerformanceTracker;
 
   log(): void {
     super.log();
@@ -136,7 +138,7 @@ export class SerializerStatistics extends RealmStatistics {
         this.optimizeReactComponentTreeRoots
       )} optimizing react component tree roots, ${format(
         this.checkThatFunctionsAreIndependent
-      )} evaluating functions to optimize`
+      )} evaluating functions to optimize, ${format(this.dumpIR)} dumping IR`
     );
     console.log(
       `${format(this.deepTraversal)} visiting residual heap, ${format(

--- a/src/utils/TextPrinter.js
+++ b/src/utils/TextPrinter.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* @flow */
+
+import type { Descriptor, PropertyBinding } from "../types.js";
+import { EnvironmentRecord, type Binding } from "../environment.js";
+import { PrimitiveValue, AbstractValue, ObjectValue, Value } from "../values/index.js";
+import invariant from "../invariant.js";
+import {
+  Printer,
+  Generator,
+  type OperationDescriptorType,
+  type CustomGeneratorEntryType,
+  type OperationDescriptorData,
+} from "./generator.js";
+
+export class TextPrinter implements Printer {
+  constructor(printLine: string => void) {
+    this._printLine = printLine;
+    this._indent = "";
+    this._abstractValueIds = new Map();
+  }
+
+  _printLine: string => void;
+  _indent: string;
+  _abstractValueIds: Map<AbstractValue, number>;
+
+  _nest(): void {
+    this._indent += " ";
+  }
+  _unnest(): void {
+    this._indent = this._indent.substring(0, this._indent.length - 1);
+  }
+
+  _print(text: string): void {
+    this._printLine(this._indent + text);
+  }
+
+  printGeneratorEntry(
+    declared: void | AbstractValue | ObjectValue,
+    type: OperationDescriptorType | CustomGeneratorEntryType,
+    args: Array<Value>,
+    data: OperationDescriptorData,
+    metadata: { isPure: boolean, mutatesOnly: void | Array<Value> }
+  ): void {
+    let text;
+    if (declared !== undefined) {
+      invariant(declared.intrinsicName !== undefined);
+      text = `${declared.intrinsicName} := `;
+    } else {
+      text = "";
+    }
+    text += type;
+
+    let dataTexts = [];
+    if (args.length > 0) dataTexts.push(`args ${this.describeValues(args)}`);
+    if (data.unaryOperator !== undefined) dataTexts.push(data.unaryOperator); // used by UNARY_EXPRESSION
+    if (data.binaryOperator !== undefined) dataTexts.push(data.binaryOperator); // used by BINARY_EXPRESSION
+    if (data.logicalOperator !== undefined) dataTexts.push(data.logicalOperator); // used by LOGICAL_EXPRESSION
+    if (data.incrementor !== undefined) dataTexts.push(data.incrementor); // used by UPDATE_INCREMENTOR
+    if (data.prefix !== undefined) dataTexts.push("prefix"); // used by UNARY_EXPRESSION
+    if (data.binding !== undefined) dataTexts.push(`binding ${this.describeBinding(data.binding)}`); // used by GET_BINDING
+    if (data.propertyBinding !== undefined)
+      dataTexts.push(`property binding ${this.describePropertyBinding(data.propertyBinding)}`); // used by LOGICAL_PROPERTY_ASSIGNMENT
+    if (data.object !== undefined) dataTexts.push(`object ${this.describeValue(data.object)}`); // used by DEFINE_PROPERTY
+    if (data.descriptor !== undefined) dataTexts.push(`desc ${this.describeDescriptor(data.descriptor)}`); // used by DEFINE_PROPERTY
+    if (data.value !== undefined) dataTexts.push(`value ${this.describeValue(data.value)}`); // used by DO_WHILE, CONDITIONAL_PROPERTY_ASSIGNMENT, LOGICAL_PROPERTY_ASSIGNMENT, LOCAL_ASSIGNMENT, CONDITIONAL_THROW, EMIT_PROPERTY_ASSIGNMENT
+    if (data.id !== undefined) dataTexts.push(`id ${data.id}`); // used by IDENTIFIER
+    if (data.boundName !== undefined) dataTexts.push(`bound name ${data.boundName.name}`); // used by FOR_IN
+    if (data.thisArg !== undefined) dataTexts.push(`this arg ${this.describeBaseValue(data.thisArg)}`); // used by CALL_BAILOUT
+    if (data.propRef !== undefined) dataTexts.push(`prop ref ${this.describeKey(data.propRef)}`); // used by CALL_BAILOUT, and then only if string
+    if (data.state !== undefined) dataTexts.push(`state ${data.state}`); // used by PROPERTY_INVARIANT
+    if (data.usesThis !== undefined) dataTexts.push(`usesThis`); // used by FOR_STATEMENT_FUNC
+    if (data.path !== undefined) dataTexts.push(`path ${this.describeValue(data.path)}`); // used by PROPERTY_ASSIGNMENT, CONDITIONAL_PROPERTY_ASSIGNMENT
+    // TODO:
+    // appendLastToInvariantOperationDescriptor?: OperationDescriptor, // used by INVARIANT
+    // callTemplate?: () => BabelNodeExpression, // used by EMIT_CALL and EMIT_CALL_AND_CAPTURE_RESULT
+    // concreteComparisons?: Array<Value>, // used by FULL_INVARIANT_ABSTRACT
+    // lh?: BabelNodeVariableDeclaration, // used by FOR_IN
+    // propertyGetter?: SupportedGraphQLGetters, // used by ABSTRACT_OBJECT_GET
+    // quasis?: Array<any>, // used by REACT_SSR_TEMPLATE_LITERAL
+    // template?: PreludeGenerator => ({}) => BabelNodeExpression, // used by ABSTRACT_FROM_TEMPLATE
+    // typeComparisons?: Set<typeof Value>, // used by FULL_INVARIANT_ABSTRACT
+    // violationConditionOperationDescriptor?: OperationDescriptor, // used by INVARIANT
+    if (dataTexts.length > 0) text += `(${dataTexts.join("; ")})`;
+
+    let metadataTexts = [];
+    if (metadata.isPure) metadataTexts.push("isPure");
+    if (metadata.mutatesOnly !== undefined && metadata.mutatesOnly.length > 0)
+      metadataTexts.push(`mutates only: ${this.describeValues(metadata.mutatesOnly)}`);
+    if (metadataTexts.length > 0) text += `[${metadataTexts.join("; ")}]`;
+
+    this._printLine(text);
+
+    switch (type) {
+      case "DO_WHILE":
+        let generator = data.generator;
+        invariant(generator !== undefined);
+        this.printGenerator(generator, "body");
+        break;
+      case "JOIN_GENERATORS":
+        let generators = data.generators;
+        invariant(generators !== undefined && generators.length === 2);
+        this.printGenerator(generators[0], "consequent");
+        this.printGenerator(generators[1], "alternate");
+        break;
+      default:
+        break;
+    }
+  }
+
+  printGenerator(generator: Generator, label?: string = "(entry point)"): void {
+    this._print(`${label}: ${generator.getName()}`);
+    this._nest();
+    if (generator.pathConditions.length > 0)
+      this._print(`path conditions: ${this.describeValues(generator.pathConditions)}`);
+    generator.print(this);
+    this._unnest();
+  }
+
+  describeValues<V: Value>(values: Array<V>): string {
+    return values.map(value => this.describeValue(value)).join(", ");
+  }
+
+  describeValue(value: Value): string {
+    if (value instanceof PrimitiveValue) return value.toDisplayString();
+    let text;
+    if (value instanceof ObjectValue) text = `object#${value.getHash()}`;
+    else {
+      invariant(value instanceof AbstractValue, value.constructor.name);
+      let id = this._abstractValueIds.get(value);
+      if (id === undefined) this._abstractValueIds.set(value, (id = this._abstractValueIds.size));
+      text = `abstract#${id}`;
+    }
+    if (value.intrinsicName) text += `[${value.intrinsicName}]`;
+    // TODO: For objects, print all properties
+    // TODO: For abstract values, "recurse" into arguments
+    return text;
+  }
+
+  describeDescriptor(desc: Descriptor): string {
+    let text = "";
+    if (desc.writable) text += "writable ";
+    if (desc.enumerable) text += "enumerable ";
+    if (desc.configurable) text += "configurable ";
+    if (desc.value !== undefined)
+      if (desc.value instanceof Value) text += `value ${this.describeValue(desc.value)}`;
+      else text += `value of internal slot`; // TODO
+    if (desc.get !== undefined) text += `get ${this.describeValue(desc.get)}`;
+    if (desc.set !== undefined) text += `set ${this.describeValue(desc.set)}`;
+
+    // TODO: joinCondition, descriptor1, descriptor2
+    return text;
+  }
+
+  describeBinding(binding: Binding): string {
+    let text = `${binding.name}: ${this.describeBaseValue(binding.environment)} `;
+    if (binding.isGlobal) text += "is global ";
+    if (binding.mightHaveBeenCaptured) text += "might have been captured ";
+    if (binding.initialized) text += "initialized ";
+    if (binding.mutable) text += "mutable ";
+    if (binding.deletable) text += "deletable ";
+    if (binding.strict) text += "strict ";
+    if (binding.hasLeaked) text += "has leaked ";
+    if (binding.value !== undefined) text += `value ${this.describeValue(binding.value)}`;
+    if (binding.phiNode !== undefined) text += `phi node ${this.describeValue(binding.phiNode)}`;
+    return text;
+  }
+
+  describeKey(key: void | string | Value): string {
+    if (key === undefined) return "(undefined)";
+    else if (typeof key === "string") return key;
+    else {
+      invariant(key instanceof Value);
+      return this.describeValue(key);
+    }
+  }
+
+  describePropertyBinding(propertyBinding: PropertyBinding): string {
+    let text = `${this.describeValue(propertyBinding.object)}.${this.describeKey(propertyBinding.key)}: `;
+    if (propertyBinding.internalSlot) text += "internal slot ";
+    if (propertyBinding.descriptor !== undefined)
+      text += `descriptor ${this.describeDescriptor(propertyBinding.descriptor)}`;
+    if (propertyBinding.pathNode !== undefined)
+      text += `path node ${this.describeDescriptor(propertyBinding.pathNode)}`;
+    return text;
+  }
+
+  describeBaseValue(value: void | EnvironmentRecord | Value): string {
+    if (value === undefined) return "(undefined)";
+    else if (value instanceof Value) return this.describeValue(value);
+    invariant(value instanceof EnvironmentRecord);
+    // TODO: Print all entries
+    return "environment record";
+  }
+}

--- a/src/utils/TextPrinter.js
+++ b/src/utils/TextPrinter.js
@@ -84,10 +84,10 @@ export class TextPrinter implements Printer {
         text += type;
 
         let dataTexts = [];
-        if (data.unaryOperator !== undefined) dataTexts.push(data.unaryOperator); // used by UNARY_EXPRESSION
-        if (data.binaryOperator !== undefined) dataTexts.push(data.binaryOperator); // used by BINARY_EXPRESSION
-        if (data.logicalOperator !== undefined) dataTexts.push(data.logicalOperator); // used by LOGICAL_EXPRESSION
-        if (data.incrementor !== undefined) dataTexts.push(data.incrementor); // used by UPDATE_INCREMENTOR
+        if (data.unaryOperator !== undefined) dataTexts.push(`unary ${data.unaryOperator}`); // used by UNARY_EXPRESSION
+        if (data.binaryOperator !== undefined) dataTexts.push(`binary ${data.binaryOperator}`); // used by BINARY_EXPRESSION
+        if (data.logicalOperator !== undefined) dataTexts.push(`logical ${data.logicalOperator}`); // used by LOGICAL_EXPRESSION
+        if (data.incrementor !== undefined) dataTexts.push(`incrementor ${data.incrementor}`); // used by UPDATE_INCREMENTOR
         if (data.prefix !== undefined) dataTexts.push("prefix"); // used by UNARY_EXPRESSION
         if (data.binding !== undefined) dataTexts.push(`binding ${this.describeBinding(data.binding)}`); // used by GET_BINDING
         if (data.propertyBinding !== undefined)
@@ -156,8 +156,9 @@ export class TextPrinter implements Printer {
 
   printAbstractValue(value: AbstractValue) {
     invariant(value.intrinsicName === undefined);
-    invariant(value.kind !== undefined);
-    let text = `${this.abstractValueName(value)} = ${value.kind}(${this.describeValues(value.args)})`;
+    const kind = value.kind;
+    invariant(kind !== undefined);
+    let text = `${this.abstractValueName(value)} = ${JSON.stringify(kind)}(${this.describeValues(value.args)})`;
     this._print(text);
   }
 

--- a/src/utils/TextPrinter.js
+++ b/src/utils/TextPrinter.js
@@ -73,20 +73,21 @@ export class TextPrinter implements Printer {
     if (data.descriptor !== undefined) dataTexts.push(`desc ${this.describeDescriptor(data.descriptor)}`); // used by DEFINE_PROPERTY
     if (data.value !== undefined) dataTexts.push(`value ${this.describeValue(data.value)}`); // used by DO_WHILE, CONDITIONAL_PROPERTY_ASSIGNMENT, LOGICAL_PROPERTY_ASSIGNMENT, LOCAL_ASSIGNMENT, CONDITIONAL_THROW, EMIT_PROPERTY_ASSIGNMENT
     if (data.id !== undefined) dataTexts.push(`id ${data.id}`); // used by IDENTIFIER
-    if (data.boundName !== undefined) dataTexts.push(`bound name ${data.boundName.name}`); // used by FOR_IN
     if (data.thisArg !== undefined) dataTexts.push(`this arg ${this.describeBaseValue(data.thisArg)}`); // used by CALL_BAILOUT
     if (data.propRef !== undefined) dataTexts.push(`prop ref ${this.describeKey(data.propRef)}`); // used by CALL_BAILOUT, and then only if string
     if (data.state !== undefined) dataTexts.push(`state ${data.state}`); // used by PROPERTY_INVARIANT
     if (data.usesThis !== undefined) dataTexts.push(`usesThis`); // used by FOR_STATEMENT_FUNC
     if (data.path !== undefined) dataTexts.push(`path ${this.describeValue(data.path)}`); // used by PROPERTY_ASSIGNMENT, CONDITIONAL_PROPERTY_ASSIGNMENT
+    if (data.callFunctionRef !== undefined) dataTexts.push(`call function ref ${data.callFunctionRef}`); // used by EMIT_CALL and EMIT_CALL_AND_CAPTURE_RESULT
+    if (data.templateSource !== undefined) dataTexts.push(`template source ${data.templateSource}`); // used by ABSTRACT_FROM_TEMPLATE
+
     // TODO:
     // appendLastToInvariantOperationDescriptor?: OperationDescriptor, // used by INVARIANT
-    // callTemplate?: () => BabelNodeExpression, // used by EMIT_CALL and EMIT_CALL_AND_CAPTURE_RESULT
     // concreteComparisons?: Array<Value>, // used by FULL_INVARIANT_ABSTRACT
+    // boundName?: BabelNodeIdentifier, // used by FOR_IN
     // lh?: BabelNodeVariableDeclaration, // used by FOR_IN
     // propertyGetter?: SupportedGraphQLGetters, // used by ABSTRACT_OBJECT_GET
-    // quasis?: Array<any>, // used by REACT_SSR_TEMPLATE_LITERAL
-    // template?: PreludeGenerator => ({}) => BabelNodeExpression, // used by ABSTRACT_FROM_TEMPLATE
+    // quasis?: Array<BabelNodeTemplateElement>, // used by REACT_SSR_TEMPLATE_LITERAL
     // typeComparisons?: Set<typeof Value>, // used by FULL_INVARIANT_ABSTRACT
     // violationConditionOperationDescriptor?: OperationDescriptor, // used by INVARIANT
     if (dataTexts.length > 0) text += `(${dataTexts.join("; ")})`;
@@ -161,6 +162,7 @@ export class TextPrinter implements Printer {
   }
 
   describeBinding(binding: Binding): string {
+    // TODO: Consider emitting just the binding identity here, and print actual bindings separately
     let text = `${binding.name}: ${this.describeBaseValue(binding.environment)} `;
     if (binding.isGlobal) text += "is global ";
     if (binding.mightHaveBeenCaptured) text += "might have been captured ";
@@ -184,6 +186,7 @@ export class TextPrinter implements Printer {
   }
 
   describePropertyBinding(propertyBinding: PropertyBinding): string {
+    // TODO: Consider emitting just the property binding identity here, and print actual property bindings separately
     let text = `${this.describeValue(propertyBinding.object)}.${this.describeKey(propertyBinding.key)}: `;
     if (propertyBinding.internalSlot) text += "internal slot ";
     if (propertyBinding.descriptor !== undefined)
@@ -197,6 +200,7 @@ export class TextPrinter implements Printer {
     if (value === undefined) return "(undefined)";
     else if (value instanceof Value) return this.describeValue(value);
     invariant(value instanceof EnvironmentRecord);
+    // TODO: Consider emitting just the environment identity here, and print actual environments separately
     // TODO: Print all entries
     return "environment record";
   }

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -545,13 +545,7 @@ class ReturnValueEntry extends GeneratorEntry {
   containingGenerator: Generator;
 
   print(printer: Printer): void {
-    printer.printGeneratorEntry(
-      undefined,
-      "RETURN",
-      [this.returnValue],
-      {},
-      { isPure: false, mutatesOnly: undefined }
-    );
+    printer.printGeneratorEntry(undefined, "RETURN", [this.returnValue], {}, { isPure: false, mutatesOnly: undefined });
   }
 
   toDisplayString(): string {

--- a/src/values/StringValue.js
+++ b/src/values/StringValue.js
@@ -42,7 +42,6 @@ export default class StringValue extends PrimitiveValue {
   }
 
   toDisplayString(): string {
-    // TODO: proper escaping
-    return `"${this.value}"`;
+    return JSON.stringify(this.value);
   }
 }


### PR DESCRIPTION
Release notes: None

This resolves #1944.

The functionality that Prepack provides can be seen as being done by two separate engines:
1) There's the "front-end", which does symbolic execution / abstract interpretation,
   computing "effects" / "generator trees" for the global code and optimized functions.
2) There's the "back-end", which takes this intermediate representation, computes what's
   reachable, and then turns it into a new executable program by performing transformations
   such as breaking cycles.

Before, Prepack developers had very few tools available to understand what goes on between the
front-end and back-end. Usually, they just look at the final output, imagine what the
intermediate representation might have been, or maybe use to debugger to poke around
memory locations, or to invoke helper functions to inspect live state that way, hoping the debugger doesn't crash along the way.

This PR (and other associated PRs such as #2490, #2491) try to improve that state by turning the intermediate representation into a first-class data structure that is printable into a human-readable textual form. This will help...
- in understanding what's going on
- enabling different back-ends by ensuring that there's a first-class intermediate representation
- enabling future transformations on a well-defined intermediate data structure, ideally breaking up what the current serializer implementation does
- new ways of testing, e.g. via snapshots of the intermediate representation, or
  (once there is a parser) feeding hand-written IR into the back-end

### Example 1
For example, for this program...
```js
let x = __abstract("number", "(x)");
if (x > 42) {
  let t = Date.now();
  let u = 2 + 3
  console.log(t + u);
} else {
  global.result = x;
}
```
... the IR would currently look like this:
```
(entry point): "main(#0)"
  * value#0 = ">"(@"(x)", 42)
  if value#0
    then: "evaluateNodeForEffects(#4)"
      path conditions value#0
      _$0 := ABSTRACT_FROM_TEMPLATE<template source @"global.Date.now()">[isPure]
      * value#1 = "+"(5, _$0)
      CONSOLE_LOG("log", value#1)
    else: "evaluateNodeForEffects(#11)"
      * value#2 = "!"(value#0)
      path conditions value#2
      GLOBAL_ASSIGNMENT(@"(x)", "result")
```
Notes:
- Indentation reflects structure of the generator tree
- Each line encodes some information. Some of the information is atemporal, e.g.
  - `* value#N = f(args)` // atemporal abstract value
- Some of the information is temporal, e.g.
  - `_$N := op-type<op-data>(args)[metadata]` // generator entry that defines a temporal value
    - `op-data` contains various essential data
    - `args` tends to be a projection of `data` capturing all values that must be visited, but it's not consistent
    - `metadata` is information that helps the visitor compute minimal reachability, but it's not semantically relevant.
  - `op-type<op-data>(args)[metadata]` // generator entry that does not define a temporal value
  - `if ... then ... else`.

### Example 2

```js
(function() {
    let obj = {};
    obj.p = obj;
    global.result = obj;
})();
```
=>
```
(entry point): "main(#0)"
  * object#14 = ObjectValue(properties [p], $Prototype @"Object.prototype")
  * object#14.p = PropertyBinding(descriptor PropertyDescriptor(writable, enumerable, configurable, value object#14))
  GLOBAL_ASSIGNMENT(object#14, "result")
```

### Example 3

Things get slightly ugly with functions.
```js
function f() { }
```
=>
```
(entry point): "main(#0)"
  * declEnv#1 = DeclarativeEnvironmentRecord()
  * globEnv#2 = GlobalEnvironmentRecord($DeclarativeRecord declEnv#1, $ObjectRecord declEnv#1, $VarNames [f], $GlobalThisValue global)
  * lexEnv#0 = LexicalEnvironment(destroyed, environment record globEnv#2)
  * func#13 = ECMAScriptSourceFunctionValue($ConstructorKind base, $ThisMode global, $FunctionKind normal, $FormalParameters 0, $Environment lexEnv#0, properties [arguments, length, caller, prototype, name], $Prototype @"Function.prototype")
  * func#13.arguments = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value undefined))
  * func#13.length = PropertyBinding(descriptor PropertyDescriptor(configurable, value 0))
  * func#13.caller = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value undefined))
  * object#14 = ObjectValue(properties [constructor], $Prototype @"Object.prototype")
  * object#14.constructor = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value func#13))
  * func#13.prototype = PropertyBinding(descriptor PropertyDescriptor(writable, value object#14))
  * func#13.name = PropertyBinding(descriptor PropertyDescriptor(configurable, value "f"))
  GLOBAL_ASSIGNMENT(func#13, "f")
```

### Example 4

Things get really ugly with optimized functions, but that's what it is right now:
```js
function f() { return 2 + 5; }
__optimize(f);
```
=>
```
(entry point): "main(#0)"
  * declEnv#1 = DeclarativeEnvironmentRecord()
  * globEnv#2 = GlobalEnvironmentRecord($DeclarativeRecord declEnv#1, $ObjectRecord declEnv#1, $VarNames [f], $GlobalThisValue global)
  * lexEnv#0 = LexicalEnvironment(destroyed, environment record globEnv#2)
  * func#13 = ECMAScriptSourceFunctionValue($ConstructorKind base, $ThisMode global, $FunctionKind normal, $FormalParameters 0, $Environment lexEnv#0, properties [arguments, length, caller, prototype, name], $Prototype @"Function.prototype")
  * func#13.arguments = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value undefined))
  * func#13.length = PropertyBinding(descriptor PropertyDescriptor(configurable, value 0))
  * func#13.caller = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value undefined))
  * object#15 = ObjectValue(properties [constructor], $Prototype @"Object.prototype")
  * object#15.constructor = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value func#13))
  * func#13.prototype = PropertyBinding(descriptor PropertyDescriptor(writable, value object#15))
  * func#13.name = PropertyBinding(descriptor PropertyDescriptor(configurable, value "f"))
  GLOBAL_ASSIGNMENT(func#13, "f")
=== optimized function func#13
  (entry point): "AdditionalFunctionEffects(#12)"
    RETURN(7)
  * object#16 = ArgumentsExotic(properties [length, callee], symbols [@"Symbol.iterator"], $Prototype @"Object.prototype")
  * object#16.length = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value 0))
  * declEnv#1 = DeclarativeEnvironmentRecord()
  * globEnv#2 = GlobalEnvironmentRecord($DeclarativeRecord declEnv#1, $ObjectRecord declEnv#1, $VarNames [f], $GlobalThisValue global)
  * lexEnv#0 = LexicalEnvironment(destroyed, environment record globEnv#2)
  * func#13 = ECMAScriptSourceFunctionValue($ConstructorKind base, $ThisMode global, $FunctionKind normal, $FormalParameters 0, $Environment lexEnv#0, properties [arguments, length, caller, prototype, name], $Prototype @"Function.prototype")
  * func#13.arguments = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value undefined))
  * func#13.length = PropertyBinding(descriptor PropertyDescriptor(configurable, value 0))
  * func#13.caller = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value undefined))
  * object#15 = ObjectValue(properties [constructor], $Prototype @"Object.prototype")
  * object#15.constructor = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value func#13))
  * func#13.prototype = PropertyBinding(descriptor PropertyDescriptor(writable, value object#15))
  * func#13.name = PropertyBinding(descriptor PropertyDescriptor(configurable, value "f"))
  * object#16.callee = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value func#13))
  * object#16.@"Symbol.iterator" = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value @"Array.prototype.values"))
  * object#16.$Prototype = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value @"Object.prototype"))
  * object#16.$Extensible = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value true))
  * object#16._isPartial = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#16._isLeaked = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#16._isSimple = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#16._simplicityIsTransitive = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#16._isFinal = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#17 = ObjectValue($Prototype null)
  * object#17.$Prototype = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value null))
  * object#17.$Extensible = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value true))
  * object#17._isPartial = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#17._isLeaked = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#17._isSimple = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#17._simplicityIsTransitive = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#17._isFinal = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#18 = ObjectValue(properties [next], $Prototype @"([][Symbol.iterator]().__proto__.__proto__)")
  * func#19 = NativeFunctionValue(properties [length, name], $Prototype @"Function.prototype")
  * func#19.length = PropertyBinding(descriptor PropertyDescriptor(configurable, value 0))
  * func#19.name = PropertyBinding(descriptor PropertyDescriptor(configurable, value "next"))
  * object#18.next = PropertyBinding(descriptor PropertyDescriptor(writable, configurable, value func#19))
  * object#18.$Prototype = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value @"([][Symbol.iterator]().__proto__.__proto__)"))
  * object#18.$Extensible = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value true))
  * object#18._isPartial = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#18._isLeaked = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#18._isSimple = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#18._simplicityIsTransitive = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#18._isFinal = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * object#18.$IteratedList = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(some array))
  * func#19.$Prototype = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value @"Function.prototype"))
  * func#19.$Extensible = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value true))
  * func#19._isPartial = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * func#19._isLeaked = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * func#19._isSimple = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * func#19._simplicityIsTransitive = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  * func#19._isFinal = PropertyBinding(internal slot, descriptor InternalSlotDescriptor(value false))
  modified property bindings: [object#16.$Prototype, object#16.$Extensible, object#16._isPartial, object#16._isLeaked, object#16._isSimple, object#16._simplicityIsTransitive, object#16._isFinal, object#17.$Prototype, object#17.$Extensible, object#17._isPartial, object#17._isLeaked, object#17._isSimple, object#17._simplicityIsTransitive, object#17._isFinal, object#16.length, object#16.@"Symbol.iterator", object#16.callee, object#18.$Prototype, object#18.$Extensible, object#18._isPartial, object#18._isLeaked, object#18._isSimple, object#18._simplicityIsTransitive, object#18._isFinal, object#18.$IteratedList, func#19.$Prototype, func#19.$Extensible, func#19._isPartial, func#19._isLeaked, func#19._isSimple, func#19._simplicityIsTransitive, func#19._isFinal, func#19.length, func#19.name, object#18.next]
  created objects: [object#16, object#17, object#18, func#19]
  result: SimpleNormalCompletion(value 7)
```

### Future work (not for this PR)

There are still a good number of things left to do. In particular:
- further simplify printing to make it more readable (and writable)
- further extend printed format to make it round-trippable
- some details of the current IR is really just an artefact of 2 years of hacking. It is in need of some additional
  rounds of refactorings and simplifications.
  - Particularly problematic / overly complicated are invariants INVARIANT, FULL_INVARIANT_ABSTRACT, FOR_IN, REACT_SSR_TEMPLATE_LITERAL
  - In `TemporalOperationEntry`, there's some duplication going on with `args` and `data`. Consider eliminating `args` and deriving this information when needed from `data`.
  - `OperationDescriptorData` could use some structure, or a (sub)type hierarchy.
  - There are already dedicated generator entry classes for some operations, and then there is `TemporalOperationEntry` with its `data` dumping ground for everything else. This is all a bit arbitrary and should be unified.
  - ...there's much more cruft.

In a way, this PR just provides yet another way of dumping values and generators. Some of the other existing ways should be consolidated or killed.

Added option --ir to test-runner to activate (and test) IR dumping.