### PR TITLE
Lint rule to prevent imports of modules from lib/*

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -218,6 +218,11 @@
       "parser": "flow",
       "trailingComma": "es5",
       "printWidth": 120,
+    }],
+
+  // Reject imports from lib/*
+    "no-restricted-imports": ["error", {
+      "patterns": ["**/../lib/**"]
     }]
   }
 }

--- a/scripts/.eslintrc
+++ b/scripts/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-restricted-imports": "off"
+  }
+}


### PR DESCRIPTION
Adds a lint rule that rejects imports such as the following:

```js
import ECMAScriptSourceFunctionValue from "../../lib/values/ECMAScriptSourceFunctionValue.js";
```

The path should contain `src` instead of `lib`.