### PR TITLE
Fix CSE in back-end

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -19,6 +19,7 @@ import { HashSet, IsArray, Get } from "../methods/index.js";
 import {
   AbstractObjectValue,
   AbstractValue,
+  ArrayValue,
   BoundFunctionValue,
   ECMAScriptFunctionValue,
   ECMAScriptSourceFunctionValue,
@@ -318,6 +319,7 @@ export class ResidualHeapVisitor {
       // Leaked object. Properties are set via assignments
       // TODO #2259: Make deduplication in the face of leaking work for custom accessors
       if (
+        !(obj instanceof ArrayValue) &&
         !obj.mightNotBeLeakedObject() &&
         (descriptor !== undefined && (descriptor.get === undefined && descriptor.set === undefined))
       )

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -311,7 +311,40 @@ export class TemporalOperationEntry extends GeneratorEntry {
       return false;
     } else {
       if (this.declared) callbacks.recordDeclaration(this.declared);
-      for (let i = 0, n = this.args.length; i < n; i++) this.args[i] = callbacks.visitEquivalentValue(this.args[i]);
+      for (let i = 0, n = this.args.length; i < n; i++) {
+        let originalArg = this.args[i];
+        let visitedArg = callbacks.visitEquivalentValue(originalArg);
+        this.args[i] = visitedArg;
+        if (i === 0) {
+          switch (this.operationDescriptor.type) {
+            case "CALL_BAILOUT":
+              if (originalArg === this.operationDescriptor.data.thisArg)
+                this.operationDescriptor.data.thisArg = visitedArg;
+              break;
+            case "CONDITIONAL_THROW":
+              this.operationDescriptor.data.value = visitedArg;
+              break;
+            default:
+              break;
+          }
+        } else if (i === 1) {
+          switch (this.operationDescriptor.type) {
+            case "EMIT_PROPERTY_ASSIGNMENT":
+            case "LOGICAL_PROPERTY_ASSIGNMENT":
+              this.operationDescriptor.data.value = visitedArg;
+              break;
+            case "CONDITIONAL_PROPERTY_ASSIGNMENT":
+              if (originalArg === this.operationDescriptor.data.value) this.operationDescriptor.data.value = visitedArg;
+              break;
+            case "DEFINE_PROPERTY":
+              invariant(visitedArg instanceof ObjectValue);
+              this.operationDescriptor.data.object = visitedArg;
+              break;
+            default:
+              break;
+          }
+        }
+      }
       if (this.dependencies)
         for (let dependency of this.dependencies) callbacks.visitGenerator(dependency, containingGenerator);
       return true;


### PR DESCRIPTION
Release note: none

This fixes two problems uncovered while debugging the failure of PR #2460 when run on a large internal test case:
1) CSE did not fix up recently introduced aliases of expressions.
2) The serializer logic visited array elements that were not visited because of recently introduced leak logic.
