### PR TITLE
Improve error message for invalid debugDiagnosticSeverity argument

### DIFF
--- a/src/prepack-cli.js
+++ b/src/prepack-cli.js
@@ -315,13 +315,12 @@ function run(
         case "debugDiagnosticSeverity":
           arg = args.shift();
           if (!DiagnosticSeverityValues.includes(arg)) {
-            console.error(`Unsupported debugDiagnosticSeverity: ${arg}`);
+            console.error(
+              `Unsupported debugDiagnosticSeverity: ${arg}, use one of ${DiagnosticSeverityValues.join(", ")}. ` +
+                `The default is FatalError.`
+            );
             process.exit(1);
           }
-          invariant(
-            arg === "FatalError" || arg === "RecoverableError" || arg === "Warning" || arg === "Information",
-            `Invalid debugger diagnostic severity: ${arg}`
-          );
           debuggerConfigArgs.diagnosticSeverity = arg;
           reproArguments.push("--debugDiagnosticSeverity", arg);
           break;


### PR DESCRIPTION
- Improve the error message on top of the #2545 
- Removed the `invariant` method call

Fixes #2509.

pairing with @jessmartin

