### PR TITLE
Fixes a bug with evaluatePure

### DIFF
--- a/src/intrinsics/prepack/global.js
+++ b/src/intrinsics/prepack/global.js
@@ -267,8 +267,10 @@ export default function(realm: Realm): void {
           invariant(functionValue instanceof ECMAScriptSourceFunctionValue);
           invariant(typeof functionValue.$Call === "function");
           let functionCall: Function = functionValue.$Call;
+          let pureScopeEnv = functionValue.$Environment;
           return realm.evaluatePure(
             () => functionCall(realm.intrinsics.undefined, []),
+            pureScopeEnv,
             /*bubbles*/ true,
             /*reportSideEffectFunc*/ callback === undefined || callback === realm.intrinsics.undefined
               ? null

--- a/src/methods/function.js
+++ b/src/methods/function.js
@@ -103,6 +103,10 @@ function InternalCall(
     let calleeContext = PrepareForOrdinaryCall(realm, F, undefined);
     let calleeEnv = calleeContext.lexicalEnvironment;
 
+    if (calleeEnv.parent === undefined) {
+      calleeEnv.parent = callerContext.lexicalEnvironment;
+    }
+
     let result;
     try {
       for (let t1 of realm.tracers) t1.beforeCall(F, thisArgument, argsList, undefined);

--- a/src/react/components.js
+++ b/src/react/components.js
@@ -309,6 +309,7 @@ export function evaluateClassConstructor(
   let instanceProperties = new Set();
   let instanceSymbols = new Set();
 
+  let pureScopeEnv = constructorFunc.$Environment;
   realm.evaluatePure(
     () =>
       realm.evaluateForEffects(
@@ -328,6 +329,7 @@ export function evaluateClassConstructor(
         /*state*/ null,
         `react component constructor: ${constructorFunc.getName()}`
       ),
+    pureScopeEnv,
     /*bubbles*/ true,
     /*reportSideEffectFunc*/ null
   );

--- a/src/react/experimental-server-rendering/rendering.js
+++ b/src/react/experimental-server-rendering/rendering.js
@@ -356,8 +356,9 @@ class ReactDOMServerRenderer {
             invariant(result instanceof Value);
             return this.render(result, namespace, depth);
           };
+          let pureScopeEnv = func.$Environment;
           let pureFuncCall = () =>
-            this.realm.evaluatePure(funcCall, /*bubbles*/ true, () => {
+            this.realm.evaluatePure(funcCall, pureScopeEnv, /*bubbles*/ true, () => {
               invariant(false, "SSR _renderArrayValue side-effect should have been caught in main React reconciler");
             });
 

--- a/src/realm.js
+++ b/src/realm.js
@@ -1483,7 +1483,9 @@ export class Realm {
       let pureScopeEnv = this.pureScopeEnv;
       let env = context.lexicalEnvironment;
       while (env !== null) {
-        if (env === pureScopeEnv) {
+        // If we reach a destroyed env, then it's outside of the pure running context.
+        // Furthermore, if we reach the pure scope env, we're also out of scope.
+        if (env === pureScopeEnv || env.destroyed) {
           return false;
         } else if (env.environmentRecord === targetEnv) {
           return true;

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -241,8 +241,10 @@ export class Functions {
         let error = new CompilerDiagnostic(msg, location, "PP1007", "Warning");
         realm.handleError(error);
       };
+      let pureScopeEnv = functionValue.$Environment;
       let effects: Effects = realm.evaluatePure(
         () => realm.evaluateForEffectsInGlobalEnv(call, undefined, "additional function"),
+        pureScopeEnv,
         /*bubbles*/ true,
         (sideEffectType, binding, expressionLocation) =>
           handleReportedSideEffect(logCompilerDiagnostic, sideEffectType, binding, expressionLocation)

--- a/src/values/ArrayValue.js
+++ b/src/values/ArrayValue.js
@@ -68,11 +68,12 @@ function evaluatePossibleNestedOptimizedFunctionsAndStoreEffects(
     }
 
     let funcCall = Utils.createModelledFunctionCall(realm, funcToModel, undefined, thisValue);
+    let pureScopeEnv = funcToModel.$Environment;
     // We take the modelled function and wrap it in a pure evaluation so we can check for
     // side-effects that occur when evaluating the function. If there are side-effects, then
     // we don't try and optimize the nested function.
     let pureFuncCall = () =>
-      realm.evaluatePure(funcCall, /*bubbles*/ false, () => {
+      realm.evaluatePure(funcCall, pureScopeEnv, /*bubbles*/ false, () => {
         throw new NestedOptimizedFunctionSideEffect();
       });
     let effects;

--- a/test/serializer/additional-functions/NestedOptimizedFunction19.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction19.js
@@ -1,0 +1,20 @@
+// arrayNestedOptimizedFunctionsEnabled
+// Copies of return 2:0
+
+function fn(a) {
+  var arr = Array.from(a);
+  var foo;
+  
+  var mapped = arr.map(function() {
+    foo = 2;
+    return 1 + 1;
+  });
+
+  return mapped;
+}
+
+inspect = function() {
+  return fn([]);
+}
+
+global.__optimize && __optimize(fn);

--- a/test/serializer/additional-functions/NestedOptimizedFunction19.js
+++ b/test/serializer/additional-functions/NestedOptimizedFunction19.js
@@ -4,7 +4,7 @@
 function fn(a) {
   var arr = Array.from(a);
   var foo;
-  
+
   var mapped = arr.map(function() {
     foo = 2;
     return 1 + 1;
@@ -15,6 +15,6 @@ function fn(a) {
 
 inspect = function() {
   return fn([]);
-}
+};
 
 global.__optimize && __optimize(fn);


### PR DESCRIPTION
Release notes: none

This fixes a bug with `evaluatePure` where it was not correctly detecting mutations/side-effects of bindings created outside the environment of the `evaluatePure` call. You now need to explicitly pass the `lexicalEnvironment` to `evaluatePure` of the "root" scope. If a binding gets mutated in this scope when traversing through it's parents from the current execution scope then it will trigger a side-effect.