### PR TITLE
Improve generatorOfEffects logic for emitting modified bindings

### DIFF
--- a/src/react/optimizing.js
+++ b/src/react/optimizing.js
@@ -117,8 +117,6 @@ function applyWriteEffectsForOptimizedComponent(
     effects,
     false,
     "ReactAdditionalFunctionEffects",
-    writeEffects,
-    preEvaluationComponentToWriteEffectFunction,
     writeEffectsKey,
     parentOptimizedFunction,
     transforms

--- a/src/serializer/functions.js
+++ b/src/serializer/functions.js
@@ -198,8 +198,6 @@ export class Functions {
         effects,
         true,
         "AdditionalFunctionEffects",
-        this._writeEffects,
-        this.reactFunctionMap,
         functionValue,
         this.getDeclaringOptimizedFunction(functionValue)
       );
@@ -253,8 +251,6 @@ export class Functions {
         effects,
         true,
         "AdditionalFunctionEffects",
-        this._writeEffects,
-        this.reactFunctionMap,
         functionValue,
         this.getDeclaringOptimizedFunction(functionValue)
       );

--- a/src/serializer/utils.js
+++ b/src/serializer/utils.js
@@ -205,20 +205,11 @@ export function createAdditionalEffects(
   effects: Effects,
   fatalOnAbrupt: boolean,
   name: string,
-  additionalFunctionEffects: Map<FunctionValue, AdditionalFunctionEffects>,
-  preEvaluationComponentToWriteEffectFunction: Map<FunctionValue, FunctionValue>,
   optimizedFunction: FunctionValue,
   parentOptimizedFunction: FunctionValue | void,
   transforms: Array<AdditionalFunctionTransform> = []
 ): AdditionalFunctionEffects | null {
-  let generator = Generator.fromEffects(
-    effects,
-    realm,
-    name,
-    additionalFunctionEffects,
-    preEvaluationComponentToWriteEffectFunction,
-    optimizedFunction
-  );
+  let generator = Generator.fromEffects(effects, realm, name, optimizedFunction);
   let retValue: AdditionalFunctionEffects = {
     parentAdditionalFunction: parentOptimizedFunction || undefined,
     effects,

--- a/src/types.js
+++ b/src/types.js
@@ -989,7 +989,7 @@ export type UtilsType = {|
   jsonToDisplayString: <T: { toDisplayJson(number): DisplayResult }>(T, number) => string,
   verboseToDisplayJson: ({}, number) => DisplayResult,
   createModelledFunctionCall: (Realm, FunctionValue, void | string | ArgModel, void | Value) => void => Value,
-  bindingWasMutated: (binding: Binding, effects: Effects, F: FunctionValue) => boolean,
+  isBindingMutationOutsideFunction: (binding: Binding, effects: Effects, F: FunctionValue) => boolean,
 |};
 
 export type DebuggerConfigArguments = {

--- a/src/types.js
+++ b/src/types.js
@@ -30,7 +30,7 @@ import type {
 import { Value } from "./values/index.js";
 import { Completion } from "./completions.js";
 import type { Descriptor as DescriptorClass } from "./descriptors.js";
-import { EnvironmentRecord, LexicalEnvironment, Reference } from "./environment.js";
+import { type Binding, EnvironmentRecord, LexicalEnvironment, Reference } from "./environment.js";
 import { ObjectValue } from "./values/index.js";
 import type {
   BabelNode,
@@ -989,6 +989,7 @@ export type UtilsType = {|
   jsonToDisplayString: <T: { toDisplayJson(number): DisplayResult }>(T, number) => string,
   verboseToDisplayJson: ({}, number) => DisplayResult,
   createModelledFunctionCall: (Realm, FunctionValue, void | string | ArgModel, void | Value) => void => Value,
+  bindingWasMutated: (binding: Binding, effects: Effects, F: FunctionValue) => boolean,
 |};
 
 export type DebuggerConfigArguments = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,7 @@
 
 /* @flow strict-local */
 
-import type { Realm } from "./realm.js";
+import type { Effects, Realm } from "./realm.js";
 import {
   AbstractValue,
   ArrayValue,
@@ -32,6 +32,7 @@ import { ShapeInformation } from "./utils/ShapeInformation.js";
 import type { ArgModel } from "./types.js";
 import { CompilerDiagnostic, FatalError } from "./errors.js";
 import { DeclarativeEnvironmentRecord, GlobalEnvironmentRecord, LexicalEnvironment } from "./environment.js";
+import type { Binding } from "./environment.js";
 import * as t from "@babel/types";
 
 export function typeToString(type: typeof Value): void | string {
@@ -211,7 +212,7 @@ export function createModelledFunctionCall(
   };
 }
 
-export function bindingWasMutated(binding: PropertyBinding, effects: Effects, F: ECMAScriptFunctionValue) {
+export function bindingWasMutated(binding: Binding, effects: Effects, F: FunctionValue): boolean {
   let env = F.$Environment;
   let bindingName = binding.name;
   if (env instanceof LexicalEnvironment) {

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -58,7 +58,7 @@ import type { PathConditions, ShapeInformationInterface } from "../types.js";
 import { PreludeGenerator } from "./PreludeGenerator.js";
 import { PropertyDescriptor } from "../descriptors.js";
 import type { AdditionalFunctionEffects } from "../serializer/types.js";
-import { FunctionEnvironmentRecord } from "../environment";
+import { bindingWasMutated } from "../utils.js";
 
 export type OperationDescriptorType =
   | "ABSTRACT_FROM_TEMPLATE"
@@ -702,35 +702,12 @@ export class Generator {
       output.emitPropertyModification(propertyBinding);
     }
 
-    for (let [modifiedBinding, previousValue] of modifiedBindings.entries()) {
-      let cannonicalize = functionValue =>
-        preEvaluationComponentToWriteEffectFunction.get(functionValue) || functionValue;
-      let optimizedFunctionValue = optimizedFunction;
-      invariant(optimizedFunctionValue);
-      invariant(
-        cannonicalize(optimizedFunctionValue) === optimizedFunctionValue,
-        "These values should be canonical already"
-      );
-      // Walks up the parent chain for the given optimized function checking if the value or any of its parents are
-      // equal to the optimized function we're currently building a generator for.
-      let valueOrParentEqualsFunction = functionValue => {
-        let canonicalOptimizedFunction = cannonicalize(functionValue);
-        if (canonicalOptimizedFunction === optimizedFunctionValue) return true;
-        let additionalEffects = additionalFunctionEffects.get(canonicalOptimizedFunction);
-        invariant(additionalEffects !== undefined);
-        let parent = additionalEffects.parentAdditionalFunction;
-        if (parent !== undefined) return valueOrParentEqualsFunction(parent);
-        return false;
-      };
-
-      let environment = modifiedBinding.environment;
-      if (environment instanceof FunctionEnvironmentRecord && environment.$FunctionObject === optimizedFunctionValue)
-        continue;
-      let creatingOptimizedFunction = environment.creatingOptimizedFunction;
-      if (creatingOptimizedFunction && valueOrParentEqualsFunction(creatingOptimizedFunction)) continue;
-      // TODO #2586: modifiedBinding.value should always exist
-      if (modifiedBinding.value || previousValue.value) {
-        output.emitBindingModification(modifiedBinding);
+    for (let [modifiedBinding] of modifiedBindings.entries()) {
+      if (bindingWasMutated(modifiedBinding, effects, optimizedFunction)) {
+        if (!modifiedBinding.hasLeaked) {
+          invariant(modifiedBinding.value !== undefined);
+          output.emitBindingModification(modifiedBinding);
+        }
       }
     }
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -58,7 +58,6 @@ import type { PathConditions, ShapeInformationInterface } from "../types.js";
 import { PreludeGenerator } from "./PreludeGenerator.js";
 import { PropertyDescriptor } from "../descriptors.js";
 import type { AdditionalFunctionEffects } from "../serializer/types.js";
-import { bindingWasMutated } from "../utils.js";
 
 export type OperationDescriptorType =
   | "ABSTRACT_FROM_TEMPLATE"
@@ -703,7 +702,7 @@ export class Generator {
     }
 
     for (let [modifiedBinding] of modifiedBindings.entries()) {
-      if (bindingWasMutated(modifiedBinding, effects, optimizedFunction)) {
+      if (Utils.bindingWasMutated(modifiedBinding, effects, optimizedFunction)) {
         if (!modifiedBinding.hasLeaked) {
           invariant(modifiedBinding.value !== undefined);
           output.emitBindingModification(modifiedBinding);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -702,7 +702,7 @@ export class Generator {
     }
 
     for (let [modifiedBinding] of modifiedBindings.entries()) {
-      if (Utils.bindingWasMutated(modifiedBinding, effects, optimizedFunction)) {
+      if (Utils.isBindingMutationOutsideFunction(modifiedBinding, effects, optimizedFunction)) {
         if (!modifiedBinding.hasLeaked) {
           invariant(modifiedBinding.value !== undefined);
           output.emitBindingModification(modifiedBinding);

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -57,7 +57,6 @@ import type { SerializerOptions } from "../options.js";
 import type { PathConditions, ShapeInformationInterface } from "../types.js";
 import { PreludeGenerator } from "./PreludeGenerator.js";
 import { PropertyDescriptor } from "../descriptors.js";
-import type { AdditionalFunctionEffects } from "../serializer/types.js";
 
 export type OperationDescriptorType =
   | "ABSTRACT_FROM_TEMPLATE"
@@ -681,9 +680,7 @@ export class Generator {
   static _generatorOfEffects(
     realm: Realm,
     name: string,
-    additionalFunctionEffects: Map<FunctionValue, AdditionalFunctionEffects>,
     optimizedFunction: FunctionValue,
-    preEvaluationComponentToWriteEffectFunction: Map<FunctionValue, FunctionValue>,
     effects: Effects
   ): Generator {
     let { result, generator, modifiedBindings, modifiedProperties, createdObjects } = effects;
@@ -728,23 +725,9 @@ export class Generator {
 
   // Make sure to to fixup
   // how to apply things around sets of things
-  static fromEffects(
-    effects: Effects,
-    realm: Realm,
-    name: string,
-    additionalFunctionEffects: Map<FunctionValue, AdditionalFunctionEffects>,
-    preEvaluationComponentToWriteEffectFunction: Map<FunctionValue, FunctionValue>,
-    optimizedFunction: FunctionValue
-  ): Generator {
+  static fromEffects(effects: Effects, realm: Realm, name: string, optimizedFunction: FunctionValue): Generator {
     return realm.withEffectsAppliedInGlobalEnv(
-      this._generatorOfEffects.bind(
-        this,
-        realm,
-        name,
-        additionalFunctionEffects,
-        optimizedFunction,
-        preEvaluationComponentToWriteEffectFunction
-      ),
+      this._generatorOfEffects.bind(this, realm, name, optimizedFunction),
       effects
     );
   }

--- a/test/serializer/optimized-functions/ModifiedResidualBindings.js
+++ b/test/serializer/optimized-functions/ModifiedResidualBindings.js
@@ -1,0 +1,24 @@
+let outermost;
+function foo() {
+  let inner1 = 0;
+  return [() => inner1, () => inner1++];
+}
+(function() {
+  let outer;
+  let [getter, incrementer] = foo();
+  function toOptimize() {
+    let inner2;
+    incrementer();
+    return getter();
+  }
+  global.bar = toOptimize;
+  global.getter = getter;
+  global.__optimize && global.__optimize(toOptimize);
+})();
+
+global.inspect = function() {
+  let x = global.getter();
+  let y = global.bar();
+  let z = global.getter();
+  return x + " " + y + " " + z;
+};

--- a/test/serializer/optimized-functions/ModifiedResidualBindings2.js
+++ b/test/serializer/optimized-functions/ModifiedResidualBindings2.js
@@ -1,0 +1,25 @@
+let outermost;
+function foo() {
+  let inner1 = 0;
+  return [() => inner1, () => inner1++];
+}
+global.__optimize && global.__optimize(foo);
+(function() {
+  let outer;
+  let [getter, incrementer] = foo();
+  function toOptimize() {
+    let inner2;
+    incrementer();
+    return getter();
+  }
+  global.bar = toOptimize;
+  global.getter = getter;
+  global.__optimize && global.__optimize(toOptimize);
+})();
+
+global.inspect = function() {
+  let x = global.getter();
+  let y = global.bar();
+  let z = global.getter();
+  return x + " " + y + " " + z;
+};

--- a/test/serializer/optimized-functions/ModifiedResidualBindings3.js
+++ b/test/serializer/optimized-functions/ModifiedResidualBindings3.js
@@ -1,0 +1,25 @@
+let outermost;
+(function() {
+  let outer = 0;
+  function toOptimize() {
+    function foo() {
+      let inner1 = outer;
+      return [() => inner1, () => inner1++];
+    }
+    global.__optimize && global.__optimize(foo);
+    let [getter, incrementer] = foo();
+    let inner2;
+    global.getter = getter;
+    incrementer();
+    return getter();
+  }
+  global.bar = toOptimize;
+  global.__optimize && global.__optimize(toOptimize);
+})();
+
+global.inspect = function() {
+  let x = global.getter();
+  let y = global.bar();
+  let z = global.getter();
+  return x + " " + y + " " + z;
+};


### PR DESCRIPTION
Release notes: none

When working on our internal React bundle and running into issues outlined in https://github.com/facebook/prepack/issues/2586, I realized that I had already solved the detection of modified bindings in my upcoming PR and that the logic was exactly the same.

I've extracted said logic into a helper function so this can be used in my other PR.

Fixes #2586.