### PR TITLE
Fixes a bug in evaluatePure

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -272,7 +272,12 @@ export default function(realm: Realm): void {
             /*bubbles*/ true,
             /*reportSideEffectFunc*/ callback === undefined || callback === realm.intrinsics.undefined
               ? null
-              : () => callback.$Call(realm.intrinsics.undefined, [])
+              : () => {
+                  invariant(callback instanceof ECMAScriptSourceFunctionValue);
+                  let call = callback.$Call;
+                  invariant(call !== undefined);
+                  call(realm.intrinsics.undefined, []);
+                }
           );
         }
       ),

--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -263,14 +263,16 @@ export default function(realm: Realm): void {
         "global.__evaluatePureFunction",
         "__evaluatePureFunction",
         0,
-        (context, [functionValue]) => {
+        (context, [functionValue, callback]) => {
           invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
           invariant(typeof functionValue.$Call === "function");
           let functionCall: Function = functionValue.$Call;
           return realm.evaluatePure(
             () => functionCall(realm.intrinsics.undefined, []),
             /*bubbles*/ true,
-            /*reportSideEffectFunc*/ null
+            /*reportSideEffectFunc*/ callback === undefined || callback === realm.intrinsics.undefined
+              ? null
+              : () => callback.$Call(realm.intrinsics.undefined, [])
           );
         }
       ),

--- a/src/realm.js
+++ b/src/realm.js
@@ -723,7 +723,7 @@ export class Realm {
       } else {
         // Add any created objects from the child evaluatePure's tracked objects set to the
         // current tracked objects set.
-        if (this.createdObjectsTrackedForLeaks !== undefined && this.createdObjects !== undefined) {
+        if (this.createdObjectsTrackedForLeaks !== undefined) {
           for (let obj of this.createdObjectsTrackedForLeaks) {
             saved_createdObjectsTrackedForLeaks.add(obj);
           }

--- a/src/realm.js
+++ b/src/realm.js
@@ -725,9 +725,7 @@ export class Realm {
         // current tracked objects set.
         if (this.createdObjectsTrackedForLeaks !== undefined && this.createdObjects !== undefined) {
           for (let obj of this.createdObjectsTrackedForLeaks) {
-            if (this.createdObjects.has(obj)) {
-              saved_createdObjectsTrackedForLeaks.add(obj);
-            }
+            saved_createdObjectsTrackedForLeaks.add(obj);
           }
         }
         this.createdObjectsTrackedForLeaks = saved_createdObjectsTrackedForLeaks;

--- a/src/realm.js
+++ b/src/realm.js
@@ -718,7 +718,21 @@ export class Realm {
     try {
       return f();
     } finally {
-      this.createdObjectsTrackedForLeaks = saved_createdObjectsTrackedForLeaks;
+      if (saved_createdObjectsTrackedForLeaks === undefined) {
+        this.createdObjectsTrackedForLeaks = undefined;
+      } else {
+        // Add any created objects from the child evaluatePure's tracked objects set to the
+        // current tracked objects set.
+        if (this.createdObjectsTrackedForLeaks !== undefined && this.createdObjects !== undefined) {
+          for (let obj of this.createdObjectsTrackedForLeaks) {
+            if (this.createdObjects.has(obj)) {
+              saved_createdObjectsTrackedForLeaks.add(obj);
+            }
+          }
+        }
+        this.createdObjectsTrackedForLeaks = saved_createdObjectsTrackedForLeaks;
+      }
+
       if (reportSideEffectFunc !== null) {
         if (!bubbleSideEffectReports && saved_reportSideEffectCallbacks !== undefined) {
           this.reportSideEffectCallbacks = saved_reportSideEffectCallbacks;
@@ -844,9 +858,11 @@ export class Realm {
     let saved_generator = this.generator;
     let saved_createdObjects = this.createdObjects;
     let saved_completion = this.savedCompletion;
+    let saved_abstractValuesDefined = this._abstractValuesDefined;
     this.generator = new Generator(this, generatorName, this.pathConditions);
     this.createdObjects = new Set();
     this.savedCompletion = undefined; // while in this call, we only explore the normal path.
+    this._abstractValuesDefined = new Set(saved_abstractValuesDefined);
 
     let result;
     try {
@@ -911,6 +927,7 @@ export class Realm {
         this.modifiedProperties = savedProperties;
         this.createdObjects = saved_createdObjects;
         this.savedCompletion = saved_completion;
+        this._abstractValuesDefined = saved_abstractValuesDefined;
       }
     } finally {
       for (let t2 of this.tracers) t2.endEvaluateForEffects(state, result);

--- a/test/serializer/pure-functions/NestedPureFunctionWrapper.js
+++ b/test/serializer/pure-functions/NestedPureFunctionWrapper.js
@@ -1,0 +1,23 @@
+var __evaluatePureFunction =
+  global.__evaluatePureFunction ||
+  function(f) {
+    return f();
+  };
+
+__evaluatePureFunction(
+  function() {
+    var x = __evaluatePureFunction(function() {
+      return {};
+    });
+
+    x.foo = 123;
+  },
+  function() {
+    throw new Error("Side-effect detected");
+  }
+);
+
+inspect = function() {
+  // we only care that the init doesn't throw an error
+  return null;
+};


### PR DESCRIPTION
Release notes: none

When working on a separate issue that involved touching `evaluatePure`, I ran into a bug where `createdObjectsTrackedForLeaks` were not being populated by any objects returned from nested `evalautePure` calls. This fixes it and adds a helper function to `__evaluatePureFunction ` for testing this.