### PR TITLE
Propagate functionResultType when resolving an abstract template property access.

### DIFF
--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -1580,6 +1580,7 @@ export class PropertiesImplementation {
             let realmGenerator = realm.generator;
             invariant(realmGenerator);
             invariant(value.operationDescriptor);
+            const functionResultType = value instanceof AbstractObjectValue ? value.functionResultType : undefined;
             value = realmGenerator.deriveAbstract(value.types, value.values, value.args, value.operationDescriptor, {
               isPure: true,
               kind: "resolved",
@@ -1591,6 +1592,10 @@ export class PropertiesImplementation {
               let args = savedUnion.args.slice(0);
               args[savedIndex] = value;
               value = AbstractValue.createAbstractConcreteUnion(realm, ...args);
+            }
+            if (functionResultType !== undefined) {
+              invariant(value instanceof AbstractObjectValue);
+              value.functionResultType = functionResultType;
             }
             if (realm.invariantLevel >= 1 && typeof P === "string" && !realm.hasBindingBeenChecked(O, P)) {
               realm.markPropertyAsChecked(O, P);

--- a/test/serializer/abstract/PropagateFunctionResultType.js
+++ b/test/serializer/abstract/PropagateFunctionResultType.js
@@ -1,4 +1,12 @@
 // add at runtime: let __obj = {f: function() { return 19; }};
-let obj = global.__abstract ? __abstract({f: __abstract(":number")}, "__obj") : {f: function() { return 19; }};
+let obj = global.__abstract
+  ? __abstract({ f: __abstract(":number") }, "__obj")
+  : {
+      f: function() {
+        return 19;
+      },
+    };
 let result = obj.f() + 23;
-global.inspect = function() { return 42; }
+global.inspect = function() {
+  return 42;
+};

--- a/test/serializer/abstract/PropagateFunctionResultType.js
+++ b/test/serializer/abstract/PropagateFunctionResultType.js
@@ -1,0 +1,4 @@
+// add at runtime: let __obj = {f: function() { return 19; }};
+let obj = global.__abstract ? __abstract({f: __abstract(":number")}, "__obj") : {f: function() { return 19; }};
+let result = obj.f() + 23;
+global.inspect = function() { return 42; }


### PR DESCRIPTION
Release notes: None

Added regression test.
This fix gets rid of a spurious internal RecoverableError.