### PR TITLE
Adds createdAbstracts Set to effects/realm for tracking

### DIFF
--- a/src/evaluators/LogicalExpression.js
+++ b/src/evaluators/LogicalExpression.js
@@ -60,11 +60,12 @@ export default function(
     modifiedBindings: modifiedBindings1,
     modifiedProperties: modifiedProperties1,
     createdObjects: createdObjects1,
+    createdAbstracts: createdAbstracts1,
   } = construct_empty_effects(realm);
   result1; // ignore
 
   // Evaluate ast.right in a sandbox to get its effects
-  let result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2;
+  let result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2, createdAbstracts2;
   try {
     let wrapper = ast.operator === "&&" ? Path.withCondition : Path.withInverseCondition;
     ({
@@ -73,6 +74,7 @@ export default function(
       modifiedBindings: modifiedBindings2,
       modifiedProperties: modifiedProperties2,
       createdObjects: createdObjects2,
+      createdAbstracts: createdAbstracts2,
     } = wrapper(lcond, () => realm.evaluateNodeForEffects(ast.right, strictCode, env)));
   } catch (e) {
     if (e instanceof InfeasiblePathError) {
@@ -91,8 +93,15 @@ export default function(
   if (ast.operator === "&&") {
     joinedEffects = Join.joinEffects(
       lcond,
-      new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2),
-      new Effects(new SimpleNormalCompletion(lval), generator1, modifiedBindings1, modifiedProperties1, createdObjects1)
+      new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2, createdAbstracts2),
+      new Effects(
+        new SimpleNormalCompletion(lval),
+        generator1,
+        modifiedBindings1,
+        modifiedProperties1,
+        createdObjects1,
+        createdAbstracts1
+      )
     );
   } else {
     joinedEffects = Join.joinEffects(
@@ -102,9 +111,10 @@ export default function(
         generator1,
         modifiedBindings1,
         modifiedProperties1,
-        createdObjects1
+        createdObjects1,
+        createdAbstracts1
       ),
-      new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2)
+      new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2, createdAbstracts2)
     );
   }
 

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -172,7 +172,7 @@ export function OrdinaryGet(
     return OrdinaryGetHelper();
   }
   invariant(joinCondition instanceof AbstractValue);
-  let result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1;
+  let result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1, createdAbstracts1;
   try {
     desc = descriptor1;
     ({
@@ -181,6 +181,7 @@ export function OrdinaryGet(
       modifiedBindings: modifiedBindings1,
       modifiedProperties: modifiedProperties1,
       createdObjects: createdObjects1,
+      createdAbstracts: createdAbstracts1,
     } = Path.withCondition(joinCondition, () => {
       return desc !== undefined
         ? realm.evaluateForEffects(() => OrdinaryGetHelper(), undefined, "OrdinaryGet/1")
@@ -195,7 +196,7 @@ export function OrdinaryGet(
       throw e;
     }
   }
-  let result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2;
+  let result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2, createdAbstracts2;
   try {
     desc = descriptor2;
     ({
@@ -204,6 +205,7 @@ export function OrdinaryGet(
       modifiedBindings: modifiedBindings2,
       modifiedProperties: modifiedProperties2,
       createdObjects: createdObjects2,
+      createdAbstracts: createdAbstracts2,
     } = Path.withInverseCondition(joinCondition, () => {
       return desc !== undefined
         ? realm.evaluateForEffects(() => OrdinaryGetHelper(), undefined, "OrdinaryGet/2")
@@ -222,8 +224,8 @@ export function OrdinaryGet(
   // of the actual value of ownDesc.joinCondition.
   let joinedEffects = Join.joinEffects(
     joinCondition,
-    new Effects(result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1),
-    new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2)
+    new Effects(result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1, createdAbstracts1),
+    new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2, createdAbstracts2)
   );
   realm.applyEffects(joinedEffects);
   return realm.returnOrThrowCompletion(joinedEffects.result);

--- a/src/methods/properties.js
+++ b/src/methods/properties.js
@@ -339,6 +339,7 @@ export class PropertiesImplementation {
         modifiedBindings: modifiedBindings1,
         modifiedProperties: modifiedProperties1,
         createdObjects: createdObjects1,
+        createdAbstracts: createdAbstracts1,
       } = e1;
       ownDesc = descriptor2;
       let e2 = Path.withInverseCondition(joinCondition, () => {
@@ -352,14 +353,15 @@ export class PropertiesImplementation {
         modifiedBindings: modifiedBindings2,
         modifiedProperties: modifiedProperties2,
         createdObjects: createdObjects2,
+        createdAbstracts: createdAbstracts2,
       } = e2;
 
       // Join the effects, creating an abstract view of what happened, regardless
       // of the actual value of ownDesc.joinCondition.
       let joinedEffects = Join.joinEffects(
         joinCondition,
-        new Effects(result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1),
-        new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2)
+        new Effects(result1, generator1, modifiedBindings1, modifiedProperties1, createdObjects1, createdAbstracts1),
+        new Effects(result2, generator2, modifiedBindings2, modifiedProperties2, createdObjects2, createdAbstracts2)
       );
       realm.applyEffects(joinedEffects);
       return To.ToBooleanPartial(realm, realm.returnOrThrowCompletion(joinedEffects.result));

--- a/src/realm.js
+++ b/src/realm.js
@@ -95,6 +95,7 @@ export type EvaluationResult = Completion | Reference;
 export type PropertyBindings = Map<PropertyBinding, void | Descriptor>;
 
 export type CreatedObjects = Set<ObjectValue>;
+export type CreatedAbstracts = Set<AbstractValue>;
 
 export type SideEffectType = "MODIFIED_BINDING" | "MODIFIED_PROPERTY" | "EXCEPTION_THROWN" | "MODIFIED_GLOBAL";
 
@@ -106,13 +107,15 @@ export class Effects {
     generator: Generator,
     bindings: Bindings,
     propertyBindings: PropertyBindings,
-    createdObjects: CreatedObjects
+    createdObjects: CreatedObjects,
+    createdAbstracts: CreatedAbstracts
   ) {
     this.result = result;
     this.generator = generator;
     this.modifiedBindings = bindings;
     this.modifiedProperties = propertyBindings;
     this.createdObjects = createdObjects;
+    this.createdAbstracts = createdAbstracts;
 
     this.canBeApplied = true;
     this._id = effects_uid++;
@@ -123,11 +126,19 @@ export class Effects {
   modifiedBindings: Bindings;
   modifiedProperties: PropertyBindings;
   createdObjects: CreatedObjects;
+  createdAbstracts: CreatedAbstracts;
   canBeApplied: boolean;
   _id: number;
 
   shallowCloneWithResult(result: Completion): Effects {
-    return new Effects(result, this.generator, this.modifiedBindings, this.modifiedProperties, this.createdObjects);
+    return new Effects(
+      result,
+      this.generator,
+      this.modifiedBindings,
+      this.modifiedProperties,
+      this.createdObjects,
+      this.createdAbstracts
+    );
   }
 
   toDisplayString(): string {
@@ -228,6 +239,7 @@ export function construct_empty_effects(
     new Generator(realm, "construct_empty_effects", realm.pathConditions),
     new Map(),
     new Map(),
+    new Set(),
     new Set()
   );
 }
@@ -365,6 +377,7 @@ export class Realm {
   modifiedProperties: void | PropertyBindings;
   createdObjects: void | CreatedObjects;
   createdObjectsTrackedForLeaks: void | CreatedObjects;
+  createdAbstracts: void | CreatedAbstracts;
   reportObjectGetOwnProperties: void | ((ObjectValue | AbstractObjectValue) => void);
   reportSideEffectCallbacks: Set<
     (sideEffectType: SideEffectType, binding: void | Binding | PropertyBinding, expressionLocation: any) => void
@@ -868,10 +881,12 @@ export class Realm {
     let [savedBindings, savedProperties] = this.getAndResetModifiedMaps();
     let saved_generator = this.generator;
     let saved_createdObjects = this.createdObjects;
+    let saved_createdAbstracts = this.createdAbstracts;
     let saved_completion = this.savedCompletion;
     let saved_abstractValuesDefined = this._abstractValuesDefined;
     this.generator = new Generator(this, generatorName, this.pathConditions);
     this.createdObjects = new Set();
+    this.createdAbstracts = new Set();
     this.savedCompletion = undefined; // while in this call, we only explore the normal path.
     this._abstractValuesDefined = new Set(saved_abstractValuesDefined);
 
@@ -901,6 +916,7 @@ export class Realm {
         let astBindings = this.modifiedBindings;
         let astProperties = this.modifiedProperties;
         let astCreatedObjects = this.createdObjects;
+        let astCreatedAbstracts = this.createdAbstracts;
 
         /* TODO #1615: The following invariant should hold.
 
@@ -913,7 +929,8 @@ export class Realm {
 
         // Return the captured state changes and evaluation result
         if (c instanceof Value) c = new SimpleNormalCompletion(c);
-        result = new Effects(c, astGenerator, astBindings, astProperties, astCreatedObjects);
+        invariant(astCreatedAbstracts !== undefined);
+        result = new Effects(c, astGenerator, astBindings, astProperties, astCreatedObjects, astCreatedAbstracts);
         return result;
       } finally {
         // Roll back the state changes
@@ -937,6 +954,7 @@ export class Realm {
         this.modifiedBindings = savedBindings;
         this.modifiedProperties = savedProperties;
         this.createdObjects = saved_createdObjects;
+        this.createdAbstracts = saved_createdAbstracts;
         this.savedCompletion = saved_completion;
         this._abstractValuesDefined = saved_abstractValuesDefined;
       }
@@ -1357,12 +1375,14 @@ export class Realm {
       (this.generator: any),
       (this.modifiedBindings: any),
       (this.modifiedProperties: any),
-      (this.createdObjects: any)
+      (this.createdObjects: any),
+      (this.createdAbstracts: any)
     );
     this.generator = new Generator(this, "captured", this.pathConditions);
     this.modifiedBindings = new Map();
     this.modifiedProperties = new Map();
     this.createdObjects = new Set();
+    this.createdAbstracts = new Set();
   }
 
   getCapturedEffects(v?: Completion | Value = this.intrinsics.undefined): Effects {
@@ -1370,12 +1390,14 @@ export class Realm {
     invariant(this.modifiedBindings !== undefined);
     invariant(this.modifiedProperties !== undefined);
     invariant(this.createdObjects !== undefined);
+    invariant(this.createdAbstracts !== undefined);
     return new Effects(
       v instanceof Completion ? v : new SimpleNormalCompletion(v),
       this.generator,
       this.modifiedBindings,
       this.modifiedProperties,
-      this.createdObjects
+      this.createdObjects,
+      this.createdAbstracts
     );
   }
 
@@ -1392,6 +1414,7 @@ export class Realm {
       this.modifiedBindings = savedEffects.modifiedBindings;
       this.modifiedProperties = savedEffects.modifiedProperties;
       this.createdObjects = savedEffects.createdObjects;
+      this.createdAbstracts = savedEffects.createdAbstracts;
     } else {
       invariant(false);
     }
@@ -1404,7 +1427,7 @@ export class Realm {
       "Effects have been applied and not properly reverted. It is not safe to apply them a second time."
     );
     effects.canBeApplied = false;
-    let { generator, modifiedBindings, modifiedProperties, createdObjects } = effects;
+    let { generator, modifiedBindings, modifiedProperties, createdObjects, createdAbstracts } = effects;
 
     // Add generated code for property modifications
     if (appendGenerator) this.appendGenerator(generator, leadingComment);
@@ -1441,6 +1464,18 @@ export class Realm {
         createdObjects.forEach((ob, a) => {
           invariant(realmCreatedObjects !== undefined);
           realmCreatedObjects.add(ob);
+        });
+      }
+    }
+
+    // add created abstracts
+    if (createdAbstracts.size > 0) {
+      let realmCreatedAbstracts = this.createdAbstracts;
+      if (realmCreatedAbstracts === undefined) this.createdAbstracts = new Set(createdAbstracts);
+      else {
+        createdAbstracts.forEach((ob, a) => {
+          invariant(realmCreatedAbstracts !== undefined);
+          realmCreatedAbstracts.add(ob);
         });
       }
     }
@@ -1592,6 +1627,12 @@ export class Realm {
     }
     if (this.createdObjectsTrackedForLeaks !== undefined) {
       this.createdObjectsTrackedForLeaks.add(object);
+    }
+  }
+
+  recordNewAbstract(abstract: AbstractValue): void {
+    if (this.createdAbstracts !== undefined) {
+      this.createdAbstracts.add(abstract);
     }
   }
 

--- a/src/values/AbstractValue.js
+++ b/src/values/AbstractValue.js
@@ -101,6 +101,7 @@ export default class AbstractValue extends Value {
   ) {
     invariant(realm.useAbstractInterpretation);
     super(realm, optionalArgs ? optionalArgs.intrinsicName : undefined);
+    realm.recordNewAbstract(this);
     invariant(!Value.isTypeCompatibleWith(types.getType(), ObjectValue) || this instanceof AbstractObjectValue);
     invariant(types.getType() !== NullValue && types.getType() !== UndefinedValue);
     this.types = types;


### PR DESCRIPTION
Release notes: adds `createdAbstracts` `Set` to both `Effects` and `Realm`.

For a feature I'm working on, where we can optionally inline function calls depending on a bunch of pre-defined heuristics, I've run into the need for a feature for tracking abstract values. When we use `evaluateForEffects` we currently get quite a bit of information of what occurred, nicely packaged up in effects. One of those is `createdObjects`, which is super useful for many cases, but I believe we also need, is a way of knowing what `AbstractValue`s were created in effects too. This PR adds that functionality.