### PR TITLE
[WIP] Remove `in` property checking for ObjectValues - fixes 2510

### DIFF
--- a/src/intrinsics/ecma262/ArrayBufferPrototype.js
+++ b/src/intrinsics/ecma262/ArrayBufferPrototype.js
@@ -27,7 +27,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
-    if (O.$ArrayBufferData !== undefined) {
+    if (O.$ArrayBufferData === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have an [[ArrayBufferData]] internal slot"
@@ -58,7 +58,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
-    if (O.$ArrayBufferData !== undefined) {
+    if (O.$ArrayBufferData === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have an [[ArrayBufferData]] internal slot"

--- a/src/intrinsics/ecma262/ArrayBufferPrototype.js
+++ b/src/intrinsics/ecma262/ArrayBufferPrototype.js
@@ -27,7 +27,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
-    if (!("$ArrayBufferData" in O)) {
+    if (O.$ArrayBufferData !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have an [[ArrayBufferData]] internal slot"
@@ -58,7 +58,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have an [[ArrayBufferData]] internal slot, throw a TypeError exception.
-    if (!("$ArrayBufferData" in O)) {
+    if (O.$ArrayBufferData !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have an [[ArrayBufferData]] internal slot"

--- a/src/intrinsics/ecma262/DataViewPrototype.js
+++ b/src/intrinsics/ecma262/DataViewPrototype.js
@@ -27,7 +27,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
-    if (O.$DataView !== undefined) {
+    if (O.$DataView === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[DataView]] internal slot"
@@ -55,7 +55,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
-    if (O.$DataView !== undefined) {
+    if (O.$DataView === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[DataView]] internal slot"
@@ -92,7 +92,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
-    if (O.$DataView !== undefined) {
+    if (O.$DataView === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[DataView]] internal slot"

--- a/src/intrinsics/ecma262/DataViewPrototype.js
+++ b/src/intrinsics/ecma262/DataViewPrototype.js
@@ -27,7 +27,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
-    if (!("$DataView" in O)) {
+    if (O.$DataView !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[DataView]] internal slot"
@@ -55,7 +55,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
-    if (!("$DataView" in O)) {
+    if (O.$DataView !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[DataView]] internal slot"
@@ -92,7 +92,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[DataView]] internal slot, throw a TypeError exception.
-    if (!("$DataView" in O)) {
+    if (O.$DataView !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[DataView]] internal slot"

--- a/src/intrinsics/ecma262/SetIteratorPrototype.js
+++ b/src/intrinsics/ecma262/SetIteratorPrototype.js
@@ -26,7 +26,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have all of the internal slots of a Set Iterator Instance (23.2.5.3), throw a TypeError exception.
-    if (O.$IteratedSet !== undefined || O.$SetNextIndex !== undefined || O.$SetIterationKind !== undefined) {
+    if (O.$IteratedSet === undefined || O.$SetNextIndex === undefined || O.$SetIterationKind === undefined) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "SetIteratorPrototype.next isn't generic");
     }
 

--- a/src/intrinsics/ecma262/SetIteratorPrototype.js
+++ b/src/intrinsics/ecma262/SetIteratorPrototype.js
@@ -26,7 +26,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have all of the internal slots of a Set Iterator Instance (23.2.5.3), throw a TypeError exception.
-    if (!("$IteratedSet" in O) || !("$SetNextIndex" in O) || !("$SetIterationKind" in O)) {
+    if (O.$IteratedSet !== undefined || O.$SetNextIndex !== undefined || O.$SetIterationKind !== undefined) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "SetIteratorPrototype.next isn't generic");
     }
 

--- a/src/intrinsics/ecma262/StringIteratorPrototype.js
+++ b/src/intrinsics/ecma262/StringIteratorPrototype.js
@@ -26,7 +26,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have all of the internal slots of an String Iterator Instance (21.1.5.3), throw a TypeError exception.
-    if (O.$IteratedString !== undefined && O.$StringIteratorNextIndex !== undefined) {
+    if (O.$IteratedString === undefined && O.$StringIteratorNextIndex === undefined) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 

--- a/src/intrinsics/ecma262/StringIteratorPrototype.js
+++ b/src/intrinsics/ecma262/StringIteratorPrototype.js
@@ -26,7 +26,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have all of the internal slots of an String Iterator Instance (21.1.5.3), throw a TypeError exception.
-    if (!("$IteratedString" in O && "$StringIteratorNextIndex" in O)) {
+    if (O.$IteratedString !== undefined && O.$StringIteratorNextIndex !== undefined) {
       throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "Type(O) is not Object");
     }
 

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -42,7 +42,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (!("$TypedArrayName" in O)) {
+    if (O.$TypedArrayName !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -70,7 +70,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (!("$TypedArrayName" in O)) {
+    if (O.$TypedArrayName !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -106,7 +106,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (!("$TypedArrayName" in O)) {
+    if (O.$TypedArrayName !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -781,7 +781,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (!("$TypedArrayName" in O)) {
+    if (O.$TypedArrayName !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -1666,7 +1666,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (!("$TypedArrayName" in O)) {
+    if (O.$TypedArrayName !== undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -1802,7 +1802,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (!(O instanceof ObjectValue)) return realm.intrinsics.undefined;
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, return undefined.
-    if (!("$TypedArrayName" in O)) return realm.intrinsics.undefined;
+    if (O.$TypedArrayName !== undefined) return realm.intrinsics.undefined;
 
     // 4. Let name be O.[[TypedArrayName]].
     let name = O.$TypedArrayName;

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -1802,7 +1802,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     if (!(O instanceof ObjectValue)) return realm.intrinsics.undefined;
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, return undefined.
-    if (O.$TypedArrayName !== undefined) return realm.intrinsics.undefined;
+    if (O.$TypedArrayName === undefined) return realm.intrinsics.undefined;
 
     // 4. Let name be O.[[TypedArrayName]].
     let name = O.$TypedArrayName;

--- a/src/intrinsics/ecma262/TypedArrayPrototype.js
+++ b/src/intrinsics/ecma262/TypedArrayPrototype.js
@@ -42,7 +42,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (O.$TypedArrayName !== undefined) {
+    if (O.$TypedArrayName === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -70,7 +70,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (O.$TypedArrayName !== undefined) {
+    if (O.$TypedArrayName === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -106,7 +106,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (O.$TypedArrayName !== undefined) {
+    if (O.$TypedArrayName === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -781,7 +781,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (O.$TypedArrayName !== undefined) {
+    if (O.$TypedArrayName === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"
@@ -1666,7 +1666,7 @@ export default function(realm: Realm, obj: ObjectValue): void {
     }
 
     // 3. If O does not have a [[TypedArrayName]] internal slot, throw a TypeError exception.
-    if (O.$TypedArrayName !== undefined) {
+    if (O.$TypedArrayName === undefined) {
       throw realm.createErrorThrowCompletion(
         realm.intrinsics.TypeError,
         "O does not have a [[TypedArrayName]] internal slot"

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -290,7 +290,7 @@ export function AllocateTypedArrayBuffer(realm: Realm, O: ObjectValue, length: n
 
   // 1. Assert: O is an Object that has a [[ViewedArrayBuffer]] internal slot.
   invariant(
-    O instanceof ObjectValue && "$ViewedArrayBuffer" in O,
+    O instanceof ObjectValue && O.$ViewedArrayBuffer !== undefined,
     "O is an Object that has a [[ViewedArrayBuffer]] internal slot"
   );
 

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -289,10 +289,8 @@ export function AllocateTypedArrayBuffer(realm: Realm, O: ObjectValue, length: n
   invariant(realm.isNewObject(O));
 
   // 1. Assert: O is an Object that has a [[ViewedArrayBuffer]] internal slot.
-  invariant(
-    O instanceof ObjectValue && O.$ViewedArrayBuffer !== undefined,
-    "O is an Object that has a [[ViewedArrayBuffer]] internal slot"
-  );
+  // Update: [[ViewedArrayBuffer]] will always be an internal slot, see #2512
+  invariant(O instanceof ObjectValue, "O is an Object that has a [[ViewedArrayBuffer]] internal slot");
 
   // 2. Assert: O.[[ViewedArrayBuffer]] is undefined.
   invariant(O.$ViewedArrayBuffer === undefined, "O.[[ViewedArrayBuffer]] is undefined");

--- a/src/methods/typedarray.js
+++ b/src/methods/typedarray.js
@@ -289,7 +289,7 @@ export function AllocateTypedArrayBuffer(realm: Realm, O: ObjectValue, length: n
   invariant(realm.isNewObject(O));
 
   // 1. Assert: O is an Object that has a [[ViewedArrayBuffer]] internal slot.
-  // Update: [[ViewedArrayBuffer]] will always be an internal slot, see #2512
+  // [[ViewedArrayBuffer]] will always be an internal slot, but that of undefined by default, see #2512
   invariant(O instanceof ObjectValue, "O is an Object that has a [[ViewedArrayBuffer]] internal slot");
 
   // 2. Assert: O.[[ViewedArrayBuffer]] is undefined.

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -77,6 +77,7 @@ export default class ObjectValue extends ConcreteValue {
     // as other code checks whether this.$IsClassPrototype === undefined
     // as a proxy for whether initialization is still ongoing.
     this.$IsClassPrototype = false;
+    this.$ViewedArrayBuffer = undefined;
   }
 
   static trackedPropertyNames = [

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -77,7 +77,6 @@ export default class ObjectValue extends ConcreteValue {
     // as other code checks whether this.$IsClassPrototype === undefined
     // as a proxy for whether initialization is still ongoing.
     this.$IsClassPrototype = false;
-    this.$ViewedArrayBuffer = undefined;
   }
 
   static trackedPropertyNames = [

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -77,6 +77,19 @@ export default class ObjectValue extends ConcreteValue {
     // as other code checks whether this.$IsClassPrototype === undefined
     // as a proxy for whether initialization is still ongoing.
     this.$IsClassPrototype = false;
+    // These properties were possibly not defined before, but now are always defined
+    // and set to undefined as their default slot state. Furthermore, these ensure
+    // that ObjectValue has the same hidden class for these properties.
+    // TODO ensure all other properties are also defined in the constructor to ensure
+    // they make ObjectValue have the same hidden class. See #2510.
+    this.$ViewedArrayBuffer = undefined;
+    this.$DataView = undefined;
+    this.$IteratedSet = undefined;
+    this.$SetNextIndex = undefined;
+    this.$SetIterationKind = undefined;
+    this.$TypedArrayName = undefined;
+    this.$IteratedString = undefined;
+    this.$StringIteratorNextIndex = undefined;
   }
 
   static trackedPropertyNames = [


### PR DESCRIPTION
Release notes: fixes potential issues with our Babel 7 transform internally

This PR is to address the issues outlined in https://github.com/facebook/prepack/issues/2510 in regards to `ObjectValue` and the usage through the Prepack codebase for where we use `in` to check for property existence. This changes that usage to explicit `undefined` checks due to our internal Babel transform compiling to output that is not compatible with `in` checks. Fixes #2510 