### PR TITLE
Change initializeMoreModules to modulesToInitialize allowing you to s…

### DIFF
--- a/scripts/test-error-handler.js
+++ b/scripts/test-error-handler.js
@@ -71,7 +71,6 @@ function runTest(name: string, code: string): boolean {
       errorHandler: errorHandler.bind(null, recover ? "Recover" : "Fail", errors),
       serialize: true,
       instantRender: false,
-      initializeMoreModules: false,
       compatibility,
     };
 

--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -71,7 +71,7 @@ function runTest(name: string, code: string): boolean {
       mathRandomSeed: "0",
       errorHandler,
       serialize: true,
-      initializeMoreModules: !modelCode,
+      modulesToInitialize: modelCode ? undefined : "ALL",
       sourceMaps: !!sourceMap,
     };
     let serialized = prepackSources(sources, options);

--- a/src/options.js
+++ b/src/options.js
@@ -66,7 +66,7 @@ export type RealmOptions = {
 export type SerializerOptions = {
   lazyObjectsRuntime?: string,
   delayInitializations?: boolean,
-  initializeMoreModules?: boolean,
+  modulesToInitialize?: Set<string> | "ALL",
   internalDebug?: boolean,
   debugScopes?: boolean,
   debugIdentifiers?: Array<string>,

--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -61,8 +61,9 @@ function run(
     --lazyObjectsRuntime     Enable lazy objects feature and specify the JS runtime that support this feature.
     --debugNames             Changes the output of Prepack so that for named functions and variables that get emitted into
                              Prepack's output, the original name is appended as a suffix to Prepack's generated identifier.
-    --initializeMoreModules  Enable speculative initialization of modules (for the module system Prepack has builtin
-                             knowledge about). Prepack will try to execute all factory functions it is able to.
+    --modulesToInitialize [ALL | comma separated list]
+                             Enable speculative initialization of modules (for the module system Prepack has builtin
+                             knowledge about). Prepack will try to execute the factory functions of the modules you specify.
     --trace                  Traces the order of module initialization.
     --check [start[, count]] Check residual functions for diagnostic messages. Do not generate code.
     --profile                Collect statistics about time and memory usage of the different internal passes
@@ -116,8 +117,8 @@ function run(
   let diagnosticAsError: void | Set<string>;
   let noDiagnostic: void | Set<string>;
   let warnAsError: void | true;
+  let modulesToInitialize: void | Set<string> | "ALL";
   let flags = {
-    initializeMoreModules: false,
     trace: false,
     debugNames: false,
     emitConcreteModel: false,
@@ -147,6 +148,10 @@ function run(
     } else {
       arg = arg.slice(2);
       switch (arg) {
+        case "modulesToInitialize":
+          let modulesString = args.shift().trim();
+          modulesToInitialize = modulesString === "ALL" ? modulesString : new Set(modulesString.split(","));
+          break;
         case "out":
           arg = args.shift();
           outputFilename = arg;
@@ -386,6 +391,7 @@ function run(
       invariantLevel,
       debuggerConfigArgs,
       debugReproArgs,
+      modulesToInitialize,
     },
     flags
   );

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -46,7 +46,7 @@ export type PrepackOptions = {|
   check?: Array<number>,
   inlineExpressions?: boolean,
   sourceMaps?: boolean,
-  initializeMoreModules?: boolean,
+  modulesToInitialize?: Set<string> | "ALL",
   statsFile?: string,
   strictlyMonotonicDateNow?: boolean,
   stripFlow?: boolean,
@@ -130,12 +130,12 @@ export function getSerializerOptions({
   logModules = false,
   profile = false,
   inlineExpressions = false,
-  initializeMoreModules = false,
+  modulesToInitialize,
   trace = false,
 }: PrepackOptions): SerializerOptions {
   let result: SerializerOptions = {
     delayInitializations,
-    initializeMoreModules,
+    modulesToInitialize,
     internalDebug,
     debugScopes,
     debugIdentifiers,

--- a/src/serializer/serializer.js
+++ b/src/serializer/serializer.js
@@ -174,8 +174,9 @@ export class Serializer {
         }
       });
 
-      if (this.options.initializeMoreModules) {
-        statistics.initializeMoreModules.measure(() => this.modules.initializeMoreModules());
+      let modulesToInitialize = this.options.modulesToInitialize;
+      if (modulesToInitialize) {
+        statistics.modulesToInitialize.measure(() => this.modules.initializeMoreModules(modulesToInitialize));
         if (this.logger.hasErrors()) return undefined;
       }
 

--- a/src/serializer/statistics.js
+++ b/src/serializer/statistics.js
@@ -26,7 +26,7 @@ export class SerializerStatistics extends RealmStatistics {
 
     this.total = new PerformanceTracker(getTime, getMemory);
     this.resolveInitializedModules = new PerformanceTracker(getTime, getMemory);
-    this.initializeMoreModules = new PerformanceTracker(getTime, getMemory);
+    this.modulesToInitialize = new PerformanceTracker(getTime, getMemory);
     this.optimizeReactComponentTreeRoots = new PerformanceTracker(getTime, getMemory);
     this.checkThatFunctionsAreIndependent = new PerformanceTracker(getTime, getMemory);
     this.processCollectedNestedOptimizedFunctions = new PerformanceTracker(getTime, getMemory);
@@ -94,7 +94,7 @@ export class SerializerStatistics extends RealmStatistics {
 
   total: PerformanceTracker;
   resolveInitializedModules: PerformanceTracker;
-  initializeMoreModules: PerformanceTracker;
+  modulesToInitialize: PerformanceTracker;
   optimizeReactComponentTreeRoots: PerformanceTracker;
   checkThatFunctionsAreIndependent: PerformanceTracker;
   processCollectedNestedOptimizedFunctions: PerformanceTracker;
@@ -135,7 +135,7 @@ export class SerializerStatistics extends RealmStatistics {
     this.logPerformanceTrackers(format);
     console.log(
       `${format(this.resolveInitializedModules)} resolving initialized modules, ${format(
-        this.initializeMoreModules
+        this.modulesToInitialize
       )} initializing more modules, ${format(
         this.optimizeReactComponentTreeRoots
       )} optimizing react component tree roots, ${format(

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -431,10 +431,11 @@ export class Modules {
     });
   }
 
-  initializeMoreModules(): void {
+  initializeMoreModules(modulesToInitialize: Set<string> | "ALL"): void {
     // partially evaluate all factory methods by calling require
     let count = 0;
     for (let moduleId of this.moduleIds) {
+      if (modulesToInitialize !== "ALL" && !modulesToInitialize.has("" + moduleId)) continue;
       if (this.initializedModules.has(moduleId)) continue;
       let effects = this.tryInitializeModule(moduleId, `Speculative initialization of module ${moduleId}`);
       if (effects === undefined) continue;

--- a/test/serializer/optimizations/require_speculatively_specific.js
+++ b/test/serializer/optimizations/require_speculatively_specific.js
@@ -1,0 +1,116 @@
+// es6
+// does not contain:1 + 2
+// does contain:3 + 4
+// initialize more modules:0
+
+var modules = Object.create(null);
+__d = define;
+
+require = function(moduleId) {
+  var moduleIdReallyIsNumber = moduleId;
+  var module = modules[moduleIdReallyIsNumber];
+  return module && module.isInitialized ? module.exports : guardedLoadModule(moduleIdReallyIsNumber, module);
+};
+
+function define(factory, moduleId, dependencyMap) {
+  if (moduleId in modules) {
+    return;
+  }
+  modules[moduleId] = {
+    dependencyMap: dependencyMap,
+    exports: undefined,
+    factory: factory,
+    hasError: false,
+    isInitialized: false,
+  };
+
+  var _verboseName = arguments[3];
+  if (_verboseName) {
+    modules[moduleId].verboseName = _verboseName;
+    global.verboseNamesToModuleIds[_verboseName] = moduleId;
+  }
+}
+
+var inGuard = false;
+function guardedLoadModule(moduleId, module) {
+  if (!inGuard && global.ErrorUtils) {
+    inGuard = true;
+    var returnValue = void 0;
+    try {
+      returnValue = loadModuleImplementation(moduleId, module);
+    } catch (e) {
+      global.ErrorUtils.reportFatalError(e);
+    }
+    inGuard = false;
+    return returnValue;
+  } else {
+    return loadModuleImplementation(moduleId, module);
+  }
+}
+
+function loadModuleImplementation(moduleId, module) {
+  var nativeRequire = global.nativeRequire;
+  if (!module && nativeRequire) {
+    nativeRequire(moduleId);
+    module = modules[moduleId];
+  }
+
+  if (!module) {
+    throw unknownModuleError(moduleId);
+  }
+
+  if (module.hasError) {
+    throw moduleThrewError(moduleId);
+  }
+
+  module.isInitialized = true;
+  var exports = (module.exports = {});
+  var _module = module,
+    factory = _module.factory,
+    dependencyMap = _module.dependencyMap;
+  try {
+    var _moduleObject = { exports: exports };
+
+    factory(global, require, _moduleObject, exports, dependencyMap);
+    module.factory = undefined;
+
+    return (module.exports = _moduleObject.exports);
+  } catch (e) {
+    module.hasError = true;
+    module.isInitialized = false;
+    module.exports = undefined;
+    throw e;
+  }
+}
+
+function unknownModuleError(id) {
+  var message = 'Requiring unknown module "' + id + '".';
+  return Error(message);
+}
+
+function moduleThrewError(id) {
+  return Error('Requiring module "' + id + '", which threw an exception.');
+}
+
+// === End require code ===
+
+define(function(global, require, module, exports) {
+  let useless = 1 + 2;
+  module.exports = { foo: " hello " };
+}, 0, null);
+
+define(function(global, r, module, exports) {
+  let useless = 3 + 4;
+  module.exports = function() {
+    return r(0);
+  };
+}, 1, null);
+
+inspect = function() {
+  return require(0).foo;
+};
+
+var verboseNamesToModuleIds = {};
+var ErrorUtils = undefined;
+var nativeRequire = undefined;
+if (global.__makePartial) __makePartial(this);


### PR DESCRIPTION
…pecify modules

Release Notes: None

Sometimes it'll be useful to allow the user to specify which specific modules you want to speculatively execute. This allows that by turning `--initializeMoreModules` into `--modulesToInitialize <ALL | comma separated list of modules>`

Updated tests as well.