### PR TITLE
Website code and warnings

### DIFF
--- a/website/css/style.css
+++ b/website/css/style.css
@@ -639,12 +639,14 @@ img.nav-logo {
   border-spacing: 5%;
 }
 
-.repl, .messagesContainer {
+.repl {
   width: 100%;
   height: 100%;
 }
 
 .messagesContainer {
+  width: 100%;
+  height: auto;
   position: absolute;
   bottom: 0;
   z-index: 5; /* one more than ace_gutter */
@@ -663,10 +665,6 @@ img.nav-logo {
 .message {
   width: 100%;
   padding: 10px;
-}
-
-.last-message {
-  height: 100%;
 }
 
 .message.error {

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -639,39 +639,53 @@ img.nav-logo {
   border-spacing: 5%;
 }
 
-.repl, .message {
+.repl, .messagesContainer {
   width: 100%;
   height: 100%;
 }
 
-.message {
-  padding: 10px;
-  font-family: "Operator Mono", "Fira Code", "Ubuntu Mono", "Droid Sans Mono", "Liberation Mono", "Source Code Pro", Menlo, Monaco, Consolas, "Courier New", monospace;
-  white-space: pre;
+.messagesContainer {
   position: absolute;
   bottom: 0;
   z-index: 5; /* one more than ace_gutter */
   overflow-x: scroll;
+  overflow-y: hidden;
 }
 
-.error {
+.messages {
+  display: inline-block;
+  min-width: 100%;
+  height: 100%;
+  font-family: "Operator Mono", "Fira Code", "Ubuntu Mono", "Droid Sans Mono", "Liberation Mono", "Source Code Pro", Menlo, Monaco, Consolas, "Courier New", monospace;
+  white-space: pre;
+}
+
+.message {
+  width: 100%;
+  padding: 10px;
+}
+
+.last-message {
+  height: 100%;
+}
+
+.message.error {
   color: #c7254e;
   background-color:#ffefee;
   border-top: 1px solid #ffe1e0;
 }
 
-.error > .line-link {
+.message.error > .line-link {
   color: red;
 }
 
-.warning {
+.message.warning {
   color: #8a6f40;
-  height: auto;
   background-color:#fffae5;
   border-top: 1px solid #fff6cc;
 }
 
-.warning > .line-link {
+.message.warning > .line-link {
   color: #7d7d7d;
 }
 

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -639,23 +639,40 @@ img.nav-logo {
   border-spacing: 5%;
 }
 
-.repl, .error {
+.repl, .message {
   width: 100%;
   height: 100%;
 }
 
-.error {
+.message {
   padding: 10px;
   font-family: "Operator Mono", "Fira Code", "Ubuntu Mono", "Droid Sans Mono", "Liberation Mono", "Source Code Pro", Menlo, Monaco, Consolas, "Courier New", monospace;
-  color: #c7254e;
   white-space: pre;
   position: absolute;
   bottom: 0;
-  height: auto;
   z-index: 5; /* one more than ace_gutter */
+  overflow-x: scroll;
+}
+
+.error {
+  color: #c7254e;
   background-color:#ffefee;
   border-top: 1px solid #ffe1e0;
-  overflow-x: scroll;
+}
+
+.error > .line-link {
+  color: red;
+}
+
+.warning {
+  color: #8a6f40;
+  height: auto;
+  background-color:#fffae5;
+  border-top: 1px solid #fff6cc;
+}
+
+.warning > .line-link {
+  color: #7d7d7d;
 }
 
 .align-left {

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -630,12 +630,10 @@ img.nav-logo {
 
 .legend-header {
   text-align: center;
-  align: center;
 }
 
 .legend-table {
   text-align: center;
-  align: center;
   margin: 0 auto;
   padding-bottom: 3%;
   border-spacing: 5%;

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -644,6 +644,7 @@ img.nav-logo {
 .repl, .error {
   width: 100%;
   height: 100%;
+  overflow-x: scroll;
 }
 
 .error {

--- a/website/css/style.css
+++ b/website/css/style.css
@@ -642,7 +642,6 @@ img.nav-logo {
 .repl, .error {
   width: 100%;
   height: 100%;
-  overflow-x: scroll;
 }
 
 .error {
@@ -650,6 +649,13 @@ img.nav-logo {
   font-family: "Operator Mono", "Fira Code", "Ubuntu Mono", "Droid Sans Mono", "Liberation Mono", "Source Code Pro", Menlo, Monaco, Consolas, "Courier New", monospace;
   color: #c7254e;
   white-space: pre;
+  position: absolute;
+  bottom: 0;
+  height: auto;
+  z-index: 5; /* one more than ace_gutter */
+  background-color:#ffefee;
+  border-top: 1px solid #ffe1e0;
+  overflow-x: scroll;
 }
 
 .align-left {

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -45,7 +45,7 @@ onmessage = function(e) {
     } else {
       let noError = onlyWarnings(buffer);
       if (noError) {
-        postMessage({ type: 'warning', data: result.code, graph: result.heapGrap, warnings: buffer });
+        postMessage({ type: 'warning', data: result.code, warnings: buffer });
       } else {
         // A well-defined error occurred.
         postMessage({ type: 'error', data: buffer });

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -45,7 +45,7 @@ onmessage = function(e) {
     } else {
       let noError = onlyWarnings(buffer);
       if (noError) {
-        postMessage({ type: 'warning', data: result.code, warnings: buffer });
+        postMessage({ type: 'warning', data: result.code, graph: result.heapGrap, warnings: buffer });
       } else {
         // A well-defined error occurred.
         postMessage({ type: 'error', data: buffer });

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -45,7 +45,7 @@ onmessage = function(e) {
     } else {
       let noError = onlyWarnings(buffer);
       if(noError) {
-        postMessage({ type: 'warning', data: result.code, warnings: buffer });
+        postMessage({ type: 'warning', data: result.code, graph: result.heapGrap, warnings: buffer });
       } else {
       // A well-defined error occurred.
       postMessage({ type: 'error', data: buffer });

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -2,7 +2,7 @@ self.importScripts('prepack.min.js');
 
 function onlyWarnings(buffer) {
   return buffer.every(function(error) {
-    return error.severity === "Warning";
+    return error.severity === "Warning" || error.severity === "Information";
   });
 }
 
@@ -39,17 +39,14 @@ onmessage = function(e) {
         options[property] = e.data.options[property];
       }
     }
+
     let result = Prepack.prepackSources(sources, options);
-    if (result && !buffer.length) {
-      postMessage({ type: 'success', data: result.code, graph: result.heapGraph });
+    let noErrors = onlyWarnings(buffer);
+    if (result && noErrors) {
+      postMessage({ type: 'success', data: result.code, graph: result.heapGraph, messages: buffer });
     } else {
-      let noError = onlyWarnings(buffer);
-      if(noError) {
-        postMessage({ type: 'warning', data: result.code, graph: result.heapGrap, warnings: buffer });
-      } else {
       // A well-defined error occurred.
       postMessage({ type: 'error', data: buffer });
-      }
     }
   } catch (err) {
     buffer.push({

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -2,7 +2,7 @@ self.importScripts('prepack.min.js');
 
 function onlyWarnings(buffer) {
   return buffer.every(function(error) {
-    return error.severity === 'Warning';
+    return error.severity === "Warning";
   });
 }
 
@@ -11,9 +11,9 @@ onmessage = function(e) {
 
   function errorHandler(error) {
     // Syntax errors contain their location at the end, remove that
-    if (error.errorCode === 'PP1004') {
+    if (error.errorCode === "PP1004") {
       let msg = error.message;
-      error.message = msg.substring(0, msg.lastIndexOf('('));
+      error.message = msg.substring(0, msg.lastIndexOf("("));
     }
     buffer.push({
       severity: error.severity,
@@ -21,17 +21,17 @@ onmessage = function(e) {
       message: error.message,
       errorCode: error.errorCode,
     });
-    return 'Recover';
+    return "Recover";
   }
 
   try {
-    let sources = [{ filePath: 'dummy', fileContents: e.data.code }];
+    let sources = [{ filePath: "dummy", fileContents: e.data.code }];
     let options = {
-      compatibility: 'browser',
-      filename: 'repl',
+      compatibility: "browser",
+      filename: "repl",
       timeout: 1000,
       serialize: true,
-      heapGraphFormat: 'VISJS',
+      heapGraphFormat: "VISJS",
       errorHandler,
     };
     for (let property in e.data.options) {
@@ -44,16 +44,16 @@ onmessage = function(e) {
       postMessage({ type: 'success', data: result.code, graph: result.heapGraph });
     } else {
       let noError = onlyWarnings(buffer);
-      if (noError) {
+      if(noError) {
         postMessage({ type: 'warning', data: result.code, warnings: buffer });
       } else {
-        // A well-defined error occurred.
-        postMessage({ type: 'error', data: buffer });
+      // A well-defined error occurred.
+      postMessage({ type: 'error', data: buffer });
       }
     }
   } catch (err) {
     buffer.push({
-      message: err.stack || 'An unknown error occurred',
+      message: err.stack || 'An unknown error occurred'
     });
     postMessage({ type: 'error', data: buffer });
   }

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -2,7 +2,7 @@ self.importScripts('prepack.min.js');
 
 function onlyWarnings(buffer) {
   return buffer.every(function(error) {
-    return error.severity === "Warning";
+    return error.severity === 'Warning';
   });
 }
 
@@ -11,9 +11,9 @@ onmessage = function(e) {
 
   function errorHandler(error) {
     // Syntax errors contain their location at the end, remove that
-    if (error.errorCode === "PP1004") {
+    if (error.errorCode === 'PP1004') {
       let msg = error.message;
-      error.message = msg.substring(0, msg.lastIndexOf("("));
+      error.message = msg.substring(0, msg.lastIndexOf('('));
     }
     buffer.push({
       severity: error.severity,
@@ -21,17 +21,17 @@ onmessage = function(e) {
       message: error.message,
       errorCode: error.errorCode,
     });
-    return "Recover";
+    return 'Recover';
   }
 
   try {
-    let sources = [{ filePath: "dummy", fileContents: e.data.code }];
+    let sources = [{ filePath: 'dummy', fileContents: e.data.code }];
     let options = {
-      compatibility: "browser",
-      filename: "repl",
+      compatibility: 'browser',
+      filename: 'repl',
       timeout: 1000,
       serialize: true,
-      heapGraphFormat: "VISJS",
+      heapGraphFormat: 'VISJS',
       errorHandler,
     };
     for (let property in e.data.options) {
@@ -44,16 +44,16 @@ onmessage = function(e) {
       postMessage({ type: 'success', data: result.code, graph: result.heapGraph });
     } else {
       let noError = onlyWarnings(buffer);
-      if(noError) {
+      if (noError) {
         postMessage({ type: 'warning', data: result.code, warnings: buffer });
       } else {
-      // A well-defined error occurred.
-      postMessage({ type: 'error', data: buffer });
+        // A well-defined error occurred.
+        postMessage({ type: 'error', data: buffer });
       }
     }
   } catch (err) {
     buffer.push({
-      message: err.stack || 'An unknown error occurred'
+      message: err.stack || 'An unknown error occurred',
     });
     postMessage({ type: 'error', data: buffer });
   }

--- a/website/js/repl-worker.js
+++ b/website/js/repl-worker.js
@@ -1,5 +1,11 @@
 self.importScripts('prepack.min.js');
 
+function onlyWarnings(buffer) {
+  return buffer.every(function(error) {
+    return error.severity === "Warning";
+  });
+}
+
 onmessage = function(e) {
   let buffer = [];
 
@@ -37,8 +43,13 @@ onmessage = function(e) {
     if (result && !buffer.length) {
       postMessage({ type: 'success', data: result.code, graph: result.heapGraph });
     } else {
+      let noError = onlyWarnings(buffer);
+      if(noError) {
+        postMessage({ type: 'warning', data: result.code, warnings: buffer });
+      } else {
       // A well-defined error occurred.
       postMessage({ type: 'error', data: buffer });
+      }
     }
   } catch (err) {
     buffer.push({

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -196,15 +196,15 @@ function compile() {
         const { data, graph, messages } = result;
         showGeneratedCode(data);
         showGenerationGraph(graph);
-      }  else if (result.type === 'error') {
-        let errors = result.data;
+      } else if (result.type === 'error') {
+        const errors = result.data;
         if (typeof errors === 'string') {
           errorOutput.style.display = 'block';
-          replOutput.style.display = 'none';
+          //replOutput.style.display = 'none';
           errorOutput.textContent = errors;
         } else {
           errorOutput.style.display = 'block';
-          replOutput.style.display = 'none';
+          //replOutput.style.display = 'none';
           for (var i in errors) {
             processError(errorOutput, errors[i]);
           }

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -192,9 +192,8 @@ function compile() {
       // turn off compiling
 
       var result = e.data;
-      if (result.type === 'success' || result.type === 'warning') {
-        var code = result.data;
-        var graph = result.graph;
+      if (result.type === 'success') {
+        const { code, graph, messages } = result.data;
         showGeneratedCode(code);
         showGenerationGraph(graph);
       }  else if (result.type === 'error') {

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -20,61 +20,61 @@ function createEditor(elem) {
 
 var optionsConfig = [
   {
-    type: 'string',
-    name: 'mathRandomSeed',
-    defaultVal: '',
-    description: 'If you want Prepack to evaluate Math.random() calls, please provide a seed.',
+    type: "string",
+    name: "mathRandomSeed",
+    defaultVal: "",
+    description: "If you want Prepack to evaluate Math.random() calls, please provide a seed."
   },
   {
-    type: 'boolean',
-    name: 'inlineExpressions',
+    type: "boolean",
+    name: "inlineExpressions",
     defaultVal: true,
-    description: 'Avoids naming expressions when they are only used once, and instead inline them where they are used.',
+    description: "Avoids naming expressions when they are only used once, and instead inline them where they are used."
   },
   {
-    type: 'boolean',
-    name: 'delayInitializations',
+    type: "boolean",
+    name: "delayInitializations",
     defaultVal: false,
-    description: 'Delay initializations.',
+    description: "Delay initializations."
   },
   {
-    type: 'choice',
-    name: 'compatibility',
-    choices: ['browser', 'jsc-600-1-4-17', 'node-source-maps', 'node-react'],
-    defaultVal: 'node-react',
-    description: 'The target environment for Prepack',
+    type: "choice",
+    name: "compatibility",
+    choices: ["browser", "jsc-600-1-4-17", "node-source-maps", "node-react"],
+    defaultVal: "node-react",
+    description: "The target environment for Prepack"
   },
   {
-    type: 'string',
-    name: 'lazyObjectsRuntime',
-    defaultVal: '',
-    description: 'Enable lazy objects feature and specify the JS runtime that supports this feature.',
+    type: "string",
+    name: "lazyObjectsRuntime",
+    defaultVal: "",
+    description: "Enable lazy objects feature and specify the JS runtime that supports this feature."
   },
   {
-    type: 'choice',
-    name: 'invariantLevel',
+    type: "choice",
+    name: "invariantLevel",
     choices: [0, 1, 2, 3],
     defaultVal: 0,
-    description: "Whether and how many checks to generate that validate Prepack's assumptions about the environment.",
+    description: "Whether and how many checks to generate that validate Prepack's assumptions about the environment."
   },
   {
-    type: 'boolean',
-    name: 'reactEnabled',
+    type: "boolean",
+    name: "reactEnabled",
     defaultVal: true,
-    description: 'Enables support for React features, such as JSX syntax.',
+    description: "Enables support for React features, such as JSX syntax."
   },
   {
-    type: 'choice',
-    name: 'reactOutput',
-    choices: ['jsx', 'create-element'],
-    defaultVal: 'jsx',
-    description: 'Specifies the serialization output of JSX nodes when React mode is enabled.',
+    type: "choice",
+    name: "reactOutput",
+    choices: ["jsx", "create-element"],
+    defaultVal: "jsx",
+    description: "Specifies the serialization output of JSX nodes when React mode is enabled."
   },
   {
-    type: 'boolean',
-    name: 'stripFlow',
+    type: "boolean",
+    name: "stripFlow",
     defaultVal: true,
-    description: 'Removes Flow type annotations from the output.',
+    description: "Removes Flow type annotations from the output."
   },
 ];
 
@@ -141,7 +141,7 @@ function getHashedDemo(hash) {
   if (hash[0] !== '#' || hash.length < 2) return null;
   var encoded = hash.slice(1);
   if (encoded.match(/^[a-zA-Z0-9+/=_-]+$/)) {
-    return LZString.decompressFromEncodedURIComponent(encoded);
+    return LZString.decompressFromEncodedURIComponent(encoded)
   }
   return null;
 }
@@ -153,18 +153,19 @@ function makeDemoSharable() {
 
 function showGeneratedCode(code) {
   if (isEmpty.test(code) && !isEmpty.test(input.getValue())) {
-    code = '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
+    code =
+      '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
   }
   drawGraphCallback = () => {
     var graphData = JSON.parse(result.graph);
     var visData = {
       nodes: graphData.nodes,
-      edges: graphData.edges,
-    };
+      edges: graphData.edges
+    }
 
     var visOptions = {};
     var boxNetwork = new vis.Network(graphBox, visData, visOptions);
-  };
+  }
   if (showGraphDiv) {
     drawGraphCallback();
   }
@@ -190,7 +191,7 @@ function compile() {
       if (result.type === 'success' || result.type === 'warning') {
         var code = result.data;
         showGeneratedCode(code);
-      } else if (result.type === 'error') {
+      }  else if (result.type === 'error') {
         let errors = result.data;
         if (typeof errors === 'string') {
           errorOutput.style.display = 'block';
@@ -207,23 +208,24 @@ function compile() {
       terminateWorker();
     };
 
-    var options = {};
+    var options = {}
     for (var configIndex in optionsConfig) {
       var config = optionsConfig[configIndex];
-      var domE = document.querySelector('#prepack-option-' + config.name);
-      if (config.type === 'choice') {
+      var domE = document.querySelector("#prepack-option-" + config.name);
+      if (config.type === "choice") {
         options[config.name] = domE.options[domE.selectedIndex].value;
-      } else if (config.type === 'boolean') {
-        options[config.name] = domE.checked === true;
-      } else if (config.type === 'string') {
+      } else if (config.type === "boolean") {
+        options[config.name] = (domE.checked === true);
+      } else if (config.type === "string") {
         if (domE.value) {
           options[config.name] = domE.value;
         }
       }
     }
 
-    worker.postMessage({ code: input.getValue(), options: options });
+    worker.postMessage({code: input.getValue(), options: options});
   }, 500);
+
 }
 
 var output = createEditor(replOutput);
@@ -340,7 +342,7 @@ function addDefaultExamples() {
     '  define("three", function() { return require("two") + require("one"); });',
     '  define("four", function() { return require("three") + require("one"); });',
     '})();',
-    'three = require("three");',
+    'three = require("three");'
   ].join('\n');
   cache[name] = code;
 
@@ -381,8 +383,8 @@ function addOptions() {
     optionStrings.push(config.name);
     optionStrings.push("<div class='prepack-option-description'>");
     optionStrings.push(config.description);
-    optionStrings.push('</div>');
-    if (config.type === 'choice') {
+    optionStrings.push("</div>");
+    if (config.type === "choice") {
       optionStrings.push("<select id='");
       optionStrings.push(configId);
       optionStrings.push("'>");
@@ -394,16 +396,16 @@ function addOptions() {
           optionStrings.push('<option value=' + name + '>' + name + '</option>');
         }
       }
-      optionStrings.push('</select>');
-    } else if (config.type === 'boolean') {
+      optionStrings.push("</select>");
+    } else if (config.type === "boolean") {
       optionStrings.push("<input type='checkbox' id='");
       optionStrings.push(configId);
       if (config.defaultVal === true) {
-        optionStrings.push("' checked=true>");
+        optionStrings.push("' checked=true>")
       } else {
         optionStrings.push("'>");
       }
-    } else if (config.type === 'string') {
+    } else if (config.type === "string") {
       optionStrings.push("<input type='text' id='");
       optionStrings.push(configId);
       if (config.defaultVal != null) {
@@ -414,31 +416,31 @@ function addOptions() {
         optionStrings.push("'>");
       }
     }
-    optionStrings.push('</label>');
-    optionStrings.push('</div>');
+    optionStrings.push("</label>");
+    optionStrings.push("</div>");
   }
   optionsRecord.innerHTML = optionStrings.join('');
   for (var configIndex in optionsConfig) {
     var config = optionsConfig[configIndex];
-    var domE = document.querySelector('#prepack-option-' + config.name);
-    if (config.type === 'choice') {
+    var domE = document.querySelector("#prepack-option-" + config.name);
+    if (config.type === "choice") {
       var demoSelector = new Select({
         el: domE,
         className: 'select-theme-dark',
       });
       domE.addEventListener('change', compile);
-    } else if (config.type === 'boolean') {
+    } else if (config.type === "boolean") {
       domE.addEventListener('change', compile);
-    } else if (config.type === 'string') {
+    } else if (config.type === "string") {
       domE.addEventListener('input', compile);
     }
   }
 
   optionsButton.onclick = function() {
-    if (optionsRecord.style.display !== 'inline-block') {
-      optionsRecord.style.display = 'inline-block';
+    if (optionsRecord.style.display !== "inline-block") {
+      optionsRecord.style.display = "inline-block" ;
     } else {
-      optionsRecord.style.display = 'none';
+      optionsRecord.style.display = "none" ;
     }
   };
 }
@@ -486,24 +488,24 @@ saveButton.addEventListener('click', () => {
 
 graphButton.addEventListener('click', () => {
   if (!showGraphDiv) {
-    inputDiv.style.width = '33%';
-    outputDiv.style.width = '33%';
-    graphDiv.style.width = '34%';
-    outputDiv.style.left = '33%';
-    graphDiv.style.display = 'block';
+    inputDiv.style.width = "33%";
+    outputDiv.style.width = "33%";
+    graphDiv.style.width = "34%";
+    outputDiv.style.left = "33%";
+    graphDiv.style.display = "block";
     showGraphDiv = true;
-    graphButton.innerHTML = 'HIDE HEAP';
+    graphButton.innerHTML = "HIDE HEAP";
     if (drawGraphCallback !== null) {
       drawGraphCallback();
       drawGraphCallback = null;
     }
   } else {
-    inputDiv.style.width = '50%';
-    outputDiv.style.width = '50%';
-    graphDiv.style.width = '50%';
-    outputDiv.style.left = '50%';
-    graphDiv.style.display = 'none';
+    inputDiv.style.width = "50%";
+    outputDiv.style.width = "50%";
+    graphDiv.style.width = "50%";
+    outputDiv.style.left = "50%";
+    graphDiv.style.display = "none";
     showGraphDiv = false;
-    graphButton.innerHTML = 'SHOW HEAP';
+    graphButton.innerHTML = "SHOW HEAP";
   }
 });

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -20,61 +20,61 @@ function createEditor(elem) {
 
 var optionsConfig = [
   {
-    type: "string",
-    name: "mathRandomSeed",
-    defaultVal: "",
-    description: "If you want Prepack to evaluate Math.random() calls, please provide a seed."
+    type: 'string',
+    name: 'mathRandomSeed',
+    defaultVal: '',
+    description: 'If you want Prepack to evaluate Math.random() calls, please provide a seed.',
   },
   {
-    type: "boolean",
-    name: "inlineExpressions",
+    type: 'boolean',
+    name: 'inlineExpressions',
     defaultVal: true,
-    description: "Avoids naming expressions when they are only used once, and instead inline them where they are used."
+    description: 'Avoids naming expressions when they are only used once, and instead inline them where they are used.',
   },
   {
-    type: "boolean",
-    name: "delayInitializations",
+    type: 'boolean',
+    name: 'delayInitializations',
     defaultVal: false,
-    description: "Delay initializations."
+    description: 'Delay initializations.',
   },
   {
-    type: "choice",
-    name: "compatibility",
-    choices: ["browser", "jsc-600-1-4-17", "node-source-maps", "node-react"],
-    defaultVal: "node-react",
-    description: "The target environment for Prepack"
+    type: 'choice',
+    name: 'compatibility',
+    choices: ['browser', 'jsc-600-1-4-17', 'node-source-maps', 'node-react'],
+    defaultVal: 'node-react',
+    description: 'The target environment for Prepack',
   },
   {
-    type: "string",
-    name: "lazyObjectsRuntime",
-    defaultVal: "",
-    description: "Enable lazy objects feature and specify the JS runtime that supports this feature."
+    type: 'string',
+    name: 'lazyObjectsRuntime',
+    defaultVal: '',
+    description: 'Enable lazy objects feature and specify the JS runtime that supports this feature.',
   },
   {
-    type: "choice",
-    name: "invariantLevel",
+    type: 'choice',
+    name: 'invariantLevel',
     choices: [0, 1, 2, 3],
     defaultVal: 0,
-    description: "Whether and how many checks to generate that validate Prepack's assumptions about the environment."
+    description: "Whether and how many checks to generate that validate Prepack's assumptions about the environment.",
   },
   {
-    type: "boolean",
-    name: "reactEnabled",
+    type: 'boolean',
+    name: 'reactEnabled',
     defaultVal: true,
-    description: "Enables support for React features, such as JSX syntax."
+    description: 'Enables support for React features, such as JSX syntax.',
   },
   {
-    type: "choice",
-    name: "reactOutput",
-    choices: ["jsx", "create-element"],
-    defaultVal: "jsx",
-    description: "Specifies the serialization output of JSX nodes when React mode is enabled."
+    type: 'choice',
+    name: 'reactOutput',
+    choices: ['jsx', 'create-element'],
+    defaultVal: 'jsx',
+    description: 'Specifies the serialization output of JSX nodes when React mode is enabled.',
   },
   {
-    type: "boolean",
-    name: "stripFlow",
+    type: 'boolean',
+    name: 'stripFlow',
     defaultVal: true,
-    description: "Removes Flow type annotations from the output."
+    description: 'Removes Flow type annotations from the output.',
   },
 ];
 
@@ -141,7 +141,7 @@ function getHashedDemo(hash) {
   if (hash[0] !== '#' || hash.length < 2) return null;
   var encoded = hash.slice(1);
   if (encoded.match(/^[a-zA-Z0-9+/=_-]+$/)) {
-    return LZString.decompressFromEncodedURIComponent(encoded)
+    return LZString.decompressFromEncodedURIComponent(encoded);
   }
   return null;
 }
@@ -153,19 +153,18 @@ function makeDemoSharable() {
 
 function showGeneratedCode(code) {
   if (isEmpty.test(code) && !isEmpty.test(input.getValue())) {
-    code =
-      '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
+    code = '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
   }
   drawGraphCallback = () => {
     var graphData = JSON.parse(result.graph);
     var visData = {
       nodes: graphData.nodes,
-      edges: graphData.edges
-    }
+      edges: graphData.edges,
+    };
 
     var visOptions = {};
     var boxNetwork = new vis.Network(graphBox, visData, visOptions);
-  }
+  };
   if (showGraphDiv) {
     drawGraphCallback();
   }
@@ -191,7 +190,7 @@ function compile() {
       if (result.type === 'success' || result.type === 'warning') {
         var code = result.data;
         showGeneratedCode(code);
-      }  else if (result.type === 'error') {
+      } else if (result.type === 'error') {
         let errors = result.data;
         if (typeof errors === 'string') {
           errorOutput.style.display = 'block';
@@ -208,24 +207,23 @@ function compile() {
       terminateWorker();
     };
 
-    var options = {}
+    var options = {};
     for (var configIndex in optionsConfig) {
       var config = optionsConfig[configIndex];
-      var domE = document.querySelector("#prepack-option-" + config.name);
-      if (config.type === "choice") {
+      var domE = document.querySelector('#prepack-option-' + config.name);
+      if (config.type === 'choice') {
         options[config.name] = domE.options[domE.selectedIndex].value;
-      } else if (config.type === "boolean") {
-        options[config.name] = (domE.checked === true);
-      } else if (config.type === "string") {
+      } else if (config.type === 'boolean') {
+        options[config.name] = domE.checked === true;
+      } else if (config.type === 'string') {
         if (domE.value) {
           options[config.name] = domE.value;
         }
       }
     }
 
-    worker.postMessage({code: input.getValue(), options: options});
+    worker.postMessage({ code: input.getValue(), options: options });
   }, 500);
-
 }
 
 var output = createEditor(replOutput);
@@ -342,7 +340,7 @@ function addDefaultExamples() {
     '  define("three", function() { return require("two") + require("one"); });',
     '  define("four", function() { return require("three") + require("one"); });',
     '})();',
-    'three = require("three");'
+    'three = require("three");',
   ].join('\n');
   cache[name] = code;
 
@@ -383,8 +381,8 @@ function addOptions() {
     optionStrings.push(config.name);
     optionStrings.push("<div class='prepack-option-description'>");
     optionStrings.push(config.description);
-    optionStrings.push("</div>");
-    if (config.type === "choice") {
+    optionStrings.push('</div>');
+    if (config.type === 'choice') {
       optionStrings.push("<select id='");
       optionStrings.push(configId);
       optionStrings.push("'>");
@@ -396,16 +394,16 @@ function addOptions() {
           optionStrings.push('<option value=' + name + '>' + name + '</option>');
         }
       }
-      optionStrings.push("</select>");
-    } else if (config.type === "boolean") {
+      optionStrings.push('</select>');
+    } else if (config.type === 'boolean') {
       optionStrings.push("<input type='checkbox' id='");
       optionStrings.push(configId);
       if (config.defaultVal === true) {
-        optionStrings.push("' checked=true>")
+        optionStrings.push("' checked=true>");
       } else {
         optionStrings.push("'>");
       }
-    } else if (config.type === "string") {
+    } else if (config.type === 'string') {
       optionStrings.push("<input type='text' id='");
       optionStrings.push(configId);
       if (config.defaultVal != null) {
@@ -416,31 +414,31 @@ function addOptions() {
         optionStrings.push("'>");
       }
     }
-    optionStrings.push("</label>");
-    optionStrings.push("</div>");
+    optionStrings.push('</label>');
+    optionStrings.push('</div>');
   }
   optionsRecord.innerHTML = optionStrings.join('');
   for (var configIndex in optionsConfig) {
     var config = optionsConfig[configIndex];
-    var domE = document.querySelector("#prepack-option-" + config.name);
-    if (config.type === "choice") {
+    var domE = document.querySelector('#prepack-option-' + config.name);
+    if (config.type === 'choice') {
       var demoSelector = new Select({
         el: domE,
         className: 'select-theme-dark',
       });
       domE.addEventListener('change', compile);
-    } else if (config.type === "boolean") {
+    } else if (config.type === 'boolean') {
       domE.addEventListener('change', compile);
-    } else if (config.type === "string") {
+    } else if (config.type === 'string') {
       domE.addEventListener('input', compile);
     }
   }
 
   optionsButton.onclick = function() {
-    if (optionsRecord.style.display !== "inline-block") {
-      optionsRecord.style.display = "inline-block" ;
+    if (optionsRecord.style.display !== 'inline-block') {
+      optionsRecord.style.display = 'inline-block';
     } else {
-      optionsRecord.style.display = "none" ;
+      optionsRecord.style.display = 'none';
     }
   };
 }
@@ -488,24 +486,24 @@ saveButton.addEventListener('click', () => {
 
 graphButton.addEventListener('click', () => {
   if (!showGraphDiv) {
-    inputDiv.style.width = "33%";
-    outputDiv.style.width = "33%";
-    graphDiv.style.width = "34%";
-    outputDiv.style.left = "33%";
-    graphDiv.style.display = "block";
+    inputDiv.style.width = '33%';
+    outputDiv.style.width = '33%';
+    graphDiv.style.width = '34%';
+    outputDiv.style.left = '33%';
+    graphDiv.style.display = 'block';
     showGraphDiv = true;
-    graphButton.innerHTML = "HIDE HEAP";
+    graphButton.innerHTML = 'HIDE HEAP';
     if (drawGraphCallback !== null) {
       drawGraphCallback();
       drawGraphCallback = null;
     }
   } else {
-    inputDiv.style.width = "50%";
-    outputDiv.style.width = "50%";
-    graphDiv.style.width = "50%";
-    outputDiv.style.left = "50%";
-    graphDiv.style.display = "none";
+    inputDiv.style.width = '50%';
+    outputDiv.style.width = '50%';
+    graphDiv.style.width = '50%';
+    outputDiv.style.left = '50%';
+    graphDiv.style.display = 'none';
     showGraphDiv = false;
-    graphButton.innerHTML = "SHOW HEAP";
+    graphButton.innerHTML = 'SHOW HEAP';
   }
 });

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -231,8 +231,6 @@ function compile() {
   debounce = setTimeout(function() {
     worker = new Worker('js/repl-worker.js');
     worker.onmessage = function(e) {
-      // turn off compiling
-
       const result = e.data;
       if (result.type === 'success') {
         const { data, graph, messages } = result;
@@ -242,6 +240,7 @@ function compile() {
       } else if (result.type === 'error') {
         const errors = result.data;
         showMessages(errors);
+        output.setValue('// Prepack is unable to produce output for this input.\n// Please check the left pane for diagnostic information.', -1);
       }
       terminateWorker();
     };

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -155,12 +155,8 @@ function showGeneratedCode(code) {
   if (isEmpty.test(code) && !isEmpty.test(input.getValue())) {
     code = '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
   }
-  output.setValue(code, -1);
-}
-
-function showGenerationGraph(graph) {
-  if (showGraphDiv && graph) {
-    var graphData = JSON.parse(graph);
+  drawGraphCallback = () => {
+    var graphData = JSON.parse(result.graph);
     var visData = {
       nodes: graphData.nodes,
       edges: graphData.edges,
@@ -168,7 +164,11 @@ function showGenerationGraph(graph) {
 
     var visOptions = {};
     var boxNetwork = new vis.Network(graphBox, visData, visOptions);
+  };
+  if (showGraphDiv) {
+    drawGraphCallback();
   }
+  output.setValue(code, -1);
 }
 
 function compile() {
@@ -189,9 +189,7 @@ function compile() {
       var result = e.data;
       if (result.type === 'success' || result.type === 'warning') {
         var code = result.data;
-        var graph = result.graph;
         showGeneratedCode(code);
-        showGenerationGraph(graph);
       } else if (result.type === 'error') {
         let errors = result.data;
         if (typeof errors === 'string') {
@@ -238,6 +236,7 @@ input.on('change', compile);
 input.on('change', makeDemoSharable);
 
 /**record **/
+
 var selectRecord = document.querySelector('select.select-record');
 var optionsRecord = document.querySelector('#optionsMenuRecord');
 var selectInput = document.querySelector('#recordName');

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -155,8 +155,12 @@ function showGeneratedCode(code) {
   if (isEmpty.test(code) && !isEmpty.test(input.getValue())) {
     code = '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
   }
-  drawGraphCallback = () => {
-    var graphData = JSON.parse(result.graph);
+  output.setValue(code, -1);
+}
+
+function showGenerationGraph(graph) {
+  if (showGraphDiv && graph) {
+    var graphData = JSON.parse(graph);
     var visData = {
       nodes: graphData.nodes,
       edges: graphData.edges,
@@ -164,11 +168,7 @@ function showGeneratedCode(code) {
 
     var visOptions = {};
     var boxNetwork = new vis.Network(graphBox, visData, visOptions);
-  };
-  if (showGraphDiv) {
-    drawGraphCallback();
   }
-  output.setValue(code, -1);
 }
 
 function compile() {
@@ -189,7 +189,9 @@ function compile() {
       var result = e.data;
       if (result.type === 'success' || result.type === 'warning') {
         var code = result.data;
+        var graph = result.graph;
         showGeneratedCode(code);
+        showGenerationGraph(graph);
       } else if (result.type === 'error') {
         let errors = result.data;
         if (typeof errors === 'string') {
@@ -236,7 +238,6 @@ input.on('change', compile);
 input.on('change', makeDemoSharable);
 
 /**record **/
-
 var selectRecord = document.querySelector('select.select-record');
 var optionsRecord = document.querySelector('#optionsMenuRecord');
 var selectInput = document.querySelector('#recordName');

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -159,16 +159,20 @@ function showGeneratedCode(code) {
 }
 
 function showGenerationGraph(graph) {
-  if (showGraphDiv && graph) {
-    var graphData = JSON.parse(graph);
-    var visData = {
-      nodes: graphData.nodes,
-      edges: graphData.edges,
-    };
+  drawGraphCallback = () => {
+    if (graph) {
+      var graphData = JSON.parse(graph);
+      var visData = {
+        nodes: graphData.nodes,
+        edges: graphData.edges,
+      };
 
-    var visOptions = {};
-    var boxNetwork = new vis.Network(graphBox, visData, visOptions);
-  }
+      var visOptions = {};
+      var boxNetwork = new vis.Network(graphBox, visData, visOptions);
+    }
+  };
+
+  if (showGraphDiv) drawGraphCallback();
 }
 
 function compile() {

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -151,6 +151,27 @@ function makeDemoSharable() {
   history.replaceState(undefined, undefined, `#${encoded}`);
 }
 
+function showGeneratedCode(code) {
+  if (isEmpty.test(code) && !isEmpty.test(input.getValue())) {
+    code =
+      '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
+  }
+  drawGraphCallback = () => {
+    var graphData = JSON.parse(result.graph);
+    var visData = {
+      nodes: graphData.nodes,
+      edges: graphData.edges
+    }
+
+    var visOptions = {};
+    var boxNetwork = new vis.Network(graphBox, visData, visOptions);
+  }
+  if (showGraphDiv) {
+    drawGraphCallback();
+  }
+  output.setValue(code, -1);
+}
+
 function compile() {
   clearTimeout(debounce);
   terminateWorker();
@@ -167,27 +188,10 @@ function compile() {
       // turn off compiling
 
       var result = e.data;
-      if (result.type === 'success') {
+      if (result.type === 'success' || result.type === 'warning') {
         var code = result.data;
-        if (isEmpty.test(code) && !isEmpty.test(input.getValue())) {
-          code =
-            '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
-        }
-        drawGraphCallback = () => {
-          var graphData = JSON.parse(result.graph);
-          var visData = {
-            nodes: graphData.nodes,
-            edges: graphData.edges
-          }
-
-          var visOptions = {};
-          var boxNetwork = new vis.Network(graphBox, visData, visOptions);
-        }
-        if (showGraphDiv) {
-          drawGraphCallback();
-        }
-        output.setValue(code, -1);
-      } else if (result.type === 'error') {
+        showGeneratedCode(code);
+      }  else if (result.type === 'error') {
         let errors = result.data;
         if (typeof errors === 'string') {
           errorOutput.style.display = 'block';

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -94,8 +94,7 @@ function generateDemosSelect(obj, dom) {
 var worker;
 var debounce;
 
-var messagesOutputContainer = document.querySelector('.output .messagesContainer');
-var messagesOutput = document.querySelector('.output .messages');
+var messagesOutput = document.querySelector('.input .messages');
 var replOutput = document.querySelector('.output .repl');
 
 var isEmpty = /^\s*$/;
@@ -167,16 +166,12 @@ function getMessageClassType(severity) {
   }
 }
 
-function showMessages(messages, containerType) {
+function showMessages(messages) {
   messagesOutput.style.display = 'inline-block';
-  messagesOutputContainer.style.height = containerType === "error" ? "100%" : "auto";
   
   for (var i in messages) {
     const message = document.createElement('div');
     message.classList.add("message", getMessageClassType(messages[i].severity));
-
-    const isLastMessage = i == messages.length - 1; // == because i is a string
-    if(isLastMessage) message.classList.add("last-message");
 
     processMessage(message, messages[i]);
 
@@ -243,10 +238,10 @@ function compile() {
         const { data, graph, messages } = result;
         showGeneratedCode(data);
         showGenerationGraph(graph);
-        showMessages(messages, "warning");
+        showMessages(messages);
       } else if (result.type === 'error') {
         const errors = result.data;
-        showMessages(errors, "error");
+        showMessages(errors);
       }
       terminateWorker();
     };

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -191,10 +191,10 @@ function compile() {
     worker.onmessage = function(e) {
       // turn off compiling
 
-      var result = e.data;
+      const result = e.data;
       if (result.type === 'success') {
-        const { code, graph, messages } = result.data;
-        showGeneratedCode(code);
+        const { data, graph, messages } = result;
+        showGeneratedCode(data);
         showGenerationGraph(graph);
       }  else if (result.type === 'error') {
         let errors = result.data;

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -159,20 +159,16 @@ function showGeneratedCode(code) {
 }
 
 function showGenerationGraph(graph) {
-  drawGraphCallback = () => {
-    if (graph) {
-      var graphData = JSON.parse(graph);
-      var visData = {
-        nodes: graphData.nodes,
-        edges: graphData.edges,
-      };
+  if (showGraphDiv && graph) {
+    var graphData = JSON.parse(graph);
+    var visData = {
+      nodes: graphData.nodes,
+      edges: graphData.edges,
+    };
 
-      var visOptions = {};
-      var boxNetwork = new vis.Network(graphBox, visData, visOptions);
-    }
-  };
-
-  if (showGraphDiv) drawGraphCallback();
+    var visOptions = {};
+    var boxNetwork = new vis.Network(graphBox, visData, visOptions);
+  }
 }
 
 function compile() {

--- a/website/js/repl.js
+++ b/website/js/repl.js
@@ -156,20 +156,24 @@ function showGeneratedCode(code) {
     code =
       '// Your code was all dead code and thus eliminated.\n' + '// Try storing a property on the global object.';
   }
-  drawGraphCallback = () => {
-    var graphData = JSON.parse(result.graph);
-    var visData = {
-      nodes: graphData.nodes,
-      edges: graphData.edges
-    }
-
-    var visOptions = {};
-    var boxNetwork = new vis.Network(graphBox, visData, visOptions);
-  }
-  if (showGraphDiv) {
-    drawGraphCallback();
-  }
   output.setValue(code, -1);
+}
+
+function showGenerationGraph(graph) {
+  drawGraphCallback = () => {
+    if (graph) {
+      var graphData = JSON.parse(graph);
+      var visData = {
+        nodes: graphData.nodes,
+        edges: graphData.edges,
+      };
+
+      var visOptions = {};
+      var boxNetwork = new vis.Network(graphBox, visData, visOptions);
+    }
+  };
+
+  if (showGraphDiv) drawGraphCallback();
 }
 
 function compile() {
@@ -190,7 +194,9 @@ function compile() {
       var result = e.data;
       if (result.type === 'success' || result.type === 'warning') {
         var code = result.data;
+        var graph = result.graph;
         showGeneratedCode(code);
+        showGenerationGraph(graph);
       }  else if (result.type === 'error') {
         let errors = result.data;
         if (typeof errors === 'string') {
@@ -238,7 +244,6 @@ input.on('change', compile);
 input.on('change', makeDemoSharable);
 
 /**record **/
-
 var selectRecord = document.querySelector('select.select-record');
 var optionsRecord = document.querySelector('#optionsMenuRecord');
 var selectInput = document.querySelector('#recordName');

--- a/website/repl.html
+++ b/website/repl.html
@@ -71,7 +71,9 @@
 
       <div id="outputDiv" class="output">
         <div class="repl"></div>
-        <div class="message"></div>
+        <div class="messagesContainer">
+          <div class="messages"></div>
+        </div>
       </div>
       <div id="graph" class ="graph">
         <div id="graphBox" class="graphBox"></div>

--- a/website/repl.html
+++ b/website/repl.html
@@ -67,13 +67,13 @@
     <div class="repl-container">
       <div id="inputDiv" class="input">
         <div class="repl"></div>
+        <div class="messagesContainer">
+          <div class="messages"></div>
+        </div>
       </div>
 
       <div id="outputDiv" class="output">
         <div class="repl"></div>
-        <div class="messagesContainer">
-          <div class="messages"></div>
-        </div>
       </div>
       <div id="graph" class ="graph">
         <div id="graphBox" class="graphBox"></div>

--- a/website/repl.html
+++ b/website/repl.html
@@ -71,7 +71,7 @@
 
       <div id="outputDiv" class="output">
         <div class="repl"></div>
-        <div class="error"></div>
+        <div class="message"></div>
       </div>
       <div id="graph" class ="graph">
         <div id="graphBox" class="graphBox"></div>


### PR DESCRIPTION
cc @NTillmann 

Following up https://github.com/facebook/prepack/issues/2285, website shows the generated coded even when there are some warnings.

Lot of changes because prettier wasn't applied to the files, but I basically only checked for the error buffer containing only items with `severity === 'Warning'` and create the `warning` result type to behave the same than `success` one.

Next step would be to show the code AND warning messages. Either using the same display than error messages or creating a variation of it (changing text color to yellow for example). I can do it if you want.

Let me know if this is what you were looking for.

Have a nice day !

P.S: not sure if this PR was supposed to be into `gh-pages` or `master`. Let me know if that needs to be changed.