### PR TITLE
Speeding up visitor by skipping redundant generator scopes

### DIFF
--- a/src/serializer/ResidualHeapVisitor.js
+++ b/src/serializer/ResidualHeapVisitor.js
@@ -1036,7 +1036,18 @@ export class ResidualHeapVisitor {
   _mark(val: Value): boolean {
     let scopes = this.values.get(val);
     if (scopes === undefined) this.values.set(val, (scopes = new Set()));
-    if (scopes.has(this.scope)) return false;
+    if (this.scope instanceof Generator && this.scope.effectsToApply === undefined) {
+      // If we've already marked this value for any simple parent (non-effect carrying) generator,
+      // then we don't need to re-mark it, as such a set of generators is reduced to the
+      // parent generator in all uses of the scopes set.
+      for (
+        let g = this.scope;
+        g instanceof Generator && g.effectsToApply === undefined;
+        g = this.generatorTree.getParent(g)
+      ) {
+        if (scopes.has(g)) return false;
+      }
+    } else if (scopes.has(this.scope)) return false;
     scopes.add(this.scope);
     return true;
   }


### PR DESCRIPTION
Release notes: None

There's no need to re-visit deep value chains in nested generators,
if a value was already visited in a parent generator.
This greatly speeds up certain internal RN scenarios.