### PR TITLE
Support constructor returning an unknown abstract value

### DIFF
--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -269,17 +269,30 @@ function InternalConstruct(
     function map(value: Value) {
       if (value === realm.intrinsics.__bottomValue) return value;
 
-      if (value instanceof AbstractValue && value.kind === "conditional") {
-        const [condition, consequent, alternate] = value.args;
-        return realm.evaluateWithAbstractConditional(
-          condition,
-          () => realm.evaluateForEffects(() => map(consequent), undefined, "AbstractValue/conditional/true"),
-          () => realm.evaluateForEffects(() => map(alternate), undefined, "AbstractValue/conditional/false")
-        );
+      if (value instanceof AbstractValue && !(value instanceof AbstractObjectValue)) {
+        if (value.kind === "conditional") {
+          const [condition, consequent, alternate] = value.args;
+          return realm.evaluateWithAbstractConditional(
+            condition,
+            () => realm.evaluateForEffects(() => map(consequent), undefined, "AbstractValue/conditional/true"),
+            () => realm.evaluateForEffects(() => map(alternate), undefined, "AbstractValue/conditional/false")
+          );
+        }
+        if (kind === "base") {
+          invariant(thisArgument, "this wasn't initialized for some reason");
+          return AbstractValue.createFromTemplate(
+            realm,
+            "typeof A === 'object' || typeof A === 'function' ? A : B",
+            ObjectValue,
+            [value, thisArgument]
+          );
+        } else {
+          value.throwIfNotConcreteObject(); // Not yet supported.
+        }
       }
 
       // a. If Type(result.[[Value]]) is Object, return NormalCompletion(result.[[Value]]).
-      if (value.mightBeObject()) return value.throwIfNotConcreteObject();
+      if (value instanceof ObjectValue || value instanceof AbstractObjectValue) return value;
 
       // b. If kind is "base", return NormalCompletion(thisArgument).
       if (kind === "base") {

--- a/test/serializer/abstract/ConstructFunctionReturnsAbstract.js
+++ b/test/serializer/abstract/ConstructFunctionReturnsAbstract.js
@@ -1,0 +1,9 @@
+function F() {
+  this.a = 1;
+  this.b = 2;
+  if (global.__abstract) return global.__abstract(undefined, "undefined");
+}
+
+const result = new F();
+
+global.inspect = () => JSON.stringify(result);


### PR DESCRIPTION
The following test case currently fails:

```js
function F() {
  this.a = 1;
  this.b = 2;
  if (global.__abstract) return global.__abstract(undefined, "undefined");
}

const result = new F();

global.inspect = () => JSON.stringify(result);
```

We hit this bug in our internal React Native bundle. I only added support for `base` construction kinds since the template for `derived` construction kinds would get more complicated.