### PR TITLE
Fix reactFailOnUnsupportedSideEffects

### DIFF
--- a/src/react/reconcilation.js
+++ b/src/react/reconcilation.js
@@ -201,7 +201,7 @@ export class Reconciler {
             if (this.realm.react.failOnUnsupportedSideEffects) {
               handleReportedSideEffect(throwUnsupportedSideEffectError, sideEffectType, binding, expressionLocation);
             }
-          },
+          }
         )
       );
     } finally {

--- a/src/realm.js
+++ b/src/realm.js
@@ -299,7 +299,7 @@ export class Realm {
       emptyArray: undefined,
       emptyObject: undefined,
       enabled: opts.reactEnabled || false,
-      failOnUnsupportedSideEffects: opts.reactFailOnUnsupportedSideEffects || true,
+      failOnUnsupportedSideEffects: opts.reactFailOnUnsupportedSideEffects === false ? false : true,
       hoistableFunctions: new WeakMap(),
       hoistableReactElements: new WeakMap(),
       noopFunction: undefined,


### PR DESCRIPTION
Release notes: none

Fixes a bug where `reactFailOnUnsupportedSideEffects` should evaluate to `false` if passed as false. Also fixes a lint issue on `master`.