### PR TITLE
Fixing handling of stack overflows.

### DIFF
--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -77,64 +77,69 @@ function InternalCall(
   argsList: Array<Value>,
   tracerIndex: number
 ): Value {
-  // 1. Assert: F is an ECMAScript function object.
-  invariant(F instanceof FunctionValue, "expected function value");
-
-  // Tracing: Give all registered tracers a chance to detour, wrapping around each other if needed.
-  while (tracerIndex < realm.tracers.length) {
-    let tracer = realm.tracers[tracerIndex];
-    let nextIndex = ++tracerIndex;
-    let detourResult = tracer.detourCall(F, thisArgument, argsList, undefined, () =>
-      InternalCall(realm, F, thisArgument, argsList, nextIndex)
-    );
-    if (detourResult instanceof Value) return detourResult;
-  }
-
-  // 2. If F's [[FunctionKind]] internal slot is "classConstructor", throw a TypeError exception.
-  if (F.$FunctionKind === "classConstructor")
-    throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
-
-  // 3. Let callerContext be the running execution context.
-  let callerContext = realm.getRunningContext();
-
-  // 4. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
-  let calleeContext = PrepareForOrdinaryCall(realm, F, undefined);
-  let calleeEnv = calleeContext.lexicalEnvironment;
-
-  let result;
+  realm.startCall();
   try {
-    for (let t1 of realm.tracers) t1.beforeCall(F, thisArgument, argsList, undefined);
+    // 1. Assert: F is an ECMAScript function object.
+    invariant(F instanceof FunctionValue, "expected function value");
 
-    // 5. Assert: calleeContext is now the running execution context.
-    invariant(realm.getRunningContext() === calleeContext, "calleeContext should be current execution context");
+    // Tracing: Give all registered tracers a chance to detour, wrapping around each other if needed.
+    while (tracerIndex < realm.tracers.length) {
+      let tracer = realm.tracers[tracerIndex];
+      let nextIndex = ++tracerIndex;
+      let detourResult = tracer.detourCall(F, thisArgument, argsList, undefined, () =>
+        InternalCall(realm, F, thisArgument, argsList, nextIndex)
+      );
+      if (detourResult instanceof Value) return detourResult;
+    }
 
-    // 6. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
-    OrdinaryCallBindThis(realm, F, calleeContext, thisArgument);
+    // 2. If F's [[FunctionKind]] internal slot is "classConstructor", throw a TypeError exception.
+    if (F.$FunctionKind === "classConstructor")
+      throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "not callable");
 
-    // 7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
-    result = OrdinaryCallEvaluateBody(realm, F, argsList);
+    // 3. Let callerContext be the running execution context.
+    let callerContext = realm.getRunningContext();
+
+    // 4. Let calleeContext be PrepareForOrdinaryCall(F, undefined).
+    let calleeContext = PrepareForOrdinaryCall(realm, F, undefined);
+    let calleeEnv = calleeContext.lexicalEnvironment;
+
+    let result;
+    try {
+      for (let t1 of realm.tracers) t1.beforeCall(F, thisArgument, argsList, undefined);
+
+      // 5. Assert: calleeContext is now the running execution context.
+      invariant(realm.getRunningContext() === calleeContext, "calleeContext should be current execution context");
+
+      // 6. Perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
+      OrdinaryCallBindThis(realm, F, calleeContext, thisArgument);
+
+      // 7. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+      result = OrdinaryCallEvaluateBody(realm, F, argsList);
+    } finally {
+      // 8. Remove calleeContext from the execution context stack and restore callerContext as the running execution context.
+      realm.popContext(calleeContext);
+      realm.onDestroyScope(calleeContext.lexicalEnvironment);
+      if (calleeContext.lexicalEnvironment !== calleeEnv) realm.onDestroyScope(calleeEnv);
+      invariant(realm.getRunningContext() === callerContext);
+
+      for (let t2 of realm.tracers) t2.afterCall(F, thisArgument, argsList, undefined, (result: any));
+    }
+
+    // 9. If result.[[Type]] is return, return NormalCompletion(result.[[Value]]).
+    if (result instanceof ReturnCompletion) {
+      return result.value;
+    }
+
+    // 10. ReturnIfAbrupt(result).
+    if (result instanceof AbruptCompletion) {
+      throw result;
+    }
+
+    // 11. Return NormalCompletion(undefined).
+    return realm.intrinsics.undefined;
   } finally {
-    // 8. Remove calleeContext from the execution context stack and restore callerContext as the running execution context.
-    realm.popContext(calleeContext);
-    realm.onDestroyScope(calleeContext.lexicalEnvironment);
-    if (calleeContext.lexicalEnvironment !== calleeEnv) realm.onDestroyScope(calleeEnv);
-    invariant(realm.getRunningContext() === callerContext);
-
-    for (let t2 of realm.tracers) t2.afterCall(F, thisArgument, argsList, undefined, (result: any));
+    realm.endCall();
   }
-
-  // 9. If result.[[Type]] is return, return NormalCompletion(result.[[Value]]).
-  if (result instanceof ReturnCompletion) {
-    return result.value;
-  }
-
-  // 10. ReturnIfAbrupt(result).
-  if (result instanceof AbruptCompletion) {
-    throw result;
-  }
-
-  // 11. Return NormalCompletion(undefined).
-  return realm.intrinsics.undefined;
 }
 
 // ECMA262 9.4.1.1
@@ -191,123 +196,128 @@ function InternalConstruct(
   thisArgument: void | ObjectValue,
   tracerIndex: number
 ): ObjectValue | AbstractObjectValue {
-  // 1. Assert: F is an ECMAScript function object.
-  invariant(F instanceof FunctionValue, "expected function");
-
-  // 2. Assert: Type(newTarget) is Object.
-  invariant(newTarget instanceof ObjectValue, "expected object");
-
-  if (!realm.hasRunningContext()) {
-    invariant(realm.useAbstractInterpretation);
-    throw new FatalError("no running context");
-  }
-
-  // 3. Let callerContext be the running execution context.
-  let callerContext = realm.getRunningContext();
-
-  // 4. Let kind be F's [[ConstructorKind]] internal slot.
-  let kind = F.$ConstructorKind;
-
-  // 5. If kind is "base", then
-  if (thisArgument === undefined && kind === "base") {
-    // a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget, "%ObjectPrototype%").
-    thisArgument = Create.OrdinaryCreateFromConstructor(realm, newTarget, "ObjectPrototype");
-  }
-
-  // Tracing: Give all registered tracers a chance to detour, wrapping around each other if needed.
-  while (tracerIndex < realm.tracers.length) {
-    let tracer = realm.tracers[tracerIndex];
-    let nextIndex = ++tracerIndex;
-    let detourResult = tracer.detourCall(F, thisArgument, argumentsList, newTarget, () =>
-      InternalConstruct(realm, F, argumentsList, newTarget, thisArgument, nextIndex)
-    );
-    if (detourResult instanceof ObjectValue) return detourResult;
-    invariant(detourResult === undefined);
-  }
-
-  // 6. Let calleeContext be PrepareForOrdinaryCall(F, newTarget).
-  let calleeContext = PrepareForOrdinaryCall(realm, F, newTarget);
-  let calleeEnv = calleeContext.lexicalEnvironment;
-
-  // 7. Assert: calleeContext is now the running execution context.
-  invariant(realm.getRunningContext() === calleeContext, "expected calleeContext to be running context");
-
-  let result, envRec;
+  realm.startCall();
   try {
-    for (let t1 of realm.tracers) t1.beforeCall(F, thisArgument, argumentsList, newTarget);
+    // 1. Assert: F is an ECMAScript function object.
+    invariant(F instanceof FunctionValue, "expected function");
 
-    // 8. If kind is "base", perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
-    if (kind === "base") {
-      invariant(thisArgument, "this wasn't initialized for some reason");
-      OrdinaryCallBindThis(realm, F, calleeContext, thisArgument);
+    // 2. Assert: Type(newTarget) is Object.
+    invariant(newTarget instanceof ObjectValue, "expected object");
+
+    if (!realm.hasRunningContext()) {
+      invariant(realm.useAbstractInterpretation);
+      throw new FatalError("no running context");
     }
 
-    // 9. Let constructorEnv be the LexicalEnvironment of calleeContext.
-    let constructorEnv = calleeContext.lexicalEnvironment;
+    // 3. Let callerContext be the running execution context.
+    let callerContext = realm.getRunningContext();
 
-    // 10. Let envRec be constructorEnv's EnvironmentRecord.
-    envRec = constructorEnv.environmentRecord;
+    // 4. Let kind be F's [[ConstructorKind]] internal slot.
+    let kind = F.$ConstructorKind;
 
-    // 11. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
-    result = OrdinaryCallEvaluateBody(realm, F, argumentsList);
-  } finally {
-    // 12. Remove calleeContext from the execution context stack and restore callerContext as the running execution context.
-    realm.popContext(calleeContext);
-    realm.onDestroyScope(calleeContext.lexicalEnvironment);
-    if (calleeContext.lexicalEnvironment !== calleeEnv) realm.onDestroyScope(calleeEnv);
-    invariant(realm.getRunningContext() === callerContext);
+    // 5. If kind is "base", then
+    if (thisArgument === undefined && kind === "base") {
+      // a. Let thisArgument be ? OrdinaryCreateFromConstructor(newTarget, "%ObjectPrototype%").
+      thisArgument = Create.OrdinaryCreateFromConstructor(realm, newTarget, "ObjectPrototype");
+    }
 
-    for (let t2 of realm.tracers) t2.afterCall(F, thisArgument, argumentsList, newTarget, result);
-  }
+    // Tracing: Give all registered tracers a chance to detour, wrapping around each other if needed.
+    while (tracerIndex < realm.tracers.length) {
+      let tracer = realm.tracers[tracerIndex];
+      let nextIndex = ++tracerIndex;
+      let detourResult = tracer.detourCall(F, thisArgument, argumentsList, newTarget, () =>
+        InternalConstruct(realm, F, argumentsList, newTarget, thisArgument, nextIndex)
+      );
+      if (detourResult instanceof ObjectValue) return detourResult;
+      invariant(detourResult === undefined);
+    }
 
-  // 13. If result.[[Type]] is return, then
-  if (result instanceof ReturnCompletion) {
-    const v = map(result.value);
-    invariant(v instanceof ObjectValue || v instanceof AbstractObjectValue);
-    return v;
+    // 6. Let calleeContext be PrepareForOrdinaryCall(F, newTarget).
+    let calleeContext = PrepareForOrdinaryCall(realm, F, newTarget);
+    let calleeEnv = calleeContext.lexicalEnvironment;
 
-    function map(value: Value) {
-      if (value === realm.intrinsics.__bottomValue) return value;
+    // 7. Assert: calleeContext is now the running execution context.
+    invariant(realm.getRunningContext() === calleeContext, "expected calleeContext to be running context");
 
-      if (value instanceof AbstractValue && value.kind === "conditional") {
-        const [condition, consequent, alternate] = value.args;
-        return realm.evaluateWithAbstractConditional(
-          condition,
-          () => realm.evaluateForEffects(() => map(consequent), undefined, "AbstractValue/conditional/true"),
-          () => realm.evaluateForEffects(() => map(alternate), undefined, "AbstractValue/conditional/false")
-        );
-      }
+    let result, envRec;
+    try {
+      for (let t1 of realm.tracers) t1.beforeCall(F, thisArgument, argumentsList, newTarget);
 
-      // a. If Type(result.[[Value]]) is Object, return NormalCompletion(result.[[Value]]).
-      if (value.mightBeObject()) return value.throwIfNotConcreteObject();
-
-      // b. If kind is "base", return NormalCompletion(thisArgument).
+      // 8. If kind is "base", perform OrdinaryCallBindThis(F, calleeContext, thisArgument).
       if (kind === "base") {
         invariant(thisArgument, "this wasn't initialized for some reason");
-        return thisArgument;
+        OrdinaryCallBindThis(realm, F, calleeContext, thisArgument);
       }
 
-      // c. If result.[[Value]] is not undefined, throw a TypeError exception.
-      if (!value.mightBeUndefined()) {
-        throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "constructor must return Object");
-      }
+      // 9. Let constructorEnv be the LexicalEnvironment of calleeContext.
+      let constructorEnv = calleeContext.lexicalEnvironment;
 
-      value.throwIfNotConcrete();
+      // 10. Let envRec be constructorEnv's EnvironmentRecord.
+      envRec = constructorEnv.environmentRecord;
 
-      // 15. Return ? envRec.GetThisBinding().
-      let envRecThisBinding = envRec.GetThisBinding();
-      invariant(envRecThisBinding instanceof ObjectValue);
-      return envRecThisBinding;
+      // 11. Let result be OrdinaryCallEvaluateBody(F, argumentsList).
+      result = OrdinaryCallEvaluateBody(realm, F, argumentsList);
+    } finally {
+      // 12. Remove calleeContext from the execution context stack and restore callerContext as the running execution context.
+      realm.popContext(calleeContext);
+      realm.onDestroyScope(calleeContext.lexicalEnvironment);
+      if (calleeContext.lexicalEnvironment !== calleeEnv) realm.onDestroyScope(calleeEnv);
+      invariant(realm.getRunningContext() === callerContext);
+
+      for (let t2 of realm.tracers) t2.afterCall(F, thisArgument, argumentsList, newTarget, result);
     }
-  } else if (result instanceof AbruptCompletion) {
-    // 14. Else, ReturnIfAbrupt(result).
-    throw result;
-  }
 
-  // 15. Return ? envRec.GetThisBinding().
-  let envRecThisBinding = envRec.GetThisBinding();
-  invariant(envRecThisBinding instanceof ObjectValue);
-  return envRecThisBinding;
+    // 13. If result.[[Type]] is return, then
+    if (result instanceof ReturnCompletion) {
+      const v = map(result.value);
+      invariant(v instanceof ObjectValue || v instanceof AbstractObjectValue);
+      return v;
+
+      function map(value: Value) {
+        if (value === realm.intrinsics.__bottomValue) return value;
+
+        if (value instanceof AbstractValue && value.kind === "conditional") {
+          const [condition, consequent, alternate] = value.args;
+          return realm.evaluateWithAbstractConditional(
+            condition,
+            () => realm.evaluateForEffects(() => map(consequent), undefined, "AbstractValue/conditional/true"),
+            () => realm.evaluateForEffects(() => map(alternate), undefined, "AbstractValue/conditional/false")
+          );
+        }
+
+        // a. If Type(result.[[Value]]) is Object, return NormalCompletion(result.[[Value]]).
+        if (value.mightBeObject()) return value.throwIfNotConcreteObject();
+
+        // b. If kind is "base", return NormalCompletion(thisArgument).
+        if (kind === "base") {
+          invariant(thisArgument, "this wasn't initialized for some reason");
+          return thisArgument;
+        }
+
+        // c. If result.[[Value]] is not undefined, throw a TypeError exception.
+        if (!value.mightBeUndefined()) {
+          throw realm.createErrorThrowCompletion(realm.intrinsics.TypeError, "constructor must return Object");
+        }
+
+        value.throwIfNotConcrete();
+
+        // 15. Return ? envRec.GetThisBinding().
+        let envRecThisBinding = envRec.GetThisBinding();
+        invariant(envRecThisBinding instanceof ObjectValue);
+        return envRecThisBinding;
+      }
+    } else if (result instanceof AbruptCompletion) {
+      // 14. Else, ReturnIfAbrupt(result).
+      throw result;
+    }
+
+    // 15. Return ? envRec.GetThisBinding().
+    let envRecThisBinding = envRec.GetThisBinding();
+    invariant(envRecThisBinding instanceof ObjectValue);
+    return envRecThisBinding;
+  } finally {
+    realm.endCall();
+  }
 }
 
 export class FunctionImplementation {

--- a/src/realm.js
+++ b/src/realm.js
@@ -258,7 +258,7 @@ export class Realm {
 
     this.start = Date.now();
     this.compatibility = opts.compatibility !== undefined ? opts.compatibility : "browser";
-    this.maxStackDepth = opts.maxStackDepth || 225;
+    this.remainingCalls = opts.maxStackDepth || 112;
     this.invariantLevel = opts.invariantLevel || 0;
     this.invariantMode = opts.invariantMode || "throw";
     this.emitConcreteModel = !!opts.emitConcreteModel;
@@ -349,7 +349,7 @@ export class Realm {
   timeout: void | number;
   mathRandomGenerator: void | (() => number);
   strictlyMonotonicDateNow: boolean;
-  maxStackDepth: number;
+  remainingCalls: number;
   invariantLevel: number;
   invariantMode: InvariantModeTypes;
   ignoreLeakLogic: boolean;
@@ -572,10 +572,20 @@ export class Realm {
     lexicalEnvironment.destroy();
   }
 
-  pushContext(context: ExecutionContext): void {
-    if (this.contextStack.length >= this.maxStackDepth) {
-      throw new FatalError("Maximum stack depth exceeded");
+  startCall() {
+    if (this.remainingCalls === 0) {
+      let error = new CompilerDiagnostic("Maximum stack depth exceeded", this.currentLocation, "PP0045", "FatalError");
+      this.handleError(error);
+      throw new FatalError();
     }
+    this.remainingCalls--;
+  }
+
+  endCall() {
+    this.remainingCalls++;
+  }
+
+  pushContext(context: ExecutionContext): void {
     this.contextStack.push(context);
   }
 
@@ -1708,11 +1718,23 @@ export class Realm {
     );
   }
 
+  evaluateWithIncreasedMaxStackDepth<T>(increaseRemainingCallsBy: number, f: () => T): T {
+    invariant(increaseRemainingCallsBy > 0);
+    this.remainingCalls += increaseRemainingCallsBy;
+    try {
+      return f();
+    } finally {
+      this.remainingCalls -= increaseRemainingCallsBy;
+    }
+  }
+
   // Pass the error to the realm's error-handler
   // Return value indicates whether the caller should try to recover from the error or not.
   handleError(diagnostic: CompilerDiagnostic): ErrorHandlerResult {
     if (!diagnostic.callStack && this.contextStack.length > 0) {
-      let error = this.evaluateWithoutEffects(() => Construct(this, this.intrinsics.Error).throwIfNotConcreteObject());
+      let error = this.evaluateWithIncreasedMaxStackDepth(1, () =>
+        this.evaluateWithoutEffects(() => Construct(this, this.intrinsics.Error).throwIfNotConcreteObject())
+      );
       let stack = error._SafeGetDataPropertyValue("stack");
       if (stack instanceof StringValue) diagnostic.callStack = stack.value;
     }

--- a/test/error-handler/stackOverflow.js
+++ b/test/error-handler/stackOverflow.js
@@ -1,0 +1,5 @@
+// expected errors: [{"location":{"start":{"line":2,"column":15},"end":{"line":2,"column":16},"identifierName":"f","source":"test/error-handler/stackOverflow.js"},"severity":"FatalError","errorCode":"PP0045"}]
+function f() {
+  f();
+}
+f();

--- a/test/error-handler/stackOverflow.js
+++ b/test/error-handler/stackOverflow.js
@@ -1,4 +1,4 @@
-// expected errors: [{"location":{"start":{"line":2,"column":15},"end":{"line":2,"column":16},"identifierName":"f","source":"test/error-handler/stackOverflow.js"},"severity":"FatalError","errorCode":"PP0045"}]
+// expected errors: [{"location":{"start":{"line":3,"column":2},"end":{"line":3,"column":3},"identifierName":"f","source":"test/error-handler/stackOverflow.js"},"severity":"FatalError","errorCode":"PP0045"}]
 function f() {
   f();
 }


### PR DESCRIPTION
Release notes: User-level stack overflows no longer crash Prepack.

This fixes #2552, and actually a bit more:
- We used to piggy-back on `pushContext` to count stack frames. However, there is no one-to-one correspondance of calls and context, so that wasn't a very good proxy. (In fact, there seem to be calls that don't push a context.) So we now count calls and constructs explicitly.
- Instead of just throwing a `FatalError` when the stack space is exceeded, which in turn causes an invariant violation since there must not be a `FatalError` thrown without a compiler diagnostics having beein issue. Now there is a regular error code PP0045.

Added error handler regression test.