### PR TITLE
Make sure all optimized functions are included in IR dumping

### DIFF
--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -161,18 +161,18 @@ export class Serializer {
         });
       }
 
+      statistics.processCollectedNestedOptimizedFunctions.measure(() =>
+        this.functions.processCollectedNestedOptimizedFunctions(environmentRecordIdAfterGlobalCode)
+      );
+
       statistics.dumpIR.measure(() => {
         if (onExecute !== undefined) {
           let optimizedFunctions = new Map();
-          for (let [functionValue, additionalFunctionEffects] of this.functions.writeEffects)
+          for (let [functionValue, additionalFunctionEffects] of this.functions.getAdditionalFunctionValuesToEffects())
             optimizedFunctions.set(functionValue, additionalFunctionEffects.generator);
           onExecute(this.realm, optimizedFunctions);
         }
       });
-
-      statistics.processCollectedNestedOptimizedFunctions.measure(() =>
-        this.functions.processCollectedNestedOptimizedFunctions(environmentRecordIdAfterGlobalCode)
-      );
 
       if (this.options.initializeMoreModules) {
         statistics.initializeMoreModules.measure(() => this.modules.initializeMoreModules());


### PR DESCRIPTION
Release notes: None

Dumping happened before `processCollectedNestedOptimizedFunctions`,
which caused them to not be included. This is being fixed, plus some
minor refactoring to hide implementation details.