### PR TITLE
Eliminate child-parent read-write conflict errors

### DIFF
--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -286,6 +286,11 @@ export class Functions {
 
     // check that functions are independent
     let conflicts: Map<BabelNodeSourceLocation, CompilerDiagnostic> = new Map();
+    let isParentOrEqualTo = (fun1, fun2) => {
+      if (fun1 === fun2) return false;
+      if (fun1.parentAdditionalFunction) return isParentOrEqualTo(fun1.parentAdditionalFunction, fun2);
+      return true;
+    }
     for (let fun1 of additionalFunctions) {
       invariant(fun1 instanceof FunctionValue);
       let fun1Location = fun1.expressionLocation;
@@ -306,7 +311,7 @@ export class Functions {
         if (this.realm.handleError(error) !== "Recover") throw new FatalError();
       }
       for (let fun2 of additionalFunctions) {
-        if (fun1 === fun2) continue;
+        if (isParentOrEqualTo(fun1, fun2)) continue;
         invariant(fun2 instanceof FunctionValue);
         let fun2Location = fun2.expressionLocation;
         let fun2Name = fun2.getDebugName() || optionalStringOfLocation(fun2Location);

--- a/test/serializer/optimized-functions/ParentInitializesLocal.js
+++ b/test/serializer/optimized-functions/ParentInitializesLocal.js
@@ -1,0 +1,19 @@
+(function () {
+    function f() {
+        let obj = {p: 42};
+        function g() { return obj.p; }
+        function h() { return obj.p; }
+        if (global.__optimize) {
+          __optimize(g);
+          __optimize(h);
+        }
+        return [g, h];
+    }
+    global.__optimize && __optimize(f);
+    global.f = f;
+
+  global.inspect = function() {
+    let [g, h] = f();
+    return g() + h();
+  }
+})();


### PR DESCRIPTION
Release Notes: None

This PR makes it so we no longer report conflicts for child optimized functions reading from values that their parents have written.

Couple of things for discussion:
- This creates somewhat confusing behavior because the child functions will take the concrete value after the parent functions' effects have been applied:
```javascript
(function () {
    let obj = {p: 42};
    function f() {
        obj.p += 3;
        function g() { return obj.p; } // Will optimize to `return 47;`
        obj.p += 1;
        __optimize(g);
        obj.p += 1;
        return g;
    }
    __optimize(f);
    global.f = f;
})();
```
- This PR creates the Parent/Child relationship based off `AdditionalFunctionEffects.parentAdditionalFunction` which goes off of syntactic nesting of functions instead of nesting of `__optimize` calls as in the issue. I believe basing the nesting off of `__optimize` calls could lead to somewhat unintuitive results (especially considering we store `parentAdditionalFunction` in `AdditionalFunctionEffects` to be the syntactic parent). 

I am not sure if it is needed by Instant Render @NTillmann? If it is, we may want to consider changing `AdditionalFunctionEffects.parentAdditionalFunction` to be based off of `__optimize` call nesting as well for consistency.

As an example a slight modification on the example above:
```javascript
(function () {
    let obj = {p: 42};
    function g() { return obj.p; }
    function f() {
        obj.p += 3;
        __optimize(g);
        obj.p += 1;
        return [g, obj];
    }
    __optimize(f);
    global.f = f;
})();
```
With this PR, we report an error. Based off of `__optimize` nesting, we would optimize `g` to `return 46;`. I would expect to see `return 42;` `return 45;` or `return obj.p;` in this case.

- To resolve the above issues, in the future, we could make any values modified by parent optimized functions into abstract values during evaluation for child optimized functions to force their accesses to be recorded in generators .

Resolves #2351 