### PR TITLE
Fix problem where a bind call can use a variable before its definition

### DIFF
--- a/src/serializer/ResidualFunctions.js
+++ b/src/serializer/ResidualFunctions.js
@@ -661,6 +661,7 @@ export class ResidualFunctions {
           }
           let funcNode;
           let firstUsage = this.firstFunctionUsages.get(functionValue);
+          // todo: why can this be undefined?
           invariant(insertionPoint !== undefined);
           if (
             // The same free variables in shared instances may refer to objects with different initialization values
@@ -668,7 +669,7 @@ export class ResidualFunctions {
             this.residualFunctionInitializers.hasInitializerStatement(functionValue) ||
             usesThis ||
             hasFunctionArg ||
-            (firstUsage !== undefined && !firstUsage.isNotEarlierThan(insertionPoint)) ||
+            (firstUsage === undefined || !firstUsage.isNotEarlierThan(insertionPoint)) ||
             this.functionPrototypes.get(functionValue) !== undefined ||
             hasAnyLeakedIds
           ) {


### PR DESCRIPTION
Release note: none

A large internal test case came up with a situation where an optimized function is rewritten with a version that early binds a yet to be declared value to one of its parameters.

This should probably never happen, so the if condition guarding this code path has been strengthened to prevent this.