### PR TITLE
Bad command-line for debugDiagnosticSeverity does not crashes Prepack anymore

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -33,6 +33,12 @@ export const InvariantModeValues = [
   "nativeLoggingHook+2",
   "nativeLoggingHook+3",
 ];
+export const DiagnosticSeverityValues = [
+  "FatalError",
+  "RecoverableError",
+  "Warning" ,
+  "Information",
+];
 
 export type ReactOutputTypes = "create-element" | "jsx" | "bytecode";
 export const ReactOutputValues = ["create-element", "jsx", "bytecode"];

--- a/src/options.js
+++ b/src/options.js
@@ -33,12 +33,7 @@ export const InvariantModeValues = [
   "nativeLoggingHook+2",
   "nativeLoggingHook+3",
 ];
-export const DiagnosticSeverityValues = [
-  "FatalError",
-  "RecoverableError",
-  "Warning" ,
-  "Information",
-];
+export const DiagnosticSeverityValues = ["FatalError", "RecoverableError", "Warning", "Information"];
 
 export type ReactOutputTypes = "create-element" | "jsx" | "bytecode";
 export const ReactOutputValues = ["create-element", "jsx", "bytecode"];

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -304,7 +304,11 @@ function run(
             console.error(`Unsupported debugDiagnosticSeverity: ${arg}`);
             process.exit(1);
           }
-          debuggerConfigArgs.diagnosticSeverity = (arg: any);
+          invariant(
+            arg === "FatalError" || arg === "RecoverableError" || arg === "Warning" || arg === "Information",
+            `Invalid debugger diagnostic severity: ${arg}`
+          );
+          debuggerConfigArgs.diagnosticSeverity = arg;
           reproArguments.push("--debugDiagnosticSeverity", arg);
           break;
         case "debugBuckRoot":

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -304,7 +304,7 @@ function run(
             console.error(`Unsupported debugDiagnosticSeverity: ${arg}`);
             process.exit(1);
           }
-          debuggerConfigArgs.diagnosticSeverity = arg;
+          debuggerConfigArgs.diagnosticSeverity = (arg: any);
           reproArguments.push("--debugDiagnosticSeverity", arg);
           break;
         case "debugBuckRoot":

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -19,6 +19,7 @@ import {
   ReactOutputValues,
   type InvariantModeTypes,
   InvariantModeValues,
+  DiagnosticSeverityValues,
 } from "./options.js";
 import { type SerializedResult } from "./serializer/types.js";
 import { TextPrinter } from "./utils/TextPrinter.js";
@@ -299,10 +300,10 @@ function run(
           break;
         case "debugDiagnosticSeverity":
           arg = args.shift();
-          invariant(
-            arg === "FatalError" || arg === "RecoverableError" || arg === "Warning" || arg === "Information",
-            `Invalid debugger diagnostic severity: ${arg}`
-          );
+          if (!DiagnosticSeverityValues.includes(arg)) {
+            console.error(`Unsupported debugDiagnosticSeverity: ${arg}`);
+            process.exit(1);
+          }
           debuggerConfigArgs.diagnosticSeverity = arg;
           reproArguments.push("--debugDiagnosticSeverity", arg);
           break;


### PR DESCRIPTION
This can be a possible fix for https://github.com/facebook/prepack/issues/2509

I have removed the `invariant` method call and added a value check as used for the _invariantMode_ option.

`node lib/prepack-cli.js --debugDiagnosticSeverity foo`

will now generate

`Unsupported debugDiagnosticSeverity: foo`