### PR TITLE
Fixing regression with default options.

### DIFF
--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -79,7 +79,7 @@ export function getRealmOptions({
   reactOutput,
   reactVerbose,
   reactOptimizeNestedFunctions,
-  serialize,
+  serialize = true,
   check,
   strictlyMonotonicDateNow,
   stripFlow,


### PR DESCRIPTION
Release notes: Fixes invariant violation regression when using webpack-prepack-plugin

This fixes #2540.
I didn't actually test it end-to-end webpack-prepack-plugin, would be great if someone could do that. We need some kind of end-to-end test for this to avoid regressions in the future.