### PR TITLE
Fix for a serialization bug in `_getPropertyAssignmentStatement`

### DIFF
--- a/src/serializer/ResidualHeapSerializer.js
+++ b/src/serializer/ResidualHeapSerializer.js
@@ -1216,6 +1216,19 @@ export class ResidualHeapSerializer {
       let serializedValue = this.serializeValue(value);
       let condition;
       if (value instanceof AbstractValue && value.kind === "conditional") {
+        let cf = this.conditionalFeasibility.get(value);
+        invariant(cf !== undefined);
+        let conditionalSerializedValue;
+        if (cf.t && !cf.f) {
+          conditionalSerializedValue = this.serializeValue(value.args[1]);
+        } else if (!cf.t && cf.f) {
+          conditionalSerializedValue = this.serializeValue(value.args[2]);
+        } else {
+          invariant(cf.t && cf.f);
+        }
+        if (conditionalSerializedValue !== undefined) {
+          return t.expressionStatement(t.assignmentExpression("=", location, conditionalSerializedValue));
+        }
         let [c, x, y] = value.args;
         if (x instanceof EmptyValue) {
           if (c instanceof AbstractValue && c.kind === "!") condition = this.serializeValue(c.args[0]);


### PR DESCRIPTION
Release notes: none

I encountered a serialization bug in my upcoming PR that hit a case where the visitor did something that mismatched the logic in the serializer. This logic was already added to the `_serializeAbstractValue` method, but may have been missed from `_getPropertyAssignmentStatement` so this PR aims to add the same logic. There are no tests as I'm not entirely sure how to re-produce this (I've been using an internal bundle of significant size).