### PR TITLE
Making diagnostics configurable.

### DIFF
--- a/scripts/test-std-in.sh
+++ b/scripts/test-std-in.sh
@@ -40,3 +40,43 @@ if [[ $? -ne 0 ]]; then
     echo "{}()" | node ./bin/prepack.js
     exit 1
 fi
+
+# Prepacks a stdin with an informational message that should get turned into an error. Checks if the correct error message is printed.
+(echo "global.r = Math.random();" | node ./bin/prepack.js --mathRandomSeed 0 --diagnosticAsError PP8000 2>&1 1>/dev/null ) | grep "In stdin(1:12) RecoverableError PP8000" > /dev/null
+# grep returns 0, even though prepack returned 1
+if [[ $? -ne 0 ]]; then
+    echo "Stdin test failed: echo \"global.r = Math.random();\" | node ./bin/prepack.js --mathRandomSeed 0 --diagnosticAsError PP8000 didn't return the expected error message."
+    # If the test failed, rerun and show the output
+    echo "global.r = Math.random();" | node ./bin/prepack.js --mathRandomSeed 0 --diagnosticAsError PP8000
+    exit 1
+fi
+
+# Prepacks a stdin with an informational message that should get suppressed. Checks that the error code does not appear in output.
+(echo "global.r = Math.random();" | node ./bin/prepack.js --mathRandomSeed 0 --noDiagnostic PP8000 2>&1 1>/dev/null ) | grep "In stdin(1:12) RecoverableError PP8000" > /dev/null
+# grep returns 0, even though prepack returned 1
+if [[ $? -eq 0 ]]; then
+    echo "Stdin test failed: echo \"global.r = Math.random();\" | node ./bin/prepack.js --mathRandomSeed 0 --noDiagnostic PP8000 didn't return the expected error message."
+    # If the test failed, rerun and show the output
+    echo "global.r = Math.random();" | node ./bin/prepack.js --mathRandomSeed 0 --noDiagnostic PP8000
+    exit 1
+fi
+
+# Prepacks a stdin with a warning message that should get turned into an error. Checks if the correct error message is printed.
+(echo "let x; function f() { x = 1; } function g() { x = 2; } __optimize(f); __optimize(g);" | node ./bin/prepack.js --warnAsError 2>&1 1>/dev/null ) | grep "In stdin(1:27) RecoverableError PP1007" > /dev/null
+# grep returns 0, even though prepack returned 1
+if [[ $? -ne 0 ]]; then
+    echo "Stdin test failed: echo \"let x; function f() { x = 1; } function g() { x = 2; } __optimize(f); __optimize(g);\" | node ./bin/prepack.js --warnAsError didn't return the expected error message."
+    # If the test failed, rerun and show the output
+    echo "let x; function f() { x = 1; } function g() { x = 2; } __optimize(f); __optimize(g);" | node ./bin/prepack.js --warnAsError
+    exit 1
+fi
+
+# Prepacks a stdin with a warning message that should get turned into an error. Checks if the correct error message is printed.
+(echo "let x; function f() { x = 1; } function g() { x = 2; } __optimize(f); __optimize(g);" | node ./bin/prepack.js --diagnosticAsError PP1007 2>&1 1>/dev/null ) | grep "In stdin(1:27) RecoverableError PP1007" > /dev/null
+# grep returns 0, even though prepack returned 1
+if [[ $? -ne 0 ]]; then
+    echo "Stdin test failed: echo \"let x; function f() { x = 1; } function g() { x = 2; } __optimize(f); __optimize(g);\" | node ./bin/prepack.js --diagnosticAsError PP1007 didn't return the expected error message."
+    # If the test failed, rerun and show the output
+    echo "let x; function f() { x = 1; } function g() { x = 2; } __optimize(f); __optimize(g);" | node ./bin/prepack.js --diagnosticAsError PP1007
+    exit 1
+fi

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -114,6 +114,7 @@ function run(
   let externalPrepackPath: void | string;
   let diagnosticAsError: void | Set<string>;
   let noDiagnostic: void | Set<string>;
+  let warnAsError: void | true;
   let flags = {
     initializeMoreModules: false,
     trace: false,
@@ -128,7 +129,6 @@ function run(
     profile: false,
     instantRender: false,
     reactEnabled: false,
-    warnAsError: false,
   };
   let reproArguments = [];
   let reproFileNames = [];
@@ -210,6 +210,10 @@ function run(
           let noDiagnosticString = args.shift();
           noDiagnostic = new Set(noDiagnosticString.split(","));
           reproArguments.push("--noDiagnostic", noDiagnosticString);
+          break;
+        case "warnAsError":
+          warnAsError = true;
+          reproArguments.push("--warnAsError");
           break;
         case "check":
           let range = args.shift();
@@ -333,6 +337,9 @@ function run(
             "--repro reprofile.zip",
             "--cpuprofile name.cpuprofile",
             "--invariantMode " + InvariantModeValues.join(" | "),
+            "--warnAsError",
+            "--diagnosticAsError PPxxxx,PPyyyy,...",
+            "--noDiagnostic PPxxxx,PPyyyy,...",
           ];
           for (let flag of Object.keys(flags)) options.push(`--${flag}`);
 
@@ -398,7 +405,7 @@ function run(
   function errorHandler(compilerDiagnostic: CompilerDiagnostic): ErrorHandlerResult {
     if (noDiagnostic !== undefined && noDiagnostic.has(compilerDiagnostic.errorCode)) return "Recover";
     if (
-      (flags.warnAsError && compilerDiagnostic.severity === "Warning") ||
+      (warnAsError && compilerDiagnostic.severity === "Warning") ||
       (diagnosticAsError !== undefined &&
         diagnosticAsError.has(compilerDiagnostic.errorCode) &&
         compilerDiagnostic.severity !== "FatalError")


### PR DESCRIPTION
Release notes: Adding CLI options --warnaserror, --diagnosticaserror, --nodiagnostic

This resolves #2517.
- --warnAsError: Turns all warnings into errors.
- --diagnosticAsError: Must be followed by a comma-separated list of non-fatal-error PPxxxx diagnostic codes that should get turned into (recoverable) errors.
- --noDiagnostic: Must be followed by a comma-separated list of non-fatal-error PPxxxx diagnostic codes that should get suppressed.

Adding tests.