### PR TITLE
Cache path implications

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -353,7 +353,6 @@ function runTest(name, code, options: PrepackOptions, args) {
   let compileJSXWithBabel = code.includes("// babel:jsx");
   let functionCloneCountMatch = code.match(/\/\/ serialized function clone count: (\d+)/);
   options = ((Object.assign({}, options, {
-    abstractValueImpliesMax: 2000,
     compatibility,
     debugNames: args.debugNames,
     debugScopes: args.debugScopes,

--- a/src/completions.js
+++ b/src/completions.js
@@ -12,6 +12,7 @@
 import type { BabelNodeSourceLocation } from "@babel/types";
 import invariant from "./invariant.js";
 import type { Effects } from "./realm.js";
+import { PathConditions } from "./types.js";
 import { AbstractValue, EmptyValue, Value } from "./values/index.js";
 
 export class Completion {
@@ -189,14 +190,14 @@ export class JoinedNormalAndAbruptCompletions extends NormalCompletion {
     this.joinCondition = joinCondition;
     this.consequent = consequent;
     this.alternate = alternate;
-    this.pathConditionsAtCreation = [].concat(joinCondition.$Realm.pathConditions);
+    this.pathConditionsAtCreation = joinCondition.$Realm.pathConditions;
   }
 
   joinCondition: AbstractValue;
   consequent: AbruptCompletion | NormalCompletion;
   alternate: AbruptCompletion | NormalCompletion;
   composedWith: void | JoinedNormalAndAbruptCompletions;
-  pathConditionsAtCreation: Array<AbstractValue>;
+  pathConditionsAtCreation: PathConditions;
   savedEffects: void | Effects;
 
   containsSelectedCompletion(selector: Completion => boolean): boolean {

--- a/src/initialize-singletons.js
+++ b/src/initialize-singletons.js
@@ -15,7 +15,7 @@ import { EnvironmentImplementation } from "./methods/environment.js";
 import { FunctionImplementation } from "./methods/function.js";
 import { LeakImplementation, MaterializeImplementation } from "./utils/leak.js";
 import { JoinImplementation } from "./methods/join.js";
-import { PathImplementation } from "./utils/paths.js";
+import { PathConditionsImplementation, PathImplementation } from "./utils/paths.js";
 import { PropertiesImplementation } from "./methods/properties.js";
 import { ToImplementation } from "./methods/to.js";
 import { WidenImplementation } from "./methods/widen.js";
@@ -31,6 +31,7 @@ export default function() {
   Singletons.setMaterialize(new MaterializeImplementation());
   Singletons.setJoin(new JoinImplementation());
   Singletons.setPath(new PathImplementation());
+  Singletons.setPathConditions(() => new PathConditionsImplementation());
   Singletons.setProperties((new PropertiesImplementation(): any));
   Singletons.setTo((new ToImplementation(): any));
   Singletons.setWiden((new WidenImplementation(): any));

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -1141,7 +1141,7 @@ export class FunctionImplementation {
     let savedCompletion = realm.savedCompletion;
     if (savedCompletion !== undefined) {
       realm.savedCompletion = undefined;
-      realm.pathConditions = [].concat(savedCompletion.pathConditionsAtCreation);
+      realm.pathConditions = savedCompletion.pathConditionsAtCreation;
       if (c === undefined) c = realm.intrinsics.empty;
       if (c instanceof Value) c = new SimpleNormalCompletion(c);
       if (savedCompletion instanceof JoinedNormalAndAbruptCompletions) {

--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -62,7 +62,7 @@ import {
   getSuggestedArrayLiteralLength,
   withDescriptorValue,
 } from "./utils.js";
-import { Environment, To } from "../singletons.js";
+import { createPathConditions, Environment, To } from "../singletons.js";
 import { isReactElement, isReactPropsObject, valueIsReactLibraryObject } from "../react/utils.js";
 import { ResidualReactElementVisitor } from "./ResidualReactElementVisitor.js";
 import { GeneratorDAG } from "./GeneratorDAG.js";
@@ -944,7 +944,7 @@ export class ResidualHeapVisitor {
     let feasibleT, feasibleF;
     let savedPath = this.realm.pathConditions;
     try {
-      this.realm.pathConditions = this.scope instanceof Generator ? this.scope.pathConditions : [];
+      this.realm.pathConditions = this.scope instanceof Generator ? this.scope.pathConditions : createPathConditions();
 
       let impliesT = Path.implies(condition);
       let impliesF = Path.impliesNot(condition);

--- a/src/singletons.js
+++ b/src/singletons.js
@@ -18,6 +18,7 @@ import type {
   JoinType,
   MaterializeType,
   PathType,
+  PathConditions,
   PropertiesType,
   ToType,
   UtilsType,
@@ -32,6 +33,7 @@ export let Leak: LeakType = (null: any);
 export let Materialize: MaterializeType = (null: any);
 export let Join: JoinType = (null: any);
 export let Path: PathType = (null: any);
+export let createPathConditions: () => PathConditions = (null: any);
 export let Properties: PropertiesType = (null: any);
 export let To: ToType = (null: any);
 export let Widen: WidenType = (null: any);
@@ -66,6 +68,10 @@ export function setJoin(singleton: JoinType): void {
 
 export function setPath(singleton: PathType): void {
   Path = singleton;
+}
+
+export function setPathConditions(f: () => PathConditions): void {
+  createPathConditions = f;
 }
 
 export function setProperties(singleton: PropertiesType): void {

--- a/src/types.js
+++ b/src/types.js
@@ -362,6 +362,28 @@ export type PathType = {
   pushInverseAndRefine(condition: Value): void,
 };
 
+export class PathConditions {
+  add(c: AbstractValue): void {}
+
+  implies(e: AbstractValue): boolean {
+    return false;
+  }
+
+  impliesNot(e: AbstractValue): boolean {
+    return false;
+  }
+
+  isEmpty(): boolean {
+    return false;
+  }
+
+  getLength(): number {
+    return 0;
+  }
+
+  refineBaseConditons(realm: Realm, depth?: number = 0): void {}
+}
+
 export type LeakType = {
   value(realm: Realm, value: Value, loc: ?BabelNodeSourceLocation): void,
 };

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -54,7 +54,7 @@ import type {
 } from "@babel/types";
 import { concretize, Join, Utils } from "../singletons.js";
 import type { SerializerOptions } from "../options.js";
-import type { ShapeInformationInterface } from "../types.js";
+import type { PathConditions, ShapeInformationInterface } from "../types.js";
 import { PreludeGenerator } from "./PreludeGenerator.js";
 import { PropertyDescriptor } from "../descriptors.js";
 
@@ -539,7 +539,7 @@ class BindingAssignmentEntry extends GeneratorEntry {
 }
 
 export class Generator {
-  constructor(realm: Realm, name: string, pathConditions: Array<AbstractValue>, effects?: Effects) {
+  constructor(realm: Realm, name: string, pathConditions: PathConditions, effects?: Effects) {
     invariant(realm.useAbstractInterpretation);
     let realmPreludeGenerator = realm.preludeGenerator;
     invariant(realmPreludeGenerator);
@@ -558,7 +558,7 @@ export class Generator {
   effectsToApply: void | Effects;
   id: number;
   _name: string;
-  pathConditions: Array<AbstractValue>;
+  pathConditions: PathConditions;
 
   toDisplayString(): string {
     return Utils.jsonToDisplayString(this, 2);

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -9,30 +9,120 @@
 
 /* @flow strict-local */
 
-import { AbstractValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
 import { InfeasiblePathError } from "../errors.js";
-import type { Realm } from "../realm.js";
 import invariant from "../invariant.js";
+import { Realm } from "../realm.js";
+import { PathConditions } from "../types.js";
+import { AbstractValue, ConcreteValue, NullValue, UndefinedValue, Value } from "../values/index.js";
+
+export class PathConditionsImplementation extends PathConditions {
+  constructor(baseConditions?: void | PathConditions) {
+    super();
+    this._assumedConditions = new Set();
+    invariant(baseConditions === undefined || baseConditions instanceof PathConditionsImplementation);
+    this._baseConditions = baseConditions;
+  }
+
+  _assumedConditions: Set<AbstractValue>;
+  _baseConditions: void | PathConditionsImplementation;
+  _impliedConditions: void | Set<AbstractValue>;
+  _impliedNegatives: void | Set<AbstractValue>;
+  _failedImplications: void | Set<AbstractValue>;
+  _failedNegativeImplications: void | Set<AbstractValue>;
+
+  add(c: AbstractValue): void {
+    this._assumedConditions.add(c);
+  }
+
+  implies(e: AbstractValue): boolean {
+    if (this._assumedConditions.has(e)) return true;
+    if (this._impliedConditions !== undefined && this._impliedConditions.has(e)) return true;
+    if (this._impliedNegatives !== undefined && this._impliedNegatives.has(e)) return false;
+    if (this._failedImplications !== undefined && this._failedImplications.has(e)) return false;
+    if (this._baseConditions !== undefined && this._baseConditions.implies(e)) return true;
+    for (let assumedCondition of this._assumedConditions) {
+      if (assumedCondition.implies(e)) {
+        if (this._impliedConditions === undefined) this._impliedConditions = new Set();
+        this._impliedConditions.add(e);
+        return true;
+      }
+    }
+    if (this._failedImplications === undefined) this._failedImplications = new Set();
+    this._failedImplications.add(e);
+    return false;
+  }
+
+  impliesNot(e: AbstractValue): boolean {
+    if (this._assumedConditions.has(e)) return false;
+    if (this._impliedConditions !== undefined && this._impliedConditions.has(e)) return false;
+    if (this._impliedNegatives !== undefined && this._impliedNegatives.has(e)) return true;
+    if (this._failedNegativeImplications !== undefined && this._failedNegativeImplications.has(e)) return false;
+    if (this._baseConditions !== undefined && this._baseConditions.impliesNot(e)) return true;
+    for (let assumedCondition of this._assumedConditions) {
+      invariant(assumedCondition !== undefined);
+      if (assumedCondition.impliesNot(e)) {
+        if (this._impliedNegatives === undefined) this._impliedNegatives = new Set();
+        this._impliedNegatives.add(e);
+        return true;
+      }
+    }
+    if (this._failedNegativeImplications === undefined) this._failedNegativeImplications = new Set();
+    this._failedNegativeImplications.add(e);
+    return false;
+  }
+
+  isEmpty(): boolean {
+    return this._assumedConditions.size === 0;
+  }
+
+  getLength(): number {
+    return this._assumedConditions.size;
+  }
+
+  refineBaseConditons(realm: Realm): void {
+    if (realm.abstractValueImpliesMax > 0) return;
+    let refine = (condition: AbstractValue) => {
+      let refinedCondition = realm.simplifyAndRefineAbstractCondition(condition);
+      if (refinedCondition !== condition) {
+        if (!refinedCondition.mightNotBeFalse()) throw new InfeasiblePathError();
+        if (refinedCondition instanceof AbstractValue) {
+          this.add(refinedCondition);
+          // These might have different answers now that we've add another path condition
+          this._failedImplications = undefined;
+          this._failedNegativeImplications = undefined;
+        }
+      }
+    };
+    if (this._baseConditions !== undefined) {
+      let savedBaseConditions = this._baseConditions;
+      try {
+        this._baseConditions = undefined;
+        for (let assumedCondition of savedBaseConditions._assumedConditions) {
+          if (assumedCondition.kind === "||") {
+            refine(assumedCondition);
+          }
+        }
+      } finally {
+        this._baseConditions = savedBaseConditions;
+      }
+      savedBaseConditions.refineBaseConditons(realm);
+    }
+  }
+}
 
 export class PathImplementation {
   implies(condition: Value): boolean {
     if (!condition.mightNotBeTrue()) return true; // any path implies true
-    let path = condition.$Realm.pathConditions;
-    for (let i = path.length - 1; i >= 0; i--) {
-      let pathCondition = path[i];
-      if (pathCondition.implies(condition)) return true;
-    }
-    return false;
+    if (!condition.mightNotBeFalse()) return false; // no path condition is false
+    invariant(condition instanceof AbstractValue);
+    return condition.$Realm.pathConditions.implies(condition);
   }
 
   impliesNot(condition: Value): boolean {
     if (!condition.mightNotBeFalse()) return true; // any path implies !false
-    let path = condition.$Realm.pathConditions;
-    for (let i = path.length - 1; i >= 0; i--) {
-      let pathCondition = path[i];
-      if (pathCondition.impliesNot(condition)) return true;
-    }
-    return false;
+    if (!condition.mightNotBeTrue()) return false; // no path condition is false, so none can imply !true
+    invariant(condition instanceof AbstractValue);
+    return condition.$Realm.pathConditions.impliesNot(condition);
   }
 
   withCondition<T>(condition: Value, evaluate: () => T): T {
@@ -42,10 +132,10 @@ export class PathImplementation {
       invariant(false, "assuming that false equals true is asking for trouble");
     }
     let savedPath = realm.pathConditions;
-    realm.pathConditions = [];
+    realm.pathConditions = new PathConditionsImplementation(savedPath);
     try {
       pushPathCondition(condition);
-      pushRefinedConditions(realm, savedPath);
+      realm.pathConditions.refineBaseConditons(realm);
       return evaluate();
     } catch (e) {
       if (e instanceof InfeasiblePathError) {
@@ -67,10 +157,10 @@ export class PathImplementation {
       invariant(false, "assuming that false equals true is asking for trouble");
     }
     let savedPath = realm.pathConditions;
-    realm.pathConditions = [];
+    realm.pathConditions = new PathConditionsImplementation(savedPath);
     try {
       pushInversePathCondition(condition);
-      pushRefinedConditions(realm, savedPath);
+      realm.pathConditions.refineBaseConditons(realm);
       return evaluate();
     } catch (e) {
       if (e instanceof InfeasiblePathError) {
@@ -88,19 +178,19 @@ export class PathImplementation {
   pushAndRefine(condition: Value): void {
     let realm = condition.$Realm;
     let savedPath = realm.pathConditions;
-    realm.pathConditions = [];
+    realm.pathConditions = new PathConditionsImplementation(savedPath);
 
     pushPathCondition(condition);
-    pushRefinedConditions(realm, savedPath);
+    realm.pathConditions.refineBaseConditons(realm);
   }
 
   pushInverseAndRefine(condition: Value): void {
     let realm = condition.$Realm;
     let savedPath = realm.pathConditions;
-    realm.pathConditions = [];
+    realm.pathConditions = new PathConditionsImplementation(savedPath);
 
     pushInversePathCondition(condition);
-    pushRefinedConditions(realm, savedPath);
+    realm.pathConditions.refineBaseConditons(realm);
   }
 }
 
@@ -133,7 +223,7 @@ function pushPathCondition(condition: Value): void {
         }
       }
     }
-    realm.pathConditions.push(condition);
+    realm.pathConditions.add(condition);
   } else {
     if (condition.kind === "!=" || condition.kind === "==") {
       let left = condition.args[0];
@@ -150,7 +240,7 @@ function pushPathCondition(condition: Value): void {
         return;
       }
     }
-    realm.pathConditions.push(condition);
+    realm.pathConditions.add(condition);
   }
 }
 
@@ -185,20 +275,11 @@ function pushInversePathCondition(condition: Value): void {
         return;
       }
     }
-    let inverseCondition = AbstractValue.createFromUnaryOp(realm, "!", condition);
+    let inverseCondition = AbstractValue.createFromUnaryOp(realm, "!", condition, false, undefined, true, true);
     pushPathCondition(inverseCondition);
     if (inverseCondition instanceof AbstractValue) {
       let simplifiedInverseCondition = realm.simplifyAndRefineAbstractCondition(inverseCondition);
       if (!simplifiedInverseCondition.equals(inverseCondition)) pushPathCondition(simplifiedInverseCondition);
     }
   }
-}
-
-function pushRefinedConditions(realm: Realm, unrefinedConditions: Array<AbstractValue>): void {
-  let refinedConditions = unrefinedConditions.map(c => realm.simplifyAndRefineAbstractCondition(c));
-  if (refinedConditions.some(c => !c.mightNotBeFalse())) throw new InfeasiblePathError();
-  let pc = realm.pathConditions;
-  realm.pathConditions = [];
-  for (let c of refinedConditions) pushPathCondition(c);
-  for (let c of pc) realm.pathConditions.push(c);
 }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -69,6 +69,13 @@ export default class Value {
     return false;
   }
 
+  impliesNot(val: Value): boolean {
+    if (this.equals(val)) return false;
+    if (!this.mightNotBeFalse()) return true;
+    if (!val.mightNotBeTrue()) return false;
+    return false;
+  }
+
   isIntrinsic(): boolean {
     return !!this.intrinsicName;
   }

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -10678,7 +10678,7 @@ ReactStatistics {
 
 exports[`Simple 22: (JSX => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -10688,13 +10688,19 @@ ReactStatistics {
           "name": "Child",
           "status": "INLINED",
         },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child2",
+          "status": "INLINED",
+        },
       ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 1,
+  "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -10702,7 +10708,7 @@ ReactStatistics {
 
 exports[`Simple 22: (JSX => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -10712,13 +10718,19 @@ ReactStatistics {
           "name": "Child",
           "status": "INLINED",
         },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child2",
+          "status": "INLINED",
+        },
       ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 1,
+  "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -10726,7 +10738,7 @@ ReactStatistics {
 
 exports[`Simple 22: (createElement => JSX) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -10736,13 +10748,19 @@ ReactStatistics {
           "name": "Child",
           "status": "INLINED",
         },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child2",
+          "status": "INLINED",
+        },
       ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 1,
+  "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }
@@ -10750,7 +10768,7 @@ ReactStatistics {
 
 exports[`Simple 22: (createElement => createElement) 1`] = `
 ReactStatistics {
-  "componentsEvaluated": 2,
+  "componentsEvaluated": 3,
   "evaluatedRootNodes": Array [
     Object {
       "children": Array [
@@ -10760,13 +10778,19 @@ ReactStatistics {
           "name": "Child",
           "status": "INLINED",
         },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child2",
+          "status": "INLINED",
+        },
       ],
       "message": "",
       "name": "App",
       "status": "ROOT",
     },
   ],
-  "inlinedComponents": 1,
+  "inlinedComponents": 2,
   "optimizedNestedClosures": 0,
   "optimizedTrees": 1,
 }

--- a/test/serializer/additional-functions/ToObject.js
+++ b/test/serializer/additional-functions/ToObject.js
@@ -1,4 +1,3 @@
-// throws introspection error
 (function() {
   function URIBase(uri) {
     if (uri instanceof URIBase) {


### PR DESCRIPTION
Release note: Speed up simplifier by using an implication cache per path branch

The realm's path conditions is now a class instances and an explicit tree, along with caches for expressions that have already been checked for true/false using Path.implies on the current set of path conditions.

The AbstractValueImplicationCounter is still there as flag, to be renamed later. It is no longer used as a global k-limit, but enables k-limits on the cost of constructing a new set of path conditions. When React is the target, path conditions are not re-specialized. This leads to a very nice performance win for the large React internal test.

A number of tweaks to the simplifier were needed to get tests to pass. Some of these were borrowed from PR #2460.