### PR TITLE
Emit Mutations to Abstract Objects on the AbstractValue instead of the ObjectValue

### DIFF
--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -322,7 +322,8 @@ export class CreateImplementation {
         writable: true,
         enumerable: false,
         configurable: false,
-      })
+      }),
+      A
     );
 
     // 11. Return A.

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -707,7 +707,14 @@ export class PropertiesImplementation {
   }
 
   //
-  OrdinaryDelete(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean {
+  // Note: The extra Target argument represents the Value that should receive any emitted effects,
+  // or null if none should be emitted.
+  OrdinaryDelete(
+    realm: Realm,
+    O: ObjectValue,
+    P: PropertyKeyValue,
+    Target: null | ObjectValue | AbstractObjectValue
+  ): boolean {
     // 1. Assert: IsPropertyKey(P) is true.
     invariant(IsPropertyKey(realm, P), "expected a property key");
 
@@ -1108,7 +1115,15 @@ export class PropertiesImplementation {
   }
 
   // ECMA262 9.1.6.1
-  OrdinaryDefineOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, Desc: Descriptor): boolean {
+  // Note: The extra Target argument represents the Value that should receive any emitted effects,
+  // or null if none should be emitted.
+  OrdinaryDefineOwnProperty(
+    realm: Realm,
+    O: ObjectValue,
+    P: PropertyKeyValue,
+    Desc: Descriptor,
+    Target: null | AbstractObjectValue | ObjectValue
+  ): boolean {
     invariant(O instanceof ObjectValue);
 
     // 1. Let current be ? O.[[GetOwnProperty]](P).
@@ -1292,14 +1307,16 @@ export class PropertiesImplementation {
   }
 
   // ECMA262 9.4.2.4
-  ArraySetLength(realm: Realm, A: ArrayValue, _Desc: Descriptor): boolean {
+  // Note: The extra Target argument represents the Value that should receive any emitted effects,
+  // or null if none should be emitted.
+  ArraySetLength(realm: Realm, A: ArrayValue, _Desc: Descriptor, Target: ObjectValue | AbstractObjectValue): boolean {
     let Desc = _Desc.throwIfNotConcrete(realm);
 
     // 1. If the [[Value]] field of Desc is absent, then
     let DescValue = Desc.value;
     if (!DescValue) {
       // a. Return OrdinaryDefineOwnProperty(A, "length", Desc).
-      return this.OrdinaryDefineOwnProperty(realm, A, "length", Desc);
+      return this.OrdinaryDefineOwnProperty(realm, A, "length", Desc, Target);
     }
     invariant(DescValue instanceof Value);
 
@@ -1341,7 +1358,7 @@ export class PropertiesImplementation {
     // 10. If newLen ≥ oldLen, then
     if (newLen >= oldLen) {
       // a. Return OrdinaryDefineOwnProperty(A, "length", newLenDesc).
-      return this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
+      return this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc, Target);
     }
 
     // 11. If oldLenDesc.[[Writable]] is false, return false.
@@ -1363,7 +1380,7 @@ export class PropertiesImplementation {
     }
 
     // 14. Let succeeded be ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
-    let succeeded = this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
+    let succeeded = this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc, Target);
 
     // 15. If succeeded is false, return false.
     if (succeeded === false) return false;
@@ -1394,7 +1411,7 @@ export class PropertiesImplementation {
         if (newWritable === false) newLenDesc.writable = false;
 
         // iii. Let succeeded be ! OrdinaryDefineOwnProperty(A, "length", newLenDesc).
-        succeeded = this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc);
+        succeeded = this.OrdinaryDefineOwnProperty(realm, A, "length", newLenDesc, Target);
 
         // iv. Return false.
         return false;
@@ -1410,7 +1427,8 @@ export class PropertiesImplementation {
         "length",
         new PropertyDescriptor({
           writable: false,
-        })
+        }),
+        Target
       );
     }
 

--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -642,7 +642,7 @@ export class ResidualHeapSerializer {
   emitDefinePropertyBody(
     deleteIfMightHaveBeenDeleted: boolean,
     locationFunction: void | (() => BabelNodeLVal),
-    val: ObjectValue,
+    val: Value,
     key: string | SymbolValue | AbstractValue,
     desc: Descriptor
   ): BabelNodeStatement {
@@ -1776,8 +1776,9 @@ export class ResidualHeapSerializer {
   }
 
   // Checks whether a property can be defined via simple assignment, or using object literal syntax.
-  _canEmbedProperty(obj: ObjectValue, key: string | SymbolValue | AbstractValue, prop: Descriptor): boolean {
+  _canEmbedProperty(obj: Value, key: string | SymbolValue | AbstractValue, prop: Descriptor): boolean {
     if (!(prop instanceof PropertyDescriptor)) return false;
+    if (!(obj instanceof ObjectValue)) return false;
 
     let targetDescriptor = this.residualHeapInspector.getTargetIntegrityDescriptor(obj);
 

--- a/src/types.js
+++ b/src/types.js
@@ -412,7 +412,12 @@ export type PropertiesType = {
   FromPropertyDescriptor(realm: Realm, Desc: ?Descriptor): Value,
 
   //
-  OrdinaryDelete(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean,
+  OrdinaryDelete(
+    realm: Realm,
+    O: ObjectValue,
+    P: PropertyKeyValue,
+    Target: null | ObjectValue | AbstractValue
+  ): boolean,
 
   // ECMA262 7.3.8
   DeletePropertyOrThrow(realm: Realm, O: ObjectValue, P: PropertyKeyValue): boolean,
@@ -434,7 +439,13 @@ export type PropertiesType = {
   ): boolean,
 
   // ECMA262 9.1.6.1
-  OrdinaryDefineOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue, Desc: Descriptor): boolean,
+  OrdinaryDefineOwnProperty(
+    realm: Realm,
+    O: ObjectValue,
+    P: PropertyKeyValue,
+    Desc: Descriptor,
+    Target: null | AbstractObjectValue | ObjectValue
+  ): boolean,
 
   // ECMA262 19.1.2.3.1
   ObjectDefineProperties(realm: Realm, O: Value, Properties: Value): ObjectValue | AbstractObjectValue,
@@ -454,7 +465,7 @@ export type PropertiesType = {
   PutValue(realm: Realm, V: Value | Reference, W: Value): void | boolean | Value,
 
   // ECMA262 9.4.2.4
-  ArraySetLength(realm: Realm, A: ArrayValue, Desc: Descriptor): boolean,
+  ArraySetLength(realm: Realm, A: ArrayValue, Desc: Descriptor, Target: ObjectValue | AbstractObjectValue): boolean,
 
   // ECMA262 9.1.5.1
   OrdinaryGetOwnProperty(realm: Realm, O: ObjectValue, P: PropertyKeyValue): Descriptor | void,

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -161,7 +161,7 @@ export type OperationDescriptorData = {
   path?: Value, // used by PROPERTY_ASSIGNMENT, CONDITIONAL_PROPERTY_ASSIGNMENT
   propertyGetter?: SupportedGraphQLGetters, // used by ABSTRACT_OBJECT_GET
   propRef?: ReferenceName | AbstractValue, // used by CALL_BAILOUT, and then only if string
-  object?: ObjectValue, // used by DEFINE_PROPERTY
+  object?: Value, // used by DEFINE_PROPERTY
   quasis?: Array<BabelNodeTemplateElement>, // used by REACT_SSR_TEMPLATE_LITERAL
   state?: "MISSING" | "PRESENT" | "DEFINED", // used by PROPERTY_INVARIANT
   thisArg?: BaseValue | Value, // used by CALL_BAILOUT
@@ -205,7 +205,7 @@ export type SerializationContext = {|
   ) => BabelNodeStatement,
   initGenerator: Generator => void,
   finalizeGenerator: Generator => void,
-  emitDefinePropertyBody: (ObjectValue, string | SymbolValue, Descriptor) => BabelNodeStatement,
+  emitDefinePropertyBody: (Value, string | SymbolValue, Descriptor) => BabelNodeStatement,
   emit: BabelNodeStatement => void,
   processValues: (Set<AbstractValue | ObjectValue>) => void,
   canOmit: Value => boolean,
@@ -834,8 +834,8 @@ export class Generator {
     });
   }
 
-  emitDefineProperty(object: ObjectValue, key: string, desc: PropertyDescriptor, isDescChanged: boolean = true): void {
-    if (object.refuseSerialization) return;
+  emitDefineProperty(object: Value, key: string, desc: PropertyDescriptor, isDescChanged: boolean = true): void {
+    if (object instanceof ObjectValue && object.refuseSerialization) return;
     if (desc.enumerable && desc.configurable && desc.writable && desc.value && !isDescChanged) {
       let descValue = desc.value;
       invariant(descValue instanceof Value);
@@ -857,8 +857,8 @@ export class Generator {
     }
   }
 
-  emitPropertyDelete(object: ObjectValue, key: string): void {
-    if (object.refuseSerialization) return;
+  emitPropertyDelete(object: Value, key: string): void {
+    if (object instanceof ObjectValue && object.refuseSerialization) return;
     this._addEntry({
       args: [object, new StringValue(this.realm, key)],
       operationDescriptor: createOperationDescriptor("PROPERTY_DELETE"),

--- a/src/values/AbstractObjectValue.js
+++ b/src/values/AbstractObjectValue.js
@@ -387,7 +387,7 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        return cv.$DefineOwnProperty(P, _Desc);
+        return cv.$DefineOwnProperty(P, _Desc, this);
       }
       invariant(false);
     } else {
@@ -477,7 +477,7 @@ export default class AbstractObjectValue extends AbstractValue {
           invariant(dval instanceof Value);
           let cond = AbstractValue.createFromBinaryOp(this.$Realm, "===", this, cv, this.expressionLocation);
           desc.value = AbstractValue.createFromConditionalOp(this.$Realm, cond, newVal, dval);
-          if (cv.$DefineOwnProperty(P, desc)) {
+          if (cv.$DefineOwnProperty(P, desc, this)) {
             sawTrue = true;
           } else sawFalse = true;
         }
@@ -961,7 +961,7 @@ export default class AbstractObjectValue extends AbstractValue {
     if (elements.size === 1) {
       for (let cv of elements) {
         invariant(cv instanceof ObjectValue);
-        return cv.$Delete(P);
+        return cv.$Delete(P, this);
       }
       invariant(false);
     } else if (this.kind === "conditional") {
@@ -1026,7 +1026,7 @@ export default class AbstractObjectValue extends AbstractValue {
         let newDesc = cloneDescriptor(d);
         invariant(newDesc);
         newDesc.value = v;
-        if (cv.$DefineOwnProperty(P, newDesc)) sawTrue = true;
+        if (cv.$DefineOwnProperty(P, newDesc, this)) sawTrue = true;
         else sawFalse = true;
       }
       if (sawTrue && sawFalse) {

--- a/src/values/ArgumentsExotic.js
+++ b/src/values/ArgumentsExotic.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
-import { ObjectValue, Value } from "./index.js";
+import { AbstractObjectValue, ObjectValue, Value } from "./index.js";
 import { IsDataDescriptor, IsAccessorDescriptor } from "../methods/is.js";
 import { HasOwnProperty } from "../methods/has.js";
 import { SameValuePartial } from "../methods/abstract.js";
@@ -58,7 +58,12 @@ export default class ArgumentsExotic extends ObjectValue {
   }
 
   // ECMA262 9.4.4.2
-  $DefineOwnProperty(P: PropertyKeyValue, _Desc: Descriptor): boolean {
+  // Note: The extra Target argument represents the Value to emit residual effects on at runtime, if any.
+  $DefineOwnProperty(
+    P: PropertyKeyValue,
+    _Desc: Descriptor,
+    Target: ObjectValue | AbstractObjectValue = this
+  ): boolean {
     let Desc = _Desc.throwIfNotConcrete(this.$Realm);
 
     // 1. Let args be the arguments object.
@@ -87,7 +92,7 @@ export default class ArgumentsExotic extends ObjectValue {
     }
 
     // 6. Let allowed be ? OrdinaryDefineOwnProperty(args, P, newArgDesc).
-    let allowed = Properties.OrdinaryDefineOwnProperty(this.$Realm, args, P, newArgDesc);
+    let allowed = Properties.OrdinaryDefineOwnProperty(this.$Realm, args, P, newArgDesc, Target);
 
     // 7. If allowed is false, return false.
     if (allowed === false) return false;
@@ -180,7 +185,8 @@ export default class ArgumentsExotic extends ObjectValue {
   }
 
   // ECMA262 9.4.4.5
-  $Delete(P: PropertyKeyValue): boolean {
+  // Note: The extra Target argument represents the Value to emit residual effects on at runtime, if any.
+  $Delete(P: PropertyKeyValue, Target: ObjectValue | AbstractObjectValue = this): boolean {
     // 1. Let args be the arguments object.
     let args = this;
 
@@ -192,7 +198,7 @@ export default class ArgumentsExotic extends ObjectValue {
     let isMapped = HasOwnProperty(this.$Realm, map, P);
 
     // 4. Let result be ? OrdinaryDelete(args, P).
-    let result = Properties.OrdinaryDelete(this.$Realm, args, P);
+    let result = Properties.OrdinaryDelete(this.$Realm, args, P, Target);
 
     // 5. If result is true and isMapped is true, then
     if (result === true && isMapped === true) {

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -13,6 +13,7 @@ import type { Effects, Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor, ObjectKind } from "../types.js";
 import {
   AbstractValue,
+  AbstractObjectValue,
   BoundFunctionValue,
   ECMAScriptSourceFunctionValue,
   NumberValue,
@@ -144,7 +145,8 @@ export default class ArrayValue extends ObjectValue {
   }
 
   // ECMA262 9.4.2.1
-  $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor): boolean {
+  // Note: The extra Target argument represents the Value to emit residual effects on at runtime, if any.
+  $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor, Target: ObjectValue | AbstractObjectValue = this): boolean {
     let A = this;
 
     // 1. Assert: IsPropertyKey(P) is true.
@@ -153,11 +155,11 @@ export default class ArrayValue extends ObjectValue {
     // 2. If P is "length", then
     if (P === "length" || (P instanceof StringValue && P.value === "length")) {
       // a. Return ? ArraySetLength(A, Desc).
-      return Properties.ArraySetLength(this.$Realm, A, Desc);
+      return Properties.ArraySetLength(this.$Realm, A, Desc, Target);
     } else if (IsArrayIndex(this.$Realm, P)) {
       if (ArrayValue.isIntrinsicAndHasWidenedNumericProperty(this)) {
         // The length of an array with widenend numeric properties is always abstract
-        let succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
+        let succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc, Target);
         if (succeeded === false) return false;
         return true;
       }
@@ -189,7 +191,7 @@ export default class ArrayValue extends ObjectValue {
       if (index >= oldLen && oldLenDesc.writable === false) return false;
 
       // f. Let succeeded be ! OrdinaryDefineOwnProperty(A, P, Desc).
-      let succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
+      let succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc, Target);
 
       // g. If succeeded is false, return false.
       if (succeeded === false) return false;
@@ -200,7 +202,9 @@ export default class ArrayValue extends ObjectValue {
         oldLenDesc.value = new NumberValue(this.$Realm, index + 1);
 
         // ii. Let succeeded be OrdinaryDefineOwnProperty(A, "length", oldLenDesc).
-        succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, "length", oldLenDesc);
+        // We pass null as the Target because we don't want to emit any extra effects for this operation
+        // since it will happen automatically by any effects emitted in the above OrdinaryDefineOwnProperty.
+        succeeded = Properties.OrdinaryDefineOwnProperty(this.$Realm, A, "length", oldLenDesc, null);
 
         // iii. Assert: succeeded is true.
         invariant(succeeded, "expected length definition to succeed");
@@ -211,7 +215,7 @@ export default class ArrayValue extends ObjectValue {
     }
 
     // 1. Return OrdinaryDefineOwnProperty(A, P, Desc).
-    return Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc);
+    return Properties.OrdinaryDefineOwnProperty(this.$Realm, A, P, Desc, Target);
   }
 
   static createTemporalWithWidenedNumericProperty(

--- a/src/values/IntegerIndexedExotic.js
+++ b/src/values/IntegerIndexedExotic.js
@@ -11,7 +11,7 @@
 
 import type { Realm } from "../realm.js";
 import type { PropertyKeyValue, Descriptor } from "../types.js";
-import { ObjectValue, NumberValue, StringValue, Value, UndefinedValue } from "./index.js";
+import { AbstractObjectValue, ObjectValue, NumberValue, StringValue, Value, UndefinedValue } from "./index.js";
 import { IsInteger, IsArrayIndex, IsAccessorDescriptor, IsDetachedBuffer, IsPropertyKey } from "../methods/is.js";
 import { OrdinaryGet } from "../methods/get.js";
 import { OrdinaryHasProperty } from "../methods/has.js";
@@ -119,7 +119,12 @@ export default class IntegerIndexedExotic extends ObjectValue {
   }
 
   // ECMA262 9.4.5.3
-  $DefineOwnProperty(P: PropertyKeyValue, _Desc: Descriptor): boolean {
+  // Note: The extra Target argument represents the Value to emit residual effects on at runtime, if any.
+  $DefineOwnProperty(
+    P: PropertyKeyValue,
+    _Desc: Descriptor,
+    Target: ObjectValue | AbstractObjectValue = this
+  ): boolean {
     let O = this;
 
     // 1. Assert: IsPropertyKey(P) is true.
@@ -184,7 +189,7 @@ export default class IntegerIndexedExotic extends ObjectValue {
     }
 
     // 4. Return ! OrdinaryDefineOwnProperty(O, P, Desc).
-    return Properties.OrdinaryDefineOwnProperty(this.$Realm, O, P, _Desc);
+    return Properties.OrdinaryDefineOwnProperty(this.$Realm, O, P, _Desc, Target);
   }
 
   // ECMA262 9.4.5.4

--- a/src/values/ObjectValue.js
+++ b/src/values/ObjectValue.js
@@ -646,9 +646,10 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   // ECMA262 9.1.6
-  $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor): boolean {
+  // Note: The extra Target argument represents the Value to emit residual effects on at runtime, if any.
+  $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor, Target: ObjectValue | AbstractObjectValue = this): boolean {
     // 1. Return ? OrdinaryDefineOwnProperty(O, P, Desc).
-    return Properties.OrdinaryDefineOwnProperty(this.$Realm, this, P, Desc);
+    return Properties.OrdinaryDefineOwnProperty(this.$Realm, this, P, Desc, Target);
   }
 
   // ECMA262 9.1.7
@@ -697,7 +698,8 @@ export default class ObjectValue extends ConcreteValue {
   }
 
   // ECMA262 9.1.10
-  $Delete(P: PropertyKeyValue): boolean {
+  // Note: The extra Target argument represents the Value to emit residual effects on at runtime, if any.
+  $Delete(P: PropertyKeyValue, Target: ObjectValue | AbstractObjectValue = this): boolean {
     if (this.unknownProperty !== undefined) {
       // TODO #946: generate a delete from the object
       AbstractValue.reportIntrospectionError(this, P);
@@ -705,7 +707,7 @@ export default class ObjectValue extends ConcreteValue {
     }
 
     // 1. Return ? OrdinaryDelete(O, P).
-    return Properties.OrdinaryDelete(this.$Realm, this, P);
+    return Properties.OrdinaryDelete(this.$Realm, this, P, Target);
   }
 
   // ECMA262 9.1.11

--- a/src/values/ProxyValue.js
+++ b/src/values/ProxyValue.js
@@ -359,7 +359,9 @@ export default class ProxyValue extends ObjectValue {
   }
 
   // ECMA262 9.5.6
-  $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor): boolean {
+  // Note: The extra Target argument is not relevant on Proxy because mutations are never performed
+  // on the Proxy itself but instead on the target/handler.
+  $DefineOwnProperty(P: PropertyKeyValue, Desc: Descriptor, Target: ObjectValue | AbstractObjectValue = this): boolean {
     let realm = this.$Realm;
 
     // 1. Assert: IsPropertyKey(P) is true.
@@ -657,7 +659,9 @@ export default class ProxyValue extends ObjectValue {
   }
 
   // ECMA262 9.5.10
-  $Delete(P: PropertyKeyValue): boolean {
+  // Note: The extra Target argument is not relevant on Proxy because mutations are never performed
+  // on the Proxy itself but instead on the target/handler.
+  $Delete(P: PropertyKeyValue, Target: ObjectValue | AbstractObjectValue = this): boolean {
     let realm = this.$Realm;
 
     // 1. Assert: IsPropertyKey(P) is true.

--- a/test/serializer/abstract/IntrinsicArrayLength.js
+++ b/test/serializer/abstract/IntrinsicArrayLength.js
@@ -1,0 +1,9 @@
+// omit invariants
+// Copies of length:1
+var arr = global.__abstract ? __abstract([], "[]") : [];
+arr[0] = 1;
+arr[1] = 2;
+
+inspect = function() {
+  return arr.length;
+};


### PR DESCRIPTION
Also, this omits emitting assignments to `array.length` when the array is intrinsic since that is implied.
