### PR TITLE
Fixed bugs involving unsafe atemporals and improved abstract concrete unions

### DIFF
--- a/src/intrinsics/ecma262/StringPrototype.js
+++ b/src/intrinsics/ecma262/StringPrototype.js
@@ -574,7 +574,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     if (O instanceof AbstractValue && O.getType() === StringValue) {
-      return AbstractValue.createFromTemplate(realm, sliceTemplateSrc, StringValue, [O, start, end]);
+      // This operation is a conditional atemporal
+      // See #2327
+      let absVal = AbstractValue.createFromTemplate(realm, sliceTemplateSrc, StringValue, [O, start, end]);
+      return AbstractValue.convertToTemporalIfArgsAreTemporal(realm, absVal, [O]);
     }
 
     // 2. Let S be ? ToString(O).
@@ -608,7 +611,10 @@ export default function(realm: Realm, obj: ObjectValue): ObjectValue {
     let O = RequireObjectCoercible(realm, context);
 
     if (O instanceof AbstractValue && O.getType() === StringValue) {
-      return AbstractValue.createFromTemplate(realm, splitTemplateSrc, ObjectValue, [O, separator, limit]);
+      // This operation is a conditional atemporal
+      // See #2327
+      let absVal = AbstractValue.createFromTemplate(realm, splitTemplateSrc, ObjectValue, [O, separator, limit]);
+      return AbstractValue.convertToTemporalIfArgsAreTemporal(realm, absVal, [O]);
     }
 
     // 2. If separator is neither undefined nor null, then

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -10,15 +10,7 @@
 /* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
-import {
-  Value,
-  AbstractValue,
-  ConcreteValue,
-  FunctionValue,
-  StringValue,
-  ObjectValue,
-  UndefinedValue,
-} from "../../values/index.js";
+import { Value, AbstractValue, FunctionValue, StringValue, ObjectValue, UndefinedValue } from "../../values/index.js";
 import { DisablePlaceholderSuffix } from "../../utils/PreludeGenerator.js";
 import { ValuesDomain } from "../../domains/index.js";
 import { describeLocation } from "../ecma262/Error.js";
@@ -67,7 +59,7 @@ export function createAbstract(
   typeNameOrTemplate?: Value | string,
   name?: string,
   options?: ObjectValue,
-  ...additionalValues: Array<ConcreteValue>
+  ...additionalValues: Array<Value>
 ): AbstractValue | AbstractObjectValue {
   if (!realm.useAbstractInterpretation) {
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");
@@ -122,7 +114,6 @@ export function createAbstract(
     result.functionResultType = functionResultType;
   }
 
-  if (additionalValues.length > 0)
-    result = AbstractValue.createAbstractConcreteUnion(realm, result, ...additionalValues);
+  if (additionalValues.length > 0) result = AbstractValue.createAbstractConcreteUnion(realm, result, additionalValues);
   return result;
 }

--- a/src/intrinsics/prepack/utils.js
+++ b/src/intrinsics/prepack/utils.js
@@ -10,7 +10,15 @@
 /* @flow strict-local */
 
 import type { Realm } from "../../realm.js";
-import { Value, AbstractValue, FunctionValue, StringValue, ObjectValue, UndefinedValue } from "../../values/index.js";
+import {
+  AbstractValue,
+  ConcreteValue,
+  FunctionValue,
+  ObjectValue,
+  StringValue,
+  UndefinedValue,
+  Value,
+} from "../../values/index.js";
 import { DisablePlaceholderSuffix } from "../../utils/PreludeGenerator.js";
 import { ValuesDomain } from "../../domains/index.js";
 import { describeLocation } from "../ecma262/Error.js";
@@ -59,7 +67,7 @@ export function createAbstract(
   typeNameOrTemplate?: Value | string,
   name?: string,
   options?: ObjectValue,
-  ...additionalValues: Array<Value>
+  ...additionalValues: Array<ConcreteValue>
 ): AbstractValue | AbstractObjectValue {
   if (!realm.useAbstractInterpretation) {
     throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "realm is not partial");

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -329,7 +329,10 @@ export function OrdinaryGetPartial(
   Receiver: Value
 ): Value {
   if (Receiver instanceof AbstractValue && Receiver.getType() === StringValue && P === "length") {
-    return AbstractValue.createFromTemplate(realm, lengthTemplateSrc, NumberValue, [Receiver]);
+    let absVal = AbstractValue.createFromTemplate(realm, lengthTemplateSrc, NumberValue, [Receiver]);
+    // This operation is a conditional atemporal
+    // See #2327
+    return AbstractValue.convertToTemporalIfArgsAreTemporal(realm, absVal, [Receiver]);
   }
 
   if (!(P instanceof AbstractValue)) return O.$Get(P, Receiver);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1584,8 +1584,9 @@ export class PropertiesImplementation {
               skipInvariant: true,
             });
             if (savedUnion !== undefined) {
-              let concreteValues = savedUnion.args.slice(1);
               invariant(value instanceof AbstractValue);
+              let concreteValues = (savedUnion.args.filter(e => e instanceof ConcreteValue): any);
+              invariant(concreteValues.length === savedUnion.args.length - 1);
               value = AbstractValue.createAbstractConcreteUnion(realm, value, concreteValues);
             }
             if (realm.invariantLevel >= 1 && typeof P === "string" && !realm.hasBindingBeenChecked(O, P)) {

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1495,12 +1495,10 @@ export class PropertiesImplementation {
               absVal = createAbstractPropertyValue(ObjectValue);
               invariant(absVal instanceof AbstractObjectValue);
               absVal.makeSimple("transitive");
-              absVal = AbstractValue.createAbstractConcreteUnion(
-                realm,
-                absVal,
+              absVal = AbstractValue.createAbstractConcreteUnion(realm, absVal, [
                 realm.intrinsics.undefined,
-                realm.intrinsics.null
-              );
+                realm.intrinsics.null,
+              ]);
             } else {
               absVal = createAbstractPropertyValue(Value);
             }
@@ -1568,12 +1566,11 @@ export class PropertiesImplementation {
       if (O.isIntrinsic() && O.isPartialObject()) {
         if (value instanceof AbstractValue) {
           let savedUnion;
-          let savedIndex;
           if (value.kind === "abstractConcreteUnion") {
+            // TODO: Simplify this code by using helpers from the AbstractValue factory
+            // instead of deriving values directly.
             savedUnion = value;
-            savedIndex = savedUnion.args.findIndex(e => e instanceof AbstractValue);
-            invariant(savedIndex >= 0);
-            value = savedUnion.args[savedIndex];
+            value = savedUnion.args[0];
             invariant(value instanceof AbstractValue);
           }
           if (value.kind !== "resolved") {
@@ -1587,10 +1584,9 @@ export class PropertiesImplementation {
               skipInvariant: true,
             });
             if (savedUnion !== undefined) {
-              invariant(savedIndex !== undefined);
-              let args = savedUnion.args.slice(0);
-              args[savedIndex] = value;
-              value = AbstractValue.createAbstractConcreteUnion(realm, ...args);
+              let concreteValues = savedUnion.args.slice(1);
+              invariant(value instanceof AbstractValue);
+              value = AbstractValue.createAbstractConcreteUnion(realm, value, concreteValues);
             }
             if (realm.invariantLevel >= 1 && typeof P === "string" && !realm.hasBindingBeenChecked(O, P)) {
               realm.markPropertyAsChecked(O, P);

--- a/src/realm.js
+++ b/src/realm.js
@@ -1599,7 +1599,8 @@ export class Realm {
   rebuildObjectProperty(object: Value, key: string, propertyValue: Value, path: string): void {
     if (!(propertyValue instanceof AbstractValue)) return;
     if (propertyValue.kind === "abstractConcreteUnion") {
-      let absVal = propertyValue.args.find(e => e instanceof AbstractValue);
+      invariant(propertyValue.args.length >= 2);
+      let absVal = propertyValue.args[0];
       invariant(absVal instanceof AbstractValue);
       propertyValue = absVal;
     }

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -2068,9 +2068,9 @@ export class ResidualHeapSerializer {
   _serializeAbstractValueHelper(val: AbstractValue): BabelNodeExpression {
     let serializedArgs = val.args.map((abstractArg, i) => this.serializeValue(abstractArg));
     if (val.kind === "abstractConcreteUnion") {
-      let abstractIndex = val.args.findIndex(v => v instanceof AbstractValue);
-      invariant(abstractIndex >= 0 && abstractIndex < val.args.length);
-      return serializedArgs[abstractIndex];
+      invariant(val.args.length >= 2);
+      invariant(val.args[0] instanceof AbstractValue);
+      return serializedArgs[0];
     }
     if (val.kind === "explicit conversion to object") {
       let ob = serializedArgs[0];

--- a/src/utils/ConcreteModelConverter.js
+++ b/src/utils/ConcreteModelConverter.js
@@ -58,7 +58,7 @@ export function concretize(realm: Realm, val: Value): ConcreteValue {
   }
   invariant(val instanceof AbstractValue);
   if (val.kind === "abstractConcreteUnion") {
-    invariant(val.args.length > 0);
+    invariant(val.args.length >= 2);
     return concretize(realm, val.args[0]);
   }
   const type = val.types.getType();

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -267,7 +267,7 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
     case "abstractConcreteUnion": {
       // The union of an abstract value with one or more concrete values.
       if (realm.pathConditions.isEmpty()) return value;
-      let [abstractValue, ...concreteValues] = value.args;
+      let [abstractValue, concreteValues] = AbstractValue.dischargeValuesFromUnion(realm, value);
       invariant(abstractValue instanceof AbstractValue);
       let remainingConcreteValues = [];
       for (let concreteValue of concreteValues) {
@@ -277,7 +277,7 @@ function simplify(realm, value: Value, isCondition: boolean = false): Value {
       }
       if (remainingConcreteValues.length === 0) return abstractValue;
       if (remainingConcreteValues.length === concreteValues.length) return value;
-      return AbstractValue.createAbstractConcreteUnion(realm, abstractValue, ...remainingConcreteValues);
+      return AbstractValue.createAbstractConcreteUnion(realm, abstractValue, remainingConcreteValues);
     }
     default:
       return value;

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -901,12 +901,13 @@ export default class AbstractValue extends Value {
     }
   }
 
-  static dischargeValuesFromUnion(realm: Realm, union: AbstractValue): [AbstractValue, Array<Value>] {
+  static dischargeValuesFromUnion(realm: Realm, union: AbstractValue): [AbstractValue, Array<ConcreteValue>] {
     invariant(union instanceof AbstractValue && union.kind === "abstractConcreteUnion");
-    invariant(union.args[0] instanceof AbstractValue);
-    invariant(union.args[1] instanceof ConcreteValue);
+    let abstractValue = union.args[0];
+    invariant(abstractValue instanceof AbstractValue);
 
-    let [abstractValue, ...concreteValues] = union.args;
+    let concreteValues = (union.args.filter(e => e instanceof ConcreteValue): any);
+    invariant(concreteValues.length === union.args.length - 1);
 
     if (!abstractValue.isTemporal()) {
       // We make the abstract value in an abstract concrete union temporal, as it is predicated
@@ -938,12 +939,12 @@ export default class AbstractValue extends Value {
   static createAbstractConcreteUnion(
     realm: Realm,
     abstractValue: AbstractValue,
-    concreteValues: Array<Value>
+    concreteValues: Array<ConcreteValue>
   ): AbstractValue {
     invariant(concreteValues.length > 0);
     invariant(abstractValue instanceof AbstractValue);
 
-    let checkedConcreteValues: Array<ConcreteValue> = (concreteValues.filter(e => e instanceof ConcreteValue): any);
+    let checkedConcreteValues = (concreteValues.filter(e => e instanceof ConcreteValue): any);
     invariant(checkedConcreteValues.length === concreteValues.length);
 
     let concreteSet: Set<ConcreteValue> = new Set(checkedConcreteValues);

--- a/src/values/ConcreteValue.js
+++ b/src/values/ConcreteValue.js
@@ -30,6 +30,9 @@ export default class ConcreteValue extends Value {
     super(realm, intrinsicName);
   }
 
+  isTemporal(): boolean {
+    return false;
+  }
   mightNotBeFalse(): boolean {
     return !this.mightBeFalse();
   }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -80,6 +80,10 @@ export default class Value {
     return !!this.intrinsicName;
   }
 
+  isTemporal() {
+    invariant(false, "abstract method; please override");
+  }
+
   isPartialObject(): boolean {
     return false;
   }

--- a/test/serializer/abstract/Issue2327InBinop.js
+++ b/test/serializer/abstract/Issue2327InBinop.js
@@ -1,0 +1,11 @@
+// expected RecoverableError: PP0004
+
+let o = global.__abstractOrNull ? __abstractOrNull("object", "undefined") : undefined;
+let s = true;
+
+if (o != undefined) s = "foobar" in o;
+if (o != undefined) s = "foobar" in o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327InBinopUnconditional.js
+++ b/test/serializer/abstract/Issue2327InBinopUnconditional.js
@@ -1,0 +1,12 @@
+// Copies of "foobar" in:1
+// expected RecoverableError: PP0004
+
+let o = global.__abstract ? __abstract("object", "('foobar42')") : "foobar42";
+let s = true;
+
+if (o != undefined) s = "foobar" in o;
+if (o != undefined) s = "foobar" in o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327InstanceOfBinop.js
+++ b/test/serializer/abstract/Issue2327InstanceOfBinop.js
@@ -1,0 +1,11 @@
+// expected RecoverableError: PP0004
+
+let o = global.__abstractOrNull ? __abstractOrNull("object", "undefined") : undefined;
+let s = true;
+
+if (o != undefined) s = "foobar" instanceof o;
+if (o != undefined) s = "foobar" instanceof o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327InstanceOfBinopUnconditional.js
+++ b/test/serializer/abstract/Issue2327InstanceOfBinopUnconditional.js
@@ -1,0 +1,12 @@
+// Copies of "foobar" instanceof:1
+// expected RecoverableError: PP0004
+
+let o = global.__abstract ? __abstract("object", "({})") : {};
+let s = true;
+
+if (o != undefined) s = "foobar" instanceof o;
+if (o != undefined) s = "foobar" instanceof o;
+
+global.s = s;
+
+inspect = () => s; // Should be true

--- a/test/serializer/abstract/Issue2327StringLength.js
+++ b/test/serializer/abstract/Issue2327StringLength.js
@@ -1,0 +1,9 @@
+let o = global.__abstractOrNull ? __abstractOrNull("string", "undefined") : undefined;
+let s;
+
+if (o != undefined) s = 5 + o.length;
+if (o != undefined) s = 7 + o.length;
+
+global.s = s;
+
+inspect = () => s;

--- a/test/serializer/abstract/Issue2327StringLengthUnconditional.js
+++ b/test/serializer/abstract/Issue2327StringLengthUnconditional.js
@@ -1,0 +1,11 @@
+// Copies of length:1
+
+let o = global.__abstract ? __abstract("string", "('xyz')") : "xyz";
+let s;
+
+if (o != undefined) s = 5 + o.length;
+if (o != undefined) s = 7 + o.length;
+
+global.s = s;
+
+inspect = () => s;

--- a/test/serializer/abstract/Issue2327StringSlice.js
+++ b/test/serializer/abstract/Issue2327StringSlice.js
@@ -1,0 +1,9 @@
+let o = global.__abstractOrNull ? __abstractOrNull("string", "undefined") : undefined;
+let s = "ok";
+
+if (o != undefined) s = "X" + o.slice(3);
+if (o != undefined) s = "Y" + o.slice(3);
+
+global.s = s;
+
+inspect = () => s;

--- a/test/serializer/abstract/Issue2327StringSliceUnconditional.js
+++ b/test/serializer/abstract/Issue2327StringSliceUnconditional.js
@@ -1,0 +1,13 @@
+// Copies of slice\(:1
+
+(function() {
+  let o = global.__abstract ? __abstract("string", "('x y z')") : "x y z";
+  let c = global.__abstract ? __abstract("boolean", "true") : true;
+  let s = "ok";
+
+  if (c) s = "X" + o.slice(3);
+  if (c) s = "Y" + o.slice(3);
+
+  global.s = s;
+  inspect = () => s;
+})();

--- a/test/serializer/abstract/Issue2327StringSplit.js
+++ b/test/serializer/abstract/Issue2327StringSplit.js
@@ -1,0 +1,9 @@
+let o = global.__abstractOrNull ? __abstractOrNull("string", "undefined") : undefined;
+let s = "ok";
+
+if (o != undefined) s = o.split();
+if (o != undefined) s = o.split();
+
+global.s = s;
+
+inspect = () => s;

--- a/test/serializer/abstract/Optional3.js
+++ b/test/serializer/abstract/Optional3.js
@@ -1,3 +1,4 @@
+// Copies of f;:2
 function f() {
   return 123;
 }

--- a/test/serializer/abstract/Optional3.js
+++ b/test/serializer/abstract/Optional3.js
@@ -1,4 +1,3 @@
-// Copies of f;:1
 function f() {
   return 123;
 }


### PR DESCRIPTION
Release notes: Fixed bugs that could cause generated code to throw

A refactor of my previous attempt to address #2327, which I had to abandon because it was incompatible with the current implementation of certain modeling primitives. Like the previous version, this PR is an intermediate fix that will be refined in a follow up PR. It consists of three changes:

1) It adds a new helper that discharges values from a union after deriving the abstract value in it if needed.

2) It makes conditionally temporal values safe using a helper called `convertToTemporalIfArgsAreTemporal`.

3) It makes the the abstract and concrete members explicit in the interface to Abstract Concrete Unions. Presently, two code sites make the assumption that the abstract member is the first element of `args`, while all others traverse the list to locate it.

Follow ups to come:
1) Update `convertToTemporalIfArgsAreTemporal` to produce a conditional value left to be simplified by the serializer.
2) Enforce the protocol *temporal args should imply temporal results* more generally (#2489).

Fixes #2327 and #2406