### PR TITLE
Support bound function values for ReactElement types

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -701,7 +701,7 @@ export class Reconciler {
       evaluatedNode.message = "RelayContainer";
       throw new NewComponentTreeBranch(evaluatedNode);
     }
-    invariant(componentType instanceof ECMAScriptSourceFunctionValue);
+    invariant(componentType instanceof ECMAScriptSourceFunctionValue || componentType instanceof BoundFunctionValue);
     let value;
     let childContext = context;
 
@@ -1138,7 +1138,11 @@ export class Reconciler {
       switch (componentResolutionStrategy) {
         case "NORMAL": {
           if (
-            !(typeValue instanceof ECMAScriptSourceFunctionValue || valueIsKnownReactAbstraction(this.realm, typeValue))
+            !(
+              typeValue instanceof ECMAScriptSourceFunctionValue ||
+              typeValue instanceof BoundFunctionValue ||
+              valueIsKnownReactAbstraction(this.realm, typeValue)
+            )
           ) {
             return this._resolveUnknownComponentType(componentType, reactElement, context, branchStatus, evaluatedNode);
           }

--- a/test/react/FunctionalComponents-test.js
+++ b/test/react/FunctionalComponents-test.js
@@ -128,6 +128,10 @@ it("Simple 24", () => {
   runTest(__dirname + "/FunctionalComponents/simple-24.js");
 });
 
+it("Bound type", () => {
+  runTest(__dirname + "/FunctionalComponents/bound-type.js");
+});
+
 it("Two roots", () => {
   runTest(__dirname + "/FunctionalComponents/two-roots.js");
 });

--- a/test/react/FunctionalComponents/bound-type.js
+++ b/test/react/FunctionalComponents/bound-type.js
@@ -1,0 +1,28 @@
+var React = require("react");
+
+function Child(props) {
+  return (
+    <div>
+      {props.x}
+      {this.y}
+    </div>
+  );
+}
+
+var foo = { y: " world" };
+const BoundChild = Child.bind(foo);
+
+function App(props) {
+  return <BoundChild x={props.x} />;
+}
+
+App.getTrials = function(renderer, Root) {
+  renderer.update(<Root />);
+  return [["simple bound function", renderer.toJSON()]];
+};
+
+if (this.__optimizeReactComponentTree) {
+  __optimizeReactComponentTree(App);
+}
+
+module.exports = App;


### PR DESCRIPTION
Release notes: none

Add support for bound function values for `ReactElement` `type`.