### PR TITLE
Support optimized Array.filter and make filter-map compositions correct

### DIFF
--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -188,8 +188,12 @@ function createArrayWithWidenedNumericProperty(
 ): ArrayValue {
   let abstractArrayValue = new ArrayValue(realm, intrinsicName);
 
-  if (possibleNestedOptimizedFunctions !== undefined && possibleNestedOptimizedFunctions.length > 0) {
-    if (realm.arrayNestedOptimizedFunctionsEnabled && (!realm.react.enabled || realm.react.optimizeNestedFunctions)) {
+  if (
+    realm.arrayNestedOptimizedFunctionsEnabled &&
+    (!realm.react.enabled || realm.react.optimizeNestedFunctions) &&
+    possibleNestedOptimizedFunctions !== undefined
+  ) {
+    if (possibleNestedOptimizedFunctions.length > 0) {
       evaluatePossibleNestedOptimizedFunctionsAndStoreEffects(
         realm,
         abstractArrayValue,

--- a/test/serializer/additional-functions/OptimizedArrayFilterOpAliasing.js
+++ b/test/serializer/additional-functions/OptimizedArrayFilterOpAliasing.js
@@ -1,0 +1,19 @@
+// arrayNestedOptimizedFunctionsEnabled
+// does contain: return 42
+
+function f(c) {
+  var arr = Array.from(c);
+  let obj = { foo: 42 };
+
+  function op(x) {
+    return obj;
+  }
+
+  let mapped = arr.filter(op);
+  mapped[0].foo = 0;
+
+  return obj.foo;
+}
+global.__optimize && __optimize(f);
+
+inspect = () => f([0]);

--- a/test/serializer/additional-functions/OptimizedArrayFilterOpAliasing2.js
+++ b/test/serializer/additional-functions/OptimizedArrayFilterOpAliasing2.js
@@ -1,0 +1,24 @@
+// arrayNestedOptimizedFunctionsEnabled
+// does not contain: return 42
+
+function f(c) {
+  var arr = Array.from(c);
+  let obj = { foo: 42 };
+
+  function op1(x) {
+    return obj;
+  }
+
+  function op2(x) {
+    return true;
+  }
+
+  let mapped = arr.map(op1);
+  let mapped2 = mapped.filter(op2);
+  mapped2[0].foo = 0;
+
+  return obj.foo;
+}
+global.__optimize && __optimize(f);
+
+inspect = () => f([0]);

--- a/test/serializer/additional-functions/OptimizedArrayFilterOpSpecialization.js
+++ b/test/serializer/additional-functions/OptimizedArrayFilterOpSpecialization.js
@@ -1,0 +1,18 @@
+// arrayNestedOptimizedFunctionsEnabled
+// does contain:return true
+
+function f(c, g) {
+  var arr = Array.from(c);
+  let obj = { foo: true };
+
+  function op(x) {
+    return obj.foo;
+  }
+
+  let mapped = arr.filter(op);
+
+  return mapped;
+}
+global.__optimize && __optimize(f);
+
+inspect = () => f([0], () => {});


### PR DESCRIPTION
Adds optimized operator support for `Array.filter`, and makes compositions in which `Array.filter` is called on a mapped array correct. Aliasing information kept in the mapped array is exposed to the `Array.filter` call, which collects it in the resulting array.

Resolves #2580 