### PR TITLE
adding new __replaceFunctionImplementation_unsafe built-in

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -551,6 +551,58 @@ export default function(realm: Realm): void {
     })
   );
 
+  // Helper function that replaces the body of a function with source code.
+  // Note that this function affects un-tracked state, so care must be taken
+  // that this helper function is executed at the right time.
+  global.$DefineOwnProperty(
+    "__replaceFunctionBody",
+    new PropertyDescriptor({
+      value: new NativeFunctionValue(
+        realm,
+        "global.__replaceFunctionBody",
+        "__replaceFunctionBody",
+        2,
+        (context, [target, source]) => {
+          if (!(target instanceof ECMAScriptSourceFunctionValue)) {
+            throw realm.createErrorThrowCompletion(
+              realm.intrinsics.TypeError,
+              "first argument is not a function with source code"
+            );
+          }
+          if (!(source instanceof ECMAScriptSourceFunctionValue)) {
+            throw realm.createErrorThrowCompletion(
+              realm.intrinsics.TypeError,
+              "second argument is not a function with source code"
+            );
+          }
+
+          // relevant properties for functionValue
+          target.$Environment = source.$Environment;
+          target.$ScriptOrModule = source.$ScriptOrModule;
+
+          // properties for ECMAScriptFunctionValue
+          target.$ConstructorKind = source.$ConstructorKind;
+          target.$ThisMode = source.$ThisMode;
+          target.$HomeObject = source.$HomeObject;
+          target.$FunctionKind = source.$FunctionKind;
+
+          // properties for ECMAScriptSourceFunctionValue
+          target.$Strict = source.$Strict;
+          target.$FormalParameters = source.$FormalParameters;
+          target.$ECMAScriptCode = source.$ECMAScriptCode;
+          target.$HasComputedName = source.$HasComputedName;
+          target.$HasEmptyConstructor = source.$HasEmptyConstructor;
+          target.loc = source.loc;
+
+          return context.$Realm.intrinsics.undefined;
+        }
+      ),
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    })
+  );
+
   global.$DefineOwnProperty(
     "__IntrospectionError",
     new PropertyDescriptor({

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -551,16 +551,25 @@ export default function(realm: Realm): void {
     })
   );
 
-  // Helper function that replaces the body of a source function with another source function body.
-  // Note that this function affects un-tracked state, so care must be taken
-  // that this helper function is executed at the right time.
+  // Helper function that replaces the implementation of a source function with
+  // the details from another source function body, including the captured
+  // environment, the actual code, etc.
+  // This realizes a form of monkey-patching, enabling mocking a function if
+  // one doesn't control all existing references to that function,
+  // or if the storage location to those references cannot be easily updated.
+  // NOTE: This function affects un-tracked state, so care must be taken
+  // that this helper function is executed at the right time; typically, one
+  // would want to execute this function before any call is executed to that
+  // function. Care must be taken not to make reachable conditionally
+  // defined values. Because of this limitations, this helper function
+  // should be considered only as a last resort.
   global.$DefineOwnProperty(
-    "__replaceFunctionBody",
+    "__replaceFunctionImplementation_unsafe",
     new PropertyDescriptor({
       value: new NativeFunctionValue(
         realm,
-        "global.__replaceFunctionBody",
-        "__replaceFunctionBody",
+        "global.__replaceFunctionImplementation_unsafe",
+        "__replaceFunctionImplementation_unsafe",
         2,
         (context, [target, source]) => {
           if (!(target instanceof ECMAScriptSourceFunctionValue)) {

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -551,7 +551,7 @@ export default function(realm: Realm): void {
     })
   );
 
-  // Helper function that replaces the body of a function with source code.
+  // Helper function that replaces the body of a source function with another source function body.
   // Note that this function affects un-tracked state, so care must be taken
   // that this helper function is executed at the right time.
   global.$DefineOwnProperty(

--- a/test/serializer/abstract/ReplaceFunctionBody.js
+++ b/test/serializer/abstract/ReplaceFunctionBody.js
@@ -1,6 +1,10 @@
 (function() {
-  function f() { return 23; }
-  function g() { return 42; }
+  function f() {
+    return 23;
+  }
+  function g() {
+    return 42;
+  }
   if (global.__abstract) {
     global.__replaceFunctionBody(f, g);
     global.inspect = f;

--- a/test/serializer/abstract/ReplaceFunctionBody.js
+++ b/test/serializer/abstract/ReplaceFunctionBody.js
@@ -1,0 +1,10 @@
+(function() {
+  function f() { return 23; }
+  function g() { return 42; }
+  if (global.__abstract) {
+    global.__replaceFunctionBody(f, g);
+    global.inspect = f;
+  } else {
+    global.inspect = g;
+  }
+})();

--- a/test/serializer/abstract/ReplaceFunctionBody.js
+++ b/test/serializer/abstract/ReplaceFunctionBody.js
@@ -6,7 +6,7 @@
     return 42;
   }
   if (global.__abstract) {
-    global.__replaceFunctionBody(f, g);
+    global.__replaceFunctionImplementation_unsafe(f, g);
     global.inspect = f;
   } else {
     global.inspect = g;


### PR DESCRIPTION
Release notes: providing __replaceFunctionImplementation_unsafe built-in

This new built-in allows replacing the method implementation (capture environment, body, ...) of source functions.

As a result, all method calls executed by the Prepack interpreter will be redirected,
and the replacement will carry over to the prepacked code.