### PR TITLE
Let prepack CLI fail in the presence of recoverable errors.

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -448,8 +448,9 @@ function run(
     for (let compilerDiagnostic of compilerDiagnosticsList) printCompilerDiagnostic(compilerDiagnostic);
     invariant(informations + warnings + recoverableErrors + fatalErrors > 0);
     let plural = (count, word) => (count === 1 ? word : `${word}s`);
+    const success = fatalErrors === 0 && recoverableErrors === 0;
     console.error(
-      `Prepack ${fatalErrors > 0 ? "failed" : "succeeded"}, reporting ${[
+      `Prepack ${success ? "succeeded" : "failed"}, reporting ${[
         fatalErrors > 0 ? `${fatalErrors} ${plural(fatalErrors, "fatal error")}` : undefined,
         recoverableErrors > 0 ? `${recoverableErrors} ${plural(recoverableErrors, "recoverable error")}` : undefined,
         warnings > 0 ? `${warnings} ${plural(warnings, "warning")}` : undefined,
@@ -459,7 +460,7 @@ function run(
         .join(", ")}.`
     );
 
-    return fatalErrors === 0;
+    return success;
   }
 
   let profiler;


### PR DESCRIPTION
Release notes: Let prepack CLI fail in the presence of recoverable errors.