### PR TITLE
Check invariant that path conditions no longer get mutated after being used as a base

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -377,6 +377,10 @@ export class PathConditions {
     return false;
   }
 
+  isReadOnly(): boolean {
+    return false;
+  }
+
   getLength(): number {
     return 0;
   }

--- a/src/utils/paths.js
+++ b/src/utils/paths.js
@@ -19,11 +19,16 @@ export class PathConditionsImplementation extends PathConditions {
   constructor(baseConditions?: void | PathConditions) {
     super();
     this._assumedConditions = new Set();
-    invariant(baseConditions === undefined || baseConditions instanceof PathConditionsImplementation);
-    this._baseConditions = baseConditions;
+    this._finalized = false;
+    if (baseConditions !== undefined) {
+      invariant(baseConditions instanceof PathConditionsImplementation);
+      baseConditions._finalized = true;
+      this._baseConditions = baseConditions;
+    }
   }
 
   _assumedConditions: Set<AbstractValue>;
+  _finalized: boolean;
   _baseConditions: void | PathConditionsImplementation;
   _impliedConditions: void | Set<AbstractValue>;
   _impliedNegatives: void | Set<AbstractValue>;
@@ -31,6 +36,7 @@ export class PathConditionsImplementation extends PathConditions {
   _failedNegativeImplications: void | Set<AbstractValue>;
 
   add(c: AbstractValue): void {
+    invariant(!this._finalized);
     this._assumedConditions.add(c);
   }
 


### PR DESCRIPTION
Release notes: None

Otherwise, this could cause issues, as path conditions get captured e.g. in generators.