### PR TITLE
Make sure that adding a path condition clears negative caches.

### DIFF
--- a/src/methods/join.js
+++ b/src/methods/join.js
@@ -129,18 +129,7 @@ export class JoinImplementation {
     return rightCompletion;
   }
 
-  composeWithEffectsWithTailDuplicaton(completion: Completion, effects: Effects): Effects {
-    if (completion instanceof AbruptCompletion) return construct_empty_effects(completion.value.$Realm, completion);
-    if (completion instanceof SimpleNormalCompletion) return effects.shallowCloneWithResult(effects.result);
-    invariant(completion instanceof JoinedNormalAndAbruptCompletions);
-    let e1 = this.composeWithEffects(completion.consequent, effects);
-    let e2 = this.composeWithEffects(completion.alternate, effects);
-    return this.joinEffects(completion.joinCondition, e1, e2);
-  }
-
   composeWithEffects(completion: Completion, normalEffects: Effects): Effects {
-    if (completion.value.$Realm.abstractValueImpliesMax > 0)
-      return this.composeWithEffectsWithTailDuplicaton(completion, normalEffects);
     if (completion instanceof JoinedNormalAndAbruptCompletions) {
       let selectAbrupt = c => c instanceof AbruptCompletion && c.value !== c.value.$Realm.intrinsics.__bottomValue;
       let composableCompletions = Completion.makeSelectedCompletionsInfeasibleInCopy(selectAbrupt, completion);

--- a/src/types.js
+++ b/src/types.js
@@ -354,7 +354,9 @@ export type DebugServerType = {
 };
 
 export type PathType = {
+  // this => val. A false value does not imply that !(this => val).
   implies(condition: Value, depth?: number): boolean,
+  // this => !val. A false value does not imply that !(this => !val).
   impliesNot(condition: Value, depth?: number): boolean,
   withCondition<T>(condition: Value, evaluate: () => T): T,
   withInverseCondition<T>(condition: Value, evaluate: () => T): T,
@@ -365,10 +367,12 @@ export type PathType = {
 export class PathConditions {
   add(c: AbstractValue): void {}
 
+  // this => val. A false value does not imply that !(this => val).
   implies(e: Value, depth: number = 0): boolean {
     return false;
   }
 
+  // this => !val. A false value does not imply that !(this => !val).
   impliesNot(e: Value, depth: number = 0): boolean {
     return false;
   }

--- a/src/values/Value.js
+++ b/src/values/Value.js
@@ -63,12 +63,14 @@ export default class Value {
   expressionLocation: ?BabelNodeSourceLocation;
   $Realm: Realm;
 
+  // this => val. A false value does not imply that !(this => val).
   implies(val: AbstractValue, depth: number = 0): boolean {
     if (!this.mightNotBeFalse()) return true;
     if (this.equals(val)) return true;
     return false;
   }
 
+  // this => !val. A false value does not imply that !(this => !val).
   impliesNot(val: AbstractValue, depth: number = 0): boolean {
     if (!this.mightNotBeFalse()) return true;
     if (this.equals(val)) return false;


### PR DESCRIPTION
Release note: none

When a new path condition is added to an existing path conditions object, the negative caches must be cleared since the new condition might allow previously failed implications to now succeed. This was already done in one case, but a few others were missed. The clearing code is now centralized and all cases go through it.

While debugging the internal test case that failed because of the caching mistake, I also realized that PathConditions.implies and PathConditions.impliesNot can profitably deconstruct expressions of the form !x before doing the implication check. This also has the advantage that it eliminates a subtle endless recursion situation in a nicer way than the current code.

I've also added some comments in places that caught my eye during debugging.