### PR TITLE
Compose without tail duplication

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -620,7 +620,7 @@ function runTest(name, code, options: PrepackOptions, args) {
                   // execInContext/execExternal failed
                   // always compare strings.
                   actual = "" + execError;
-                  actualStack = execError.stack;
+                  actualStack = execError && execError.stack;
                   return Promise.resolve("" + execError);
                 })
                 .then(function(_actual) {

--- a/src/evaluators/BinaryExpression.js
+++ b/src/evaluators/BinaryExpression.js
@@ -9,6 +9,7 @@
 
 /* @flow strict-local */
 
+import { SimpleNormalCompletion } from "../completions.js";
 import type { Realm } from "../realm.js";
 import { TypesDomain, ValuesDomain } from "../domains/index.js";
 import type { LexicalEnvironment } from "../environment.js";
@@ -310,7 +311,7 @@ export function computeBinary(
 
     if (isPure && effects) {
       realm.applyEffects(effects);
-      return realm.returnOrThrowCompletion(effects.result);
+      if (effects.result instanceof SimpleNormalCompletion) return effects.result.value;
     }
 
     // If this ended up reporting an error, it might not be pure, so we'll leave it in

--- a/src/evaluators/Program.js
+++ b/src/evaluators/Program.js
@@ -265,22 +265,18 @@ export default function(ast: BabelNodeProgram, strictCode: boolean, env: Lexical
   function emitThrowStatementsIfNeeded(completion: Completion): void {
     let generator = realm.generator;
     invariant(generator !== undefined);
-    if (
-      res instanceof ThrowCompletion &&
-      res.value !== realm.intrinsics.__bottomValue &&
-      !(res.value instanceof EmptyValue)
-    ) {
+    let selector = c =>
+      c instanceof ThrowCompletion && c.value !== realm.intrinsics.__bottomValue && !(c.value instanceof EmptyValue);
+    if (res instanceof ThrowCompletion && selector(res)) {
       generator.emitThrow(res.value);
     } else if (
       (res instanceof JoinedAbruptCompletions || res instanceof JoinedNormalAndAbruptCompletions) &&
-      res.containsSelectedCompletion(c => c instanceof ThrowCompletion)
+      res.containsSelectedCompletion(selector)
     ) {
-      let selector = c =>
-        c instanceof ThrowCompletion && c.value !== realm.intrinsics.__bottomValue && !(c.value instanceof EmptyValue);
-      generator.emitConditionalThrow(Join.joinValuesOfSelectedCompletions(selector, res));
+      generator.emitConditionalThrow(Join.joinValuesOfSelectedCompletions(selector, res, true));
       res = realm.intrinsics.undefined;
     } else {
-      invariant(res instanceof Value); // other kinds of abrupt completions should not get this far
+      // might get here for completions where all throws have already been handled.
     }
   }
 }

--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -118,6 +118,13 @@ export class JoinImplementation {
       }
       return joinedCompletion;
     }
+    if (leftCompletion instanceof Value) leftCompletion = new SimpleNormalCompletion(leftCompletion);
+    if (
+      leftCompletion instanceof Completion &&
+      leftCompletion.value === leftCompletion.value.$Realm.intrinsics.__bottomValue
+    ) {
+      return leftCompletion;
+    }
     if (rightCompletion instanceof Value) rightCompletion = new SimpleNormalCompletion(rightCompletion);
     return rightCompletion;
   }
@@ -239,19 +246,47 @@ export class JoinImplementation {
     return new Effects(c, generator, bindings, properties, createdObjects);
   }
 
-  joinValuesOfSelectedCompletions(selector: Completion => boolean, completion: Completion): Value {
+  joinValuesOfSelectedCompletions(
+    selector: Completion => boolean,
+    completion: Completion,
+    keepInfeasiblePaths: boolean = false
+  ): Value {
     let realm = completion.value.$Realm;
+    let bottom = realm.intrinsics.__bottomValue;
     if (completion instanceof JoinedAbruptCompletions || completion instanceof JoinedNormalAndAbruptCompletions) {
       let joinCondition = completion.joinCondition;
       let c = this.joinValuesOfSelectedCompletions(selector, completion.consequent);
       let a = this.joinValuesOfSelectedCompletions(selector, completion.alternate);
+      // do some simplification
+      if (c === bottom) {
+        // joinCondition will never be true when this completion is reached
+        if (a instanceof AbstractValue) {
+          a = Path.withInverseCondition(joinCondition, () => {
+            invariant(a instanceof AbstractValue);
+            return realm.simplifyAndRefineAbstractValue(a);
+          });
+        }
+        if (!keepInfeasiblePaths) return a;
+      } else if (a === bottom) {
+        // joinCondition will never be false when this completion is reached
+        if (c instanceof AbstractValue) {
+          c = Path.withCondition(joinCondition, () => {
+            invariant(c instanceof AbstractValue);
+            return realm.simplifyAndRefineAbstractValue(c);
+          });
+        }
+        if (!keepInfeasiblePaths) return c;
+      }
       let getAbstractValue = (v1: void | Value, v2: void | Value): Value => {
+        if (v1 === bottom) v1 = realm.intrinsics.empty;
+        if (v2 === bottom) v2 = realm.intrinsics.empty;
         return AbstractValue.createFromConditionalOp(realm, joinCondition, v1, v2);
       };
       let jv = this.joinValues(realm, c, a, getAbstractValue);
       invariant(jv instanceof Value);
       if (completion instanceof JoinedNormalAndAbruptCompletions && completion.composedWith !== undefined) {
         let composedWith = completion.composedWith;
+        if (!composedWith.containsSelectedCompletion(selector)) return jv;
         let cjv = this.joinValuesOfSelectedCompletions(selector, composedWith);
         joinCondition = AbstractValue.createJoinConditionForSelectedCompletions(selector, composedWith);
         jv = this.joinValues(realm, jv, cjv, getAbstractValue);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -714,7 +714,7 @@ export class Generator {
     } else if (result instanceof JoinedNormalAndAbruptCompletions) {
       let selector = c =>
         c instanceof ThrowCompletion && c.value !== realm.intrinsics.__bottomValue && !(c.value instanceof EmptyValue);
-      output.emitConditionalThrow(Join.joinValuesOfSelectedCompletions(selector, result));
+      output.emitConditionalThrow(Join.joinValuesOfSelectedCompletions(selector, result, true));
       output.emitReturnValue(result.value);
     } else {
       invariant(false);

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -42,6 +42,7 @@ export class PathConditionsImplementation extends PathConditions {
     if (this._impliedConditions !== undefined && this._impliedConditions.has(e)) return true;
     if (this._impliedNegatives !== undefined && this._impliedNegatives.has(e)) return false;
     if (this._failedImplications !== undefined && this._failedImplications.has(e)) return false;
+    if (depth > 10) return false;
     if (this._baseConditions !== undefined && this._baseConditions.implies(e, depth + 1)) return true;
     for (let assumedCondition of this._assumedConditions) {
       if (assumedCondition.implies(e, depth + 1)) return this.cacheImplicationSuccess(e);
@@ -96,6 +97,7 @@ export class PathConditionsImplementation extends PathConditions {
     if (this._impliedConditions !== undefined && this._impliedConditions.has(e)) return false;
     if (this._impliedNegatives !== undefined && this._impliedNegatives.has(e)) return true;
     if (this._failedNegativeImplications !== undefined && this._failedNegativeImplications.has(e)) return false;
+    if (depth > 10) return false;
     if (this._baseConditions !== undefined && this._baseConditions.impliesNot(e, depth + 1)) return true;
     for (let assumedCondition of this._assumedConditions) {
       if (assumedCondition.impliesNot(e, depth + 1)) return this.cacheNegativeImplicationSuccess(e);

--- a/src/utils/simplifier.js
+++ b/src/utils/simplifier.js
@@ -25,6 +25,7 @@ export default function simplifyAndRefineAbstractValue(
   isCondition: boolean, // The value is only used after converting it to a Boolean
   value: AbstractValue
 ): Value {
+  if (value.intrinsicName !== undefined) return value;
   let savedHandler = realm.errorHandler;
   let savedIsReadOnly = realm.isReadOnly;
   realm.isReadOnly = true;

--- a/test/react/__snapshots__/Reconciliation-test.js.snap
+++ b/test/react/__snapshots__/Reconciliation-test.js.snap
@@ -9,13 +9,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -39,13 +39,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -69,13 +69,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -99,13 +99,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -417,18 +417,6 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
           "name": "Bar",
           "status": "INLINED",
         },
@@ -436,6 +424,18 @@ ReactStatistics {
           "children": Array [],
           "message": "",
           "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -459,18 +459,6 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
           "name": "Bar",
           "status": "INLINED",
         },
@@ -478,6 +466,18 @@ ReactStatistics {
           "children": Array [],
           "message": "",
           "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -501,18 +501,6 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
           "name": "Bar",
           "status": "INLINED",
         },
@@ -520,6 +508,18 @@ ReactStatistics {
           "children": Array [],
           "message": "",
           "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -543,18 +543,6 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Foo",
-          "status": "INLINED",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
           "name": "Bar",
           "status": "INLINED",
         },
@@ -562,6 +550,18 @@ ReactStatistics {
           "children": Array [],
           "message": "",
           "name": "Bar",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
+          "status": "INLINED",
+        },
+        Object {
+          "children": Array [],
+          "message": "",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -825,13 +825,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
       ],
@@ -855,13 +855,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
       ],
@@ -885,13 +885,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
       ],
@@ -915,13 +915,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
       ],
@@ -1065,13 +1065,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1095,13 +1095,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1125,13 +1125,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1155,13 +1155,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1185,13 +1185,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1215,13 +1215,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1245,13 +1245,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1275,13 +1275,13 @@ ReactStatistics {
         Object {
           "children": Array [],
           "message": "",
-          "name": "Foo",
+          "name": "Bar",
           "status": "INLINED",
         },
         Object {
           "children": Array [],
           "message": "",
-          "name": "Bar",
+          "name": "Foo",
           "status": "INLINED",
         },
       ],
@@ -1312,7 +1312,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -1325,7 +1325,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -1356,7 +1356,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -1369,7 +1369,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -1400,7 +1400,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -1413,7 +1413,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -1444,7 +1444,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -1457,7 +1457,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -1599,6 +1599,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -1610,12 +1616,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",
@@ -1636,6 +1636,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -1647,12 +1653,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",
@@ -1673,6 +1673,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -1684,12 +1690,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",
@@ -1710,6 +1710,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -1721,12 +1727,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",
@@ -2716,7 +2716,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -2729,7 +2729,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -2760,7 +2760,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -2773,7 +2773,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -2804,7 +2804,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -2817,7 +2817,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -2848,7 +2848,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "MessagePane",
+          "name": "SettingsPane",
           "status": "INLINED",
         },
         Object {
@@ -2861,7 +2861,7 @@ ReactStatistics {
             },
           ],
           "message": "",
-          "name": "SettingsPane",
+          "name": "MessagePane",
           "status": "INLINED",
         },
       ],
@@ -2883,6 +2883,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -2894,12 +2900,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",
@@ -2920,6 +2920,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -2931,12 +2937,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",
@@ -2957,6 +2957,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -2968,12 +2974,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",
@@ -2994,6 +2994,12 @@ ReactStatistics {
     Object {
       "children": Array [
         Object {
+          "children": Array [],
+          "message": "",
+          "name": "Stateful",
+          "status": "NEW_TREE",
+        },
+        Object {
           "children": Array [
             Object {
               "children": Array [],
@@ -3005,12 +3011,6 @@ ReactStatistics {
           "message": "",
           "name": "React.Fragment",
           "status": "NORMAL",
-        },
-        Object {
-          "children": Array [],
-          "message": "",
-          "name": "Stateful",
-          "status": "NEW_TREE",
         },
       ],
       "message": "",

--- a/test/serializer/abstract/ComposedCompletions.js
+++ b/test/serializer/abstract/ComposedCompletions.js
@@ -1,0 +1,15 @@
+let n1 = global.__abstract ? __abstract("number", "4") : 4;
+
+function f1() {
+  if (n1 === 1) return 10;
+  if (n1 === 2) throw 20;
+  if (n1 === 3) return 30;
+  if (n1 === 4) return 40;
+  throw 50;
+}
+
+var x = f1();
+
+inspect = function() {
+  return x;
+};

--- a/test/serializer/optimized-functions/ForLoop.js
+++ b/test/serializer/optimized-functions/ForLoop.js
@@ -1,14 +1,19 @@
-var x = global.__abstract ? (x = __abstract("number", "(3)")) : 3;
+// throws introspection error
+var x = global.__abstract ? (x = __abstract("number", "(2)")) : 2;
 
 function func1() {
-  for (let i = 0; i < 10; i++) {
+  for (let i = 0; i < 3; i++) {
     if (i === x) {
       break;
     }
-    if (i === 4) {
-      throw new Error("X is 4");
+    if (i === 2) {
+      throw new Error("X is 2");
     }
   }
 }
 
 if (global.__optimize) __optimize(func1);
+
+inspect = function() {
+  return func1();
+};


### PR DESCRIPTION
Release note: none

Closes #2435
Closes #1829

Join.composeWithEffects composes a forked completion with subsequent effects. When two or more forks could end normally, this could result in shallow copies of the subsequent effects. These were then joined together and applied, so it was mostly OK. The generator of the subsequent effects, however, ended up being joined with itself and thus transformed the generator tree to a DAG, which is not desirable for the serializer.

The new approach is to extract a join condition from the forked completion and using it to join the subsequent effects with a newly constructed empty effects. The condition ensures that the subsequent effects are applied only in situations where the forked completion is not abrupt.
Extracting this condition makes for complicated abstract expressions and this uncovered some existing bugs and limitations that are also addressed in this pull request. As a side effect, path conditions are now longer and the time to compile unrolled loops with conditional abrupt completions inside their bodies has gone up so much that the unroll limit had to be lowered.

Please note that the expected output React tests has changed because of re-ordering. I'm none too sure that this re-ordering is necessarily benign, so please review carefully.

