### PR TITLE
Allow invalid render return values in the React reconciler

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -77,7 +77,6 @@ import { Logger } from "../utils/logger.js";
 import type { ClassComponentMetadata, ReactComponentTreeConfig, ReactHint } from "../types.js";
 import { handleReportedSideEffect } from "../serializer/utils.js";
 import { createOperationDescriptor } from "../utils/generator.js";
-import { optionalStringOfLocation } from "../utils/babelhelpers.js";
 
 type ComponentResolutionStrategy =
   | "NORMAL"
@@ -1379,10 +1378,12 @@ export class Reconciler {
       return this._resolveArray(componentType, value, context, branchStatus, evaluatedNode, needsKey);
     } else if (value instanceof ObjectValue && isReactElement(value)) {
       return this._resolveReactElement(componentType, value, context, branchStatus, evaluatedNode, needsKey);
-    } else {
-      let location = optionalStringOfLocation(value.expressionLocation);
-      throw new ExpectedBailOut(`invalid return value from render${location}`);
     }
+    // This value is not a valid return value of a render, but given we might be
+    // in a && condition,  it may never result in a runtime error. Still, if it does
+    // result in a runtime error, it would have been the same error before compilation.
+    // See issue #https://github.com/facebook/prepack/issues/2497 for more context.
+    return value;
   }
 
   _assignBailOutMessage(reactElement: ObjectValue, message: string): void {

--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -1380,9 +1380,9 @@ export class Reconciler {
       return this._resolveReactElement(componentType, value, context, branchStatus, evaluatedNode, needsKey);
     }
     // This value is not a valid return value of a render, but given we might be
-    // in a && condition,  it may never result in a runtime error. Still, if it does
+    // in a "&&"" condition, it may never result in a runtime error. Still, if it does
     // result in a runtime error, it would have been the same error before compilation.
-    // See issue #https://github.com/facebook/prepack/issues/2497 for more context.
+    // See issue #2497 for more context.
     return value;
   }
 

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -124,6 +124,10 @@ it("Simple 23", () => {
   runTest(__dirname + "/FunctionalComponents/simple-23.js");
 });
 
+it("Simple 24", () => {
+  runTest(__dirname + "/FunctionalComponents/simple-24.js");
+});
+
 it("Two roots", () => {
   runTest(__dirname + "/FunctionalComponents/two-roots.js");
 });

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -116,6 +116,14 @@ it("Simple 21", () => {
   runTest(__dirname + "/FunctionalComponents/simple-21.js");
 });
 
+it("Simple 22", () => {
+  runTest(__dirname + "/FunctionalComponents/simple-22.js");
+});
+
+it("Simple 23", () => {
+  runTest(__dirname + "/FunctionalComponents/simple-23.js");
+});
+
 it("Two roots", () => {
   runTest(__dirname + "/FunctionalComponents/two-roots.js");
 });

--- a/test/react/FunctionalComponents/simple-22.js
+++ b/test/react/FunctionalComponents/simple-22.js
@@ -1,0 +1,25 @@
+var React = require("react");
+
+function Child() {
+  return <div>This should be inlined</div>;
+}
+
+function Child2() {
+  return <span>This should be inlined too</span>;
+}
+
+function App(props) {
+  var a = props.x ? null : <Child2 />;
+  return a && <Child />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [["simple conditions", renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/FunctionalComponents/simple-23.js
+++ b/test/react/FunctionalComponents/simple-23.js
@@ -1,0 +1,21 @@
+var React = require("react");
+
+function Child() {
+  return <div>This should be inlined</div>;
+}
+
+function App(props) {
+  var a = props.x ? null : function() {};
+  return a && <Child />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [["simple render", renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/FunctionalComponents/simple-24.js
+++ b/test/react/FunctionalComponents/simple-24.js
@@ -1,17 +1,18 @@
 var React = require("react");
 
-function Child() {
-  return <div>This should be inlined</div>;
-}
-
 function App(props) {
-  var a = props.x ? null : function() {};
-  return a && <Child />;
+  if (props.neverHappens) {
+    return <Bad />
+  }
+  return null;
 }
 
+function Bad() {
+  return {}; // Invalid
+}
 App.getTrials = function(renderer, Root) {
   renderer.update(<Root />);
-  return [["simple conditions #2", renderer.toJSON()]];
+  return [["simple conditions #3", renderer.toJSON()]];
 };
 
 if (this.__optimizeReactComponentTree) {

--- a/test/react/FunctionalComponents/simple-24.js
+++ b/test/react/FunctionalComponents/simple-24.js
@@ -2,7 +2,7 @@ var React = require("react");
 
 function App(props) {
   if (props.neverHappens) {
-    return <Bad />
+    return <Bad />;
   }
   return null;
 }

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -10676,6 +10676,198 @@ ReactStatistics {
 }
 `;
 
+exports[`Simple 22: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 22: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 22: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 22: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 23: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 23: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 23: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 23: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Child",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Simple children: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -10868,6 +10868,102 @@ ReactStatistics {
 }
 `;
 
+exports[`Simple 24: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bad",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 24: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bad",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 24: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bad",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`Simple 24: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 2,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Bad",
+          "status": "INLINED",
+        },
+      ],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 1,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`Simple children: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,


### PR DESCRIPTION
Release notes: none

This unblocks an issue found in https://github.com/facebook/prepack/pull/2494.

After looking into https://github.com/facebook/prepack/pull/2494, which showed that without that PR, some conditions with `&&` weren't being passed correctly to the React reconciler to be properly inlined. With this PR applied however, this issue no longer occurs but we do run into another problem.

The React reconciler will attempt to evaluate, resolve and inline all paths. Typically, if a "value" that a React component returned wasn't that of a valid type (string, ReactElement, null and some other objects) we would throw an `ExpectedBailOut`. This turned out to break logic in common use-case though: `&&` conditions.

Take the below example though:

```js
function Child() {
  return <div>This should be inlined</div>;
}
 function App(props) {
  var a = props.x ? null : function() {};
  return a && <Child />;
}
```

In this case with, the React reconciler will see `function () {}` as one of the paths of the `&&` condition and try and inline all paths and hit the fact you can't return `function () {}` and throw the `ExpectedBailOut`.

The realism is that the React reconciler in Prepack is being too smart here. It doesn't need to be concerned with the fact that the valid might not be valid. If the result is not valid, then the user will hit a runtime issue with React with their original input too. Ultimately, all we need to do is return the valid.

There are three tests attached to this PR. Only `simple-24` is a direct test for the changes in this PR, `simple-22` and `simple-23` are regression tests for when https://github.com/facebook/prepack/pull/2494 is applied.