### PR TITLE
Fix for React.cloneElement

### DIFF
--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -379,7 +379,6 @@ export function cloneReactElement(
   if (children !== undefined) {
     hardModifyReactObjectPropertyBinding(realm, props, "children", children);
   } else {
-    let elementProps = getProperty(realm, reactElement, "props");
     invariant(elementProps instanceof ObjectValue);
     let elementChildren = getProperty(realm, elementProps, "children");
     hardModifyReactObjectPropertyBinding(realm, props, "children", elementChildren);

--- a/src/react/elements.js
+++ b/src/react/elements.js
@@ -319,7 +319,8 @@ export function cloneReactElement(
     }
   };
 
-  applyObjectAssignConfigsForReactElement(realm, props, [config]);
+  let elementProps = getProperty(realm, reactElement, "props");
+  applyObjectAssignConfigsForReactElement(realm, props, [elementProps, config]);
   props.makeFinal();
 
   let key = getProperty(realm, reactElement, "key");

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -268,6 +268,10 @@ it("React.cloneElement", () => {
   runTest(__dirname + "/FunctionalComponents/clone-element.js");
 });
 
+it("React.cloneElement 2", () => {
+  runTest(__dirname + "/FunctionalComponents/clone-element2.js");
+});
+
 it("Return text", () => {
   runTest(__dirname + "/FunctionalComponents/return-text.js");
 });

--- a/test/react/FunctionalComponents/clone-element2.js
+++ b/test/react/FunctionalComponents/clone-element2.js
@@ -1,0 +1,17 @@
+var React = require("react");
+
+function App(props) {
+  var a = <div className="123" />;
+  return React.cloneElement(a, { id: "456" }, "Hello world!");
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [["clone element 2", renderer.toJSON()]];
+}
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;

--- a/test/react/FunctionalComponents/clone-element2.js
+++ b/test/react/FunctionalComponents/clone-element2.js
@@ -8,7 +8,7 @@ function App(props) {
 App.getTrials = function(renderer, Root) {
   renderer.update(<Root />);
   return [["clone element 2", renderer.toJSON()]];
-}
+};
 
 if (this.__optimizeReactComponentTree) {
   __optimizeReactComponentTree(App);

--- a/test/react/__snapshots__/FunctionalComponents-test.js.snap
+++ b/test/react/__snapshots__/FunctionalComponents-test.js.snap
@@ -8780,6 +8780,74 @@ ReactStatistics {
 }
 `;
 
+exports[`React.cloneElement 2: (JSX => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`React.cloneElement 2: (JSX => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`React.cloneElement 2: (createElement => JSX) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
+exports[`React.cloneElement 2: (createElement => createElement) 1`] = `
+ReactStatistics {
+  "componentsEvaluated": 1,
+  "evaluatedRootNodes": Array [
+    Object {
+      "children": Array [],
+      "message": "",
+      "name": "App",
+      "status": "ROOT",
+    },
+  ],
+  "inlinedComponents": 0,
+  "optimizedNestedClosures": 0,
+  "optimizedTrees": 1,
+}
+`;
+
 exports[`React.cloneElement: (JSX => JSX) 1`] = `
 ReactStatistics {
   "componentsEvaluated": 3,


### PR DESCRIPTION
Release notes: none

Fixes mixing functionality from React.cloneElement, where the original ReactElement props where missing from being copied to the new props.