### PR TITLE
Allow speculative module intialization to take file

### DIFF
--- a/scripts/test-internal.js
+++ b/scripts/test-internal.js
@@ -56,9 +56,11 @@ function runTest(name: string, code: string): boolean {
     errorList = [];
     let modelName = name + ".model";
     let sourceMapName = name + ".map";
+    let modulesName = name + ".modules";
     let sourceCode = fs.readFileSync(name, "utf8");
     let modelCode = fs.existsSync(modelName) ? fs.readFileSync(modelName, "utf8") : undefined;
     let sourceMap = fs.existsSync(sourceMapName) ? fs.readFileSync(sourceMapName, "utf8") : undefined;
+    let modulesString = fs.existsSync(modulesName) ? JSON.parse(fs.readFileSync(modulesName, "utf8")) : undefined;
     let sources = [];
     if (modelCode) {
       sources.push({ filePath: modelName, fileContents: modelCode });
@@ -71,7 +73,7 @@ function runTest(name: string, code: string): boolean {
       mathRandomSeed: "0",
       errorHandler,
       serialize: true,
-      modulesToInitialize: modelCode ? undefined : "ALL",
+      modulesToInitialize: modulesString || (modelCode ? undefined : "ALL"),
       sourceMaps: !!sourceMap,
     };
     let serialized = prepackSources(sources, options);

--- a/src/options.js
+++ b/src/options.js
@@ -66,7 +66,7 @@ export type RealmOptions = {
 export type SerializerOptions = {
   lazyObjectsRuntime?: string,
   delayInitializations?: boolean,
-  modulesToInitialize?: Set<string> | "ALL",
+  modulesToInitialize?: Set<string | number> | "ALL",
   internalDebug?: boolean,
   debugScopes?: boolean,
   debugIdentifiers?: Array<string>,

--- a/src/prepack-options.js
+++ b/src/prepack-options.js
@@ -46,7 +46,7 @@ export type PrepackOptions = {|
   check?: Array<number>,
   inlineExpressions?: boolean,
   sourceMaps?: boolean,
-  modulesToInitialize?: Set<string> | "ALL",
+  modulesToInitialize?: Set<string | number> | "ALL",
   statsFile?: string,
   strictlyMonotonicDateNow?: boolean,
   stripFlow?: boolean,

--- a/src/realm.js
+++ b/src/realm.js
@@ -1773,25 +1773,25 @@ export class Realm {
         let loc_end = diagnostic.location.end;
         msg += ` at ${loc_start.line}:${loc_start.column} to ${loc_end.line}:${loc_end.column}`;
       }
-      try {
-        switch (diagnostic.severity) {
-          case "Information":
-            console.log(`Info: ${msg}`);
-            return "Recover";
-          case "Warning":
-            console.warn(`Warn: ${msg}`);
-            return "Recover";
-          case "RecoverableError":
-            console.error(`Error: ${msg}`);
-            return "Fail";
-          case "FatalError":
-            console.error(`Fatal Error: ${msg}`);
-            return "Fail";
-          default:
-            invariant(false, "Unexpected error type");
-        }
-      } finally {
-        console.log(diagnostic.callStack);
+      switch (diagnostic.severity) {
+        case "Information":
+          console.log(`Info: ${msg}`);
+          console.log(diagnostic.callStack);
+          return "Recover";
+        case "Warning":
+          console.warn(`Warn: ${msg}`);
+          console.warn(diagnostic.callStack);
+          return "Recover";
+        case "RecoverableError":
+          console.error(`Error: ${msg}`);
+          console.error(diagnostic.callStack);
+          return "Fail";
+        case "FatalError":
+          console.error(`Fatal Error: ${msg}`);
+          console.error(diagnostic.callStack);
+          return "Fail";
+        default:
+          invariant(false, "Unexpected error type");
       }
     }
     return errorHandler(diagnostic, this.suppressDiagnostics);

--- a/src/utils/DebugReproPackager.js
+++ b/src/utils/DebugReproPackager.js
@@ -78,7 +78,8 @@ export class DebugReproPackager {
         this._reproZip.file(path.basename(file), content);
       } catch (err) {
         console.error(`Could not zip input file ${err}`);
-        process.exit(1);
+        if (shouldExitWithError) process.exit(1);
+        else return;
       }
     }
 
@@ -89,7 +90,8 @@ export class DebugReproPackager {
         this._reproZip.file(path.basename(map), content);
       } catch (err) {
         console.error(`Could not zip sourcemap: ${err}`);
-        process.exit(1);
+        if (shouldExitWithError) process.exit(1);
+        else return;
       }
     }
 

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -25,6 +25,7 @@ import {
   UndefinedValue,
   NullValue,
 } from "../values/index.js";
+import { NormalCompletion } from "../completions.js";
 import * as t from "@babel/types";
 import type {
   BabelNodeIdentifier,
@@ -108,7 +109,7 @@ export class ModuleTracer extends Tracer {
       this.requireStack.push(moduleIdValue);
       try {
         let value = performCall();
-        if (this.modules.moduleIds.has(moduleIdValue)) this.modules.recordModuleInitialized(moduleIdValue, value);
+        if (this.modules.moduleIds.has("" + moduleIdValue)) this.modules.recordModuleInitialized(moduleIdValue, value);
         return value;
       } finally {
         invariant(this.requireStack.pop() === moduleIdValue);
@@ -180,6 +181,7 @@ export class ModuleTracer extends Tracer {
         let moduleIdValue = moduleId.value;
         let factoryFunction = argumentsList[0];
         if (factoryFunction instanceof FunctionValue) {
+          this.modules.moduleIds.add("" + moduleIdValue);
           let dependencies = this._tryExtractDependencies(argumentsList[2]);
           if (dependencies !== undefined) {
             this.modules.moduleDependencies.set(moduleIdValue, dependencies);
@@ -191,8 +193,6 @@ export class ModuleTracer extends Tracer {
             );
         } else
           this.modules.logger.logError(factoryFunction, "First argument to define function is not a function value.");
-
-        this.modules.moduleIds.add(moduleIdValue);
       } else
         this.modules.logger.logError(moduleId, "Second argument to define function is not a number or string value.");
     }
@@ -223,8 +223,8 @@ export class Modules {
   _define: Value;
   factoryFunctionDependencies: Map<FunctionValue, Array<Value>>;
   moduleDependencies: Map<number | string, Array<Value>>;
-  moduleIds: Set<number | string>;
-  initializedModules: Map<number | string, Value>;
+  moduleIds: Set<string>;
+  initializedModules: Map<string, Value>;
   active: boolean;
   moduleTracer: ModuleTracer;
 
@@ -431,19 +431,20 @@ export class Modules {
     });
   }
 
-  initializeMoreModules(modulesToInitialize: Set<string> | "ALL"): void {
+  initializeMoreModules(modulesToInitialize: Set<string | number> | "ALL"): void {
     // partially evaluate all factory methods by calling require
     let count = 0;
-    for (let moduleId of this.moduleIds) {
-      if (modulesToInitialize !== "ALL" && !modulesToInitialize.has("" + moduleId)) continue;
-      if (this.initializedModules.has(moduleId)) continue;
+    let body = (moduleId: string) => {
+      if (this.initializedModules.has(moduleId)) return;
       let effects = this.tryInitializeModule(moduleId, `Speculative initialization of module ${moduleId}`);
-      if (effects === undefined) continue;
+      if (effects === undefined) return;
       let result = effects.result;
-      if (!(result instanceof Value)) continue; // module might throw
+      if (!(result instanceof NormalCompletion)) return; // module might throw
       count++;
-      this.initializedModules.set(moduleId, result);
-    }
+      this.initializedModules.set(moduleId, result.value);
+    };
+    if (modulesToInitialize === "ALL") for (let moduleId of this.moduleIds) body(moduleId);
+    else for (let moduleId of modulesToInitialize) body("" + moduleId);
     if (count > 0) console.log(`=== speculatively initialized ${count} additional modules`);
   }
 }

--- a/src/utils/modules.js
+++ b/src/utils/modules.js
@@ -443,8 +443,11 @@ export class Modules {
       count++;
       this.initializedModules.set(moduleId, result.value);
     };
-    if (modulesToInitialize === "ALL") for (let moduleId of this.moduleIds) body(moduleId);
-    else for (let moduleId of modulesToInitialize) body("" + moduleId);
+    if (modulesToInitialize === "ALL") {
+      for (let moduleId of this.moduleIds) body(moduleId);
+    } else {
+      for (let moduleId of modulesToInitialize) body("" + moduleId);
+    }
     if (count > 0) console.log(`=== speculatively initialized ${count} additional modules`);
   }
 }


### PR DESCRIPTION
Release Notes: `--initializeMoreModules` can take a JSON file of module ids to initialize

Allows testing this in `test-internal` with a new `.modules` file.

Also fixes ReproPackageManager to not exit prepack if a file can't be found while zipping a repro. 