### PR TITLE
Return correct recovery code for FatalError

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -425,7 +425,7 @@ function run(
     }
     if (compilerDiagnostic.location) compilerDiagnostics.set(compilerDiagnostic.location, compilerDiagnostic);
     else compilerDiagnosticsList.push(compilerDiagnostic);
-    return "Recover";
+    return compilerDiagnostic.severity === "FatalError" ? "Fail" : "Recover";
   }
 
   function printDiagnostics(caughtFatalError: boolean, caughtUnexpectedError: boolean = false): boolean {


### PR DESCRIPTION
In support of #2547. Sometimes, it is more desirable (less costly, better for debugging) to flag a warning for a possibly anomalous condition, than to assume that it is anomalous and enforce it as an error. This change exposes warnings that a user upgrades to errors, so that they can then be enforced as such.